### PR TITLE
feat: restrict Agent tool models to multi-model role pool in multi-mode

### DIFF
--- a/src/extensions/agents/index.test.ts
+++ b/src/extensions/agents/index.test.ts
@@ -90,7 +90,15 @@ vi.mock("../orchestration/model-registry/index.js", () => ({
 	MODEL_CAPABILITIES: {},
 }))
 
+vi.mock("../orchestration/model-roles.js", () => ({
+	getAllowedMultiModelRefs: vi
+		.fn()
+		.mockReturnValue(["kimchi-dev/kimi-k2.7", "kimchi-dev/minimax-m3", "kimchi-dev/nemotron-3-ultra-fp4"]),
+}))
+
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { getAllowedMultiModelRefs } from "../orchestration/model-roles.js"
+import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import agentsExtension from "./index.js"
 import { AgentManager as MockedAgentManager } from "./manager/agent-manager.js"
 
@@ -195,5 +203,257 @@ describe("session_shutdown nudge race (integration)", () => {
 
 		// No sendMessage should have been called — the batch timer was cleared
 		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+})
+
+// ---- Multi-mode model guard ----
+//
+// These tests exercise the registered Agent tool's execute() handler to
+// verify the multi-model guard: when multi-model mode is active, explicit
+// model parameters must belong to the configured role pool.
+
+interface MockModelEntry {
+	id: string
+	name: string
+	provider: string
+	input: string[]
+}
+
+/**
+ * Build a mock ModelRegistry whose find()/getAvailable()/getAll() return
+ * ModelEntry-shaped objects sufficient for resolveModel() to resolve
+ * explicit and partial model IDs.
+ */
+function makeMockModelRegistry(entries: MockModelEntry[]): unknown {
+	const all = entries.map((e) => ({
+		id: e.id,
+		name: e.name,
+		provider: e.provider,
+		input: e.input,
+	}))
+	const availableSet = new Set(all.map((m) => `${m.provider}/${m.id}`.toLowerCase()))
+	return {
+		find: (provider: string, modelId: string) => all.find((m) => m.provider === provider && m.id === modelId),
+		getAll: () => all,
+		getAvailable: () => all.filter((m) => availableSet.has(`${m.provider}/${m.id}`.toLowerCase())),
+	}
+}
+
+/**
+ * Build an ExtensionContext-like object suitable for invoking the Agent
+ * tool's execute(). Uses run_in_background to avoid the foreground
+ * spinner/await-promise machinery which the AgentManager mock does not
+ * fully satisfy.
+ */
+function makeMockCtx(modelRegistry: unknown, parentModel?: unknown): unknown {
+	return {
+		ui: undefined,
+		mode: "json",
+		hasUI: false,
+		cwd: "/tmp",
+		sessionManager: {
+			getBranch: () => [],
+			getSessionDir: () => "/tmp",
+			getSessionFile: () => "/tmp/session.json",
+			getSessionId: () => "test-session",
+		},
+		modelRegistry,
+		model: parentModel,
+		isIdle: () => true,
+		isProjectTrusted: () => true,
+		signal: undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getSystemPrompt: () => "",
+	}
+}
+
+/** Retrieve the registered "Agent" tool from pi.registerTool mock calls. */
+function getRegisteredAgentTool(pi: ReturnType<typeof makeMockPi>): {
+	execute: (
+		id: string,
+		params: Record<string, unknown>,
+		signal: AbortSignal | undefined,
+		onUpdate: unknown,
+		ctx: unknown,
+	) => Promise<{ content: { type: string; text: string }[] }>
+} {
+	const calls = (pi.registerTool as ReturnType<typeof vi.fn>).mock.calls
+	const tool = calls.map((c: unknown[]) => c[0]).find((t: unknown) => (t as { name?: string }).name === "Agent")
+	expect(tool).toBeDefined()
+	return tool as unknown as {
+		execute: (
+			id: string,
+			params: Record<string, unknown>,
+			signal: AbortSignal | undefined,
+			onUpdate: unknown,
+			ctx: unknown,
+		) => Promise<{ content: { type: string; text: string }[] }>
+	}
+}
+
+describe("Agent tool multi-mode model guard", () => {
+	beforeEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+		vi.mocked(getMultiModelEnabled).mockReturnValue(false)
+		vi.mocked(getAllowedMultiModelRefs).mockReturnValue([
+			"kimchi-dev/kimi-k2.7",
+			"kimchi-dev/minimax-m3",
+			"kimchi-dev/nemotron-3-ultra-fp4",
+		])
+	})
+
+	it("calls spawn when multi-mode is enabled and the model is allowed", async () => {
+		vi.mocked(getMultiModelEnabled).mockReturnValue(true)
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		const registry = makeMockModelRegistry([
+			{ id: "kimi-k2.7", name: "Kimi K2.7", provider: "kimchi-dev", input: ["text"] },
+			{ id: "gpt-4o", name: "GPT-4o", provider: "openai", input: ["text", "image"] },
+		])
+		const ctx = makeMockCtx(registry, { id: "kimi-k2.7", provider: "kimchi-dev" })
+		const tool = getRegisteredAgentTool(pi)
+
+		const result = await tool.execute(
+			"call-1",
+			{
+				prompt: "do work",
+				description: "test",
+				subagent_type: "general-purpose",
+				model: "kimchi-dev/kimi-k2.7",
+				run_in_background: true,
+			},
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(managerInstance.spawn).toHaveBeenCalledTimes(1)
+		const text = result.content[0]?.text ?? ""
+		expect(text).not.toContain("not allowed in multi-model mode")
+	})
+
+	it("rejects a disallowed model when multi-mode is enabled and does not spawn", async () => {
+		vi.mocked(getMultiModelEnabled).mockReturnValue(true)
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		const registry = makeMockModelRegistry([
+			{ id: "kimi-k2.7", name: "Kimi K2.7", provider: "kimchi-dev", input: ["text"] },
+			{ id: "gpt-4o", name: "GPT-4o", provider: "openai", input: ["text", "image"] },
+		])
+		const ctx = makeMockCtx(registry, { id: "kimi-k2.7", provider: "kimchi-dev" })
+		const tool = getRegisteredAgentTool(pi)
+
+		const result = await tool.execute(
+			"call-2",
+			{
+				prompt: "do work",
+				description: "test",
+				subagent_type: "general-purpose",
+				model: "openai/gpt-4o",
+				run_in_background: true,
+			},
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(managerInstance.spawn).not.toHaveBeenCalled()
+		const text = result.content[0]?.text ?? ""
+		expect(text).toContain("not allowed in multi-model mode")
+		expect(text).toContain("openai/gpt-4o")
+		// Allowed models should be listed in the rejection message.
+		expect(text).toContain("kimchi-dev/kimi-k2.7")
+		expect(text).toContain("kimchi-dev/minimax-m3")
+		expect(text).toContain("kimchi-dev/nemotron-3-ultra-fp4")
+	})
+
+	it("calls spawn when multi-mode is disabled even for a disallowed model (existing behavior)", async () => {
+		vi.mocked(getMultiModelEnabled).mockReturnValue(false)
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		const registry = makeMockModelRegistry([
+			{ id: "gpt-4o", name: "GPT-4o", provider: "openai", input: ["text", "image"] },
+		])
+		const ctx = makeMockCtx(registry, { id: "kimi-k2.7", provider: "kimchi-dev" })
+		const tool = getRegisteredAgentTool(pi)
+
+		const result = await tool.execute(
+			"call-3",
+			{
+				prompt: "do work",
+				description: "test",
+				subagent_type: "general-purpose",
+				model: "openai/gpt-4o",
+				run_in_background: true,
+			},
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(managerInstance.spawn).toHaveBeenCalledTimes(1)
+		const text = result.content[0]?.text ?? ""
+		expect(text).not.toContain("not allowed in multi-model mode")
+	})
+
+	it("calls spawn when no model parameter is supplied regardless of multi-mode", async () => {
+		vi.mocked(getMultiModelEnabled).mockReturnValue(true)
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		const registry = makeMockModelRegistry([
+			{ id: "kimi-k2.7", name: "Kimi K2.7", provider: "kimchi-dev", input: ["text"] },
+		])
+		const parentModel = { id: "kimi-k2.7", provider: "kimchi-dev", name: "Kimi K2.7" }
+		const ctx = makeMockCtx(registry, parentModel)
+		const tool = getRegisteredAgentTool(pi)
+
+		const result = await tool.execute(
+			"call-4",
+			{ prompt: "do work", description: "test", subagent_type: "general-purpose", run_in_background: true },
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(managerInstance.spawn).toHaveBeenCalledTimes(1)
+		const text = result.content[0]?.text ?? ""
+		expect(text).not.toContain("not allowed in multi-model mode")
+	})
+})
+
+// Sanity check: the imported mocks are wired through the module system so
+// the guard reads the toggled values rather than a frozen snapshot.
+describe("mock wiring", () => {
+	it("getMultiModelEnabled reflects mock toggles", () => {
+		vi.mocked(getMultiModelEnabled).mockReturnValue(true)
+		expect(getMultiModelEnabled()).toBe(true)
+		vi.mocked(getMultiModelEnabled).mockReturnValue(false)
+		expect(getMultiModelEnabled()).toBe(false)
+	})
+
+	it("getAllowedMultiModelRefs reflects mock overrides", () => {
+		vi.mocked(getAllowedMultiModelRefs).mockReturnValue(["openai/gpt-4o"])
+		expect(getAllowedMultiModelRefs()).toEqual(["openai/gpt-4o"])
 	})
 })

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -27,6 +27,7 @@ import { isToolExpanded, registerToolCall } from "../../expand-state.js"
 import { filterThinkingForDisplay } from "../hide-thinking.js"
 import { sessionHasImages } from "../model-guard.js"
 import { KIMCHI_DEV_PROVIDER, MODEL_CAPABILITIES } from "../orchestration/model-registry/index.js"
+import { getAllowedMultiModelRefs } from "../orchestration/model-roles.js"
 import { getMultiModelEnabled } from "../prompt-construction/prompt-enrichment.js"
 import { isRawInputCaptureActive } from "../shared-input.js"
 import { isStaleCtxError } from "../stale-ctx.js"
@@ -125,7 +126,7 @@ export const AGENT_TOOL_GUIDELINES = `Guidelines:
 - Use inherit_context if the agent needs the parent conversation history.`
 
 export const AGENT_MODEL_PARAMETER_DESCRIPTION =
-	'Model identifier for the spawned agent. If omitted, the agent uses the current session model. Follow your system prompt\'s delegation rules when deciding whether to provide this. Format "provider/modelId" (e.g. "kimchi-dev/minimax-m2.7"). Partial model IDs such as "kimi" or "nemotron" are accepted when unambiguous; specify the full versioned model ID when the exact version matters.'
+	'Model identifier for the spawned agent. If omitted, the agent uses the current session model. Follow your system prompt\'s delegation rules when deciding whether to provide this. Format "provider/modelId" (e.g. "kimchi-dev/minimax-m2.7"). Partial model IDs such as "kimi" or "nemotron" are accepted when unambiguous; specify the full versioned model ID when the exact version matters. In multi-model mode, only the models configured in the multi-model roles may be used.'
 
 function textResult<T = AgentDetails>(msg: string, details?: T) {
 	return { content: [{ type: "text" as const, text: msg }], details: details as unknown }
@@ -1141,6 +1142,23 @@ ${AGENT_TOOL_GUIDELINES}`,
 						if (resolvedConfig.modelFromParams) return textResult(resolvedModel)
 					} else {
 						model = resolvedModel as typeof ctx.model
+					}
+				}
+
+				// Multi-model guard: when multi-model mode is active and the caller supplied
+				// an explicit model, the resolved model must belong to the configured
+				// multi-model role pool. This runs before budget-retry and task_ref checks
+				// so invalid models are rejected immediately.
+				if (getMultiModelEnabled() && resolvedConfig.modelFromParams) {
+					const fullRef = `${(model as { provider?: string }).provider}/${(model as { id?: string }).id}`
+					const allowed = new Set(getAllowedMultiModelRefs())
+					if (!allowed.has(fullRef)) {
+						const allowedList = Array.from(allowed)
+							.map((ref) => `  - ${ref}`)
+							.join("\n")
+						return textResult(
+							`Model "${fullRef}" is not allowed in multi-model mode.\n\nAllowed models:\n${allowedList}\n\nOmit the model parameter to use the current session model, or specify one of the allowed models.`,
+						)
 					}
 				}
 

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -6,7 +6,9 @@ import { type ModelCustomMetadata, resetModelMetadataCache, saveModelMetadata } 
 import {
 	DEFAULT_MODEL_ROLES,
 	type ModelRoles,
+	applyRoleAugmentation,
 	extractCustomConfigs,
+	getAllowedMultiModelRefs,
 	modelIdFromRef,
 	normalizeRoleModels,
 	parseModelRoles,
@@ -444,5 +446,75 @@ describe("saveModelRoles", () => {
 		const saved = JSON.parse(readFileSync(testPath, "utf-8"))
 		expect(saved.modelMetadata["anthropic/claude-opus-4-6"]).toEqual({ tier: "heavy" })
 		expect(saved.modelRoles.builder).toBe("openai/gpt-4o")
+	})
+})
+
+describe("getAllowedMultiModelRefs", () => {
+	it("returns sorted unique refs for default roles", () => {
+		applyRoleAugmentation(() => ({ ...DEFAULT_MODEL_ROLES }))
+		expect(getAllowedMultiModelRefs()).toEqual([
+			"kimchi-dev/kimi-k2.7",
+			"kimchi-dev/minimax-m3",
+			"kimchi-dev/nemotron-3-ultra-fp4",
+		])
+	})
+
+	it("de-duplicates refs shared across multiple roles", () => {
+		const roles: ModelRoles = {
+			orchestrator: "kimchi-dev/kimi-k2.7",
+			planner: "kimchi-dev/kimi-k2.7",
+			builder: ["kimchi-dev/minimax-m3", "kimchi-dev/kimi-k2.7"],
+			reviewer: ["kimchi-dev/kimi-k2.7"],
+			explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+			researcher: "kimchi-dev/minimax-m3",
+			judge: ["kimchi-dev/kimi-k2.7"],
+		}
+		applyRoleAugmentation(() => roles)
+		// kimi-k2.7 appears in 5 roles but should be listed once
+		expect(getAllowedMultiModelRefs()).toEqual([
+			"kimchi-dev/kimi-k2.7",
+			"kimchi-dev/minimax-m3",
+			"kimchi-dev/nemotron-3-ultra-fp4",
+		])
+	})
+
+	it("returns refs in sorted order regardless of configuration order", () => {
+		const roles: ModelRoles = {
+			orchestrator: "openai/gpt-4o",
+			planner: "anthropic/claude-sonnet-4-5",
+			builder: ["google/gemini-pro"],
+			reviewer: "anthropic/claude-opus-4-7",
+			explorer: "openai/gpt-4o",
+			researcher: "anthropic/claude-sonnet-4-5",
+			judge: ["google/gemini-pro"],
+		}
+		applyRoleAugmentation(() => roles)
+		expect(getAllowedMultiModelRefs()).toEqual([
+			"anthropic/claude-opus-4-7",
+			"anthropic/claude-sonnet-4-5",
+			"google/gemini-pro",
+			"openai/gpt-4o",
+		])
+	})
+
+	it("handles mixed single-string and array roles", () => {
+		const roles: ModelRoles = {
+			orchestrator: "provider-a/model-1",
+			planner: "provider-b/model-2",
+			builder: "provider-c/model-3",
+			reviewer: ["provider-d/model-4"],
+			explorer: "provider-e/model-5",
+			researcher: ["provider-a/model-1"],
+			judge: "provider-f/model-6",
+		}
+		applyRoleAugmentation(() => roles)
+		expect(getAllowedMultiModelRefs()).toEqual([
+			"provider-a/model-1",
+			"provider-b/model-2",
+			"provider-c/model-3",
+			"provider-d/model-4",
+			"provider-e/model-5",
+			"provider-f/model-6",
+		])
 	})
 })

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -273,6 +273,27 @@ export function getModelRolesWarnings(): readonly ModelRolesWarning[] {
 	return _resolved.warnings
 }
 
+/**
+ * Collect every model ref referenced by any role (orchestrator, planner,
+ * builder, reviewer, explorer, researcher, judge) into a de-duplicated,
+ * deterministically sorted array. Normalization is limited to exact string
+ * de-duplication; the configured case is preserved and ordering is fixed via
+ * `.sort()` so the result is stable across calls.
+ */
+export function getAllowedMultiModelRefs(): string[] {
+	const roles = getModelRoles()
+	const refs = new Set<string>()
+	for (const key of ROLE_KEYS) {
+		const value = roles[key]
+		if (Array.isArray(value)) {
+			for (const ref of value) refs.add(ref)
+		} else if (typeof value === "string" && value.length > 0) {
+			refs.add(value)
+		}
+	}
+	return Array.from(refs).sort()
+}
+
 export function resetModelRolesCache(): void {
 	_resolved = undefined
 }


### PR DESCRIPTION
## Summary

When the harness is in multi-model mode, the `Agent` tool now rejects explicit `model` parameters that are not configured in the multi-model role pool. The rejection message lists the allowed models and notes that omitting the `model` parameter falls back to the current session model.

## Changes

- Added `getAllowedMultiModelRefs()` helper in `src/extensions/orchestration/model-roles.ts` to collect all models referenced by the multi-model roles.
- Added an early guard in the `Agent` tool (`src/extensions/agents/index.ts`) that runs after model resolution and rejects disallowed models when multi-mode is active.
- Updated the `AGENT_MODEL_PARAMETER_DESCRIPTION` to mention the multi-mode restriction.
- Added unit tests for the helper and the `Agent` tool guard.

## Verification

- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run test src/extensions/orchestration/model-roles.test.ts src/extensions/agents/index.test.ts` — 64 tests passed

Closes #0