### PR TITLE
fix: ferment progress bar visibility and live updates

### DIFF
--- a/src/components/footer.ts
+++ b/src/components/footer.ts
@@ -505,16 +505,24 @@ export class StatsFooter implements Component {
 	}
 
 	private fermentSegment(pinned = false): Segment | null {
-		if (!pinned) return null
 		const display = formatFermentFooterDisplay(getActiveFerment(), getFermentContinuationPolicy(), {
 			dim: (s) => this.dim(s),
 			accent: (s) => this.accent(s),
 		})
+		// No active ferment: only show the placeholder when the user has
+		// explicitly pinned the segment (so they can see it's wired up but
+		// idle). Unpinned, hide it entirely — "Ferment: —" is noise when no
+		// ferment is running.
 		if (!display) {
+			if (!pinned) return null
 			const text = `${this.dim("Ferment:")} ${this.dim("—")}`
 			return { id: "ferment", text, width: visibleWidth(text) }
 		}
 
+		// Active ferment: always render, even when unpinned. The status line is
+		// the primary surface for ferment progress and must not be hidden by
+		// default. This matches the ScriptFooter path (ui.ts) which shows the
+		// ferment segment unconditionally when there is one.
 		return {
 			id: "ferment",
 			text: display.text,

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -403,7 +403,7 @@ describe("FermentCommandController", () => {
 			}),
 			{ triggerTurn: false },
 		)
-		expect(requestSharedFooterRenderMock).toHaveBeenCalledTimes(1)
+		expect(requestSharedFooterRenderMock).toHaveBeenCalledTimes(2)
 		expect(h.ctx.abort).toHaveBeenCalledTimes(1)
 	})
 

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -9,6 +9,7 @@ import { pr_bold, pr_dim, pr_orange, pr_success, pr_teal } from "./colors.js"
 import { type FermentCommand, parseFermentCommand } from "./command-parser.js"
 import { decideContinuation } from "./continuation.js"
 import { emitFermentCreated } from "./domain-events-emitter.js"
+import { FERMENT_EVENTS } from "./domain-events.js"
 import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { appendRefEntry, resetReactiveContinuationNudgeCount } from "./nudge.js"
@@ -393,103 +394,191 @@ async function openFermentProgress(pi: ExtensionAPI, ctx: FermentUiContext, runt
 	const select = ctx.ui.select.bind(ctx.ui)
 	const confirm = ctx.ui.confirm.bind(ctx.ui)
 
-	let atPhaseList = true
-	while (atPhaseList) {
-		const f = runtime.getStorage().get(active.id) ?? active
-		const phaseListOpts = buildPhaseListOptions(f)
-		const phaseListPhaseCount = f.phases.length
+	// Auto-refresh: when a ferment domain event fires (step started/completed,
+	// phase activated, etc.), abort the current select() so it re-opens with
+	// fresh data. Without this, the overlay shows stale counts while the
+	// agent makes progress in the background.
+	//
+	// Each select() call receives an AbortSignal. When a relevant event fires,
+	// we abort the current controller and create a new one. The select()
+	// returns undefined on abort, which the navigation loop treats as "stay on
+	// this layer" — so the user sees the title/options refresh in place.
+	const REFRESH_EVENTS = [
+		FERMENT_EVENTS.STEP_STARTED,
+		FERMENT_EVENTS.STEP_COMPLETED,
+		FERMENT_EVENTS.STEP_FAILED,
+		FERMENT_EVENTS.PHASE_STARTED,
+		FERMENT_EVENTS.PHASE_COMPLETED,
+		FERMENT_EVENTS.SUSPENDED,
+		FERMENT_EVENTS.RESUMED,
+	] as const
 
-		const l1choice = await select(buildPhaseListTitle(f, runtime), phaseListOpts)
+	let currentController: AbortController | undefined
 
-		if (!l1choice || l1choice === "Close") {
-			atPhaseList = false
-			continue
+	const refreshHandler = () => {
+		currentController?.abort()
+	}
+	const unsubscribers: (() => void)[] = []
+	for (const evt of REFRESH_EVENTS) {
+		unsubscribers.push(pi.events.on(evt, refreshHandler))
+	}
+	const unsubscribe = () => {
+		for (const unsub of unsubscribers) unsub()
+	}
+
+	// Auto-refreshing select: retries with fresh title/options when the
+	// underlying ferment state changes while the dialog is open.
+	async function liveSelect(buildTitle: () => string, buildOptions: () => string[]): Promise<string | undefined> {
+		while (true) {
+			const controller = new AbortController()
+			currentController = controller
+			const choice = await select(buildTitle(), buildOptions(), { signal: controller.signal })
+			currentController = undefined
+			// If aborted by a domain event, loop and re-render with fresh data.
+			if (choice === undefined && controller.signal.aborted) continue
+			return choice
 		}
+	}
 
-		if (l1choice === "Abandon ferment") {
-			const confirmed = await confirm(
-				`Abandon "${f.name}"?`,
-				"Marks the ferment abandoned. Work done so far is preserved.",
+	try {
+		let atPhaseList = true
+		while (atPhaseList) {
+			const f = runtime.getStorage().get(active.id) ?? active
+			const phaseListOpts = buildPhaseListOptions(f)
+			const phaseListPhaseCount = f.phases.length
+
+			const l1choice = await liveSelect(
+				() => buildPhaseListTitle(runtime.getStorage().get(active.id) ?? active, runtime),
+				() => buildPhaseListOptions(runtime.getStorage().get(active.id) ?? active),
 			)
-			if (confirmed) {
-				const outcome = applyAndPersist(f.id, { type: "abandon" })
-				if (outcome.ok) setActiveFermentAndApplyProfile(pi, runtime, undefined)
-				runtime.clearFermentState(f.id)
+
+			if (!l1choice || l1choice === "Close") {
 				atPhaseList = false
-			}
-			continue
-		}
-
-		const l1idx = phaseListOpts.indexOf(l1choice)
-		if (l1idx < 0 || l1idx >= phaseListPhaseCount) continue
-		const selectedPhaseIndex = f.phases[l1idx].index
-
-		let atStepList = true
-		while (atStepList) {
-			const f2 = runtime.getStorage().get(f.id) ?? f
-			const ph = f2.phases.find((p) => p.index === selectedPhaseIndex)
-			if (!ph) {
-				atStepList = false
-				break
+				continue
 			}
 
-			const stepOpts = buildPhaseStepOptions(ph)
-			const stepCount = ph.steps.length
-
-			const l2choice = await select(buildPhaseDetailTitle(f2, ph), stepOpts)
-
-			if (!l2choice || l2choice === "Back") {
-				atStepList = false
-				break
-			}
-
-			if (l2choice === "Phase actions") {
-				let atPhaseActions = true
-				while (atPhaseActions) {
-					const f3 = runtime.getStorage().get(f.id) ?? f
-					const ph3 = f3.phases.find((p) => p.index === selectedPhaseIndex)
-					if (!ph3) {
-						atPhaseActions = false
-						break
-					}
-					const actionChoice = await select(buildPhaseDetailTitle(f3, ph3), buildPhaseActionOptions(f3, ph3))
-					if (!actionChoice || actionChoice === "Back to steps") {
-						atPhaseActions = false
-						break
-					}
-					await handlePhaseAction(actionChoice, f3, ph3, ctx, runtime)
+			if (l1choice === "Abandon ferment") {
+				const confirmed = await confirm(
+					`Abandon "${f.name}"?`,
+					"Marks the ferment abandoned. Work done so far is preserved.",
+				)
+				if (confirmed) {
+					const outcome = applyAndPersist(f.id, { type: "abandon" })
+					if (outcome.ok) setActiveFermentAndApplyProfile(pi, runtime, undefined)
+					runtime.clearFermentState(f.id)
+					atPhaseList = false
 				}
 				continue
 			}
 
-			const l2idx = stepOpts.indexOf(l2choice)
-			if (l2idx < 0 || l2idx >= stepCount) continue
-			const selectedStepIndex = ph.steps[l2idx].index
+			const l1idx = phaseListOpts.indexOf(l1choice)
+			if (l1idx < 0 || l1idx >= phaseListPhaseCount) continue
+			const selectedPhaseIndex = f.phases[l1idx].index
 
-			let atStepDetail = true
-			while (atStepDetail) {
-				const f3 = runtime.getStorage().get(f.id) ?? f
-				const ph3 = f3.phases.find((p) => p.index === selectedPhaseIndex)
-				if (!ph3) {
-					atStepDetail = false
-					break
-				}
-				const st = ph3.steps.find((s) => s.index === selectedStepIndex)
-				if (!st) {
-					atStepDetail = false
+			let atStepList = true
+			while (atStepList) {
+				const f2 = runtime.getStorage().get(f.id) ?? f
+				const ph = f2.phases.find((p) => p.index === selectedPhaseIndex)
+				if (!ph) {
+					atStepList = false
 					break
 				}
 
-				const stepActionOpts = buildStepActionOptions(ph3, st)
-				const l3choice = await select(buildStepDetailTitle(ph3, st), stepActionOpts)
+				const stepOpts = buildPhaseStepOptions(ph)
+				const stepCount = ph.steps.length
 
-				if (!l3choice || l3choice === "Back to phase") {
-					atStepDetail = false
+				const l2choice = await liveSelect(
+					() => {
+						const lf = runtime.getStorage().get(f.id) ?? f
+						const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+						return lph ? buildPhaseDetailTitle(lf, lph) : buildPhaseDetailTitle(lf, ph)
+					},
+					() => {
+						const lf = runtime.getStorage().get(f.id) ?? f
+						const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+						return lph ? buildPhaseStepOptions(lph) : stepOpts
+					},
+				)
+
+				if (!l2choice || l2choice === "Back") {
+					atStepList = false
 					break
 				}
-				await handleStepAction(l3choice, f3, ph3, st, ctx, runtime)
+
+				if (l2choice === "Phase actions") {
+					let atPhaseActions = true
+					while (atPhaseActions) {
+						const f3 = runtime.getStorage().get(f.id) ?? f
+						const ph3 = f3.phases.find((p) => p.index === selectedPhaseIndex)
+						if (!ph3) {
+							atPhaseActions = false
+							break
+						}
+						const actionChoice = await liveSelect(
+							() => {
+								const lf = runtime.getStorage().get(f.id) ?? f
+								const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+								return lph ? buildPhaseDetailTitle(lf, lph) : buildPhaseDetailTitle(lf, ph3)
+							},
+							() => {
+								const lf = runtime.getStorage().get(f.id) ?? f
+								const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+								return lph ? buildPhaseActionOptions(lf, lph) : buildPhaseActionOptions(f3, ph3)
+							},
+						)
+						if (!actionChoice || actionChoice === "Back to steps") {
+							atPhaseActions = false
+							break
+						}
+						await handlePhaseAction(actionChoice, f3, ph3, ctx, runtime)
+					}
+					continue
+				}
+
+				const l2idx = stepOpts.indexOf(l2choice)
+				if (l2idx < 0 || l2idx >= stepCount) continue
+				const selectedStepIndex = ph.steps[l2idx].index
+
+				let atStepDetail = true
+				while (atStepDetail) {
+					const f3 = runtime.getStorage().get(f.id) ?? f
+					const ph3 = f3.phases.find((p) => p.index === selectedPhaseIndex)
+					if (!ph3) {
+						atStepDetail = false
+						break
+					}
+					const st = ph3.steps.find((s) => s.index === selectedStepIndex)
+					if (!st) {
+						atStepDetail = false
+						break
+					}
+
+					const stepActionOpts = buildStepActionOptions(ph3, st)
+					const l3choice = await liveSelect(
+						() => {
+							const lf = runtime.getStorage().get(f.id) ?? f
+							const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+							const lst = lph?.steps.find((s) => s.index === selectedStepIndex)
+							return lst ? buildStepDetailTitle(lph ?? ph3, lst) : buildStepDetailTitle(ph3, st)
+						},
+						() => {
+							const lf = runtime.getStorage().get(f.id) ?? f
+							const lph = lf.phases.find((p) => p.index === selectedPhaseIndex)
+							const lst = lph?.steps.find((s) => s.index === selectedStepIndex)
+							return lst ? buildStepActionOptions(lph ?? ph3, lst) : stepActionOpts
+						},
+					)
+
+					if (!l3choice || l3choice === "Back to phase") {
+						atStepDetail = false
+						break
+					}
+					await handleStepAction(l3choice, f3, ph3, st, ctx, runtime)
+				}
 			}
 		}
+	} finally {
+		unsubscribe()
 	}
 }
 

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -411,6 +411,7 @@ async function openFermentProgress(pi: ExtensionAPI, ctx: FermentUiContext, runt
 		FERMENT_EVENTS.PHASE_COMPLETED,
 		FERMENT_EVENTS.SUSPENDED,
 		FERMENT_EVENTS.RESUMED,
+		FERMENT_EVENTS.STALLED,
 	] as const
 
 	let currentController: AbortController | undefined

--- a/src/extensions/ferment/progress-overlay.test.ts
+++ b/src/extensions/ferment/progress-overlay.test.ts
@@ -83,6 +83,44 @@ describe("progress overlay action handlers", () => {
 		expect(title).toContain("2m ago")
 	})
 
+	it("shows running step count and active step in the title", () => {
+		const { runtime, ferment, step } = createHarness()
+		// The harness has one phase with one step in "running" status.
+		const title = buildPhaseListTitle(ferment, runtime)
+
+		// Progress bar includes a partial-fill glyph (▌) for the running step.
+		expect(title).toContain("▌")
+		// Running step count is shown.
+		expect(title).toContain("+1 running")
+		// "now:" line shows the active phase and the running step description.
+		expect(title).toContain("now:")
+		expect(title).toContain("P1")
+		expect(title).toContain(step.description)
+	})
+
+	it("shows 0% and no running tag when all steps are pending", () => {
+		const { runtime, storage, ferment } = createHarness()
+		// Reset the step back to pending by reading from storage and creating
+		// a fresh ferment with all-pending steps.
+		const fresh = storage.get(ferment.id)
+		if (!fresh) throw new Error("ferment not found in storage")
+		const pendingFerment: Ferment = {
+			...fresh,
+			phases: fresh.phases.map((p) => ({
+				...p,
+				steps: p.steps.map((s) => ({ ...s, status: "pending" as const })),
+			})),
+		}
+		const title = buildPhaseListTitle(pendingFerment, runtime)
+
+		// No partial fill, no running tag.
+		expect(title).not.toContain("▌")
+		expect(title).not.toContain("running")
+		// 0% progress, 0/1 steps.
+		expect(title).toContain("0%")
+		expect(title).toContain("0/1")
+	})
+
 	it("uses injected runtime state for step actions", async () => {
 		const { runtime, storage, ferment, phase, step, ctx, setActiveSpy, clearStepStartSpy } = createHarness()
 

--- a/src/extensions/ferment/progress-overlay.ts
+++ b/src/extensions/ferment/progress-overlay.ts
@@ -11,7 +11,6 @@
  * blocked even after manual intervention.
  */
 
-import { getScopingProgress } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import {
 	DIM,
@@ -46,7 +45,9 @@ function parallelMarkerVerbose(s: Step): string {
 }
 
 export function buildPhaseListTitle(f: Ferment, runtime: FermentRuntime = defaultFermentRuntime): string {
-	// Count terminal steps across all phases. If no steps exist, fall back to phase-level counting.
+	// Count terminal and running steps across all phases.
+	// The progress bar fills completed steps with █ and running steps with ▌
+	// so the user can see both what's done and what's in-flight at a glance.
 	const totalSteps = f.phases.reduce((sum, p) => sum + p.steps.length, 0)
 	const terminalSteps = f.phases.reduce(
 		(sum, p) =>
@@ -56,6 +57,7 @@ export function buildPhaseListTitle(f: Ferment, runtime: FermentRuntime = defaul
 			).length,
 		0,
 	)
+	const runningSteps = f.phases.reduce((sum, p) => sum + p.steps.filter((s) => s.status === "running").length, 0)
 
 	// Fallback to phase-level counting if there are no steps yet
 	const terminalPhases = f.phases.filter(
@@ -65,28 +67,54 @@ export function buildPhaseListTitle(f: Ferment, runtime: FermentRuntime = defaul
 
 	const progress =
 		totalSteps > 0
-			? { total: totalSteps, terminal: terminalSteps, unit: "steps" as const }
-			: { total: totalPhases, terminal: terminalPhases, unit: "phases" as const }
+			? { total: totalSteps, terminal: terminalSteps, running: runningSteps, unit: "steps" as const }
+			: { total: totalPhases, terminal: terminalPhases, running: 0, unit: "phases" as const }
 
 	const progressTotal = progress.total
 	const progressTerminal = progress.terminal
+	const progressRunning = progress.running
 	const progressUnit = progress.unit
 
 	const barLen = 28
-	const filled = progressTotal > 0 ? Math.round((progressTerminal / progressTotal) * barLen) : 0
-	const bar = `${SUCCESS_FG}${"█".repeat(filled)}${RST_FG}${DIM}${"░".repeat(barLen - filled)}${RST_ALL}`
+	const filledWhole = progressTotal > 0 ? Math.floor((progressTerminal / progressTotal) * barLen) : 0
+	const hasPartial = progressTotal > 0 && progressRunning > 0
+	const filledTotal = Math.min(filledWhole + (hasPartial ? 1 : 0), barLen)
+	const bar = [
+		`${SUCCESS_FG}${"█".repeat(filledWhole)}`,
+		hasPartial ? `${pr_orange("▌")}${RST_FG}` : "",
+		`${DIM}${"░".repeat(barLen - filledTotal)}${RST_ALL}`,
+	].join("")
 	const pct = progressTotal > 0 ? Math.round((progressTerminal / progressTotal) * 100) : 0
-	const scopeProgress = getScopingProgress(f)
-	const scopeTag = f.status === "draft" ? pr_dim(`  scoping ${scopeProgress.answered}/4`) : ""
+	const runningTag = progressRunning > 0 ? pr_orange(` +${progressRunning} running`) : ""
+	const scopeTag = ""
 	const fermentGrade = f.grade ? `  ${gradeColor(f.grade.grade)}` : ""
 	const lastHumanInputAt = runtime.getLastHumanInputAt()
 	const sinceHuman = lastHumanInputAt
 		? formatDuration(runtime.now().getTime() - lastHumanInputAt.getTime())
 		: pr_dim("n/a")
 
+	// "Now" line: show the active phase and any running steps so the user
+	// can immediately see what the agent is working on without drilling in.
+	const activePhase = f.phases.find((p) => p.id === f.activePhaseId)
+	const nowParts: string[] = []
+	if (activePhase) {
+		const runningInPhase = activePhase.steps.filter((s) => s.status === "running")
+		if (runningInPhase.length > 0) {
+			const stepDescs = runningInPhase.map((s) => truncateLabel(s.description, 40)).join(", ")
+			nowParts.push(`${pr_dim("now:")} ${pr_teal(`P${activePhase.index}`)} ${pr_dim("·")} ${stepDescs}`)
+		} else {
+			nowParts.push(`${pr_dim("now:")} ${pr_teal(`P${activePhase.index} ${activePhase.name}`)}`)
+		}
+	} else if (f.status === "planned") {
+		nowParts.push(`${pr_dim("now:")} ${pr_dim("waiting for phase activation")}`)
+	} else if (f.status === "draft") {
+		nowParts.push(`${pr_dim("now:")} ${pr_dim("scoping")}`)
+	}
+
 	return [
 		`${pr_teal("🍺")} ${pr_bold(f.name)}${fermentGrade}${scopeTag}`,
-		`${bar}  ${pr_teal(`${pct}%`)}  ${pr_dim(`${progressTerminal}/${progressTotal} ${progressUnit}`)}`,
+		`${bar}  ${pr_teal(`${pct}%`)}  ${pr_dim(`${progressTerminal}/${progressTotal} ${progressUnit}`)}${runningTag}`,
+		...nowParts,
 		`${pr_dim("human:")} ${sinceHuman}  ${pr_dim("branch:")} ${f.worktree.branch ? pr_teal(f.worktree.branch) : pr_dim("—")}`,
 		f.goal ? `${pr_dim("goal:")} ${truncateLabel(f.goal, 70)}` : "",
 	]

--- a/src/extensions/ferment/progress-overlay.ts
+++ b/src/extensions/ferment/progress-overlay.ts
@@ -86,7 +86,6 @@ export function buildPhaseListTitle(f: Ferment, runtime: FermentRuntime = defaul
 	].join("")
 	const pct = progressTotal > 0 ? Math.round((progressTerminal / progressTotal) * 100) : 0
 	const runningTag = progressRunning > 0 ? pr_orange(` +${progressRunning} running`) : ""
-	const scopeTag = ""
 	const fermentGrade = f.grade ? `  ${gradeColor(f.grade.grade)}` : ""
 	const lastHumanInputAt = runtime.getLastHumanInputAt()
 	const sinceHuman = lastHumanInputAt
@@ -112,7 +111,7 @@ export function buildPhaseListTitle(f: Ferment, runtime: FermentRuntime = defaul
 	}
 
 	return [
-		`${pr_teal("🍺")} ${pr_bold(f.name)}${fermentGrade}${scopeTag}`,
+		`${pr_teal("🍺")} ${pr_bold(f.name)}${fermentGrade}`,
 		`${bar}  ${pr_teal(`${pct}%`)}  ${pr_dim(`${progressTerminal}/${progressTotal} ${progressUnit}`)}${runningTag}`,
 		...nowParts,
 		`${pr_dim("human:")} ${sinceHuman}  ${pr_dim("branch:")} ${f.worktree.branch ? pr_teal(f.worktree.branch) : pr_dim("—")}`,

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { determineNextAction, getScopingProgress } from "../../ferment/engine.js"
+import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment } from "../../ferment/types.js"
 import { formatActionNudgeLine } from "./action-tool-names.js"
 import { appendRefEntry } from "./nudge.js"
@@ -153,8 +153,7 @@ export function resumeFerment(
 
 	const action = determineNextAction(existing)
 	const baseMsg = action ? formatActionNudgeLine(action) : ""
-	const scopeProgress = getScopingProgress(existing)
-	const breadcrumb = `Resumed ferment: "${existing.name}" [${existing.status}] ${runtime.getContinuationPolicy()} policy · scoping ${scopeProgress.answered}/${scopeProgress.total}`
+	const breadcrumb = `Resumed ferment: "${existing.name}" [${existing.status}] ${runtime.getContinuationPolicy()} policy`
 
 	const imperative =
 		existing.status === "running"

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -1,5 +1,4 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { getScopingProgress } from "../../ferment/engine.js"
 import type { DeclarativeAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { formatActionNudgeLine } from "./action-tool-names.js"
@@ -194,7 +193,6 @@ export function scheduleNextFermentAction(
 	const breadcrumb = `${tag} [${action.kind}]: "${ferment.name}" [${ferment.status}]${phaseInfo}${stepInfo}`
 
 	const baseMsg = buildContextualNudge(ferment, action)
-	const scopeProgress = getScopingProgress(ferment)
 	const interruptedPrefix =
 		ferment.status === "running"
 			? `RESUMING ferment "${ferment.name}" — the previous session was interrupted. Pick up the work immediately. Do NOT explain or summarize — execute the next action below.\n\n`
@@ -203,7 +201,7 @@ export function scheduleNextFermentAction(
 
 	tryPiAction(() => {
 		pi.appendEntry("ferment_breadcrumb", {
-			text: `${breadcrumb} · policy ${runtime.getContinuationPolicy()} · scoping ${scopeProgress.answered}/${scopeProgress.total}`,
+			text: `${breadcrumb} · policy ${runtime.getContinuationPolicy()}`,
 		})
 		safeSendMessage(
 			pi,
@@ -234,11 +232,10 @@ export function scheduleFermentWakeUp(
 	if (opts.skipNudge && decision.action.kind === "scope") return
 	if (shouldSuppressHiddenNudge(decision.action, runtime.getContinuationPolicy())) return
 
-	const scopeProgress = getScopingProgress(ferment)
 	const tag = opts.tag ?? "Wake-up"
 	tryPiAction(() => {
 		pi.appendEntry("ferment_breadcrumb", {
-			text: `${tag} [${decision.action.kind}]: "${ferment.name}" [${ferment.status}] · policy ${runtime.getContinuationPolicy()} · scoping ${scopeProgress.answered}/${scopeProgress.total}`,
+			text: `${tag} [${decision.action.kind}]: "${ferment.name}" [${ferment.status}] · policy ${runtime.getContinuationPolicy()}`,
 		})
 		safeSendMessage(
 			pi,

--- a/src/extensions/ferment/tool-helpers.test.ts
+++ b/src/extensions/ferment/tool-helpers.test.ts
@@ -139,15 +139,11 @@ describe("createApplyAndPersist", () => {
 		expect(renderSpy).toHaveBeenCalledTimes(1)
 
 		// Failed mutation does NOT trigger a render request (no state change).
+		// complete_ferment fails because the phase is still active (non-terminal).
 		renderSpy.mockClear()
-		const reject = applyAndPersist(ferment.id, { type: "pause" })
-		// pause is not legal mid-phase in this minimal harness; outcome is still ok here
-		// so assert the invariant: a render happens iff the mutation succeeded.
-		if (reject.ok) {
-			expect(renderSpy).toHaveBeenCalledTimes(1)
-		} else {
-			expect(renderSpy).not.toHaveBeenCalled()
-		}
+		const reject = applyAndPersist(ferment.id, { type: "complete_ferment" })
+		expect(reject.ok).toBe(false)
+		expect(renderSpy).not.toHaveBeenCalled()
 		renderSpy.mockRestore()
 	})
 })

--- a/src/extensions/ferment/tool-helpers.test.ts
+++ b/src/extensions/ferment/tool-helpers.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import type { Ferment } from "../../ferment/types.js"
+import * as sharedFooter from "../shared-footer.js"
 import { type FermentRuntime, createDefaultFermentRuntime } from "./runtime.js"
 import { createApplyAndPersist } from "./tool-helpers.js"
 
@@ -117,5 +118,36 @@ describe("createApplyAndPersist", () => {
 
 		expect(outcome.ok).toBe(true)
 		if (outcome.ok) expect(outcome.ferment.status).toBe("planned")
+	})
+
+	it("requests a footer re-render after every successful mutation", () => {
+		// Regression: tool-call mutations (start_ferment_step, complete_ferment_step,
+		// activate_ferment_phase, ...) flow through createApplyAndPersist. The footer's
+		// ferment segment reads getActive() at render time, so without an explicit
+		// render request the status line goes stale until a keypress or message
+		// render happens. Each successful mutation must trigger requestSharedFooterRender.
+		const renderSpy = vi.spyOn(sharedFooter, "requestSharedFooterRender").mockImplementation(() => {})
+		const { runtime, storage } = createRuntime()
+		const applyAndPersist = createApplyAndPersist(runtime)
+		const ferment = scopeDraft(applyAndPersist, storage.create("Render On Mutate"))
+		renderSpy.mockClear()
+
+		// Successful mutation triggers a render request.
+		const phase = ferment.phases[0]
+		const activate = applyAndPersist(ferment.id, { type: "activate_phase", phaseId: phase.id })
+		expect(activate.ok).toBe(true)
+		expect(renderSpy).toHaveBeenCalledTimes(1)
+
+		// Failed mutation does NOT trigger a render request (no state change).
+		renderSpy.mockClear()
+		const reject = applyAndPersist(ferment.id, { type: "pause" })
+		// pause is not legal mid-phase in this minimal harness; outcome is still ok here
+		// so assert the invariant: a render happens iff the mutation succeeded.
+		if (reject.ok) {
+			expect(renderSpy).toHaveBeenCalledTimes(1)
+		} else {
+			expect(renderSpy).not.toHaveBeenCalled()
+		}
+		renderSpy.mockRestore()
 	})
 })

--- a/src/extensions/ferment/tool-helpers.ts
+++ b/src/extensions/ferment/tool-helpers.ts
@@ -13,6 +13,7 @@ import type { Command, TransitionError } from "../../ferment/state-machine.js"
 import { applyCommand } from "../../ferment/state-machine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
+import { requestSharedFooterRender } from "../shared-footer.js"
 import { publicToolNameForActionKind } from "./action-tool-names.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { type FermentRuntime, defaultFermentRuntime } from "./runtime.js"
@@ -200,6 +201,12 @@ export function createApplyAndPersist(runtime: FermentRuntime) {
 		)
 		if (outcome.ok) {
 			runtime.setActive(outcome.ferment)
+			// The footer's ferment segment reads getActive() at render time, but
+			// tool-call mutations happen mid-agent-run with no natural render
+			// trigger. Request a footer re-render so the status line reflects the
+			// new phase/step/state immediately instead of going stale until the
+			// next user keypress or message render.
+			requestSharedFooterRender()
 			if (runtime.events) {
 				try {
 					emitFermentDomainEvent(runtime.events, cmd, outcome.ferment)

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Ferment } from "../../ferment/types.js"
 import * as ToolProfileManager from "../../shared/planning/tool-profile-manager.js"
 import { isAgentWorker } from "../agent-worker-context.js"
+import { requestSharedFooterRender } from "../shared-footer.js"
 import type { FermentRuntime } from "./runtime.js"
 import { FERMENT_TOOLS } from "./tool-names.js"
 
@@ -173,4 +174,9 @@ export function setActiveFermentAndApplyProfile(
 ): void {
 	runtime.setActive(ferment)
 	applyFermentToolProfile(pi, profileForFerment(ferment))
+	// setActive is called from session_start resume paths (resumeFerment /
+	// loadFermentSilently) which run as deferred actions outside any natural
+	// render cycle. Request a footer render so the status line picks up the
+	// newly-active (or newly-cleared) ferment immediately.
+	requestSharedFooterRender()
 }

--- a/src/ferment/engine.ts
+++ b/src/ferment/engine.ts
@@ -285,16 +285,6 @@ export function isScopingComplete(f: Ferment): boolean {
 	return !!(f.scoping.goal && f.scoping.criteria && f.scoping.constraints && f.scoping.phases)
 }
 
-export function getScopingProgress(f: Ferment): { answered: number; total: number } {
-	const s = f.scoping
-	let answered = 0
-	if (s.goal) answered++
-	if (s.criteria) answered++
-	if (s.constraints) answered++
-	if (s.phases) answered++
-	return { answered, total: 4 }
-}
-
 function findActivePhase(f: Ferment): Phase | undefined {
 	if (f.activePhaseId) {
 		const byId = f.phases.find((p) => p.id === f.activePhaseId)

--- a/tests/e2e/tui/ferment-footer-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-footer-updates-on-mutation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E TUI test: the ferment footer segment reflects state changes driven by
+ * tool calls (activate_ferment_phase, start_ferment_step, ...).
+ *
+ * Regression: `createApplyAndPersist` (the canonical path for all ferment
+ * tool-call mutations) updated the in-memory active ferment via
+ * `runtime.setActive()` but never requested a footer re-render. The footer's
+ * ferment segment reads `getActive()` at render time, so without an explicit
+ * render request the status line went stale until a keypress or message render
+ * happened. The fix calls `requestSharedFooterRender()` after every
+ * successful mutation.
+ *
+ * This test pins the ferment footer segment, starts a ferment, scopes it, and
+ * has the model call `activate_ferment_phase`. The footer must show the ferment
+ * name + "Planned" after scoping, then update to "Running" after activation.
+ *
+ * The response script mirrors the passing `todo-widget-ferment` test so the
+ * fake-server queue stays aligned with the host's turn sequence.
+ */
+
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "Footer Update Test",
+	goal: "Verify the footer ferment segment updates on tool-call mutations.",
+	success_criteria: ["Footer shows Running after activate_ferment_phase"],
+	constraints: [],
+	assumptions: "The footer segment is pinned.",
+	phases: [
+		{
+			name: "Implementation",
+			goal: "Activate the phase.",
+			steps: [{ description: "Do the work.", verify: "true" }],
+		},
+	],
+	questions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "true" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "tests pass", evidence: "n/a" },
+	],
+})
+
+test("ferment footer segment updates after activate_ferment_phase tool call", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "ferment-footer-updates-on-mutation",
+			gitInit: true,
+			responses: [
+				// Turn 1: orientation text then propose_ferment_scoping.
+				{
+					stream: ["I'll outline the scope."],
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD,
+							},
+						},
+					],
+				},
+				// Turn 2 (after tool result): short text, no trailing "?".
+				{ stream: ["I've outlined the scope for this test."] },
+				// Turn 3 (post-confirmation keepalive): mirrors ferment-new-runs-planning.
+				{},
+				// Turn 4 (host nudge): activate the implementation phase.
+				{
+					stream: ["Starting implementation."],
+					toolCalls: [
+						{
+							function: {
+								name: "activate_ferment_phase",
+								arguments: JSON.stringify({
+									ferment_id: "__FERMENT_ID__",
+									phase_id: "phase-1",
+								}),
+							},
+						},
+					],
+				},
+				// Keepalive after implementation turn.
+				{},
+			],
+		},
+		async (_fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", {
+				timeoutMs: STARTUP_TIMEOUT_MS,
+			})
+			trace.step("ready prompt visible")
+
+			// Stage 2: enter ferment.
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("typed /ferment")
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			// Stage 3: intent prompt appears.
+			await waitForText(terminal, "would you like to ferment", {
+				timeoutMs: STARTUP_TIMEOUT_MS,
+			})
+			trace.step("intent prompt visible")
+
+			// Stage 4: submit intent → model proposes scoping.
+			terminal.submit("Verify footer updates on mutation")
+			trace.step("submitted intent")
+
+			// Stage 5: plan-review dialog appears.
+			await waitForText(terminal, "Proceed with this plan?", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await waitForText(terminal, "Start execution", {
+				timeoutMs: INPUT_TIMEOUT_MS,
+			})
+			trace.step("plan-review dialog visible")
+
+			// Stage 6: confirm → ferment is scoped.
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			// Stage 7: footer must show the ferment name. The ferment segment now
+			// renders whenever a ferment is active, even when not pinned (matches
+			// the ScriptFooter path). This guards the "doesn't show when there's an
+			// active ferment" regression.
+			//
+			// We wait for the footer to show the ferment status specifically — the
+			// bottom status line. Asserting on bare "Footer Update Test" would also
+			// match the plan-review dialog and breadcrumb, so we target the footer
+			// line which combines name + status + stop policy.
+			await waitForText(terminal, /Running · Stop:/, { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("footer shows ferment name + Running status")
+
+			// Stage 8: after activate_ferment_phase, the footer must update to
+			// "Running". This is the "doesn't reliably update as things progress"
+			// half — createApplyAndPersist now triggers requestSharedFooterRender()
+			// after every successful mutation.
+			//
+			// The footer line combines the ferment name with its status.
+			await waitForText(terminal, /Footer Update Test · Running/, { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("footer updated to Running after activate_ferment_phase")
+
+			// Final assertion: both name and status are present.
+			const text = viewText(terminal)
+			expect(text).toContain("Footer Update Test")
+		},
+	)
+})

--- a/tests/e2e/tui/ferment-footer-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-footer-updates-on-mutation.test.ts
@@ -10,16 +10,12 @@
  * happened. The fix calls `requestSharedFooterRender()` after every
  * successful mutation.
  *
- * This test pins the ferment footer segment, starts a ferment, scopes it, and
- * has the model call `activate_ferment_phase`. The footer must show the ferment
- * name + "Planned" after scoping, then update to "Running" after activation.
- *
- * The response script mirrors the passing `todo-widget-ferment` test so the
- * fake-server queue stays aligned with the host's turn sequence.
+ * This test starts a ferment, scopes it, and has the model call
+ * `activate_ferment_phase`. The footer must show the ferment name + "Running".
  */
 
-import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -84,71 +80,61 @@ test("ferment footer segment updates after activate_ferment_phase tool call", as
 						},
 					],
 				},
-				// Keepalive after implementation turn.
-				{},
+				// Turn 5 (host nudge): start step 1 — must comply to avoid nudge loop.
+				{
+					stream: ["Starting step 1."],
+					toolCalls: [
+						{
+							function: {
+								name: "start_ferment_step",
+								arguments: JSON.stringify({
+									ferment_id: "__FERMENT_ID__",
+									phase_id: "phase-1",
+									step_id: "step-1",
+								}),
+							},
+						},
+					],
+				},
+				// Extra text-only responses to absorb continuation nudges.
+				{ stream: ["Waiting."] }, { stream: ["Waiting."] }, { stream: ["Waiting."] },
+				{ stream: ["Waiting."] }, { stream: ["Waiting."] },
 			],
 		},
 		async (_fixture, trace) => {
-			// Stage 1: ready prompt visible.
-			await waitForText(terminal, "ask anything or type / for commands", {
-				timeoutMs: STARTUP_TIMEOUT_MS,
-			})
+			// Stage 1: ready prompt.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
 			terminal.write("/ferment")
 			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
 			terminal.submit("")
 			trace.step("ran /ferment")
 
-			// Stage 3: intent prompt appears.
-			await waitForText(terminal, "would you like to ferment", {
-				timeoutMs: STARTUP_TIMEOUT_MS,
-			})
+			// Stage 3: intent prompt.
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("intent prompt visible")
 
 			// Stage 4: submit intent → model proposes scoping.
 			terminal.submit("Verify footer updates on mutation")
 			trace.step("submitted intent")
 
-			// Stage 5: plan-review dialog appears.
-			await waitForText(terminal, "Proceed with this plan?", {
-				timeoutMs: STREAM_TIMEOUT_MS,
-			})
-			await waitForText(terminal, "Start execution", {
-				timeoutMs: INPUT_TIMEOUT_MS,
-			})
+			// Stage 5: plan-review dialog.
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("plan-review dialog visible")
 
-			// Stage 6: confirm → ferment is scoped.
+			// Stage 6: confirm.
 			terminal.submit("")
 			trace.step("confirmed 'Start execution'")
 
-			// Stage 7: footer must show the ferment name. The ferment segment now
-			// renders whenever a ferment is active, even when not pinned (matches
-			// the ScriptFooter path). This guards the "doesn't show when there's an
-			// active ferment" regression.
-			//
-			// We wait for the footer to show the ferment status specifically — the
-			// bottom status line. Asserting on bare "Footer Update Test" would also
-			// match the plan-review dialog and breadcrumb, so we target the footer
-			// line which combines name + status + stop policy.
-			await waitForText(terminal, /Running · Stop:/, { timeoutMs: STREAM_TIMEOUT_MS })
+			// Stage 7: footer must show the ferment name + "Running" status.
+			// The ferment segment now renders whenever a ferment is active, even
+			// when not pinned (matches the ScriptFooter path). This guards the
+			// "doesn't show when there's an active ferment" regression.
+			await waitForText(terminal, /Footer Update Test · Running/, { timeoutMs: 30_000 })
 			trace.step("footer shows ferment name + Running status")
-
-			// Stage 8: after activate_ferment_phase, the footer must update to
-			// "Running". This is the "doesn't reliably update as things progress"
-			// half — createApplyAndPersist now triggers requestSharedFooterRender()
-			// after every successful mutation.
-			//
-			// The footer line combines the ferment name with its status.
-			await waitForText(terminal, /Footer Update Test · Running/, { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("footer updated to Running after activate_ferment_phase")
-
-			// Final assertion: both name and status are present.
-			const text = viewText(terminal)
-			expect(text).toContain("Footer Update Test")
 		},
 	)
 })

--- a/tests/e2e/tui/ferment-progress-overlay.test.ts
+++ b/tests/e2e/tui/ferment-progress-overlay.test.ts
@@ -1,0 +1,201 @@
+/**
+ * E2E TUI tests for the `/ferment progress` overlay.
+ *
+ * Covers two user-visible behaviors:
+ * 1. The overlay opens and shows the ferment name, progress bar, phase list,
+ *    and the "now:" line.
+ * 2. The overlay shows 1/2 steps done after a complete step lifecycle
+ *    (start → complete), verifying the overlay reads fresh state.
+ *
+ * The response scripts follow the host's continuation nudge sequence: after
+ * each tool call, the host nudges the model to call the next action. The fake
+ * model must comply with each nudge (activate → start_step → complete_step →
+ * start_step) so the agent eventually goes idle and the prompt returns.
+ * Extra text-only responses absorb any remaining continuation nudges.
+ */
+
+import { test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "Progress Overlay Test",
+	goal: "Verify the /ferment progress overlay shows live state.",
+	success_criteria: ["Overlay shows phase list and progress bar"],
+	constraints: [],
+	assumptions: "The overlay renders correctly.",
+	phases: [
+		{
+			name: "Implementation",
+			goal: "Implement and verify the feature.",
+			steps: [
+				{ description: "Write the code", verify: "true" },
+				{ description: "Run the tests", verify: "true" },
+			],
+		},
+	],
+	questions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "true" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "tests pass", evidence: "n/a" },
+	],
+})
+
+// Shared response turns for the tool-call sequence after plan confirmation.
+const ACTIVATE_PHASE = {
+	stream: ["Starting implementation."],
+	toolCalls: [
+		{ function: { name: "activate_ferment_phase", arguments: JSON.stringify({ ferment_id: "__FERMENT_ID__", phase_id: "phase-1" }) } },
+	],
+}
+const START_STEP_1 = {
+	stream: ["Starting step 1."],
+	toolCalls: [
+		{ function: { name: "start_ferment_step", arguments: JSON.stringify({ ferment_id: "__FERMENT_ID__", phase_id: "phase-1", step_id: "step-1" }) } },
+	],
+}
+const COMPLETE_STEP_1 = {
+	stream: ["Step 1 done."],
+	toolCalls: [
+		{ function: { name: "complete_ferment_step", arguments: JSON.stringify({
+			ferment_id: "__FERMENT_ID__", phase_id: "phase-1", step_id: "step-1", summary: "Code written.",
+			gates: [
+				{ id: "S1", verdict: "pass", rationale: "Summary matches", evidence: "n/a" },
+				{ id: "S2", verdict: "pass", rationale: "Verify is real", evidence: "n/a" },
+				{ id: "S3", verdict: "pass", rationale: "Edge cases handled", evidence: "n/a" },
+			],
+		}) } },
+	],
+}
+const START_STEP_2 = {
+	stream: ["Starting step 2."],
+	toolCalls: [
+		{ function: { name: "start_ferment_step", arguments: JSON.stringify({ ferment_id: "__FERMENT_ID__", phase_id: "phase-1", step_id: "step-2" }) } },
+	],
+}
+
+// Extra text-only responses to absorb continuation nudges after the last
+// tool call. The host keeps nudging while the ferment is running; these
+// responses let the reactive continuation nudge counter exhaust so the
+// agent eventually goes idle and the prompt returns.
+const WAITING = Array.from({ length: 10 }, () => ({ stream: ["Waiting."] }))
+
+test("/ferment progress overlay shows ferment name, progress bar, and phase list", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "ferment-progress-overlay-basics",
+			gitInit: true,
+			responses: [
+				{ stream: ["I'll outline the scope."], toolCalls: [{ function: { name: "propose_ferment_scoping", arguments: PROPOSE_SCOPING_PAYLOAD } }] },
+				{ stream: ["I've outlined the scope."] },
+				{},
+				ACTIVATE_PHASE,
+				START_STEP_1,
+				COMPLETE_STEP_1,
+				START_STEP_2,
+				...WAITING,
+			],
+		},
+		async (_fixture, trace) => {
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("intent prompt visible")
+
+			terminal.submit("Verify progress overlay")
+			trace.step("submitted intent")
+
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("plan-review dialog visible")
+
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			await waitForText(terminal, "Tip: Open Ferment progress", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("agent idle, prompt available")
+
+			terminal.submit("/ferment progress")
+			trace.step("opened /ferment progress")
+
+			await waitForText(terminal, "Progress Overlay Test", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("overlay shows ferment name")
+
+			await waitForText(terminal, /[█░]/, { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("progress bar visible")
+
+			await waitForText(terminal, "Implementation", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("phase list visible")
+
+			await waitForText(terminal, "now:", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("now line visible")
+
+			await waitForText(terminal, "1/2", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("step count visible")
+		},
+	)
+})
+
+test("/ferment progress overlay shows step count after completing a step", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "ferment-progress-overlay-step-count",
+			gitInit: true,
+			responses: [
+				{ stream: ["I'll outline the scope."], toolCalls: [{ function: { name: "propose_ferment_scoping", arguments: PROPOSE_SCOPING_PAYLOAD } }] },
+				{ stream: ["I've outlined the scope."] },
+				{},
+				ACTIVATE_PHASE,
+				START_STEP_1,
+				COMPLETE_STEP_1,
+				START_STEP_2,
+				...WAITING,
+			],
+		},
+		async (_fixture, trace) => {
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			terminal.write("/ferment")
+			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			trace.step("ran /ferment")
+
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("intent prompt visible")
+
+			terminal.submit("Verify progress overlay")
+			trace.step("submitted intent")
+
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("plan-review dialog visible")
+
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			await waitForText(terminal, "Tip: Open Ferment progress", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("agent idle, prompt available")
+
+			terminal.submit("/ferment progress")
+			trace.step("opened /ferment progress")
+
+			await waitForText(terminal, "1/2", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("shows 1/2 steps after completion")
+		},
+	)
+})

--- a/tests/e2e/tui/ferment-progress-overlay.test.ts
+++ b/tests/e2e/tui/ferment-progress-overlay.test.ts
@@ -110,7 +110,7 @@ test("/ferment progress overlay shows ferment name, progress bar, and phase list
 			terminal.submit("")
 			trace.step("ran /ferment")
 
-			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("intent prompt visible")
 
 			terminal.submit("Verify progress overlay")
@@ -123,8 +123,7 @@ test("/ferment progress overlay shows ferment name, progress bar, and phase list
 			terminal.submit("")
 			trace.step("confirmed 'Start execution'")
 
-			await waitForText(terminal, "Tip: Open Ferment progress", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: 30_000 })
 			trace.step("agent idle, prompt available")
 
 			terminal.submit("/ferment progress")
@@ -174,7 +173,7 @@ test("/ferment progress overlay shows step count after completing a step", async
 			terminal.submit("")
 			trace.step("ran /ferment")
 
-			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
+			await waitForText(terminal, "would you like to ferment", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("intent prompt visible")
 
 			terminal.submit("Verify progress overlay")
@@ -187,8 +186,7 @@ test("/ferment progress overlay shows step count after completing a step", async
 			terminal.submit("")
 			trace.step("confirmed 'Start execution'")
 
-			await waitForText(terminal, "Tip: Open Ferment progress", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: 30_000 })
 			trace.step("agent idle, prompt available")
 
 			terminal.submit("/ferment progress")


### PR DESCRIPTION
## Summary

Fixes four issues with the ferment progress bar:

1. **Footer didn't show when there was an active ferment** — the ferment segment was gated on the user's `pinned` list, and `ferment` is not in `DEFAULT_FOOTER_PINNED`. Now always renders when there's an active ferment (matching the ScriptFooter path).

2. **Footer didn't update as things progressed** — `createApplyAndPersist` (the canonical path for all tool-call mutations) and `setActiveFermentAndApplyProfile` (session-start resume) updated in-memory state but never called `requestSharedFooterRender()`. Now both trigger a footer re-render after state changes.

3. **`/ferment progress` overlay didn't reflect what's happening now** — the progress bar only counted terminal (done/verified/skipped/failed) steps. A running step was invisible (`1/3` stayed `1/3`). Now shows:
   - A `▌` partial-fill glyph for running steps in the bar
   - A `+N running` tag in the count line
   - A `now:` line with the active phase and running step description

4. **`/ferment progress` overlay didn't auto-refresh** — the blocking `select()` dialog showed stale data while the agent made progress. Now subscribes to ferment domain events (`step_started/completed/failed`, `phase_started/completed`, `suspended`, `resumed`) and aborts the current `select()` via `AbortSignal`, re-opening with fresh data from storage.

Also removes the confusing `scoping N/4` indicator from user-facing surfaces (progress overlay title, resume breadcrumbs, scheduler breadcrumbs) — the 4 refers to internal scoping questionnaire fields that users aren't aware of.

## Changes

| File | Change |
|---|---|
| `src/components/footer.ts` | Ferment segment always renders when there's an active ferment (not gated on `pinned`) |
| `src/extensions/ferment/tool-helpers.ts` | `createApplyAndPersist` calls `requestSharedFooterRender()` after successful mutations |
| `src/extensions/ferment/tool-scope.ts` | `setActiveFermentAndApplyProfile` calls `requestSharedFooterRender()` |
| `src/extensions/ferment/progress-overlay.ts` | Progress bar shows `▌` for running steps, `+N running` tag, `now:` line with active phase/step |
| `src/extensions/ferment/commands.ts` | `/ferment progress` overlay auto-refreshes on domain events via `AbortSignal` + `liveSelect()` |
| `src/extensions/ferment/resume.ts` | Remove `scoping N/4` from resume breadcrumb |
| `src/extensions/ferment/scheduler.ts` | Remove `scoping N/4` from continuation/wake-up breadcrumbs |

## Tests

- **Unit** (`tool-helpers.test.ts`): Verifies `requestSharedFooterRender` is called after successful mutations, not after failures.
- **Unit** (`progress-overlay.test.ts`): Verifies the running-step bar glyph, `+N running` tag, `now:` line, and the all-pending case.
- **E2E TUI** (`ferment-footer-updates-on-mutation.test.ts`): Full `/ferment` → scope → `activate_ferment_phase` flow asserting the footer shows the ferment name + status without manual pinning.
- **E2E TUI** (`ferment-progress-overlay.test.ts`): Two tests covering the overlay opening, showing ferment name/progress bar/phase list/`now:` line, and step count after completing a step.

## Checklist

- [x] Every `catch` block logs or rethrows — none are empty.
- [x] Every async call in a callback/timeout has a `.catch` or is awaited in a `try/catch`.
- [x] No module-level mutable state for per-session/per-ferment data.
- [x] No `execSync` with interpolated paths.
- [x] No `as any` / `as unknown as` casts without a runtime guard.
- [x] Tests exercise the real code path, cover error branches, and use exact assertions.
- [x] Lifecycle events fire from a central point on all creation/abandon paths.
- [x] State is persisted *after* the user's choice, not before.
- [x] No hardcoded values that duplicate an existing constant.
- [x] Correlation keys are stable IDs, not display text or array indices.