### PR TITLE
feat: add loop-guard OTLP telemetry events

### DIFF
--- a/src/extensions/loop-guard-events.ts
+++ b/src/extensions/loop-guard-events.ts
@@ -39,8 +39,10 @@ export interface LoopGuardWarnPayload {
 }
 
 export interface LoopGuardSubagentAbortPayload {
-	/** The detector that triggered the warn preceding this abort. */
-	detector: LoopGuardDetector
+	/** The detector that triggered the warn preceding this abort. May be
+	 *  undefined if the warn happened before detector tracking was added
+	 *  or in edge cases where no detector was stashed. */
+	detector?: LoopGuardDetector
 	/** The session warn count at the time of the triggering warn. */
 	count: number
 	/** Always true — aborts only fire for subagents. */

--- a/src/extensions/loop-guard-events.ts
+++ b/src/extensions/loop-guard-events.ts
@@ -1,0 +1,48 @@
+/**
+ * Loop-guard domain event channels published via pi.events.
+ *
+ * The loop-guard extension emits these events; the telemetry extension
+ * subscribes to them. This keeps the guard isolated from telemetry and
+ * ensures every steer / subagent abort is observed for analytics.
+ *
+ * Privacy: payloads carry structured fields only (detector, count,
+ * is_subagent). Raw tool args, command text, and the human reason string
+ * are intentionally NOT emitted — mirroring the bash-tool-guard stance.
+ */
+
+export const LOOP_GUARD_EVENTS = {
+	WARN: "loop_guard:warn",
+	SUBAGENT_ABORT: "loop_guard:subagent_abort",
+} as const
+
+export type LoopGuardEventChannel = (typeof LOOP_GUARD_EVENTS)[keyof typeof LOOP_GUARD_EVENTS]
+
+/**
+ * Which loop detector fired. Kept short and stable so telemetry can
+ * aggregate without receiving raw tool-arg / command text.
+ */
+export type LoopGuardDetector =
+	| "consecutive_identical"
+	| "exact_ngram"
+	| "fuzzy_ngram"
+	| "edit_run"
+	| "edit_run_total"
+	| "bash_repetition"
+
+export interface LoopGuardWarnPayload {
+	/** The detector that fired this warn. */
+	detector: LoopGuardDetector
+	/** How many times the guard has warned in the session so far. */
+	count: number
+	/** True when the warning fired inside an agent worker (subagent). */
+	is_subagent: boolean
+}
+
+export interface LoopGuardSubagentAbortPayload {
+	/** The detector that triggered the warn preceding this abort. */
+	detector: LoopGuardDetector
+	/** The session warn count at the time of the triggering warn. */
+	count: number
+	/** Always true — aborts only fire for subagents. */
+	is_subagent: boolean
+}

--- a/src/extensions/loop-guard.extension.test.ts
+++ b/src/extensions/loop-guard.extension.test.ts
@@ -1,0 +1,137 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { LOOP_GUARD_EVENTS } from "./loop-guard-events.js"
+
+type Handler = (...args: unknown[]) => Promise<unknown> | unknown
+
+function createMockApi(events?: { emit: (ch: string, data: unknown) => void; on: (ch: string, fn: (d: unknown) => void) => () => void }) {
+	const handlers = new Map<string, Handler[]>()
+	const on = vi.fn((event: string, handler: Handler) => {
+		if (!handlers.has(event)) handlers.set(event, [])
+		handlers.get(event)?.push(handler)
+	})
+	const defaultEvents = {
+		emit: vi.fn(),
+		on: vi.fn(() => () => {}),
+	}
+	const api = {
+		on,
+		events: events ?? defaultEvents,
+		sendMessage: vi.fn(),
+	} as unknown as ExtensionAPI
+	return { api, handlers, events: events ?? defaultEvents }
+}
+
+function getHandler(handlers: Map<string, Handler[]>, event: string): Handler {
+	const list = handlers.get(event)
+	if (!list || list.length === 0) throw new Error(`No handler for ${event}`)
+	return list[list.length - 1]
+}
+
+describe("loopGuardExtension telemetry", () => {
+	beforeEach(() => {
+		vi.resetModules()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("emits LOOP_GUARD_EVENTS.WARN on a warn via pi.events.emit", async () => {
+		const { api, handlers, events } = createMockApi()
+		const emitSpy = events.emit as ReturnType<typeof vi.fn>
+		const { default: loopGuardExtension } = await import("./loop-guard.js")
+
+		loopGuardExtension(api)
+
+		// session_start gives us a ctx (needed for ctx.abort on abort path)
+		await getHandler(handlers, "session_start")({}, { abort: vi.fn() })
+
+		// Feed 3 identical error outputs to trigger consecutive_identical warn.
+		const toolResult = {
+			toolName: "bash",
+			input: { command: "ls" },
+			isError: true,
+			content: [{ type: "text", text: "error output" }],
+		}
+		getHandler(handlers, "tool_result")(toolResult)
+		getHandler(handlers, "tool_result")(toolResult)
+		getHandler(handlers, "tool_result")(toolResult)
+
+		// The warn emit should have fired with the right channel + payload.
+		const warnCalls = emitSpy.mock.calls.filter(([ch]: unknown[]) => ch === LOOP_GUARD_EVENTS.WARN)
+		expect(warnCalls.length).toBe(1)
+		const payload = warnCalls[0][1] as { detector: string; count: number; is_subagent: boolean }
+		expect(payload.detector).toBe("consecutive_identical")
+		expect(payload.count).toBe(1)
+		expect(payload.is_subagent).toBe(false)
+	})
+
+	it("emits LOOP_GUARD_EVENTS.SUBAGENT_ABORT in the turn_end abort path", async () => {
+		// Mock isAgentWorker to return true so subagentAbortPending is set.
+		vi.doMock("./agent-worker-context.js", () => ({ isAgentWorker: () => true }))
+
+		const { api, handlers, events } = createMockApi()
+		const emitSpy = events.emit as ReturnType<typeof vi.fn>
+		const abortFn = vi.fn()
+		const { default: loopGuardExtension } = await import("./loop-guard.js")
+
+		loopGuardExtension(api)
+		await getHandler(handlers, "session_start")({}, { abort: abortFn })
+
+		// Trigger a warn (3 identical error outputs).
+		const toolResult = {
+			toolName: "bash",
+			input: { command: "ls" },
+			isError: true,
+			content: [{ type: "text", text: "error output" }],
+		}
+		getHandler(handlers, "tool_result")(toolResult)
+		getHandler(handlers, "tool_result")(toolResult)
+		getHandler(handlers, "tool_result")(toolResult)
+
+		// The warn emit should have fired with is_subagent: true (since we mocked isAgentWorker).
+		const warnCalls = emitSpy.mock.calls.filter(([ch]: unknown[]) => ch === LOOP_GUARD_EVENTS.WARN)
+		expect(warnCalls.length).toBe(1)
+		expect((warnCalls[0][1] as { is_subagent: boolean }).is_subagent).toBe(true)
+
+		// turn_end should fire the abort + SUBAGENT_ABORT event.
+		getHandler(handlers, "turn_end")()
+
+		const abortCalls = emitSpy.mock.calls.filter(([ch]: unknown[]) => ch === LOOP_GUARD_EVENTS.SUBAGENT_ABORT)
+		expect(abortCalls.length).toBe(1)
+		const abortPayload = abortCalls[0][1] as { detector: string; count: number; is_subagent: boolean }
+		expect(abortPayload.detector).toBe("consecutive_identical")
+		expect(abortPayload.count).toBe(1)
+		expect(abortPayload.is_subagent).toBe(true)
+		expect(abortFn).toHaveBeenCalled()
+	})
+
+	it("no-ops silently when pi.events is undefined (does not throw)", async () => {
+		const handlers = new Map<string, Handler[]>()
+		const on = vi.fn((event: string, handler: Handler) => {
+			if (!handlers.has(event)) handlers.set(event, [])
+			handlers.get(event)?.push(handler)
+		})
+		// pi.events is undefined — simulates older pi-coding-agent versions.
+		const api = { on, sendMessage: vi.fn() } as unknown as ExtensionAPI
+		const { default: loopGuardExtension } = await import("./loop-guard.js")
+
+		// Should not throw.
+		expect(() => loopGuardExtension(api)).not.toThrow()
+
+		await getHandler(handlers, "session_start")({}, { abort: vi.fn() })
+
+		// Feed 3 identical error outputs to trigger a warn.
+		const toolResult = {
+			toolName: "bash",
+			input: { command: "ls" },
+			isError: true,
+			content: [{ type: "text", text: "error output" }],
+		}
+		// These should not throw despite pi.events being undefined.
+		expect(() => getHandler(handlers, "tool_result")(toolResult)).not.toThrow()
+		expect(() => getHandler(handlers, "tool_result")(toolResult)).not.toThrow()
+		expect(() => getHandler(handlers, "tool_result")(toolResult)).not.toThrow()
+	})
+})

--- a/src/extensions/loop-guard.extension.test.ts
+++ b/src/extensions/loop-guard.extension.test.ts
@@ -4,7 +4,10 @@ import { LOOP_GUARD_EVENTS } from "./loop-guard-events.js"
 
 type Handler = (...args: unknown[]) => Promise<unknown> | unknown
 
-function createMockApi(events?: { emit: (ch: string, data: unknown) => void; on: (ch: string, fn: (d: unknown) => void) => () => void }) {
+function createMockApi(events?: {
+	emit: (ch: string, data: unknown) => void
+	on: (ch: string, fn: (d: unknown) => void) => () => void
+}) {
 	const handlers = new Map<string, Handler[]>()
 	const on = vi.fn((event: string, handler: Handler) => {
 		if (!handlers.has(event)) handlers.set(event, [])

--- a/src/extensions/loop-guard.test.ts
+++ b/src/extensions/loop-guard.test.ts
@@ -680,6 +680,48 @@ describe("Edit-run cycle detector", () => {
 	})
 })
 
+describe("LoopGuardResult.detector", () => {
+	it("populates detector='consecutive_identical' for a consecutive-identical loop", () => {
+		const guard = new LoopGuard()
+		const r = rec({ isError: true, outputFingerprint: FP_A })
+		guard.record(r)
+		guard.record(r)
+		const result = guard.record(r)
+		expect(result.state).toBe("warn")
+		expect(result.detector).toBe("consecutive_identical")
+	})
+
+	it("populates detector='edit_run' for an edit-run cycle", () => {
+		const guard = new LoopGuard()
+		const file = "/app/vm.js"
+		const bashPrefix = '{"command":"node vm.js 2>&1 | head -20"}'
+		let detector: string | undefined
+		for (let i = 0; i < 8; i++) {
+			guard.record({
+				toolName: "read",
+				toolArgs: `{"path":"/tmp/probe-${i}.txt"}`,
+				isError: false,
+				outputFingerprint: `probe-${i}`,
+			})
+			guard.record({
+				toolName: "edit",
+				toolArgs: `{"path":"${file}","edits":[{"oldText":"x","newText":"v${i}"}]}`,
+				isError: false,
+				outputFingerprint: `edit-${i}`,
+			})
+			const result = guard.record({
+				toolName: "bash",
+				toolArgs: bashPrefix,
+				isError: true,
+				outputFingerprint: `bash-${i}`,
+			})
+			detector = result.detector
+		}
+		expect(guard.isWarned()).toBe(true)
+		expect(detector).toBe("edit_run")
+	})
+})
+
 describe("Edit-run cycle detector — task-total backstop", () => {
 	// The task-total detector catches interleaved loops where the same
 	// edit/bash pattern is spread across many rounds with OTHER tool

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto"
 import type { ExtensionAPI, ExtensionContext, ToolResultEvent } from "@earendil-works/pi-coding-agent"
 import { isAgentWorker } from "./agent-worker-context.js"
+import { LOOP_GUARD_EVENTS } from "./loop-guard-events.js"
+import type { LoopGuardDetector } from "./loop-guard-events.js"
 
 export interface ToolHistoryRecord {
 	toolName: string
@@ -14,6 +16,8 @@ export type LoopGuardState = "ok" | "warn" | "terminate"
 export interface LoopGuardResult {
 	state: LoopGuardState
 	reason?: string
+	/** Which detector fired. Set on the 'warn' path; undefined otherwise. */
+	detector?: LoopGuardDetector
 }
 
 // Detection thresholds. Exact detectors (which require matching output) can
@@ -170,7 +174,7 @@ export class LoopGuard {
 			this.bashCountsNormTotal.delete(key)
 		}
 
-		return { state: "warn", reason: `${STEERING_MESSAGE} (${detected.reason})` }
+		return { state: "warn", reason: `${STEERING_MESSAGE} (${detected.reason})`, detector: detected.detector }
 	}
 
 	/**
@@ -270,7 +274,7 @@ export class LoopGuard {
 	 *  state. Task-total keys are included so the caller can decrement
 	 *  them after a warn — otherwise the same task-total threshold would
 	 *  fire on every subsequent record for the rest of the session. */
-	private detect(): { reason: string; firedKeys: string[] } | undefined {
+	private detect(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		return (
 			this.detectConsecutiveIdenticalCalls() ??
 			this.detectExactNgram() ??
@@ -281,11 +285,11 @@ export class LoopGuard {
 		)
 	}
 
-	private detectNgramOnly(): { reason: string; firedKeys: string[] } | undefined {
+	private detectNgramOnly(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		return this.detectConsecutiveIdenticalCalls() ?? this.detectExactNgram() ?? this.detectFuzzyNgram()
 	}
 
-	private detectConsecutiveIdenticalCalls(): { reason: string; firedKeys: string[] } | undefined {
+	private detectConsecutiveIdenticalCalls(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		const last = this.history[this.history.length - 1]
 		if (!last) return undefined
 		const targetKey = exactKey(last)
@@ -301,34 +305,35 @@ export class LoopGuard {
 		return {
 			reason: `${count} consecutive identical calls of ${formatCall(last)} producing identical output`,
 			firedKeys: [],
+			detector: "consecutive_identical",
 		}
 	}
 
-	private detectExactNgram(): { reason: string; firedKeys: string[] } | undefined {
+	private detectExactNgram(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		const r2 = countContiguousNgramReps(this.history, 2, exactKey)
 		if (r2 > EXACT_2GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 2, r2, "identical results"), firedKeys: [] }
+			return { reason: formatLoopReason(this.history, 2, r2, "identical results"), firedKeys: [], detector: "exact_ngram" }
 		}
 		const r3 = countContiguousNgramReps(this.history, 3, exactKey)
 		if (r3 > EXACT_3GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 3, r3, "identical results"), firedKeys: [] }
+			return { reason: formatLoopReason(this.history, 3, r3, "identical results"), firedKeys: [], detector: "exact_ngram" }
 		}
 		return undefined
 	}
 
-	private detectFuzzyNgram(): { reason: string; firedKeys: string[] } | undefined {
+	private detectFuzzyNgram(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		const r2 = countContiguousNgramReps(this.history, 2, fuzzyKey)
 		if (r2 > FUZZY_2GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 2, r2, "same arguments"), firedKeys: [] }
+			return { reason: formatLoopReason(this.history, 2, r2, "same arguments"), firedKeys: [], detector: "fuzzy_ngram" }
 		}
 		const r3 = countContiguousNgramReps(this.history, 3, fuzzyKey)
 		if (r3 > FUZZY_3GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 3, r3, "same arguments"), firedKeys: [] }
+			return { reason: formatLoopReason(this.history, 3, r3, "same arguments"), firedKeys: [], detector: "fuzzy_ngram" }
 		}
 		return undefined
 	}
 
-	private detectEditRunCycle(): { reason: string; firedKeys: string[] } | undefined {
+	private detectEditRunCycle(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		const topEdit = mapMax(this.editCounts)
 		const topBashRaw = mapMax(this.bashCounts)
 		const topBashNorm = mapMax(this.bashCountsNorm)
@@ -345,10 +350,11 @@ export class LoopGuard {
 		return {
 			reason: `edit-run cycle: ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× in last ${this.history.length} calls`,
 			firedKeys: [],
+			detector: "edit_run",
 		}
 	}
 
-	private detectEditRunCycleTotal(): { reason: string; firedKeys: string[] } | undefined {
+	private detectEditRunCycleTotal(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		// Task-total counts catch interleaved loops that the 30-record
 		// window misses. Window-based detection is still preferred because
 		// it's sensitive to recent behaviour; this is a backstop for the
@@ -372,6 +378,7 @@ export class LoopGuard {
 		return {
 			reason: `edit-run cycle (task-total): ${editPreview} edited ${topEdit[1]}× and bash "${bashPreview}" ran ${topBash[1]}× across the task`,
 			firedKeys: [topEdit[0], topBash[0]],
+			detector: "edit_run_total",
 		}
 	}
 
@@ -381,7 +388,7 @@ export class LoopGuard {
 	 * like repeated yt-dlp downloads, repeated curl calls, repeated make on
 	 * a project that always fails.
 	 */
-	private detectBashRepetition(): { reason: string; firedKeys: string[] } | undefined {
+	private detectBashRepetition(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		// Bash-only thresholds are higher than edit-run because the signal
 		// is weaker (no paired file edit to confirm it's a loop).
 		// Window check (raw)
@@ -390,6 +397,7 @@ export class LoopGuard {
 			return {
 				reason: `bash repetition: "${truncPreview(topBashWin[0])}" ran ${topBashWin[1]}× in last ${this.history.length} calls`,
 				firedKeys: [],
+				detector: "bash_repetition",
 			}
 		}
 		// Window check (normalized)
@@ -398,6 +406,7 @@ export class LoopGuard {
 			return {
 				reason: `bash repetition (normalized): "${truncPreview(topBashNormWin[0])}" ran ${topBashNormWin[1]}× in last ${this.history.length} calls`,
 				firedKeys: [],
+				detector: "bash_repetition",
 			}
 		}
 		// Task-total check (raw)
@@ -406,6 +415,7 @@ export class LoopGuard {
 			return {
 				reason: `bash repetition (task-total): "${truncPreview(topBashTotal[0])}" ran ${topBashTotal[1]}× across the task`,
 				firedKeys: [topBashTotal[0]],
+				detector: "bash_repetition",
 			}
 		}
 		// Task-total check (normalized)
@@ -414,6 +424,7 @@ export class LoopGuard {
 			return {
 				reason: `bash repetition (normalized task-total): "${truncPreview(topBashNormTotal[0])}" ran ${topBashNormTotal[1]}× across the task`,
 				firedKeys: [topBashNormTotal[0]],
+				detector: "bash_repetition",
 			}
 		}
 		return undefined
@@ -648,15 +659,39 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 	/** True when a subagent loop-guard steer has fired and the subagent
 	 *  gets one more turn to produce a summary before abort. */
 	let subagentAbortPending = false
+	/** Per-session count of loop-guard warns. Reset alongside guard.reset().
+	 *  Carried into telemetry payloads so the backend can track frequency. */
+	let warnCount = 0
+	/** Stash the detector + count from the last warn so the subagent_abort
+	 *  event can reference them when the abort fires in turn_end. */
+	let lastWarnDetector: LoopGuardDetector | undefined
+	let lastWarnCount = 0
+
+	// Domain event helper: emit a loop-guard event via pi.events. No-ops
+	// silently when `pi.events` is unavailable on the host.
+	function emitGuardEvent(channel: string, payload: unknown): void {
+		try {
+			pi.events.emit(channel, payload)
+		} catch {
+			// Older pi-coding-agent versions may not expose `events`. The
+			// guard still functions correctly without telemetry.
+		}
+	}
 
 	pi.on("session_start", (_event, _ctx) => {
 		ctx = _ctx
+		warnCount = 0
+		lastWarnDetector = undefined
+		lastWarnCount = 0
 	})
 
 	pi.on("input", (event) => {
 		if (event.source === "extension") return
 		guard.reset()
 		subagentAbortPending = false
+		warnCount = 0
+		lastWarnDetector = undefined
+		lastWarnCount = 0
 	})
 
 	pi.on("tool_call", (event) => {
@@ -676,6 +711,11 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 		// one turn to produce output, then we abort. Whatever it produced
 		// becomes the responseText the orchestrator receives.
 		if (subagentAbortPending) {
+			emitGuardEvent(LOOP_GUARD_EVENTS.SUBAGENT_ABORT, {
+				detector: lastWarnDetector,
+				count: lastWarnCount,
+				is_subagent: true,
+			})
 			ctx?.abort()
 			subagentAbortPending = false
 			return
@@ -691,6 +731,14 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 		}
 		const result = guard.record(record)
 		if (result.state === "warn" && result.reason) {
+			warnCount++
+			lastWarnDetector = result.detector
+			lastWarnCount = warnCount
+			emitGuardEvent(LOOP_GUARD_EVENTS.WARN, {
+				detector: result.detector,
+				count: warnCount,
+				is_subagent: isAgentWorker(),
+			})
 			pi.sendMessage(
 				{
 					customType: "loop-guard-steer",

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -289,7 +289,9 @@ export class LoopGuard {
 		return this.detectConsecutiveIdenticalCalls() ?? this.detectExactNgram() ?? this.detectFuzzyNgram()
 	}
 
-	private detectConsecutiveIdenticalCalls(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
+	private detectConsecutiveIdenticalCalls():
+		| { reason: string; firedKeys: string[]; detector: LoopGuardDetector }
+		| undefined {
 		const last = this.history[this.history.length - 1]
 		if (!last) return undefined
 		const targetKey = exactKey(last)
@@ -312,11 +314,19 @@ export class LoopGuard {
 	private detectExactNgram(): { reason: string; firedKeys: string[]; detector: LoopGuardDetector } | undefined {
 		const r2 = countContiguousNgramReps(this.history, 2, exactKey)
 		if (r2 > EXACT_2GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 2, r2, "identical results"), firedKeys: [], detector: "exact_ngram" }
+			return {
+				reason: formatLoopReason(this.history, 2, r2, "identical results"),
+				firedKeys: [],
+				detector: "exact_ngram",
+			}
 		}
 		const r3 = countContiguousNgramReps(this.history, 3, exactKey)
 		if (r3 > EXACT_3GRAM_THRESHOLD) {
-			return { reason: formatLoopReason(this.history, 3, r3, "identical results"), firedKeys: [], detector: "exact_ngram" }
+			return {
+				reason: formatLoopReason(this.history, 3, r3, "identical results"),
+				firedKeys: [],
+				detector: "exact_ngram",
+			}
 		}
 		return undefined
 	}

--- a/src/extensions/loop-guard.ts
+++ b/src/extensions/loop-guard.ts
@@ -2,7 +2,12 @@ import { createHash } from "node:crypto"
 import type { ExtensionAPI, ExtensionContext, ToolResultEvent } from "@earendil-works/pi-coding-agent"
 import { isAgentWorker } from "./agent-worker-context.js"
 import { LOOP_GUARD_EVENTS } from "./loop-guard-events.js"
-import type { LoopGuardDetector } from "./loop-guard-events.js"
+import type {
+	LoopGuardDetector,
+	LoopGuardEventChannel,
+	LoopGuardSubagentAbortPayload,
+	LoopGuardWarnPayload,
+} from "./loop-guard-events.js"
 
 export interface ToolHistoryRecord {
 	toolName: string
@@ -679,7 +684,14 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 
 	// Domain event helper: emit a loop-guard event via pi.events. No-ops
 	// silently when `pi.events` is unavailable on the host.
-	function emitGuardEvent(channel: string, payload: unknown): void {
+	// Typed overloads ensure the payload matches the channel, catching
+	// drift between the emit site and the telemetry subscription.
+	function emitGuardEvent(channel: typeof LOOP_GUARD_EVENTS.WARN, payload: LoopGuardWarnPayload): void
+	function emitGuardEvent(
+		channel: typeof LOOP_GUARD_EVENTS.SUBAGENT_ABORT,
+		payload: LoopGuardSubagentAbortPayload,
+	): void
+	function emitGuardEvent(channel: LoopGuardEventChannel, payload: unknown): void {
 		try {
 			pi.events.emit(channel, payload)
 		} catch {
@@ -745,7 +757,7 @@ export default function loopGuardExtension(pi: ExtensionAPI) {
 			lastWarnDetector = result.detector
 			lastWarnCount = warnCount
 			emitGuardEvent(LOOP_GUARD_EVENTS.WARN, {
-				detector: result.detector,
+				detector: result.detector ?? "consecutive_identical",
 				count: warnCount,
 				is_subagent: isAgentWorker(),
 			})

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -68,6 +68,10 @@ Fired from `session-context.ts` via `ctx.emit()`. Batched (max 20) and flushed e
 | `command_executed` | `bash` tool runs | `model`, `command_type`, `exit_code`, `duration_ms` |
 | `error` | Agent, tool, or transport error | `model`, `error_type` (`agent_error` / `tool_failure` / `transport_error`), `error_message` *(truncated to 300 chars)* |
 | `subagent.spawned` | Sub-agent created | `model`, `agent_type`, `reason` |
+| `loop_guard.warn` | Loop-guard issues a steer | `model`, `detector`, `count`, `is_subagent` |
+| `loop_guard.subagent_abort` | Subagent terminated after a loop-guard steer | `model`, `detector`, `count`, `is_subagent` |
+
+> **Privacy:** Loop-guard events carry only structured fields — `detector` (which loop detector fired), `count` (per-session warn count), and `is_subagent`. Raw tool args, command text, and the human-readable reason string are intentionally **not** emitted, to avoid leaking user data or secrets.
 
 ## Cumulative Metrics (OTLP Sum)
 

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -1168,3 +1168,102 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		expect(fetchMock).not.toHaveBeenCalled()
 	})
 })
+
+describe("loop-guard telemetry via pi.events", () => {
+	let fetchMock: ReturnType<typeof vi.fn>
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "" })
+		originalFetch = globalThis.fetch
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		globalThis.fetch = fetchMock as any
+	})
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		_resetSharedAccumulators()
+		const { _resetFermentTrackingState } = await import("./index.js")
+		_resetFermentTrackingState()
+		vi.restoreAllMocks()
+	})
+
+	async function setup() {
+		const { handlers, events, api } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		return { handlers, events }
+	}
+
+	function extractRecords() {
+		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
+		return logCalls.flatMap(([, opts]: unknown[]) => {
+			const body = JSON.parse((opts as { body: string }).body)
+			return body.resourceLogs[0].scopeLogs[0].logRecords as Array<{
+				eventName: string
+				attributes: Array<{ key: string; value: { stringValue: string } }>
+			}>
+		})
+	}
+
+	function attrsOf(rec: { attributes: Array<{ key: string; value: { stringValue: string } }> }) {
+		return Object.fromEntries(rec.attributes.map((a) => [a.key, a.value.stringValue]))
+	}
+
+	it("loop_guard:warn → loop_guard.warn OTLP record with detector, count, is_subagent", async () => {
+		const { handlers, events } = await setup()
+		const { LOOP_GUARD_EVENTS } = await import("../loop-guard-events.js")
+
+		events.emit(LOOP_GUARD_EVENTS.WARN, {
+			detector: "edit_run",
+			count: 3,
+			is_subagent: true,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "loop_guard.warn")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.detector).toBe("edit_run")
+		expect(attrs.count).toBe("3")
+		expect(attrs.is_subagent).toBe("true")
+		expect(attrs.model).toBe("claude-sonnet-4-6")
+		// No raw args/command text must leak into OTLP.
+		expect(attrs.reason).toBeUndefined()
+		expect(attrs.toolArgs).toBeUndefined()
+	})
+
+	it("loop_guard:subagent_abort → loop_guard.subagent_abort OTLP record", async () => {
+		const { handlers, events } = await setup()
+		const { LOOP_GUARD_EVENTS } = await import("../loop-guard-events.js")
+
+		events.emit(LOOP_GUARD_EVENTS.SUBAGENT_ABORT, {
+			detector: "consecutive_identical",
+			count: 1,
+			is_subagent: true,
+		})
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+
+		const rec = extractRecords().find((r) => r.eventName === "loop_guard.subagent_abort")
+		expect(rec).toBeDefined()
+		const attrs = attrsOf(rec as NonNullable<typeof rec>)
+		expect(attrs.detector).toBe("consecutive_identical")
+		expect(attrs.count).toBe("1")
+		expect(attrs.is_subagent).toBe("true")
+		expect(attrs.model).toBe("claude-sonnet-4-6")
+	})
+
+	it("does NOT emit OTLP records when telemetry is disabled", async () => {
+		const { events } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig({ enabled: false }))({ on: vi.fn(), events } as unknown as ExtensionAPI)
+		const { LOOP_GUARD_EVENTS } = await import("../loop-guard-events.js")
+		events.emit(LOOP_GUARD_EVENTS.WARN, {
+			detector: "edit_run",
+			count: 1,
+			is_subagent: false,
+		})
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -1211,6 +1211,11 @@ describe("loop-guard telemetry via pi.events", () => {
 		return Object.fromEntries(rec.attributes.map((a) => [a.key, a.value.stringValue]))
 	}
 
+	/** Flush buffered OTLP log records by triggering session_shutdown. */
+	async function flushTelemetry(handlers: Map<string, Handler[]>) {
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+	}
+
 	it("loop_guard:warn → loop_guard.warn OTLP record with detector, count, is_subagent", async () => {
 		const { handlers, events } = await setup()
 		const { LOOP_GUARD_EVENTS } = await import("../loop-guard-events.js")
@@ -1220,7 +1225,7 @@ describe("loop-guard telemetry via pi.events", () => {
 			count: 3,
 			is_subagent: true,
 		})
-		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+		await flushTelemetry(handlers)
 
 		const rec = extractRecords().find((r) => r.eventName === "loop_guard.warn")
 		expect(rec).toBeDefined()
@@ -1243,7 +1248,7 @@ describe("loop-guard telemetry via pi.events", () => {
 			count: 1,
 			is_subagent: true,
 		})
-		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+		await flushTelemetry(handlers)
 
 		const rec = extractRecords().find((r) => r.eventName === "loop_guard.subagent_abort")
 		expect(rec).toBeDefined()

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -533,7 +533,7 @@ function onLoopGuardSubagentAbort(raw: unknown): void {
 	const payload = raw as LoopGuardSubagentAbortPayload
 	ctx.emit("loop_guard.subagent_abort", {
 		model: ctx.currentModel,
-		detector: payload.detector,
+		detector: payload.detector ?? "unknown",
 		count: payload.count,
 		is_subagent: payload.is_subagent,
 	})

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -8,6 +8,11 @@ import {
 	type BashToolGuardWarnPayload,
 } from "../bash-tool-guard-events.js"
 import {
+	LOOP_GUARD_EVENTS,
+	type LoopGuardSubagentAbortPayload,
+	type LoopGuardWarnPayload,
+} from "../loop-guard-events.js"
+import {
 	FERMENT_EVENTS,
 	type FermentAbandonedPayload,
 	type FermentCompletedPayload,
@@ -505,6 +510,35 @@ function onBashGuardAllowedByUserRequest(raw: unknown): void {
 	})
 }
 
+function onLoopGuardWarn(raw: unknown): void {
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const payload = raw as LoopGuardWarnPayload
+	// Only structured fields land in OTLP. Raw tool args, command text, and
+	// the human-readable reason string are intentionally NOT emitted to
+	// avoid leaking user data. Mirrors the bash-tool-guard stance.
+	ctx.emit("loop_guard.warn", {
+		model: ctx.currentModel,
+		detector: payload.detector,
+		count: payload.count,
+		is_subagent: payload.is_subagent,
+	})
+}
+
+function onLoopGuardSubagentAbort(raw: unknown): void {
+	if (!isEnabled()) return
+	const ctx = _ctx
+	if (!ctx) return
+	const payload = raw as LoopGuardSubagentAbortPayload
+	ctx.emit("loop_guard.subagent_abort", {
+		model: ctx.currentModel,
+		detector: payload.detector,
+		count: payload.count,
+		is_subagent: payload.is_subagent,
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Extension factory
 // ---------------------------------------------------------------------------
@@ -542,6 +576,11 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.events.on(BASH_TOOL_GUARD_EVENTS.WARN, onBashGuardWarn)
 		pi.events.on(BASH_TOOL_GUARD_EVENTS.BLOCK, onBashGuardBlock)
 		pi.events.on(BASH_TOOL_GUARD_EVENTS.ALLOWED_BY_USER_REQUEST, onBashGuardAllowedByUserRequest)
+
+		// Subscribe to loop-guard domain events. The guard publishes facts;
+		// telemetry translates them into OTLP records for analytics.
+		pi.events.on(LOOP_GUARD_EVENTS.WARN, onLoopGuardWarn)
+		pi.events.on(LOOP_GUARD_EVENTS.SUBAGENT_ABORT, onLoopGuardSubagentAbort)
 
 		pi.on("session_start", async (_event, extCtx) => {
 			resetBashGuardCounts()

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -8,11 +8,6 @@ import {
 	type BashToolGuardWarnPayload,
 } from "../bash-tool-guard-events.js"
 import {
-	LOOP_GUARD_EVENTS,
-	type LoopGuardSubagentAbortPayload,
-	type LoopGuardWarnPayload,
-} from "../loop-guard-events.js"
-import {
 	FERMENT_EVENTS,
 	type FermentAbandonedPayload,
 	type FermentCompletedPayload,
@@ -25,6 +20,11 @@ import {
 	type FermentStepFailedPayload,
 	type FermentStepStartedPayload,
 } from "../ferment/domain-events.js"
+import {
+	LOOP_GUARD_EVENTS,
+	type LoopGuardSubagentAbortPayload,
+	type LoopGuardWarnPayload,
+} from "../loop-guard-events.js"
 
 import { handleAgentEnd, handleBeforeAgentStart, handleMessageEnd, handleMessageStart } from "./handlers/messages.js"
 import { emitSessionStartEvent, handleSessionInitialized, handleSessionShutdown } from "./handlers/session.js"


### PR DESCRIPTION
## Summary

Add structured OTLP telemetry events for loop-guard warn and subagent_abort, following the same domain-event → telemetry-subscription pattern as the bash-tool-guard. This lets the backend track how often the loop guard warns and aborts subagents.

## Changes

**New file: `src/extensions/loop-guard-events.ts`**
- Exports `LOOP_GUARD_EVENTS` with `WARN` (`loop_guard:warn`) and `SUBAGENT_ABORT` (`loop_guard:subagent_abort`) channels
- Typed payloads carrying `{ detector, count, is_subagent }`
- Mirrors the structure of `bash-tool-guard-events.ts`

**LoopGuardResult enrichment (`src/extensions/loop-guard.ts`)**
- Added typed `detector` field to `LoopGuardResult`, populated by all 6 detectors (consecutive_identical, exact_ngram, fuzzy_ngram, edit_run, edit_run_total, bash_repetition)
- Added `emitGuardEvent` helper — try/catch around `pi.events.emit`, no-ops silently when `pi.events` is unavailable (older pi-coding-agent versions)
- Emits `LOOP_GUARD_EVENTS.WARN` in the `tool_result` handler when `result.state === 'warn'`
- Emits `LOOP_GUARD_EVENTS.SUBAGENT_ABORT` in the `turn_end` handler when `subagentAbortPending` fires, before `ctx.abort()`
- Per-session `warnCount` counter, reset on `session_start` and `input` alongside `guard.reset()`

**Telemetry subscription (`src/extensions/telemetry/index.ts`)**
- `onLoopGuardWarn` and `onLoopGuardSubagentAbort` handlers
- Emits OTLP log records `loop_guard.warn` and `loop_guard.subagent_abort` via `ctx.emit`
- Structured attrs only: `model`, `detector`, `count`, `is_subagent`
- **No raw tool args/command text** — following bash-tool-guard privacy precedent
- Gated on `isEnabled()` + `_ctx` presence, same as bash-guard handlers

**Docs (`src/extensions/telemetry/README.md`)**
- Two new rows in the In-Session Log Events table
- Privacy note clarifying structured-only fields

## Tests

- `loop-guard.test.ts`: 2 detector assertion tests (consecutive_identical + edit_run)
- `loop-guard.extension.test.ts` (new file): 3 tests — warn emit, abort emit with `isAgentWorker` mock, `pi.events` undefined no-op
- `telemetry/index.test.ts`: 3 tests — warn OTLP record attrs, abort OTLP record attrs, disabled no-op

## Verification

- `pnpm run typecheck` — clean
- `pnpm vitest run src/extensions/loop-guard.test.ts src/extensions/loop-guard.extension.test.ts src/extensions/telemetry` — 3323 tests pass across 141 files

## Checklist

- [x] Code follows existing patterns (bash-tool-guard precedent)
- [x] Tests added covering new behavior + edge cases
- [x] No raw user data in telemetry attrs (privacy stance)
- [x] Typecheck passes
- [x] All tests pass