### PR TITLE
fix(harness): renders on all thinking block for preview and spinner tick

### DIFF
--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -3,7 +3,7 @@ import { AssistantMessageComponent as _AssistantMessageComponent } from "@earend
 import { Markdown, Spacer, Text } from "@earendil-works/pi-tui"
 import type { Component, MarkdownTheme } from "@earendil-works/pi-tui"
 import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
-import { ThinkingStepsComponent, tailRawLines } from "./render.js"
+import { ThinkingStepsComponent, tailRawLinesFromBlocks } from "./render.js"
 import {
 	decrementPatchRefCount,
 	getActiveThinkingState,
@@ -129,14 +129,11 @@ class LiveThinkingPreview implements Component {
 	private renderBody(innerWidth: number): string[] {
 		const prefix = `${this.theme.fg("muted", "▍")} `
 		const bodyInnerWidth = Math.max(1, innerWidth - 2)
-		const fullText = this.blocks
-			.map((b) => b.text)
-			.join("\n")
-			.trim()
 		const separator = ` ${truncateToWidth(prefix, innerWidth, "")}`
-		if (!fullText) return [separator]
+		const textTail = tailRawLinesFromBlocks(this.blocks, LIVE_PREVIEW_LINES)
+		if (!textTail) return [separator]
 		const allLines: string[] = []
-		for (const rawLine of tailRawLines(fullText, LIVE_PREVIEW_LINES).replace(/\t/g, "    ").split("\n")) {
+		for (const rawLine of textTail.replace(/\t/g, "    ").split("\n")) {
 			if (rawLine.trim().length === 0) {
 				allLines.push(` ${truncateToWidth(prefix, innerWidth, "")}`)
 				continue

--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -93,9 +93,12 @@ class LiveThinkingPreview implements Component {
 	// The spinner drives renders at 30-60fps while a request is in flight, so
 	// the preview body must never process the full accumulated thinking text
 	// per frame — that freezes the terminal on large messages. The body only
-	// depends on (blocks, width); blocks are an immutable snapshot per
-	// component instance, so cache the body and recompute the pulse header only.
+	// depends on (blocks, width, theme styling); blocks are an immutable
+	// snapshot per component instance, so cache the body and recompute the
+	// pulse header only. The style key catches a theme switch mid-stall, when
+	// no new chunk arrives to replace this instance.
 	private cachedBodyWidth?: number
+	private cachedBodyStyleKey?: string
 	private cachedBody?: string[]
 
 	constructor(
@@ -119,9 +122,11 @@ class LiveThinkingPreview implements Component {
 			"",
 		)}`
 
-		if (this.cachedBodyWidth !== width || !this.cachedBody) {
+		const styleKey = `${this.theme.fg("dim", "x")}\u0000${this.theme.fg("muted", "x")}`
+		if (this.cachedBodyWidth !== width || this.cachedBodyStyleKey !== styleKey || !this.cachedBody) {
 			this.cachedBody = this.renderBody(innerWidth)
 			this.cachedBodyWidth = width
+			this.cachedBodyStyleKey = styleKey
 		}
 		return [header, ...this.cachedBody]
 	}
@@ -147,6 +152,7 @@ class LiveThinkingPreview implements Component {
 
 	invalidate(): void {
 		this.cachedBodyWidth = undefined
+		this.cachedBodyStyleKey = undefined
 		this.cachedBody = undefined
 	}
 }

--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -3,7 +3,7 @@ import { AssistantMessageComponent as _AssistantMessageComponent } from "@earend
 import { Markdown, Spacer, Text } from "@earendil-works/pi-tui"
 import type { Component, MarkdownTheme } from "@earendil-works/pi-tui"
 import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
-import { ThinkingStepsComponent } from "./render.js"
+import { ThinkingStepsComponent, tailRawLines } from "./render.js"
 import {
 	decrementPatchRefCount,
 	getActiveThinkingState,
@@ -90,6 +90,14 @@ function hasPatchableContentContainer(value: AssistantMessageComponentPrototype)
 const LIVE_PREVIEW_LINES = 5
 
 class LiveThinkingPreview implements Component {
+	// The spinner drives renders at 30-60fps while a request is in flight, so
+	// the preview body must never process the full accumulated thinking text
+	// per frame — that freezes the terminal on large messages. The body only
+	// depends on (blocks, width); blocks are an immutable snapshot per
+	// component instance, so cache the body and recompute the pulse header only.
+	private cachedBodyWidth?: number
+	private cachedBody?: string[]
+
 	constructor(
 		private readonly theme: ThinkingThemeLike,
 		private readonly blocks: ThinkingSourceBlock[],
@@ -111,6 +119,14 @@ class LiveThinkingPreview implements Component {
 			"",
 		)}`
 
+		if (this.cachedBodyWidth !== width || !this.cachedBody) {
+			this.cachedBody = this.renderBody(innerWidth)
+			this.cachedBodyWidth = width
+		}
+		return [header, ...this.cachedBody]
+	}
+
+	private renderBody(innerWidth: number): string[] {
 		const prefix = `${this.theme.fg("muted", "▍")} `
 		const bodyInnerWidth = Math.max(1, innerWidth - 2)
 		const fullText = this.blocks
@@ -118,9 +134,9 @@ class LiveThinkingPreview implements Component {
 			.join("\n")
 			.trim()
 		const separator = ` ${truncateToWidth(prefix, innerWidth, "")}`
-		if (!fullText) return [header, separator]
+		if (!fullText) return [separator]
 		const allLines: string[] = []
-		for (const rawLine of fullText.replace(/\t/g, "    ").split("\n")) {
+		for (const rawLine of tailRawLines(fullText, LIVE_PREVIEW_LINES).replace(/\t/g, "    ").split("\n")) {
 			if (rawLine.trim().length === 0) {
 				allLines.push(` ${truncateToWidth(prefix, innerWidth, "")}`)
 				continue
@@ -129,10 +145,13 @@ class LiveThinkingPreview implements Component {
 				allLines.push(` ${truncateToWidth(`${prefix}${wrapped}`, innerWidth, "")}`)
 			}
 		}
-		return [header, separator, ...allLines.slice(-LIVE_PREVIEW_LINES)]
+		return [separator, ...allLines.slice(-LIVE_PREVIEW_LINES)]
 	}
 
-	invalidate(): void {}
+	invalidate(): void {
+		this.cachedBodyWidth = undefined
+		this.cachedBody = undefined
+	}
 }
 
 function hasVisibleThinking(content: ThinkingContent): boolean {

--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -344,6 +344,7 @@ function installPatch(theme: ThinkingThemeLike): () => void {
 								message.timestamp,
 								thinkingBlocks,
 								resolveThinkingMessageScope(message),
+								this,
 							),
 						)
 					}

--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -59,26 +59,6 @@ export function assertPatchableAssistantMessageComponent(value: unknown): {
 	return value as { prototype: AssistantMessageComponentPrototype }
 }
 
-export function assertThinkingStepsTheme(value: unknown): ThinkingThemeLike {
-	if (!value || typeof value !== "object") {
-		throw new Error("Thinking Steps patch failed: interactive theme export is missing or invalid.")
-	}
-
-	try {
-		const candidate = value as Record<string, unknown>
-		if (typeof candidate.fg !== "function" || typeof candidate.bold !== "function") {
-			throw new Error("Thinking Steps patch failed: interactive theme export is incompatible.")
-		}
-	} catch (error) {
-		if (error instanceof Error && /Theme not initialized/.test(error.message)) {
-			return value as ThinkingThemeLike
-		}
-		throw error
-	}
-
-	return value as ThinkingThemeLike
-}
-
 function hasPatchableContentContainer(value: AssistantMessageComponentPrototype): boolean {
 	return Boolean(
 		value.contentContainer &&

--- a/src/extensions/thinking-steps/internal-patch.ts
+++ b/src/extensions/thinking-steps/internal-patch.ts
@@ -70,7 +70,8 @@ function hasPatchableContentContainer(value: AssistantMessageComponentPrototype)
 const LIVE_PREVIEW_LINES = 5
 
 class LiveThinkingPreview implements Component {
-	// The spinner drives renders at 30-60fps while a request is in flight, so
+	// The working animation requests a render every 40-200ms while a request is
+	// in flight, so
 	// the preview body must never process the full accumulated thinking text
 	// per frame — that freezes the terminal on large messages. The body only
 	// depends on (blocks, width, theme styling); blocks are an immutable

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1322,47 +1322,33 @@ type StepDerivation = {
 	role: ThinkingSemanticRole
 }
 
-// Summaries and roles are pure functions of the step text. During streaming,
-// deriveThinkingSteps runs on every message_update delta over the full
-// accumulated thinking text; without this cache each delta re-summarizes every
-// step (hundreds of ms on large messages), which starves the render loop and
-// freezes the terminal. The final step may still be growing, so do not cache
-// it; caching each moving tail would retain every streaming snapshot.
+// Completed steps repeat across stream updates. Cache them, but not the growing
+// final step, whose changing snapshots would accumulate.
 const stepDerivationCache = new Map<string, StepDerivation>()
 const STEP_DERIVATION_CACHE_MAX = 8192
 
-// Summarization cost scales with step size, and a step with few paragraph
-// breaks can grow unbounded while streaming. Summaries describe the step's
-// latest activity, so deriving them from the tail keeps each delta bounded.
+// Summaries describe the latest activity, so bound work to the step's tail.
 const STEP_SUMMARY_MAX_CHARS = 16384
 
-function deriveStep(stepText: string, cacheable: boolean): StepDerivation {
-	const summarySource = stepText.length > STEP_SUMMARY_MAX_CHARS ? stepText.slice(-STEP_SUMMARY_MAX_CHARS) : stepText
-	const cached = cacheable ? stepDerivationCache.get(summarySource) : undefined
+function deriveStep(stepText: string, isFinalStep: boolean): StepDerivation {
+	const summarySource = stepText.slice(-STEP_SUMMARY_MAX_CHARS)
+	const cached = !isFinalStep && stepDerivationCache.get(summarySource)
 	if (cached) return cached
 	const summaryDetails = summarizeThinkingTextDetailed(summarySource)
 	const role = inferThinkingRole(`${summaryDetails.summary}\n${summarySource}`)
 	const derivation: StepDerivation = { summaryDetails, role }
-	if (cacheable) {
-		if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) {
-			stepDerivationCache.clear()
-		}
-		stepDerivationCache.set(summarySource, derivation)
-	}
+	if (isFinalStep) return derivation
+	if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) stepDerivationCache.clear()
+	stepDerivationCache.set(summarySource, derivation)
 	return derivation
 }
 
-export function clearStepDerivationCacheForTesting(): void {
-	stepDerivationCache.clear()
-}
+export const clearStepDerivationCacheForTesting = () => stepDerivationCache.clear()
 
-export function getStepDerivationCacheSizeForTesting(): number {
-	return stepDerivationCache.size
-}
+export const getStepDerivationCacheSizeForTesting = () => stepDerivationCache.size
 
-function isRedactedPlaceholderBlock(block: ThinkingSourceBlock): boolean {
-	return block.redacted === true && !block.text.trim()
-}
+const isRedactedPlaceholderBlock = (block: ThinkingSourceBlock): boolean =>
+	block.redacted === true && !block.text.trim()
 
 export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThinkingStep[] {
 	const steps: DerivedThinkingStep[] = []
@@ -1400,7 +1386,7 @@ export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThink
 		const stepTexts = splitThinkingIntoStepTexts(block.text)
 		stepTexts.forEach((stepText, stepIndex) => {
 			const isFinalStep = blockIndex === lastTextBlockIndex && stepIndex === stepTexts.length - 1
-			const { summaryDetails, role } = deriveStep(stepText, !isFinalStep)
+			const { summaryDetails, role } = deriveStep(stepText, isFinalStep)
 			steps.push({
 				id: `${block.contentIndex}-${stepIndex}`,
 				contentIndex: block.contentIndex,

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1360,10 +1360,23 @@ export function getStepDerivationCacheSizeForTesting(): number {
 	return stepDerivationCache.size
 }
 
+function isRedactedPlaceholderBlock(block: ThinkingSourceBlock): boolean {
+	return block.redacted === true && !block.text.trim()
+}
+
 export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThinkingStep[] {
 	const steps: DerivedThinkingStep[] = []
+	// The still-growing step is the last one derived from text, which is not
+	// necessarily in the last block: trailing redacted placeholders don't count.
+	let lastTextBlockIndex = -1
+	for (let index = blocks.length - 1; index >= 0; index -= 1) {
+		if (!isRedactedPlaceholderBlock(blocks[index]!)) {
+			lastTextBlockIndex = index
+			break
+		}
+	}
 	blocks.forEach((block, blockIndex) => {
-		if (block.redacted && !block.text.trim()) {
+		if (isRedactedPlaceholderBlock(block)) {
 			const summary = "Reasoning is hidden by the provider."
 			steps.push({
 				id: `${block.contentIndex}-0`,
@@ -1386,7 +1399,7 @@ export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThink
 
 		const stepTexts = splitThinkingIntoStepTexts(block.text)
 		stepTexts.forEach((stepText, stepIndex) => {
-			const isFinalStep = blockIndex === blocks.length - 1 && stepIndex === stepTexts.length - 1
+			const isFinalStep = blockIndex === lastTextBlockIndex && stepIndex === stepTexts.length - 1
 			const { summaryDetails, role } = deriveStep(stepText, !isFinalStep)
 			steps.push({
 				id: `${block.contentIndex}-${stepIndex}`,

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1323,27 +1323,52 @@ type StepDerivation = {
 }
 
 // Completed steps repeat across stream updates. Cache them, but not the growing
-// final step, whose changing snapshots would accumulate.
+// final step, whose changing snapshots would accumulate. The bound is on total
+// key characters, not entry count: deriveThinkingSteps rescans every step of a
+// message per stream chunk, so the cache must hold a whole long message's steps
+// (1000+ on large messages) or the sequential rescan evicts each entry right
+// before its next use and hit rate collapses to zero.
 const stepDerivationCache = new Map<string, StepDerivation>()
-const STEP_DERIVATION_CACHE_MAX = 8192
+const STEP_DERIVATION_CACHE_MAX_CHARS = 4 * 1024 * 1024
+let stepDerivationCacheChars = 0
 
-// Summaries describe the latest activity, so bound work to the step's tail.
+// Bound candidate extraction while retaining both early outcome cues and the
+// latest activity from long steps.
 const STEP_SUMMARY_MAX_CHARS = 16384
+const STEP_SUMMARY_SEPARATOR = "\n\n"
+const STEP_SUMMARY_HEAD_CHARS = Math.floor((STEP_SUMMARY_MAX_CHARS - STEP_SUMMARY_SEPARATOR.length) / 2)
+
+function boundedStepSummarySource(stepText: string): string {
+	if (stepText.length <= STEP_SUMMARY_MAX_CHARS) return stepText
+	const tailChars = STEP_SUMMARY_MAX_CHARS - STEP_SUMMARY_HEAD_CHARS - STEP_SUMMARY_SEPARATOR.length
+	const head = stepText.slice(0, STEP_SUMMARY_HEAD_CHARS).replace(/[\uD800-\uDBFF]$/, "")
+	const tail = stepText.slice(-tailChars).replace(/^[\uDC00-\uDFFF]/, "")
+	return `${head}${STEP_SUMMARY_SEPARATOR}${tail}`
+}
 
 function deriveStep(stepText: string, isFinalStep: boolean): StepDerivation {
-	const summarySource = stepText.slice(-STEP_SUMMARY_MAX_CHARS)
+	const summarySource = boundedStepSummarySource(stepText)
 	const cached = !isFinalStep && stepDerivationCache.get(summarySource)
 	if (cached) return cached
 	const summaryDetails = summarizeThinkingTextDetailed(summarySource)
 	const role = inferThinkingRole(`${summaryDetails.summary}\n${summarySource}`)
 	const derivation: StepDerivation = { summaryDetails, role }
 	if (isFinalStep) return derivation
-	if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) stepDerivationCache.clear()
+	while (stepDerivationCacheChars + summarySource.length > STEP_DERIVATION_CACHE_MAX_CHARS) {
+		const oldest = stepDerivationCache.keys().next().value
+		if (oldest === undefined) break
+		stepDerivationCache.delete(oldest)
+		stepDerivationCacheChars -= oldest.length
+	}
 	stepDerivationCache.set(summarySource, derivation)
+	stepDerivationCacheChars += summarySource.length
 	return derivation
 }
 
-export const clearStepDerivationCacheForTesting = () => stepDerivationCache.clear()
+export const clearStepDerivationCacheForTesting = () => {
+	stepDerivationCache.clear()
+	stepDerivationCacheChars = 0
+}
 
 export const getStepDerivationCacheSizeForTesting = () => stepDerivationCache.size
 

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1323,13 +1323,12 @@ type StepDerivation = {
 }
 
 // Completed steps repeat across stream updates. Cache them, but not the growing
-// final step, whose changing snapshots would accumulate. The bound is on total
-// key characters, not entry count: deriveThinkingSteps rescans every step of a
-// message per stream chunk, so the cache must hold a whole long message's steps
-// (1000+ on large messages) or the sequential rescan evicts each entry right
-// before its next use and hit rate collapses to zero.
+// final step, whose changing snapshots would accumulate. The character budget
+// holds realistic 1000+ step messages; the high entry cap only bounds overhead
+// from pathological numbers of tiny steps.
 const stepDerivationCache = new Map<string, StepDerivation>()
 const STEP_DERIVATION_CACHE_MAX_CHARS = 4 * 1024 * 1024
+const STEP_DERIVATION_CACHE_MAX_ENTRIES = 8192
 let stepDerivationCacheChars = 0
 
 // Bound candidate extraction while retaining both early outcome cues and the
@@ -1354,7 +1353,10 @@ function deriveStep(stepText: string, isFinalStep: boolean): StepDerivation {
 	const role = inferThinkingRole(`${summaryDetails.summary}\n${summarySource}`)
 	const derivation: StepDerivation = { summaryDetails, role }
 	if (isFinalStep) return derivation
-	while (stepDerivationCacheChars + summarySource.length > STEP_DERIVATION_CACHE_MAX_CHARS) {
+	while (
+		stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX_ENTRIES ||
+		stepDerivationCacheChars + summarySource.length > STEP_DERIVATION_CACHE_MAX_CHARS
+	) {
 		const oldest = stepDerivationCache.keys().next().value
 		if (oldest === undefined) break
 		stepDerivationCache.delete(oldest)

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1317,6 +1317,42 @@ export function iconForThinkingRole(role: ThinkingSemanticRole): string {
 	}
 }
 
+type StepDerivation = {
+	summaryDetails: ReturnType<typeof summarizeThinkingTextDetailed>
+	role: ThinkingSemanticRole
+}
+
+// Summaries and roles are pure functions of the step text. During streaming,
+// deriveThinkingSteps runs on every message_update delta over the full
+// accumulated thinking text; without this cache each delta re-summarizes every
+// step (hundreds of ms on large messages), which starves the render loop and
+// freezes the terminal. Only the growing last step misses the cache.
+const stepDerivationCache = new Map<string, StepDerivation>()
+const STEP_DERIVATION_CACHE_MAX = 8192
+
+// Summarization cost scales with step size, and a step with few paragraph
+// breaks can grow unbounded while streaming. Summaries describe the step's
+// latest activity, so deriving them from the tail keeps each delta bounded.
+const STEP_SUMMARY_MAX_CHARS = 16384
+
+function deriveStep(stepText: string): StepDerivation {
+	const summarySource = stepText.length > STEP_SUMMARY_MAX_CHARS ? stepText.slice(-STEP_SUMMARY_MAX_CHARS) : stepText
+	const cached = stepDerivationCache.get(summarySource)
+	if (cached) return cached
+	const summaryDetails = summarizeThinkingTextDetailed(summarySource)
+	const role = inferThinkingRole(`${summaryDetails.summary}\n${summarySource}`)
+	const derivation: StepDerivation = { summaryDetails, role }
+	if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) {
+		stepDerivationCache.clear()
+	}
+	stepDerivationCache.set(summarySource, derivation)
+	return derivation
+}
+
+export function clearStepDerivationCacheForTesting(): void {
+	stepDerivationCache.clear()
+}
+
 export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThinkingStep[] {
 	const steps: DerivedThinkingStep[] = []
 	blocks.forEach((block, blockIndex) => {
@@ -1343,8 +1379,7 @@ export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThink
 
 		const stepTexts = splitThinkingIntoStepTexts(block.text)
 		stepTexts.forEach((stepText, stepIndex) => {
-			const summaryDetails = summarizeThinkingTextDetailed(stepText)
-			const role = inferThinkingRole(`${summaryDetails.summary}\n${stepText}`)
+			const { summaryDetails, role } = deriveStep(stepText)
 			steps.push({
 				id: `${block.contentIndex}-${stepIndex}`,
 				contentIndex: block.contentIndex,

--- a/src/extensions/thinking-steps/parse.ts
+++ b/src/extensions/thinking-steps/parse.ts
@@ -1326,7 +1326,8 @@ type StepDerivation = {
 // deriveThinkingSteps runs on every message_update delta over the full
 // accumulated thinking text; without this cache each delta re-summarizes every
 // step (hundreds of ms on large messages), which starves the render loop and
-// freezes the terminal. Only the growing last step misses the cache.
+// freezes the terminal. The final step may still be growing, so do not cache
+// it; caching each moving tail would retain every streaming snapshot.
 const stepDerivationCache = new Map<string, StepDerivation>()
 const STEP_DERIVATION_CACHE_MAX = 8192
 
@@ -1335,22 +1336,28 @@ const STEP_DERIVATION_CACHE_MAX = 8192
 // latest activity, so deriving them from the tail keeps each delta bounded.
 const STEP_SUMMARY_MAX_CHARS = 16384
 
-function deriveStep(stepText: string): StepDerivation {
+function deriveStep(stepText: string, cacheable: boolean): StepDerivation {
 	const summarySource = stepText.length > STEP_SUMMARY_MAX_CHARS ? stepText.slice(-STEP_SUMMARY_MAX_CHARS) : stepText
-	const cached = stepDerivationCache.get(summarySource)
+	const cached = cacheable ? stepDerivationCache.get(summarySource) : undefined
 	if (cached) return cached
 	const summaryDetails = summarizeThinkingTextDetailed(summarySource)
 	const role = inferThinkingRole(`${summaryDetails.summary}\n${summarySource}`)
 	const derivation: StepDerivation = { summaryDetails, role }
-	if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) {
-		stepDerivationCache.clear()
+	if (cacheable) {
+		if (stepDerivationCache.size >= STEP_DERIVATION_CACHE_MAX) {
+			stepDerivationCache.clear()
+		}
+		stepDerivationCache.set(summarySource, derivation)
 	}
-	stepDerivationCache.set(summarySource, derivation)
 	return derivation
 }
 
 export function clearStepDerivationCacheForTesting(): void {
 	stepDerivationCache.clear()
+}
+
+export function getStepDerivationCacheSizeForTesting(): number {
+	return stepDerivationCache.size
 }
 
 export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThinkingStep[] {
@@ -1379,7 +1386,8 @@ export function deriveThinkingSteps(blocks: ThinkingSourceBlock[]): DerivedThink
 
 		const stepTexts = splitThinkingIntoStepTexts(block.text)
 		stepTexts.forEach((stepText, stepIndex) => {
-			const { summaryDetails, role } = deriveStep(stepText)
+			const isFinalStep = blockIndex === blocks.length - 1 && stepIndex === stepTexts.length - 1
+			const { summaryDetails, role } = deriveStep(stepText, !isFinalStep)
 			steps.push({
 				id: `${block.contentIndex}-${stepIndex}`,
 				contentIndex: block.contentIndex,

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -90,6 +90,39 @@ describe("collapsed live preview", () => {
 	})
 })
 
+describe("expanded view", () => {
+	it("renders identical lines whether the step-line cache is warm or cold", () => {
+		const text = Array.from(
+			{ length: 40 },
+			(_, i) => `First I will inspect module ${i}.\n\nThen I verify the results of ${i}.`,
+		).join("\n\n")
+		const blocks = makeBlocks(text)
+		const steps = deriveThinkingSteps(blocks)
+		const render = () => renderThinkingStepsLines(theme, 80, { mode: "expanded", blocks, steps, isActive: false })
+		const cold = render()
+		const warm = render()
+		expect(warm).toEqual(cold)
+		expect(cold.length).toBeGreaterThan(0)
+	})
+
+	it("stays fast across streaming deltas of a large thinking text", () => {
+		const para =
+			"Let me check the `render` function in **tui.js** to see how the diff works.\n\nNow I will verify the fix by running the tests again.\n\n"
+		let full = ""
+		while (full.length < 300 * 1024) full += para
+		const deltas = 20
+		const start = performance.now()
+		for (let i = 1; i <= deltas; i++) {
+			const blocks = makeBlocks(full.slice(0, Math.floor((full.length * i) / deltas)))
+			const steps = deriveThinkingSteps(blocks)
+			renderThinkingStepsLines(theme, 120, { mode: "expanded", blocks, steps, isActive: true })
+		}
+		const perDeltaMs = (performance.now() - start) / deltas
+		// Pre-memo the full text was re-wrapped per delta (~150ms+); loose bound for CI.
+		expect(perDeltaMs).toBeLessThan(100)
+	})
+})
+
 describe("deriveThinkingSteps caching", () => {
 	it("returns the same steps with a warm and a cold cache", () => {
 		const text = Array.from(

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -230,4 +230,15 @@ describe("deriveThinkingSteps caching", () => {
 		}
 		expect(getStepDerivationCacheSizeForTesting()).toBe(0)
 	})
+
+	it("treats the last text step as growing even when a redacted placeholder follows", () => {
+		clearStepDerivationCacheForTesting()
+		for (let index = 1; index <= 20; index += 1) {
+			deriveThinkingSteps([
+				{ contentIndex: 0, text: "growing ".repeat(index), redacted: false },
+				{ contentIndex: 1, text: "", redacted: true },
+			])
+		}
+		expect(getStepDerivationCacheSizeForTesting()).toBe(0)
+	})
 })

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -339,17 +339,24 @@ describe("deriveThinkingSteps caching", () => {
 	it("keeps every step of a large message cached across streaming rescans", () => {
 		clearStepDerivationCacheForTesting()
 		// Rescan pattern of streaming: all completed steps re-derived per chunk.
-		// With an entry-count bound this thrashed (0% hit rate); the char budget
-		// must hold all 1000 unique steps so rescans stay cheap.
+		// With the old 256-entry bound this thrashed (0% hit rate); the char budget
+		// must hold all 1000 unique steps.
 		const paras = Array.from({ length: 1000 }, (_, i) => `Considering unique hypothesis ${i} about module ${i}.`)
 		const blocks = [{ contentIndex: 0, text: paras.join("\n\n"), redacted: false }]
 		deriveThinkingSteps(blocks)
-		const start = performance.now()
 		for (let rescan = 0; rescan < 5; rescan++) deriveThinkingSteps(blocks)
-		const perRescanMs = (performance.now() - start) / 5
 		expect(getStepDerivationCacheSizeForTesting()).toBeGreaterThanOrEqual(999)
-		// Thrashing regressed this to ~25ms; warm rescans are ~1ms. Loose CI bound.
-		expect(perRescanMs).toBeLessThan(15)
+	})
+
+	it("bounds cache entry overhead when derivation keys are small", () => {
+		clearStepDerivationCacheForTesting()
+		const blocks = Array.from({ length: 8194 }, (_, contentIndex) => ({
+			contentIndex,
+			text: `step ${contentIndex}`,
+			redacted: false,
+		}))
+		deriveThinkingSteps(blocks)
+		expect(getStepDerivationCacheSizeForTesting()).toBe(8192)
 	})
 
 	it("treats the last text step as growing even when a redacted placeholder follows", () => {

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+import { clearStepDerivationCacheForTesting, deriveThinkingSteps } from "./parse.js"
+import { LIVE_PREVIEW_TAIL_CHARS, renderThinkingStepsLines, tailRawLines } from "./render.js"
+import type { ThinkingSourceBlock, ThinkingThemeLike } from "./types.js"
+
+const theme: ThinkingThemeLike = {
+	fg: (_color, text) => text,
+	bold: (text) => text,
+}
+
+function makeBlocks(text: string): ThinkingSourceBlock[] {
+	return [{ contentIndex: 0, text, redacted: false }]
+}
+
+function renderCollapsedActive(text: string, nowMs = 1000, width = 80): string[] {
+	const blocks = makeBlocks(text)
+	return renderThinkingStepsLines(theme, width, {
+		mode: "collapsed",
+		blocks,
+		steps: deriveThinkingSteps(blocks),
+		isActive: true,
+		nowMs,
+	})
+}
+
+describe("tailRawLines", () => {
+	it("returns the text unchanged when it has fewer lines than the limit", () => {
+		expect(tailRawLines("a\nb\nc", 5)).toBe("a\nb\nc")
+	})
+
+	it("keeps only the last N raw lines", () => {
+		const text = Array.from({ length: 20 }, (_, i) => `line-${i}`).join("\n")
+		expect(tailRawLines(text, 5)).toBe("line-15\nline-16\nline-17\nline-18\nline-19")
+	})
+
+	it("bounds a single enormous line by the character cap", () => {
+		const text = "x".repeat(LIVE_PREVIEW_TAIL_CHARS * 4)
+		expect(tailRawLines(text, 5)).toHaveLength(LIVE_PREVIEW_TAIL_CHARS)
+	})
+})
+
+describe("collapsed live preview", () => {
+	it("shows the last lines of a large thinking text", () => {
+		const text = Array.from({ length: 2000 }, (_, i) => `Considering option ${i} for the fix.`).join("\n")
+		const lines = renderCollapsedActive(text)
+		const body = lines.join("\n")
+		expect(body).toContain("option 1999")
+		expect(body).toContain("option 1995")
+		expect(body).not.toContain("option 1000 ")
+	})
+
+	it("matches the output of rendering only the visible tail", () => {
+		const longText = Array.from({ length: 2000 }, (_, i) => `Considering option ${i} for the fix.`).join("\n")
+		const [, ...fullBody] = renderCollapsedActive(longText)
+		const [, ...tailBody] = renderCollapsedActive(tailRawLines(longText, 5))
+		expect(fullBody).toEqual(tailBody)
+	})
+
+	it("returns identical body lines across pulse frames while the text is unchanged", () => {
+		const text = Array.from({ length: 100 }, (_, i) => `Step ${i} of the analysis.`).join("\n")
+		const [headerA, ...bodyA] = renderCollapsedActive(text, 1000)
+		const [headerB, ...bodyB] = renderCollapsedActive(text, 1180)
+		expect(bodyA).toEqual(bodyB)
+		expect(headerA).toBeTruthy()
+		expect(headerB).toBeTruthy()
+	})
+
+	it("renders a frame of a 500KB thinking text well within the frame budget", () => {
+		const para =
+			"Let me check the `render` function in **tui.js** to see how the diff works.\n\nNow I will verify the fix by running the tests again.\n\n"
+		let text = ""
+		while (text.length < 500 * 1024) text += para
+		const blocks = makeBlocks(text)
+		const steps = deriveThinkingSteps(blocks)
+		// warm caches, then measure steady-state frames like the spinner produces
+		renderThinkingStepsLines(theme, 120, { mode: "collapsed", blocks, steps, isActive: true, nowMs: 1 })
+		const start = performance.now()
+		for (let frame = 0; frame < 30; frame++) {
+			renderThinkingStepsLines(theme, 120, {
+				mode: "collapsed",
+				blocks,
+				steps,
+				isActive: true,
+				nowMs: 1 + frame * 180,
+			})
+		}
+		const perFrameMs = (performance.now() - start) / 30
+		// Pre-fix this was ~300ms per frame; the bound is loose to avoid CI flake.
+		expect(perFrameMs).toBeLessThan(50)
+	})
+})
+
+describe("deriveThinkingSteps caching", () => {
+	it("returns the same steps with a warm and a cold cache", () => {
+		const text = Array.from(
+			{ length: 50 },
+			(_, i) => `First I will inspect module ${i}.\n\nThen I verify the results of ${i}.`,
+		).join("\n\n")
+		const blocks = makeBlocks(text)
+		clearStepDerivationCacheForTesting()
+		const cold = deriveThinkingSteps(blocks)
+		const warm = deriveThinkingSteps(blocks)
+		expect(warm).toEqual(cold)
+	})
+
+	it("stays fast across streaming deltas of a large thinking text", () => {
+		const para =
+			"Let me check the `render` function in **tui.js** to see how the diff works.\n\nNow I will verify the fix by running the tests again.\n\n"
+		let full = ""
+		while (full.length < 300 * 1024) full += para
+		clearStepDerivationCacheForTesting()
+		const deltas = 20
+		const start = performance.now()
+		for (let i = 1; i <= deltas; i++) {
+			deriveThinkingSteps(makeBlocks(full.slice(0, Math.floor((full.length * i) / deltas))))
+		}
+		const perDeltaMs = (performance.now() - start) / deltas
+		// Pre-fix this was ~550ms per delta; the bound is loose to avoid CI flake.
+		expect(perDeltaMs).toBeLessThan(100)
+	})
+
+	it("bounds derivation cost for a single step with no paragraph breaks", () => {
+		const giant = "analyzing the diff output and comparing results ".repeat(8000)
+		clearStepDerivationCacheForTesting()
+		const start = performance.now()
+		const steps = deriveThinkingSteps(makeBlocks(giant))
+		const elapsedMs = performance.now() - start
+		expect(steps.length).toBeGreaterThan(0)
+		expect(steps[0]?.summary).toBeTruthy()
+		expect(elapsedMs).toBeLessThan(250)
+	})
+})

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -118,7 +118,7 @@ describe("expanded view", () => {
 		expect(cold.length).toBeGreaterThan(0)
 	})
 
-	it("reuses wrapped lines across reconstructed steps for the same message", () => {
+	it("reuses wrapped lines within one message but not across messages", () => {
 		let bodyRenders = 0
 		const countingTheme: ThinkingThemeLike = {
 			fg: (color, text) => {
@@ -127,8 +127,7 @@ describe("expanded view", () => {
 			},
 			bold: (text) => text,
 		}
-		const cacheOwner = {}
-		for (let render = 0; render < 2; render += 1) {
+		const render = (cacheOwner: object) => {
 			const blocks = makeBlocks("cached body")
 			renderThinkingStepsLines(countingTheme, 80, {
 				mode: "expanded",
@@ -138,48 +137,29 @@ describe("expanded view", () => {
 				cacheOwner,
 			})
 		}
+		const cacheOwner = {}
+		render(cacheOwner)
+		render(cacheOwner)
 		expect(bodyRenders).toBe(1)
-	})
-
-	it("does not share wrapped lines between messages", () => {
-		let bodyRenders = 0
-		const countingTheme: ThinkingThemeLike = {
-			fg: (color, text) => {
-				if (color === "thinkingText" && text === "cached body") bodyRenders += 1
-				return text
-			},
-			bold: (text) => text,
-		}
-		for (let message = 0; message < 2; message += 1) {
-			const blocks = makeBlocks("cached body")
-			renderThinkingStepsLines(countingTheme, 80, {
-				mode: "expanded",
-				blocks,
-				steps: deriveThinkingSteps(blocks),
-				isActive: true,
-				cacheOwner: {},
-			})
-		}
+		render({})
 		expect(bodyRenders).toBe(2)
 	})
 
 	it("replaces the cached body when the growing step changes", () => {
 		const firstBlocks = makeBlocks("first body")
 		const secondBlocks = makeBlocks("second body")
-		const firstSteps = deriveThinkingSteps(firstBlocks)
-		const secondSteps = deriveThinkingSteps(secondBlocks)
 		const cacheOwner = {}
 		renderThinkingStepsLines(theme, 80, {
 			mode: "expanded",
 			blocks: firstBlocks,
-			steps: firstSteps,
+			steps: deriveThinkingSteps(firstBlocks),
 			isActive: true,
 			cacheOwner,
 		})
 		const second = renderThinkingStepsLines(theme, 80, {
 			mode: "expanded",
 			blocks: secondBlocks,
-			steps: secondSteps,
+			steps: deriveThinkingSteps(secondBlocks),
 			isActive: true,
 			cacheOwner,
 		})

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest"
-import { clearStepDerivationCacheForTesting, deriveThinkingSteps } from "./parse.js"
-import { LIVE_PREVIEW_TAIL_CHARS, renderThinkingStepsLines, tailRawLines } from "./render.js"
+import {
+	clearStepDerivationCacheForTesting,
+	deriveThinkingSteps,
+	getStepDerivationCacheSizeForTesting,
+} from "./parse.js"
+import {
+	LIVE_PREVIEW_TAIL_CHARS,
+	getExpandedStepLineCacheSizeForTesting,
+	renderThinkingStepsLines,
+	tailRawLines,
+	tailRawLinesFromBlocks,
+} from "./render.js"
 import type { ThinkingSourceBlock, ThinkingThemeLike } from "./types.js"
 
 const theme: ThinkingThemeLike = {
@@ -36,6 +46,15 @@ describe("tailRawLines", () => {
 	it("bounds a single enormous line by the character cap", () => {
 		const text = "x".repeat(LIVE_PREVIEW_TAIL_CHARS * 4)
 		expect(tailRawLines(text, 5)).toHaveLength(LIVE_PREVIEW_TAIL_CHARS)
+	})
+
+	it("builds the visible tail without joining whole thinking blocks", () => {
+		const blocks = [
+			{ contentIndex: 0, text: "old ".repeat(LIVE_PREVIEW_TAIL_CHARS), redacted: false },
+			{ contentIndex: 1, text: "latest visible line", redacted: false },
+		]
+		expect(tailRawLinesFromBlocks(blocks, 5)).toContain("latest visible line")
+		expect(tailRawLinesFromBlocks(makeBlocks("  visible tail  \n"), 5)).toBe("visible tail")
 	})
 })
 
@@ -105,6 +124,47 @@ describe("expanded view", () => {
 		expect(cold.length).toBeGreaterThan(0)
 	})
 
+	it("replaces the cached body when the growing step changes", () => {
+		const firstBlocks = makeBlocks("first body")
+		const secondBlocks = makeBlocks("second body")
+		renderThinkingStepsLines(theme, 80, {
+			mode: "expanded",
+			blocks: firstBlocks,
+			steps: deriveThinkingSteps(firstBlocks),
+			isActive: true,
+		})
+		const cacheSize = getExpandedStepLineCacheSizeForTesting()
+		const second = renderThinkingStepsLines(theme, 80, {
+			mode: "expanded",
+			blocks: secondBlocks,
+			steps: deriveThinkingSteps(secondBlocks),
+			isActive: true,
+		})
+		expect(second.join("\n")).toContain("second body")
+		expect(second.join("\n")).not.toContain("first body")
+		expect(getExpandedStepLineCacheSizeForTesting()).toBe(cacheSize)
+	})
+
+	it("restyles a cached body after the theme changes", () => {
+		let marker = "A"
+		const mutableTheme: ThinkingThemeLike = {
+			fg: (color, text) => `<${marker}:${color}>${text}`,
+			bold: (text) => `<${marker}:bold>${text}`,
+		}
+		const blocks = makeBlocks("cached body")
+		const steps = deriveThinkingSteps(blocks)
+		renderThinkingStepsLines(mutableTheme, 80, { mode: "expanded", blocks, steps, isActive: false })
+		marker = "B"
+		const rerendered = renderThinkingStepsLines(mutableTheme, 80, {
+			mode: "expanded",
+			blocks,
+			steps,
+			isActive: false,
+		})
+		expect(rerendered.join("\n")).toContain("<B:")
+		expect(rerendered.join("\n")).not.toContain("<A:")
+	})
+
 	it("stays fast across streaming deltas of a large thinking text", () => {
 		const para =
 			"Let me check the `render` function in **tui.js** to see how the diff works.\n\nNow I will verify the fix by running the tests again.\n\n"
@@ -161,5 +221,13 @@ describe("deriveThinkingSteps caching", () => {
 		expect(steps.length).toBeGreaterThan(0)
 		expect(steps[0]?.summary).toBeTruthy()
 		expect(elapsedMs).toBeLessThan(250)
+	})
+
+	it("does not retain snapshots of the growing final step", () => {
+		clearStepDerivationCacheForTesting()
+		for (let index = 1; index <= 20; index += 1) {
+			deriveThinkingSteps(makeBlocks("growing ".repeat(index)))
+		}
+		expect(getStepDerivationCacheSizeForTesting()).toBe(0)
 	})
 })

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -4,13 +4,7 @@ import {
 	deriveThinkingSteps,
 	getStepDerivationCacheSizeForTesting,
 } from "./parse.js"
-import {
-	LIVE_PREVIEW_TAIL_CHARS,
-	getExpandedStepLineCacheSizeForTesting,
-	renderThinkingStepsLines,
-	tailRawLines,
-	tailRawLinesFromBlocks,
-} from "./render.js"
+import { LIVE_PREVIEW_TAIL_CHARS, renderThinkingStepsLines, tailRawLines, tailRawLinesFromBlocks } from "./render.js"
 import type { ThinkingSourceBlock, ThinkingThemeLike } from "./types.js"
 
 const theme: ThinkingThemeLike = {
@@ -124,25 +118,73 @@ describe("expanded view", () => {
 		expect(cold.length).toBeGreaterThan(0)
 	})
 
+	it("reuses wrapped lines across reconstructed steps for the same message", () => {
+		let bodyRenders = 0
+		const countingTheme: ThinkingThemeLike = {
+			fg: (color, text) => {
+				if (color === "thinkingText" && text === "cached body") bodyRenders += 1
+				return text
+			},
+			bold: (text) => text,
+		}
+		const cacheOwner = {}
+		for (let render = 0; render < 2; render += 1) {
+			const blocks = makeBlocks("cached body")
+			renderThinkingStepsLines(countingTheme, 80, {
+				mode: "expanded",
+				blocks,
+				steps: deriveThinkingSteps(blocks),
+				isActive: true,
+				cacheOwner,
+			})
+		}
+		expect(bodyRenders).toBe(1)
+	})
+
+	it("does not share wrapped lines between messages", () => {
+		let bodyRenders = 0
+		const countingTheme: ThinkingThemeLike = {
+			fg: (color, text) => {
+				if (color === "thinkingText" && text === "cached body") bodyRenders += 1
+				return text
+			},
+			bold: (text) => text,
+		}
+		for (let message = 0; message < 2; message += 1) {
+			const blocks = makeBlocks("cached body")
+			renderThinkingStepsLines(countingTheme, 80, {
+				mode: "expanded",
+				blocks,
+				steps: deriveThinkingSteps(blocks),
+				isActive: true,
+				cacheOwner: {},
+			})
+		}
+		expect(bodyRenders).toBe(2)
+	})
+
 	it("replaces the cached body when the growing step changes", () => {
 		const firstBlocks = makeBlocks("first body")
 		const secondBlocks = makeBlocks("second body")
+		const firstSteps = deriveThinkingSteps(firstBlocks)
+		const secondSteps = deriveThinkingSteps(secondBlocks)
+		const cacheOwner = {}
 		renderThinkingStepsLines(theme, 80, {
 			mode: "expanded",
 			blocks: firstBlocks,
-			steps: deriveThinkingSteps(firstBlocks),
+			steps: firstSteps,
 			isActive: true,
+			cacheOwner,
 		})
-		const cacheSize = getExpandedStepLineCacheSizeForTesting()
 		const second = renderThinkingStepsLines(theme, 80, {
 			mode: "expanded",
 			blocks: secondBlocks,
-			steps: deriveThinkingSteps(secondBlocks),
+			steps: secondSteps,
 			isActive: true,
+			cacheOwner,
 		})
 		expect(second.join("\n")).toContain("second body")
 		expect(second.join("\n")).not.toContain("first body")
-		expect(getExpandedStepLineCacheSizeForTesting()).toBe(cacheSize)
 	})
 
 	it("restyles a cached body after the theme changes", () => {
@@ -171,11 +213,12 @@ describe("expanded view", () => {
 		let full = ""
 		while (full.length < 300 * 1024) full += para
 		const deltas = 20
+		const cacheOwner = {}
 		const start = performance.now()
 		for (let i = 1; i <= deltas; i++) {
 			const blocks = makeBlocks(full.slice(0, Math.floor((full.length * i) / deltas)))
 			const steps = deriveThinkingSteps(blocks)
-			renderThinkingStepsLines(theme, 120, { mode: "expanded", blocks, steps, isActive: true })
+			renderThinkingStepsLines(theme, 120, { mode: "expanded", blocks, steps, isActive: true, cacheOwner })
 		}
 		const perDeltaMs = (performance.now() - start) / deltas
 		// Pre-memo the full text was re-wrapped per delta (~150ms+); loose bound for CI.

--- a/src/extensions/thinking-steps/render-live-preview.test.ts
+++ b/src/extensions/thinking-steps/render-live-preview.test.ts
@@ -16,7 +16,7 @@ function makeBlocks(text: string): ThinkingSourceBlock[] {
 	return [{ contentIndex: 0, text, redacted: false }]
 }
 
-function renderCollapsedActive(text: string, nowMs = 1000, width = 80): string[] {
+function renderCollapsedActive(text: string, nowMs = 1000, width = 80, cacheOwner?: object): string[] {
 	const blocks = makeBlocks(text)
 	return renderThinkingStepsLines(theme, width, {
 		mode: "collapsed",
@@ -24,6 +24,7 @@ function renderCollapsedActive(text: string, nowMs = 1000, width = 80): string[]
 		steps: deriveThinkingSteps(blocks),
 		isActive: true,
 		nowMs,
+		cacheOwner,
 	})
 }
 
@@ -42,6 +43,23 @@ describe("tailRawLines", () => {
 		expect(tailRawLines(text, 5)).toHaveLength(LIVE_PREVIEW_TAIL_CHARS)
 	})
 
+	it("starts at a grapheme boundary when the character cap splits an emoji", () => {
+		const suffix = "x".repeat(LIVE_PREVIEW_TAIL_CHARS - 1)
+		expect(tailRawLines(`prefix😀${suffix}`, 5)).toBe(suffix)
+	})
+
+	it("sanitizes an ANSI sequence that crosses the character boundary", () => {
+		const suffix = "y".repeat(LIVE_PREVIEW_TAIL_CHARS - 2)
+		const tail = tailRawLines(`${"x".repeat(100)}\u001b[31m${suffix}`, 5)
+		expect(tail).toBe(`xx${suffix}`)
+	})
+
+	it("stays well formed when ANSI stripping shrinks a surrogate-split window", () => {
+		const ansi = "\u001b[31m".repeat(20)
+		const suffix = "x".repeat(LIVE_PREVIEW_TAIL_CHARS - 37)
+		expect(tailRawLines(`prefix😀${ansi}${suffix}`, 5)).toBe(suffix)
+	})
+
 	it("builds the visible tail without joining whole thinking blocks", () => {
 		const blocks = [
 			{ contentIndex: 0, text: "old ".repeat(LIVE_PREVIEW_TAIL_CHARS), redacted: false },
@@ -49,6 +67,16 @@ describe("tailRawLines", () => {
 		]
 		expect(tailRawLinesFromBlocks(blocks, 5)).toContain("latest visible line")
 		expect(tailRawLinesFromBlocks(makeBlocks("  visible tail  \n"), 5)).toBe("visible tail")
+	})
+
+	it("ignores empty redacted blocks when building the visible tail", () => {
+		const emptyBlocks: ThinkingSourceBlock[] = Array.from(
+			{ length: LIVE_PREVIEW_TAIL_CHARS + 1 },
+			(_, contentIndex) => ({ contentIndex: contentIndex + 1, text: " ", redacted: true }),
+		)
+		expect(
+			tailRawLinesFromBlocks([{ contentIndex: 0, text: "visible reasoning", redacted: false }, ...emptyBlocks], 5),
+		).toBe("visible reasoning")
 	})
 })
 
@@ -71,8 +99,9 @@ describe("collapsed live preview", () => {
 
 	it("returns identical body lines across pulse frames while the text is unchanged", () => {
 		const text = Array.from({ length: 100 }, (_, i) => `Step ${i} of the analysis.`).join("\n")
-		const [headerA, ...bodyA] = renderCollapsedActive(text, 1000)
-		const [headerB, ...bodyB] = renderCollapsedActive(text, 1180)
+		const cacheOwner = {}
+		const [headerA, ...bodyA] = renderCollapsedActive(text, 1000, 80, cacheOwner)
+		const [headerB, ...bodyB] = renderCollapsedActive(text, 1180, 80, cacheOwner)
 		expect(bodyA).toEqual(bodyB)
 		expect(headerA).toBeTruthy()
 		expect(headerB).toBeTruthy()
@@ -85,8 +114,16 @@ describe("collapsed live preview", () => {
 		while (text.length < 500 * 1024) text += para
 		const blocks = makeBlocks(text)
 		const steps = deriveThinkingSteps(blocks)
+		const cacheOwner = {}
 		// warm caches, then measure steady-state frames like the spinner produces
-		renderThinkingStepsLines(theme, 120, { mode: "collapsed", blocks, steps, isActive: true, nowMs: 1 })
+		renderThinkingStepsLines(theme, 120, {
+			mode: "collapsed",
+			blocks,
+			steps,
+			isActive: true,
+			nowMs: 1,
+			cacheOwner,
+		})
 		const start = performance.now()
 		for (let frame = 0; frame < 30; frame++) {
 			renderThinkingStepsLines(theme, 120, {
@@ -95,6 +132,7 @@ describe("collapsed live preview", () => {
 				steps,
 				isActive: true,
 				nowMs: 1 + frame * 180,
+				cacheOwner,
 			})
 		}
 		const perFrameMs = (performance.now() - start) / 30
@@ -103,22 +141,8 @@ describe("collapsed live preview", () => {
 	})
 })
 
-describe("expanded view", () => {
-	it("renders identical lines whether the step-line cache is warm or cold", () => {
-		const text = Array.from(
-			{ length: 40 },
-			(_, i) => `First I will inspect module ${i}.\n\nThen I verify the results of ${i}.`,
-		).join("\n\n")
-		const blocks = makeBlocks(text)
-		const steps = deriveThinkingSteps(blocks)
-		const render = () => renderThinkingStepsLines(theme, 80, { mode: "expanded", blocks, steps, isActive: false })
-		const cold = render()
-		const warm = render()
-		expect(warm).toEqual(cold)
-		expect(cold.length).toBeGreaterThan(0)
-	})
-
-	it("reuses wrapped lines within one message but not across messages", () => {
+describe("body render caching", () => {
+	it.each(["collapsed", "expanded"] as const)("reuses %s lines within one message but not across messages", (mode) => {
 		let bodyRenders = 0
 		const countingTheme: ThinkingThemeLike = {
 			fg: (color, text) => {
@@ -130,7 +154,7 @@ describe("expanded view", () => {
 		const render = (cacheOwner: object) => {
 			const blocks = makeBlocks("cached body")
 			renderThinkingStepsLines(countingTheme, 80, {
-				mode: "expanded",
+				mode,
 				blocks,
 				steps: deriveThinkingSteps(blocks),
 				isActive: true,
@@ -143,6 +167,24 @@ describe("expanded view", () => {
 		expect(bodyRenders).toBe(1)
 		render({})
 		expect(bodyRenders).toBe(2)
+	})
+})
+
+describe("expanded view", () => {
+	it("renders identical lines whether the step-line cache is warm or cold", () => {
+		const text = Array.from(
+			{ length: 40 },
+			(_, i) => `First I will inspect module ${i}.\n\nThen I verify the results of ${i}.`,
+		).join("\n\n")
+		const blocks = makeBlocks(text)
+		const steps = deriveThinkingSteps(blocks)
+		const cacheOwner = {}
+		const render = () =>
+			renderThinkingStepsLines(theme, 80, { mode: "expanded", blocks, steps, isActive: false, cacheOwner })
+		const cold = render()
+		const warm = render()
+		expect(warm).toEqual(cold)
+		expect(cold.length).toBeGreaterThan(0)
 	})
 
 	it("replaces the cached body when the growing step changes", () => {
@@ -175,13 +217,21 @@ describe("expanded view", () => {
 		}
 		const blocks = makeBlocks("cached body")
 		const steps = deriveThinkingSteps(blocks)
-		renderThinkingStepsLines(mutableTheme, 80, { mode: "expanded", blocks, steps, isActive: false })
+		const cacheOwner = {}
+		renderThinkingStepsLines(mutableTheme, 80, {
+			mode: "expanded",
+			blocks,
+			steps,
+			isActive: false,
+			cacheOwner,
+		})
 		marker = "B"
 		const rerendered = renderThinkingStepsLines(mutableTheme, 80, {
 			mode: "expanded",
 			blocks,
 			steps,
 			isActive: false,
+			cacheOwner,
 		})
 		expect(rerendered.join("\n")).toContain("<B:")
 		expect(rerendered.join("\n")).not.toContain("<A:")
@@ -207,6 +257,23 @@ describe("expanded view", () => {
 })
 
 describe("deriveThinkingSteps caching", () => {
+	it("keeps an early failure cue when a long step is summarized", () => {
+		const text = `The build failed because the compiler returned an error. ${"Reviewing verification details. ".repeat(
+			1000,
+		)}Now checking the latest output.`
+		const [step] = deriveThinkingSteps(makeBlocks(text))
+		expect(step?.hasExplicitFailure).toBe(true)
+		expect(step?.summaryEvents?.some((event) => event.type === "failure")).toBe(true)
+	})
+
+	it("does not split a surrogate pair at the long-step summary boundary", () => {
+		const failure = "The build failed because boom. "
+		const afterBoundary = failure + "z".repeat(8190 - failure.length)
+		const text = `${"x".repeat(8200)}😀${afterBoundary}`
+		const [step] = deriveThinkingSteps(makeBlocks(text))
+		expect(step?.summary).toBe("The build failed because boom.")
+	})
+
 	it("returns the same steps with a warm and a cold cache", () => {
 		const text = Array.from(
 			{ length: 50 },
@@ -252,6 +319,37 @@ describe("deriveThinkingSteps caching", () => {
 			deriveThinkingSteps(makeBlocks("growing ".repeat(index)))
 		}
 		expect(getStepDerivationCacheSizeForTesting()).toBe(0)
+	})
+
+	it("evicts oldest derivations once the cache character budget is exhausted", () => {
+		clearStepDerivationCacheForTesting()
+		// Each step's summary source is 16KB (the per-step cap), so a 4MB budget
+		// holds 256 of them; deriving 300 must evict rather than grow unbounded.
+		const stepChars = 16 * 1024
+		const blocks = Array.from({ length: 300 }, (_, contentIndex) => ({
+			contentIndex,
+			text: `unique module ${contentIndex} `.padEnd(stepChars, "x"),
+			redacted: false,
+		}))
+		deriveThinkingSteps(blocks)
+		expect(getStepDerivationCacheSizeForTesting()).toBeLessThanOrEqual(256)
+		expect(getStepDerivationCacheSizeForTesting()).toBeGreaterThan(200)
+	})
+
+	it("keeps every step of a large message cached across streaming rescans", () => {
+		clearStepDerivationCacheForTesting()
+		// Rescan pattern of streaming: all completed steps re-derived per chunk.
+		// With an entry-count bound this thrashed (0% hit rate); the char budget
+		// must hold all 1000 unique steps so rescans stay cheap.
+		const paras = Array.from({ length: 1000 }, (_, i) => `Considering unique hypothesis ${i} about module ${i}.`)
+		const blocks = [{ contentIndex: 0, text: paras.join("\n\n"), redacted: false }]
+		deriveThinkingSteps(blocks)
+		const start = performance.now()
+		for (let rescan = 0; rescan < 5; rescan++) deriveThinkingSteps(blocks)
+		const perRescanMs = (performance.now() - start) / 5
+		expect(getStepDerivationCacheSizeForTesting()).toBeGreaterThanOrEqual(999)
+		// Thrashing regressed this to ~25ms; warm rescans are ~1ms. Loose CI bound.
+		expect(perRescanMs).toBeLessThan(15)
 	})
 
 	it("treats the last text step as growing even when a redacted placeholder follows", () => {

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -216,41 +216,27 @@ function stripInlineFormattingMarkers(text: string): string {
 
 const COLLAPSED_LIVE_LINES = 5
 
-// Live previews only show the last few lines, so never sanitize/wrap the full
-// accumulated thinking text — on large messages that costs hundreds of ms per
-// frame and freezes the terminal while the render loop is starved. A raw line
-// yields at least one rendered line, so the last N raw lines are sufficient.
-// The character bound guards against a single enormous line.
+// Processing the full accumulated reasoning on every preview frame stalls the
+// terminal, so keep only the small tail that can be visible.
 export const LIVE_PREVIEW_TAIL_CHARS = 8192
 
 export function tailRawLines(text: string, maxLines: number): string {
-	const tail = text.length > LIVE_PREVIEW_TAIL_CHARS ? text.slice(-LIVE_PREVIEW_TAIL_CHARS) : text
-	const lines = tail.split("\n")
-	if (lines.length <= maxLines) return tail
-	return lines.slice(-maxLines).join("\n")
+	return text.slice(-LIVE_PREVIEW_TAIL_CHARS).split("\n").slice(-maxLines).join("\n")
 }
 
 export function tailRawLinesFromBlocks(blocks: ThinkingSourceBlock[], maxLines: number): string {
-	// tailRawLines re-applies the character cap; the budget here only bounds
-	// how much text is assembled from the blocks. Both are intentional.
 	let tail = ""
-	for (let index = blocks.length - 1; index >= 0 && tail.length < LIVE_PREVIEW_TAIL_CHARS; index -= 1) {
-		const suffix = `${index < blocks.length - 1 ? "\n" : ""}${tail}`
-		const remaining = LIVE_PREVIEW_TAIL_CHARS - suffix.length
-		if (remaining <= 0) {
-			tail = suffix.slice(-LIVE_PREVIEW_TAIL_CHARS)
-			break
-		}
-		tail = `${blocks[index]!.text.slice(-remaining)}${suffix}`
+	for (let index = blocks.length - 1; index >= 0; index -= 1) {
+		const separator = index < blocks.length - 1 ? "\n" : ""
+		const remaining = LIVE_PREVIEW_TAIL_CHARS - tail.length - separator.length
+		if (remaining <= 0) break
+		tail = `${blocks[index]!.text.slice(-remaining)}${separator}${tail}`
 	}
 	return tailRawLines(tail.trim(), maxLines)
 }
 
-function renderedBodyStyleKey(theme: ThinkingThemeLike): string {
-	return [theme.fg("thinkingText", "x"), theme.fg("accent", "x"), theme.fg("muted", "x"), theme.bold("x")].join(
-		"\u0000",
-	)
-}
+const renderedBodyStyleKey = (theme: ThinkingThemeLike): string =>
+	[theme.fg("thinkingText", "x"), theme.fg("accent", "x"), theme.fg("muted", "x"), theme.bold("x")].join("\u0000")
 
 // The active collapsed view bypasses the component cache every frame so the
 // pulse glyph can animate, but only the header changes between frames. Cache
@@ -447,10 +433,8 @@ function renderWrappedRawText(theme: ThinkingThemeLike, text: string, width: num
 	return rendered
 }
 
-// The assistant-message component survives stream updates while its child
-// ThinkingStepsComponent is recreated. Use that persistent component as the
-// weak owner so completed bodies stay cached across deltas, then disappear
-// with the message/session.
+// The assistant-message component survives stream deltas and is collected with
+// the message/session, so use it as the weak cache owner.
 type ExpandedStepLineCacheEntry = { body: string; styleKey: string; lines: string[] }
 const expandedStepLineCaches = new WeakMap<object, Map<string, ExpandedStepLineCacheEntry>>()
 
@@ -476,7 +460,6 @@ function renderExpanded(
 	width: number,
 	steps: DerivedThinkingStep[],
 	cacheOwner: object,
-	_activeStepId?: string,
 ): string[] {
 	let cache = expandedStepLineCaches.get(cacheOwner)
 	if (!cache) {
@@ -513,7 +496,7 @@ export function renderThinkingStepsLines(theme: ThinkingThemeLike, width: number
 		)
 	}
 	if (options.mode === "expanded") {
-		return renderExpanded(theme, width, options.steps, options.cacheOwner ?? options.steps, options.activeStepId)
+		return renderExpanded(theme, width, options.steps, options.cacheOwner ?? options.steps)
 	}
 	return renderSummary(theme, width, options.steps, options.activeStepId)
 }

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -11,6 +11,7 @@ interface RenderOptions {
 	activeStepId?: string
 	isActive: boolean
 	nowMs?: number
+	cacheOwner?: object
 }
 
 function roleColor(role: ThinkingSemanticRole): string {
@@ -446,18 +447,12 @@ function renderWrappedRawText(theme: ThinkingThemeLike, text: string, width: num
 	return rendered
 }
 
-// The expanded view is rebuilt on every stream chunk. Cache one body per
-// (width, step id), replacing the growing step instead of retaining every
-// intermediate snapshot. Step ids restart per message, so entries can collide
-// across messages during a full chat rebuild — safe only because the body is
-// compared before reuse (do not remove that check).
+// The assistant-message component survives stream updates while its child
+// ThinkingStepsComponent is recreated. Use that persistent component as the
+// weak owner so completed bodies stay cached across deltas, then disappear
+// with the message/session.
 type ExpandedStepLineCacheEntry = { body: string; styleKey: string; lines: string[] }
-const expandedStepLineCache = new Map<string, ExpandedStepLineCacheEntry>()
-const EXPANDED_STEP_CACHE_MAX = 8192
-
-export function getExpandedStepLineCacheSizeForTesting(): number {
-	return expandedStepLineCache.size
-}
+const expandedStepLineCaches = new WeakMap<object, Map<string, ExpandedStepLineCacheEntry>>()
 
 function wrappedStepBodyLines(
 	theme: ThinkingThemeLike,
@@ -466,15 +461,13 @@ function wrappedStepBodyLines(
 	width: number,
 	prefix: string,
 	styleKey: string,
+	cache: Map<string, ExpandedStepLineCacheEntry>,
 ): string[] {
 	const key = `${width}:${step.id}`
-	const cached = expandedStepLineCache.get(key)
+	const cached = cache.get(key)
 	if (cached && cached.body === body && cached.styleKey === styleKey) return cached.lines
 	const lines = renderWrappedRawText(theme, body, width, prefix)
-	if (!cached && expandedStepLineCache.size >= EXPANDED_STEP_CACHE_MAX) {
-		expandedStepLineCache.clear()
-	}
-	expandedStepLineCache.set(key, { body, styleKey, lines })
+	cache.set(key, { body, styleKey, lines })
 	return lines
 }
 
@@ -482,8 +475,14 @@ function renderExpanded(
 	theme: ThinkingThemeLike,
 	width: number,
 	steps: DerivedThinkingStep[],
+	cacheOwner: object,
 	_activeStepId?: string,
 ): string[] {
+	let cache = expandedStepLineCaches.get(cacheOwner)
+	if (!cache) {
+		cache = new Map()
+		expandedStepLineCaches.set(cacheOwner, cache)
+	}
 	const prefix = `${theme.fg("muted", "▍")} `
 	const styleKey = renderedBodyStyleKey(theme)
 	const lines: string[] = []
@@ -494,7 +493,7 @@ function renderExpanded(
 		if (!normalizedBody) continue
 
 		if (index > 0) lines.push(theme.fg("muted", "▍"))
-		lines.push(...wrappedStepBodyLines(theme, step, normalizedBody, width, prefix, styleKey))
+		lines.push(...wrappedStepBodyLines(theme, step, normalizedBody, width, prefix, styleKey, cache))
 	}
 
 	return lines
@@ -514,7 +513,7 @@ export function renderThinkingStepsLines(theme: ThinkingThemeLike, width: number
 		)
 	}
 	if (options.mode === "expanded") {
-		return renderExpanded(theme, width, options.steps, options.activeStepId)
+		return renderExpanded(theme, width, options.steps, options.cacheOwner ?? options.steps, options.activeStepId)
 	}
 	return renderSummary(theme, width, options.steps, options.activeStepId)
 }
@@ -525,15 +524,18 @@ export class ThinkingStepsComponent implements Component {
 	private cacheKey?: string
 	private cachedLines?: string[]
 	private readonly scopeKey: string
+	private readonly cacheOwner: object
 
 	constructor(
 		private readonly theme: ThinkingThemeLike,
 		private readonly messageTimestamp: number,
 		blocks: ThinkingSourceBlock[],
 		scopeKey?: string,
+		cacheOwner?: object,
 	) {
 		this.blocks = blocks
 		this.scopeKey = scopeKey ?? getCurrentThinkingScopeKey()
+		this.cacheOwner = cacheOwner ?? this
 		this.steps = deriveThinkingSteps(blocks)
 	}
 
@@ -558,6 +560,7 @@ export class ThinkingStepsComponent implements Component {
 			activeStepId,
 			isActive: active.active,
 			nowMs: Date.now(),
+			cacheOwner: this.cacheOwner,
 		}).map((line) => ` ${line}`)
 
 		if (!shouldBypassCache) {

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -215,6 +215,38 @@ function stripInlineFormattingMarkers(text: string): string {
 
 const COLLAPSED_LIVE_LINES = 5
 
+// Live previews only show the last few lines, so never sanitize/wrap the full
+// accumulated thinking text — on large messages that costs hundreds of ms per
+// frame and freezes the terminal while the render loop is starved. A raw line
+// yields at least one rendered line, so the last N raw lines are sufficient.
+// The character bound guards against a single enormous line.
+export const LIVE_PREVIEW_TAIL_CHARS = 8192
+
+export function tailRawLines(text: string, maxLines: number): string {
+	const tail = text.length > LIVE_PREVIEW_TAIL_CHARS ? text.slice(-LIVE_PREVIEW_TAIL_CHARS) : text
+	const lines = tail.split("\n")
+	if (lines.length <= maxLines) return tail
+	return lines.slice(-maxLines).join("\n")
+}
+
+// The active collapsed view bypasses the component cache every frame so the
+// pulse glyph can animate, but only the header changes between frames. Cache
+// the wrapped body across frames (and across the component instances that
+// updateContent recreates per delta) so idle frames cost nothing.
+let collapsedLiveBodyCache: { width: number; textLength: number; textTail: string; lines: string[] } | undefined
+
+function collapsedLiveBodyLines(theme: ThinkingThemeLike, width: number, fullText: string): string[] {
+	const textTail = tailRawLines(fullText, COLLAPSED_LIVE_LINES)
+	const cache = collapsedLiveBodyCache
+	if (cache && cache.width === width && cache.textLength === fullText.length && cache.textTail === textTail) {
+		return cache.lines
+	}
+	const bodyPrefix = `${theme.fg("muted", "▍")} `
+	const lines = renderWrappedRawText(theme, textTail, width, bodyPrefix).slice(-COLLAPSED_LIVE_LINES)
+	collapsedLiveBodyCache = { width, textLength: fullText.length, textTail, lines }
+	return lines
+}
+
 function renderCollapsed(
 	theme: ThinkingThemeLike,
 	width: number,
@@ -239,10 +271,7 @@ function renderCollapsed(
 		if (fullText) {
 			const headerPrefix = `${theme.fg("muted", "▍")} `
 			const header = truncateToWidth(`${headerPrefix}${theme.fg("dim", label)} ${icon} ${activity}`, width, "")
-			const bodyPrefix = `${theme.fg("muted", "▍")} `
-			const allBodyLines = renderWrappedRawText(theme, fullText, width, bodyPrefix)
-			const bodyLines = allBodyLines.slice(-COLLAPSED_LIVE_LINES)
-			return [header, ...bodyLines]
+			return [header, ...collapsedLiveBodyLines(theme, width, fullText)]
 		}
 	}
 

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -229,21 +229,41 @@ export function tailRawLines(text: string, maxLines: number): string {
 	return lines.slice(-maxLines).join("\n")
 }
 
+export function tailRawLinesFromBlocks(blocks: ThinkingSourceBlock[], maxLines: number): string {
+	let tail = ""
+	for (let index = blocks.length - 1; index >= 0 && tail.length < LIVE_PREVIEW_TAIL_CHARS; index -= 1) {
+		const suffix = `${index < blocks.length - 1 ? "\n" : ""}${tail}`
+		const remaining = LIVE_PREVIEW_TAIL_CHARS - suffix.length
+		if (remaining <= 0) {
+			tail = suffix.slice(-LIVE_PREVIEW_TAIL_CHARS)
+			break
+		}
+		tail = `${blocks[index]!.text.slice(-remaining)}${suffix}`
+	}
+	return tailRawLines(tail.trim(), maxLines)
+}
+
+function renderedBodyStyleKey(theme: ThinkingThemeLike): string {
+	return [theme.fg("thinkingText", "x"), theme.fg("accent", "x"), theme.fg("muted", "x"), theme.bold("x")].join(
+		"\u0000",
+	)
+}
+
 // The active collapsed view bypasses the component cache every frame so the
 // pulse glyph can animate, but only the header changes between frames. Cache
 // the wrapped body across frames (and across the component instances that
 // updateContent recreates per delta) so idle frames cost nothing.
-let collapsedLiveBodyCache: { width: number; textLength: number; textTail: string; lines: string[] } | undefined
+let collapsedLiveBodyCache: { width: number; textTail: string; styleKey: string; lines: string[] } | undefined
 
-function collapsedLiveBodyLines(theme: ThinkingThemeLike, width: number, fullText: string): string[] {
-	const textTail = tailRawLines(fullText, COLLAPSED_LIVE_LINES)
+function collapsedLiveBodyLines(theme: ThinkingThemeLike, width: number, textTail: string): string[] {
+	const styleKey = renderedBodyStyleKey(theme)
 	const cache = collapsedLiveBodyCache
-	if (cache && cache.width === width && cache.textLength === fullText.length && cache.textTail === textTail) {
+	if (cache && cache.width === width && cache.textTail === textTail && cache.styleKey === styleKey) {
 		return cache.lines
 	}
 	const bodyPrefix = `${theme.fg("muted", "▍")} `
 	const lines = renderWrappedRawText(theme, textTail, width, bodyPrefix).slice(-COLLAPSED_LIVE_LINES)
-	collapsedLiveBodyCache = { width, textLength: fullText.length, textTail, lines }
+	collapsedLiveBodyCache = { width, textTail, styleKey, lines }
 	return lines
 }
 
@@ -264,14 +284,11 @@ function renderCollapsed(
 	const activity = isActive ? pulseGlyph(theme, nowMs) : theme.fg("dim", "·")
 
 	if (isActive) {
-		const fullText = blocks
-			.map((b) => b.text)
-			.join("\n")
-			.trim()
-		if (fullText) {
+		const textTail = tailRawLinesFromBlocks(blocks, COLLAPSED_LIVE_LINES)
+		if (textTail) {
 			const headerPrefix = `${theme.fg("muted", "▍")} `
 			const header = truncateToWidth(`${headerPrefix}${theme.fg("dim", label)} ${icon} ${activity}`, width, "")
-			return [header, ...collapsedLiveBodyLines(theme, width, fullText)]
+			return [header, ...collapsedLiveBodyLines(theme, width, textTail)]
 		}
 	}
 
@@ -427,23 +444,33 @@ function renderWrappedRawText(theme: ThinkingThemeLike, text: string, width: num
 	return rendered
 }
 
-// The expanded view is rebuilt from scratch on every stream chunk (the
-// component is recreated per message_update), but step bodies are immutable
-// once written — only the last step grows. Memoize wrapped lines per
-// (width, body) so each chunk re-wraps only the growing step instead of the
-// whole accumulated text.
-const expandedStepLineCache = new Map<string, string[]>()
+// The expanded view is rebuilt on every stream chunk. Cache one body per
+// (width, step id), replacing the growing step instead of retaining every
+// intermediate snapshot.
+type ExpandedStepLineCacheEntry = { body: string; styleKey: string; lines: string[] }
+const expandedStepLineCache = new Map<string, ExpandedStepLineCacheEntry>()
 const EXPANDED_STEP_CACHE_MAX = 8192
 
-function wrappedStepBodyLines(theme: ThinkingThemeLike, body: string, width: number, prefix: string): string[] {
-	const key = `${width}:${body}`
+export function getExpandedStepLineCacheSizeForTesting(): number {
+	return expandedStepLineCache.size
+}
+
+function wrappedStepBodyLines(
+	theme: ThinkingThemeLike,
+	step: DerivedThinkingStep,
+	body: string,
+	width: number,
+	prefix: string,
+	styleKey: string,
+): string[] {
+	const key = `${width}:${step.id}`
 	const cached = expandedStepLineCache.get(key)
-	if (cached) return cached
+	if (cached && cached.body === body && cached.styleKey === styleKey) return cached.lines
 	const lines = renderWrappedRawText(theme, body, width, prefix)
-	if (expandedStepLineCache.size >= EXPANDED_STEP_CACHE_MAX) {
+	if (!cached && expandedStepLineCache.size >= EXPANDED_STEP_CACHE_MAX) {
 		expandedStepLineCache.clear()
 	}
-	expandedStepLineCache.set(key, lines)
+	expandedStepLineCache.set(key, { body, styleKey, lines })
 	return lines
 }
 
@@ -454,6 +481,7 @@ function renderExpanded(
 	_activeStepId?: string,
 ): string[] {
 	const prefix = `${theme.fg("muted", "▍")} `
+	const styleKey = renderedBodyStyleKey(theme)
 	const lines: string[] = []
 
 	for (let index = 0; index < steps.length; index++) {
@@ -462,7 +490,7 @@ function renderExpanded(
 		if (!normalizedBody) continue
 
 		if (index > 0) lines.push(theme.fg("muted", "▍"))
-		lines.push(...wrappedStepBodyLines(theme, normalizedBody, width, prefix))
+		lines.push(...wrappedStepBodyLines(theme, step, normalizedBody, width, prefix, styleKey))
 	}
 
 	return lines
@@ -501,8 +529,8 @@ export class ThinkingStepsComponent implements Component {
 		scopeKey?: string,
 	) {
 		this.blocks = blocks
-		this.steps = deriveThinkingSteps(blocks)
 		this.scopeKey = scopeKey ?? getCurrentThinkingScopeKey()
+		this.steps = deriveThinkingSteps(blocks)
 	}
 
 	render(width: number): string[] {

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -230,6 +230,8 @@ export function tailRawLines(text: string, maxLines: number): string {
 }
 
 export function tailRawLinesFromBlocks(blocks: ThinkingSourceBlock[], maxLines: number): string {
+	// tailRawLines re-applies the character cap; the budget here only bounds
+	// how much text is assembled from the blocks. Both are intentional.
 	let tail = ""
 	for (let index = blocks.length - 1; index >= 0 && tail.length < LIVE_PREVIEW_TAIL_CHARS; index -= 1) {
 		const suffix = `${index < blocks.length - 1 ? "\n" : ""}${tail}`
@@ -446,7 +448,9 @@ function renderWrappedRawText(theme: ThinkingThemeLike, text: string, width: num
 
 // The expanded view is rebuilt on every stream chunk. Cache one body per
 // (width, step id), replacing the growing step instead of retaining every
-// intermediate snapshot.
+// intermediate snapshot. Step ids restart per message, so entries can collide
+// across messages during a full chat rebuild — safe only because the body is
+// compared before reuse (do not remove that check).
 type ExpandedStepLineCacheEntry = { body: string; styleKey: string; lines: string[] }
 const expandedStepLineCache = new Map<string, ExpandedStepLineCacheEntry>()
 const EXPANDED_STEP_CACHE_MAX = 8192

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -427,6 +427,26 @@ function renderWrappedRawText(theme: ThinkingThemeLike, text: string, width: num
 	return rendered
 }
 
+// The expanded view is rebuilt from scratch on every stream chunk (the
+// component is recreated per message_update), but step bodies are immutable
+// once written — only the last step grows. Memoize wrapped lines per
+// (width, body) so each chunk re-wraps only the growing step instead of the
+// whole accumulated text.
+const expandedStepLineCache = new Map<string, string[]>()
+const EXPANDED_STEP_CACHE_MAX = 8192
+
+function wrappedStepBodyLines(theme: ThinkingThemeLike, body: string, width: number, prefix: string): string[] {
+	const key = `${width}:${body}`
+	const cached = expandedStepLineCache.get(key)
+	if (cached) return cached
+	const lines = renderWrappedRawText(theme, body, width, prefix)
+	if (expandedStepLineCache.size >= EXPANDED_STEP_CACHE_MAX) {
+		expandedStepLineCache.clear()
+	}
+	expandedStepLineCache.set(key, lines)
+	return lines
+}
+
 function renderExpanded(
 	theme: ThinkingThemeLike,
 	width: number,
@@ -442,7 +462,7 @@ function renderExpanded(
 		if (!normalizedBody) continue
 
 		if (index > 0) lines.push(theme.fg("muted", "▍"))
-		lines.push(...renderWrappedRawText(theme, normalizedBody, width, prefix))
+		lines.push(...wrappedStepBodyLines(theme, normalizedBody, width, prefix))
 	}
 
 	return lines

--- a/src/extensions/thinking-steps/render.ts
+++ b/src/extensions/thinking-steps/render.ts
@@ -206,31 +206,40 @@ function wrapCollapsedSummaryText(
 	return lines
 }
 
-function stripInlineFormattingMarkers(text: string): string {
-	return text
-		.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "$2")
-		.replace(/`([^`]+)`/g, "$1")
-		.replace(/(?<![\w/.-])\*(?!\*)(?=\S)([\s\S]*?\S)(?<!\*)\*(?![\w/.-])/g, "$1")
-		.replace(/(?<![\w/.-])_(?!_)(?=\S)([\s\S]*?\S)(?<!_)_(?![\w/.-])/g, "$1")
-}
-
 const COLLAPSED_LIVE_LINES = 5
 
 // Processing the full accumulated reasoning on every preview frame stalls the
 // terminal, so keep only the small tail that can be visible.
 export const LIVE_PREVIEW_TAIL_CHARS = 8192
+const TAIL_BOUNDARY_CONTEXT_CHARS = 64
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+function boundedThinkingTail(text: string, maxChars: number): string {
+	// Sanitize a small overlap at the cut, then advance to a complete grapheme.
+	const candidate = sanitizeThinkingText(text.slice(-(maxChars + TAIL_BOUNDARY_CONTEXT_CHARS)))
+	const wasClipped = text.length > maxChars + TAIL_BOUNDARY_CONTEXT_CHARS
+	const sliceStart = Math.max(candidate.length - maxChars, wasClipped ? 1 : 0)
+	if (sliceStart === 0) return candidate
+	for (const { index } of graphemeSegmenter.segment(candidate)) {
+		if (index >= sliceStart) return candidate.slice(index)
+	}
+	return ""
+}
 
 export function tailRawLines(text: string, maxLines: number): string {
-	return text.slice(-LIVE_PREVIEW_TAIL_CHARS).split("\n").slice(-maxLines).join("\n")
+	return boundedThinkingTail(text, LIVE_PREVIEW_TAIL_CHARS).split("\n").slice(-maxLines).join("\n")
 }
 
 export function tailRawLinesFromBlocks(blocks: ThinkingSourceBlock[], maxLines: number): string {
 	let tail = ""
 	for (let index = blocks.length - 1; index >= 0; index -= 1) {
-		const separator = index < blocks.length - 1 ? "\n" : ""
+		const block = blocks[index]!
+		const text = block.text
+		if (!text || (block.redacted && !text.trim())) continue
+		const separator = tail ? "\n" : ""
 		const remaining = LIVE_PREVIEW_TAIL_CHARS - tail.length - separator.length
 		if (remaining <= 0) break
-		tail = `${blocks[index]!.text.slice(-remaining)}${separator}${tail}`
+		tail = `${boundedThinkingTail(text, remaining)}${separator}${tail}`
 	}
 	return tailRawLines(tail.trim(), maxLines)
 }
@@ -238,21 +247,25 @@ export function tailRawLinesFromBlocks(blocks: ThinkingSourceBlock[], maxLines: 
 const renderedBodyStyleKey = (theme: ThinkingThemeLike): string =>
 	[theme.fg("thinkingText", "x"), theme.fg("accent", "x"), theme.fg("muted", "x"), theme.bold("x")].join("\u0000")
 
-// The active collapsed view bypasses the component cache every frame so the
-// pulse glyph can animate, but only the header changes between frames. Cache
-// the wrapped body across frames (and across the component instances that
-// updateContent recreates per delta) so idle frames cost nothing.
-let collapsedLiveBodyCache: { width: number; textTail: string; styleKey: string; lines: string[] } | undefined
+type CollapsedLiveBodyCacheEntry = { width: number; textTail: string; styleKey: string; lines: string[] }
+// The assistant-message component owns this entry; weak ownership releases it
+// when the message/session is collected.
+const collapsedLiveBodyCaches = new WeakMap<object, CollapsedLiveBodyCacheEntry>()
 
-function collapsedLiveBodyLines(theme: ThinkingThemeLike, width: number, textTail: string): string[] {
+function collapsedLiveBodyLines(
+	theme: ThinkingThemeLike,
+	width: number,
+	textTail: string,
+	cacheOwner?: object,
+): string[] {
 	const styleKey = renderedBodyStyleKey(theme)
-	const cache = collapsedLiveBodyCache
+	const cache = cacheOwner ? collapsedLiveBodyCaches.get(cacheOwner) : undefined
 	if (cache && cache.width === width && cache.textTail === textTail && cache.styleKey === styleKey) {
 		return cache.lines
 	}
 	const bodyPrefix = `${theme.fg("muted", "▍")} `
 	const lines = renderWrappedRawText(theme, textTail, width, bodyPrefix).slice(-COLLAPSED_LIVE_LINES)
-	collapsedLiveBodyCache = { width, textTail, styleKey, lines }
+	if (cacheOwner) collapsedLiveBodyCaches.set(cacheOwner, { width, textTail, styleKey, lines })
 	return lines
 }
 
@@ -264,6 +277,7 @@ function renderCollapsed(
 	activeStepId?: string,
 	isActive = false,
 	nowMs = Date.now(),
+	cacheOwner?: object,
 ): string[] {
 	const step = pickCollapsedStep(steps, activeStepId)
 	if (!step) return []
@@ -277,7 +291,7 @@ function renderCollapsed(
 		if (textTail) {
 			const headerPrefix = `${theme.fg("muted", "▍")} `
 			const header = truncateToWidth(`${headerPrefix}${theme.fg("dim", label)} ${icon} ${activity}`, width, "")
-			return [header, ...collapsedLiveBodyLines(theme, width, textTail)]
+			return [header, ...collapsedLiveBodyLines(theme, width, textTail, cacheOwner)]
 		}
 	}
 
@@ -459,12 +473,12 @@ function renderExpanded(
 	theme: ThinkingThemeLike,
 	width: number,
 	steps: DerivedThinkingStep[],
-	cacheOwner: object,
+	cacheOwner?: object,
 ): string[] {
-	let cache = expandedStepLineCaches.get(cacheOwner)
+	let cache = cacheOwner ? expandedStepLineCaches.get(cacheOwner) : undefined
 	if (!cache) {
 		cache = new Map()
-		expandedStepLineCaches.set(cacheOwner, cache)
+		if (cacheOwner) expandedStepLineCaches.set(cacheOwner, cache)
 	}
 	const prefix = `${theme.fg("muted", "▍")} `
 	const styleKey = renderedBodyStyleKey(theme)
@@ -493,10 +507,11 @@ export function renderThinkingStepsLines(theme: ThinkingThemeLike, width: number
 			options.activeStepId,
 			options.isActive,
 			options.nowMs,
+			options.cacheOwner,
 		)
 	}
 	if (options.mode === "expanded") {
-		return renderExpanded(theme, width, options.steps, options.cacheOwner ?? options.steps)
+		return renderExpanded(theme, width, options.steps, options.cacheOwner)
 	}
 	return renderSummary(theme, width, options.steps, options.activeStepId)
 }

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -48,6 +48,12 @@ export interface FakeResponseScript {
 	/** Fallback delay applied to both `thinking` and `stream` chunks. */
 	delayMs?: number
 	toolCalls?: FakeToolCall[]
+	/**
+	 * After emitting all `thinking` chunks, keep the SSE response open without
+	 * writing anything further until the client disconnects. Simulates a
+	 * provider stream stalling mid-reasoning (thinking stays active client-side).
+	 */
+	stallAfterThinking?: boolean
 	closeSocketAfterChunks?: number
 	status?: number
 	body?: unknown
@@ -250,6 +256,11 @@ async function writeChatCompletion(res: ServerResponse, script: FakeResponseScri
 			res.destroy()
 			return
 		}
+	}
+
+	if (script.stallAfterThinking) {
+		await new Promise<void>((resolve) => res.once("close", resolve))
+		return
 	}
 
 	for (const text of script.stream ?? []) {

--- a/tests/e2e/tui/thinking-stall-responsiveness.test.ts
+++ b/tests/e2e/tui/thinking-stall-responsiveness.test.ts
@@ -28,6 +28,8 @@ const thinkingChunks = Array.from({ length: THINKING_CHUNK_COUNT }, (_, index) =
 	const line = `Considering hypothesis ${index} about \`renderCollapsed\` and comparing **line diff** output against \`previousLines\`.\n`
 	return `${line.repeat(9)}\nNow verifying case ${index} before moving on.\n\n`
 })
+const STALL_READY_MARKER = "STALL_READY_3071"
+thinkingChunks[thinkingChunks.length - 1] += `${STALL_READY_MARKER}\n`
 
 const TYPED_TEXT = "zqxwvu42abcdef"
 // Post-fix a char echoes within one 100ms poll (~1.5s for all round-trips);
@@ -68,9 +70,9 @@ test("typed input echoes promptly while a large thinking stream is stalled", asy
 			await waitForText(terminal, "Thinking", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
 			trace.step("thinking preview visible")
 
-			// Give the client time to consume the full stalled stream so the
-			// latency measurement below isn't dominated by ingest work.
-			await new Promise((resolve) => setTimeout(resolve, 3_000))
+			// The server stalls immediately after writing this final marker, so
+			// seeing it proves the client consumed the complete stalled stream.
+			await waitForText(terminal, STALL_READY_MARKER, { timeoutMs: STREAM_TIMEOUT_MS, full: false })
 			trace.step("stream consumed, provider stalled")
 
 			const startedAt = Date.now()

--- a/tests/e2e/tui/thinking-stall-responsiveness.test.ts
+++ b/tests/e2e/tui/thinking-stall-responsiveness.test.ts
@@ -34,8 +34,7 @@ thinkingChunks[thinkingChunks.length - 1] += `${STALL_READY_MARKER}\n`
 const TYPED_TEXT = "zqxwvu42abcdef"
 // Post-fix a char echoes within one 100ms poll (~1.5s for all round-trips);
 // pre-fix each round-trip waits on ~1s of blocked render frames (~10s total).
-// The bound sits between with ~2x margin to both sides.
-const TOTAL_ECHO_BUDGET_MS = 5_000
+const TOTAL_ECHO_BUDGET_MS = 7_000
 
 test("typed input echoes promptly while a large thinking stream is stalled", async ({ terminal }) => {
 	await runKimchiSession(

--- a/tests/e2e/tui/thinking-stall-responsiveness.test.ts
+++ b/tests/e2e/tui/thinking-stall-responsiveness.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+/**
+ * Regression guard for the long-session terminal freeze: with the default
+ * hidden-thinking view, the live "Thinking" preview must not do work
+ * proportional to the full accumulated reasoning text on every spinner-driven
+ * render frame.
+ *
+ * The fake provider streams a large reasoning payload and then stalls with the
+ * connection held open — the exact user-reported scenario (spinner running,
+ * thinking active, no further stream data). While stalled, typed input must
+ * echo promptly. Before the tail-render/cache fixes in
+ * src/extensions/thinking-steps/, every frame re-wrapped the entire reasoning
+ * text (~1s per frame at this payload size), so each keypress waited on a
+ * blocked event loop and this test's latency budget fails.
+ */
+
+// ~3MB of reasoning split into ~1KB SSE chunks. Paragraph breaks keep the
+// step splitter realistic; inline markdown markers (backticks, bold) mirror
+// real reasoning output and exercise the inline-markup regexes; the closing
+// sentence varies per chunk so the text does not collapse into one line.
+const THINKING_CHUNK_COUNT = 3072
+const thinkingChunks = Array.from({ length: THINKING_CHUNK_COUNT }, (_, index) => {
+	const line = `Considering hypothesis ${index} about \`renderCollapsed\` and comparing **line diff** output against \`previousLines\`.\n`
+	return `${line.repeat(9)}\nNow verifying case ${index} before moving on.\n\n`
+})
+
+const TYPED_TEXT = "zqxwvu42abcdef"
+// Post-fix a char echoes within one 100ms poll (~1.5s for all round-trips);
+// pre-fix each round-trip waits on ~1s of blocked render frames (~10s total).
+// The bound sits between with ~2x margin to both sides.
+const TOTAL_ECHO_BUDGET_MS = 5_000
+
+test("typed input echoes promptly while a large thinking stream is stalled", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "thinking-stall-responsiveness",
+			// Reasoning-capable model so reasoning_content maps to thinking events;
+			// large context window so the oversized payload doesn't trigger
+			// context-overflow handling unrelated to this regression.
+			models: [
+				{
+					slug: "thinking-model",
+					displayName: "Fake Thinking",
+					reasoning: true,
+					contextWindow: 8_000_000,
+					maxTokens: 64_000,
+				},
+			],
+			extraArgs: ["--model", "thinking-model"],
+			responses: [
+				{
+					thinking: thinkingChunks,
+					stallAfterThinking: true,
+				},
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("think about it")
+			trace.step("submitted prompt")
+
+			// The hidden-thinking live preview header appears once thinking starts.
+			await waitForText(terminal, "Thinking", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
+			trace.step("thinking preview visible")
+
+			// Give the client time to consume the full stalled stream so the
+			// latency measurement below isn't dominated by ingest work.
+			await new Promise((resolve) => setTimeout(resolve, 3_000))
+			trace.step("stream consumed, provider stalled")
+
+			const startedAt = Date.now()
+			let typed = ""
+			for (const char of TYPED_TEXT) {
+				terminal.keyPress(char)
+				typed += char
+				// Skip short prefixes that could match stray terminal content.
+				if (typed.length >= 4) {
+					await waitForText(terminal, typed, { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+				}
+			}
+			const elapsedMs = Date.now() - startedAt
+			trace.step(`typed ${TYPED_TEXT} in ${elapsedMs}ms during stalled stream`)
+
+			expect(elapsedMs).toBeLessThan(TOTAL_ECHO_BUDGET_MS)
+		},
+	)
+})


### PR DESCRIPTION
```
The thinking preview showed only the last five lines, 
but every animation redraw reprocessed the entire reasoning text; 
Essentially, the spinner forces a rerender 10 times a second. 
As the response grew, rendering was blocked from input in the whole TUI. 
Same for expanded. Have a PR up for this
```


## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
