### PR TITLE
fix: prevent duplicate Agent header rendering in tool output

### DIFF
--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -1,5 +1,11 @@
-import { type Theme, ToolExecutionComponent, UserMessageComponent, initTheme } from "@earendil-works/pi-coding-agent"
-import { visibleWidth } from "@earendil-works/pi-tui"
+import {
+	type Theme,
+	type ToolDefinition,
+	ToolExecutionComponent,
+	UserMessageComponent,
+	initTheme,
+} from "@earendil-works/pi-coding-agent"
+import { Text, visibleWidth } from "@earendil-works/pi-tui"
 import { beforeAll, describe, expect, it } from "vitest"
 import toolRenderingExtension, {
 	formatToolTimer,
@@ -397,5 +403,44 @@ describe("set_phase tool summary", () => {
 	it("summarizes set_phase calls with unknown phase fallback", () => {
 		const summary = summarizeOpenAiToolCall("set_phase", {}, plainTheme, (path) => path)
 		expect(summary).toBe("set phase")
+	})
+})
+
+describe("Agent tool rendering", () => {
+	beforeAll(() => {
+		toolRenderingExtension({
+			registerCommand: () => {},
+			registerTool: () => {},
+			on: () => {},
+		} as never)
+	})
+
+	function createAgentComponent() {
+		return new ToolExecutionComponent(
+			"Agent",
+			"tc-agent-1",
+			{ description: "Add multi-mode agent tool tests", subagent_type: "Builder" },
+			{},
+			{
+				renderCall: (args: { description?: string }, theme: Theme) =>
+					new Text(`▸ ${theme.fg("toolTitle", theme.bold("Agent"))} ${args.description ?? ""}`, 0, 0),
+				renderResult: () => new Text("  ⎿ Done", 0, 0),
+			} as unknown as ToolDefinition,
+			// biome-ignore lint/suspicious/noExplicitAny: minimal UI test double
+			{ requestRender: () => {} } as any,
+			"/tmp",
+		)
+	}
+
+	it("uses the registered tool definition renderers instead of the generic renderer", () => {
+		const component = createAgentComponent()
+		component.markExecutionStarted()
+		component.updateResult({ content: [{ type: "text", text: "Agent completed" }], isError: false }, false)
+
+		const rendered = component.render(80).join("\n")
+		const description = "Add multi-mode agent tool tests"
+
+		expect(rendered).toContain(description)
+		expect(rendered.split(description).length - 1).toBe(1)
 	})
 })

--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -408,10 +408,12 @@ describe("set_phase tool summary", () => {
 
 describe("Agent tool rendering", () => {
 	beforeAll(() => {
+		initTheme("default")
 		toolRenderingExtension({
 			registerCommand: () => {},
 			registerTool: () => {},
 			on: () => {},
+			getAllTools: () => [],
 		} as never)
 	})
 
@@ -437,10 +439,16 @@ describe("Agent tool rendering", () => {
 		component.markExecutionStarted()
 		component.updateResult({ content: [{ type: "text", text: "Agent completed" }], isError: false }, false)
 
-		const rendered = component.render(80).join("\n")
+		// Strip ANSI escape codes so we can assert on visible text content.
+		const ansi = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g")
+		const rendered = component.render(80).join("\n").replace(ansi, "")
 		const description = "Add multi-mode agent tool tests"
 
+		// The custom renderCall produces a line starting with ▸ (arrow), while the
+		// generic renderer would produce a plain "Agent" header without the arrow.
+		expect(rendered).toContain("▸ Agent")
 		expect(rendered).toContain(description)
+		// Description must appear exactly once — no duplicate header rendering.
 		expect(rendered.split(description).length - 1).toBe(1)
 	})
 })

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2571,7 +2571,11 @@ const OPENAI_STYLE_TOOL_NAMES = new Set([
 	"Skill",
 	"EnterPlanMode",
 	"ExitPlanMode",
-	"Agent",
+	// Agent is deliberately excluded: it has its own renderCall/renderResult in
+	// extensions/agents/index.ts. Routing it through the generic renderer causes
+	// the call header and the result header to be rendered as two duplicate
+	// "Agent <description>" lines because ToolExecutionComponent keeps them as
+	// separate components.
 	"get_subagent_result",
 	"steer_subagent",
 	"TaskCreate",

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -2547,7 +2547,24 @@ function getMode<T extends string>(value: unknown, allowed: readonly T[], fallba
 	return typeof value === "string" && (allowed as readonly string[]).includes(value) ? (value as T) : fallback
 }
 
-const CORE_TOOL_OVERRIDES = new Set(["read", "bash", "grep", "find", "ls", "write", "edit", "set_phase"])
+// Tools that have their own renderCall/renderResult and must NOT be routed
+// through the generic OpenAI-style renderer (patchToolExecutionRenderers uses
+// this set via shouldUseGenericToolRenderer; registerOpenAiToolOverrides uses
+// OPENAI_STYLE_TOOL_NAMES). Agent, get_subagent_result, and steer_subagent
+// all register custom renderers in extensions/agents/index.ts.
+const CORE_TOOL_OVERRIDES = new Set([
+	"read",
+	"bash",
+	"grep",
+	"find",
+	"ls",
+	"write",
+	"edit",
+	"set_phase",
+	"Agent",
+	"get_subagent_result",
+	"steer_subagent",
+])
 
 const OPENAI_STYLE_TOOL_NAMES = new Set([
 	"apply_patch",

--- a/tests/e2e/tui/agent-duplicate-render.test.ts
+++ b/tests/e2e/tui/agent-duplicate-render.test.ts
@@ -1,0 +1,58 @@
+/**
+ * E2E regression test for duplicate Agent header rendering.
+ *
+ * Before the fix, the generic OpenAI-style tool renderer and the agent-specific
+ * renderer both emitted an "Agent <description>" header, producing duplicate
+ * header lines in the chat output. This test verifies the header appears
+ * exactly once when a foreground agent is running.
+ */
+
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+function foregroundAgentCall(id: string, description: string, prompt: string) {
+	return {
+		id,
+		function: {
+			name: "Agent",
+			arguments: JSON.stringify({ prompt, description, subagent_type: "General-Purpose" }),
+		},
+	}
+}
+
+const SLOW_STREAM = { stream: ["working", " working", " working", " working"], textDelayMs: 5_000 }
+
+test("foreground Agent tool call header is not duplicated", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "agent-dup-header",
+			models: [{ slug: "basic", displayName: "Fake Basic", input: ["text"] }],
+			responses: [
+				{ toolCalls: [foregroundAgentCall("call_agent_dup_hdr_1", "dup check", "Reply with: finished")] },
+				SLOW_STREAM,
+				{ stream: ["acknowledged"] },
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("spawn a slow agent")
+			await waitForText(terminal, "ctrl+b to run in background", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("foreground agent running")
+
+			const view = viewText(terminal)
+			// The call header line "▸ General Purpose  dup check" must appear exactly once.
+			// Before the fix, it appeared twice (once from generic renderer, once from agent renderer).
+			const headerOccurrences = (view.match(/General Purpose.*dup check/g) || []).length
+			expect(headerOccurrences).toBe(1)
+
+			// The agent-specific spinner hint must appear at most once.
+			const hintOccurrences = (view.match(/ctrl\+b to run in background/g) || []).length
+			expect(hintOccurrences).toBeLessThanOrEqual(1)
+
+			trace.step("agent header is not duplicated")
+		},
+	)
+})


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Fixes duplicate "Agent" header rendering in tool output. The Agent tool (along with `get_subagent_result` and `steer_subagent`) has its own `renderCall`/`renderResult` handlers in `extensions/agents/index.ts`. Two override mechanisms in `tool-rendering.ts` can bypass these custom renderers and route through the generic OpenAI-style renderer instead, causing the call header and result header to render as separate duplicate "Agent \<description\>" lines.

### Problem before:
<img width="1198" height="627" alt="Screenshot 2026-07-09 at 12 01 30" src="https://github.com/user-attachments/assets/cebcd0fa-a5ef-4595-8528-51e2d58bee4f" />

### After the fix:
...

## Root cause

`tool-rendering.ts` has **two** override paths that can route a tool through the generic renderer:

1. **`OPENAI_STYLE_TOOL_NAMES`** — used by `registerOpenAiToolOverrides()` which re-registers tools with generic renderers on `session_start`/`before_agent_start`.
2. **`CORE_TOOL_OVERRIDES`** — used by `shouldUseGenericToolRenderer()`, which `patchToolExecutionRenderers()` calls to monkey-patch `ToolExecutionComponent.prototype.getCallRenderer` / `getResultRenderer`.

The first commit (1e266be1) only addressed path #1 — removing "Agent" from `OPENAI_STYLE_TOOL_NAMES`. Path #2 was missed: `shouldUseGenericToolRenderer("Agent")` still returned `true` because "Agent" was not in `CORE_TOOL_OVERRIDES`, so the prototype patch continued to override the Agent tool's custom renderers with the generic ones.

## The fix

Add `"Agent"`, `"get_subagent_result"`, and `"steer_subagent"` to `CORE_TOOL_OVERRIDES`. All three register custom `renderCall`/`renderResult` in `extensions/agents/index.ts` and must not be routed through the generic renderer on either path.

`resume_subagent` was intentionally **not** added — it has no custom renderers and relies on the generic renderer.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed