### PR TITLE
fix(error-handling): classify LLM gateway failures for retry and infra exit

### DIFF
--- a/src/cli-infrastructure-exit.test.ts
+++ b/src/cli-infrastructure-exit.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { applyPostMainInfrastructureExitPolicy } from "./cli-infrastructure-exit.js"
-import { KIMCHI_INFRA_ERROR_EXIT_CODE } from "./infrastructure-error.js"
+import { type InfrastructureFailure, KIMCHI_INFRA_ERROR_EXIT_CODE } from "./infrastructure-error.js"
+import { classifyLLMGatewayError } from "./llm-gateway-error.js"
+
+function createFailure(errorMessage: string, overrides: Partial<InfrastructureFailure> = {}): InfrastructureFailure {
+	const error = classifyLLMGatewayError(errorMessage)
+	if (!error) throw new Error(`Expected test message to classify: ${errorMessage}`)
+	return {
+		error,
+		consecutiveInfraErrors: 1,
+		...overrides,
+	}
+}
 
 describe("post-main CLI infrastructure exit policy", () => {
 	let previousExitCode: typeof process.exitCode
@@ -21,11 +32,10 @@ describe("post-main CLI infrastructure exit policy", () => {
 		const exitProcess = vi.fn()
 
 		const applied = applyPostMainInfrastructureExitPolicy(
-			{
-				errorMessage: "ERR_SOCKET_CLOSED",
+			createFailure("ERR_SOCKET_CLOSED", {
 				consecutiveInfraErrors: 2,
 				sessionPath: "/tmp/session.jsonl",
-			},
+			}),
 			exitProcess,
 		)
 
@@ -41,7 +51,7 @@ describe("post-main CLI infrastructure exit policy", () => {
 		process.exitCode = undefined
 		expect(
 			applyPostMainInfrastructureExitPolicy(
-				{ errorMessage: "ERR_SOCKET_CLOSED", consecutiveInfraErrors: 1 },
+				createFailure("ERR_SOCKET_CLOSED", { consecutiveInfraErrors: 1 }),
 				exitProcess,
 			),
 		).toBe(false)

--- a/src/extensions/infrastructure-breaker.test.ts
+++ b/src/extensions/infrastructure-breaker.test.ts
@@ -61,8 +61,18 @@ describe("infrastructure breaker extension", () => {
 		const { isRetryable, emit } = createHarness(2)
 
 		expect(isRetryable(networkError)).toBe(true)
-		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "429 rate limit exceeded" })
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "insufficient_quota" })
 		expect(isRetryable(networkError)).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
+		expect(isInfrastructureBreakerTripped()).toBe(true)
+	})
+
+	it("does not reset on rate limits", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		const { isRetryable, emit } = createHarness(2)
+
+		expect(isRetryable(networkError)).toBe(true)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "429 rate limit exceeded" })
 		expect(isRetryable(networkError)).toBe(false)
 		expect(isInfrastructureBreakerTripped()).toBe(true)
 	})

--- a/src/extensions/infrastructure-breaker.test.ts
+++ b/src/extensions/infrastructure-breaker.test.ts
@@ -38,52 +38,58 @@ describe("infrastructure breaker extension", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const { isRetryable, emit } = createHarness(2)
 
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isRetryable(networkError)).toBe(true)
 		emit({ role: "assistant", content: [], stopReason: "stop" })
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isRetryable(networkError)).toBe(true)
-		expect(isRetryable(networkError)).toBe(false)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 
 	it("does not reset on infra errored assistant messages or non-assistant messages", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const { isRetryable, emit } = createHarness(2)
 
-		expect(isRetryable(networkError)).toBe(true)
 		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		emit({ role: "user", content: "hello" })
-		expect(isRetryable(networkError)).toBe(false)
+		expect(isRetryable(networkError)).toBe(true)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 
 	it("resets on non-infra provider verdicts", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const { isRetryable, emit } = createHarness(2)
 
-		expect(isRetryable(networkError)).toBe(true)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "insufficient_quota" })
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isRetryable(networkError)).toBe(true)
-		expect(isRetryable(networkError)).toBe(false)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 
 	it("does not reset on rate limits", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const { isRetryable, emit } = createHarness(2)
 
-		expect(isRetryable(networkError)).toBe(true)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "429 rate limit exceeded" })
-		expect(isRetryable(networkError)).toBe(false)
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 
 	it("does not reset on provider 5xx errors", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const { isRetryable, emit } = createHarness(2)
 
-		expect(isRetryable(networkError)).toBe(true)
+		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "read ECONNRESET" })
 		emit({ role: "assistant", content: [], stopReason: "error", errorMessage: "500 internal server error" })
-		expect(isRetryable(networkError)).toBe(false)
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 })

--- a/src/extensions/infrastructure-breaker.ts
+++ b/src/extensions/infrastructure-breaker.ts
@@ -1,12 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { isInfrastructureProviderError } from "../infrastructure-error.js"
-import { resetInfrastructureBreaker } from "../upstream-retry-patch.js"
+import { recordInfrastructureBreakerFailure, resetInfrastructureBreaker } from "../upstream-retry-patch.js"
 
 /**
- * Reset half of the infrastructure-error circuit breaker. Errored attempts are counted
- * where they are classified, in the patched retry classifier
- * (upstream-retry-patch.ts); this extension closes the breaker again on any
- * successful assistant message or non-infra provider verdict.
+ * Counts infrastructure-classified assistant errors once per message_end and
+ * closes the breaker again on any successful assistant message or non-infra
+ * provider verdict.
  */
 export default function infrastructureBreakerExtension(pi: ExtensionAPI): void {
 	pi.on("message_end", (event) => {
@@ -16,7 +15,9 @@ export default function infrastructureBreakerExtension(pi: ExtensionAPI): void {
 			resetInfrastructureBreaker()
 			return
 		}
-		if (typeof message.errorMessage !== "string" || !isInfrastructureProviderError(message.errorMessage)) {
+		if (typeof message.errorMessage === "string" && isInfrastructureProviderError(message.errorMessage)) {
+			recordInfrastructureBreakerFailure()
+		} else {
 			resetInfrastructureBreaker()
 		}
 	})

--- a/src/infrastructure-error.test.ts
+++ b/src/infrastructure-error.test.ts
@@ -1,11 +1,24 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
+	GATEWAY_CLASSIFICATION_AUDIT_TYPE,
+	type InfrastructureFailure,
 	KIMCHI_INFRA_ERROR_EXIT_CODE,
 	applyInfrastructureExitPolicy,
 	createInfrastructureErrorTracker,
 	isInfrastructureProviderError,
 } from "./infrastructure-error.js"
+import { classifyLLMGatewayError } from "./llm-gateway-error.js"
+
+function createFailure(errorMessage: string, overrides: Partial<InfrastructureFailure> = {}): InfrastructureFailure {
+	const error = classifyLLMGatewayError(errorMessage)
+	if (!error) throw new Error(`Expected test message to classify: ${errorMessage}`)
+	return {
+		error,
+		consecutiveInfraErrors: 1,
+		...overrides,
+	}
+}
 
 describe("infrastructure error classification", () => {
 	it.each([
@@ -34,12 +47,12 @@ describe("infrastructure error classification", () => {
 		"socket hang up during TLS authentication",
 		"connect ETIMEDOUT 10.0.0.1:443",
 		"getaddrinfo EAI_AGAIN api.example.com",
+		"429 rate limit exceeded",
 	])("classifies provider transport error: %s", (message) => {
 		expect(isInfrastructureProviderError(message)).toBe(true)
 	})
 
 	it.each([
-		"429 rate limit exceeded",
 		"insufficient_quota: billing hard limit reached",
 		"context window exceeded",
 		"401 unauthorized",
@@ -55,19 +68,25 @@ describe("infrastructure error classification", () => {
 describe("infrastructure error tracker", () => {
 	const sessionFile = "/tmp/project/session.jsonl"
 
-	function createTrackerHarness() {
+	function createTrackerHarness(options: { appendEntry?: (customType: string, data: unknown) => void } = {}) {
 		const tracker = createInfrastructureErrorTracker()
+		const auditEntries: Array<{ customType: string; data: unknown }> = []
 		let handler: ((event: unknown, ctx: unknown) => void) | undefined
 		const pi = {
 			on: (event: string, h: (event: unknown, ctx: unknown) => void) => {
 				if (event === "message_end") handler = h
 			},
+			appendEntry:
+				options.appendEntry ??
+				((customType: string, data: unknown) => {
+					auditEntries.push({ customType, data })
+				}),
 		} as unknown as ExtensionAPI
 		tracker.extension(pi)
 		const ctx = { sessionManager: { getSessionFile: () => sessionFile } }
 		const emit = (message: Record<string, unknown>, overrideCtx: unknown = ctx) =>
 			handler?.({ type: "message_end", message }, overrideCtx)
-		return { tracker, emit }
+		return { tracker, emit, auditEntries }
 	}
 
 	function assistantError(errorMessage: string): Record<string, unknown> {
@@ -78,26 +97,94 @@ describe("infrastructure error tracker", () => {
 		return { role: "assistant", content: [{ type: "text", text }], stopReason: "stop" }
 	}
 
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("appends a classification audit entry for every classified error, including unrecognized ones", () => {
+		const { emit, auditEntries } = createTrackerHarness()
+		emit(assistantError("503 Service Unavailable"))
+		emit(assistantError("some error string the classifier does not recognize"))
+
+		expect(auditEntries).toEqual([
+			{
+				customType: GATEWAY_CLASSIFICATION_AUDIT_TYPE,
+				data: {
+					rawMessage: "503 Service Unavailable",
+					reason: "provider_5xx",
+					retryable: true,
+					isInfrastructure: true,
+					exitCode: KIMCHI_INFRA_ERROR_EXIT_CODE,
+					httpStatusCode: 503,
+				},
+			},
+			{
+				customType: GATEWAY_CLASSIFICATION_AUDIT_TYPE,
+				data: {
+					rawMessage: "some error string the classifier does not recognize",
+					reason: "unclassified",
+					retryable: false,
+					isInfrastructure: false,
+					exitCode: null,
+					httpStatusCode: null,
+				},
+			},
+		])
+	})
+
+	it("does not audit successful or non-error assistant messages", () => {
+		const { emit, auditEntries } = createTrackerHarness()
+		emit(assistantStop("all good"))
+		emit({ role: "user", content: "hello" })
+
+		expect(auditEntries).toEqual([])
+	})
+
+	it("keeps tracking the failure when the audit sink throws", () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		const { tracker, emit } = createTrackerHarness({
+			appendEntry: () => {
+				throw new Error("session log unavailable")
+			},
+		})
+
+		emit(assistantError("503 Service Unavailable"))
+
+		expect(tracker.getFailure()?.error.reason).toBe("provider_5xx")
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+	})
+
 	it("records a trailing infra error with the session path", () => {
 		const { tracker, emit } = createTrackerHarness()
 		emit(assistantError("socket connection was closed unexpectedly"))
 		emit(assistantError("ECONNRESET: connection reset by peer"))
 
-		expect(tracker.getFailure()).toEqual({
-			errorMessage: "ECONNRESET: connection reset by peer",
+		expect(tracker.getFailure()).toMatchObject({
+			error: {
+				reason: "transport_failure",
+				rawMessage: "ECONNRESET: connection reset by peer",
+			},
 			consecutiveInfraErrors: 2,
 			sessionPath: sessionFile,
 		})
+		expect(tracker.getFailure()?.error.retryable).toBe(true)
+		expect(tracker.getFailure()?.error.isInfrastructure).toBe(true)
+		expect(tracker.getFailure()?.error.exitCode()).toBe(KIMCHI_INFRA_ERROR_EXIT_CODE)
 	})
 
 	it("records a trailing infra error without a session manager", () => {
 		const { tracker, emit } = createTrackerHarness()
 		emit(assistantError("socket connection was closed unexpectedly"), {})
 
-		expect(tracker.getFailure()).toEqual({
-			errorMessage: "socket connection was closed unexpectedly",
+		expect(tracker.getFailure()).toMatchObject({
+			error: {
+				reason: "transport_failure",
+				rawMessage: "socket connection was closed unexpectedly",
+			},
 			consecutiveInfraErrors: 1,
 		})
+		expect(tracker.getFailure()?.error.retryable).toBe(true)
+		expect(tracker.getFailure()?.error.isInfrastructure).toBe(true)
 	})
 
 	it("clears the failure when a later assistant message succeeds", () => {
@@ -111,9 +198,25 @@ describe("infrastructure error tracker", () => {
 	it("clears the failure when the trailing error is non-infra", () => {
 		const { tracker, emit } = createTrackerHarness()
 		emit(assistantError("socket connection was closed unexpectedly"))
-		emit(assistantError("429 rate limit exceeded"))
+		emit(assistantError("context window exceeded"))
 
 		expect(tracker.getFailure()).toBeUndefined()
+	})
+
+	it("records a trailing rate limit so a failed process can exit as infra", () => {
+		const { tracker, emit } = createTrackerHarness()
+		emit(assistantError("kimi-k2.7 model is rate limited until 2026-07-09T13:18:18Z"))
+
+		expect(tracker.getFailure()).toMatchObject({
+			error: {
+				reason: "rate_limit",
+				rawMessage: "kimi-k2.7 model is rate limited until 2026-07-09T13:18:18Z",
+			},
+			consecutiveInfraErrors: 1,
+			sessionPath: sessionFile,
+		})
+		expect(tracker.getFailure()?.error.retryable).toBe(true)
+		expect(tracker.getFailure()?.error.isInfrastructure).toBe(true)
 	})
 
 	it("restarts the consecutive count after a recovery", () => {
@@ -122,7 +225,10 @@ describe("infrastructure error tracker", () => {
 		emit(assistantStop("recovered"))
 		emit(assistantError("socket hang up"))
 
-		expect(tracker.getFailure()).toMatchObject({ errorMessage: "socket hang up", consecutiveInfraErrors: 1 })
+		expect(tracker.getFailure()).toMatchObject({
+			error: { rawMessage: "socket hang up" },
+			consecutiveInfraErrors: 1,
+		})
 	})
 
 	it("ignores non-assistant messages", () => {
@@ -130,7 +236,7 @@ describe("infrastructure error tracker", () => {
 		emit(assistantError("write EPIPE"))
 		emit({ role: "user", content: "hello" })
 
-		expect(tracker.getFailure()).toMatchObject({ errorMessage: "write EPIPE" })
+		expect(tracker.getFailure()).toMatchObject({ error: { rawMessage: "write EPIPE" } })
 	})
 })
 
@@ -149,11 +255,12 @@ describe("infrastructure exit policy", () => {
 	})
 
 	it("prints the normalized infra marker and sets the infra exit code for a failure", () => {
-		const applied = applyInfrastructureExitPolicy({
-			errorMessage: "ERR_SOCKET_CLOSED",
-			consecutiveInfraErrors: 3,
-			sessionPath: "/tmp/project/session.jsonl",
-		})
+		const applied = applyInfrastructureExitPolicy(
+			createFailure("ERR_SOCKET_CLOSED", {
+				consecutiveInfraErrors: 3,
+				sessionPath: "/tmp/project/session.jsonl",
+			}),
+		)
 
 		expect(applied).toBe(true)
 		expect(process.exitCode).toBe(KIMCHI_INFRA_ERROR_EXIT_CODE)
@@ -163,6 +270,18 @@ describe("infrastructure exit policy", () => {
 		expect(message).toContain("3 consecutive infra errors")
 		expect(message).toContain("ERR_SOCKET_CLOSED")
 		expect(message).toContain("/tmp/project/session.jsonl")
+	})
+
+	it("does not stamp infra exit for classified non-infra request errors", () => {
+		const applied = applyInfrastructureExitPolicy(
+			createFailure("400 Bad Request", {
+				consecutiveInfraErrors: 3,
+			}),
+		)
+
+		expect(applied).toBe(false)
+		expect(process.exitCode).toBe(previousExitCode)
+		expect(consoleErrorSpy).not.toHaveBeenCalled()
 	})
 
 	it("does nothing without a failure", () => {

--- a/src/infrastructure-error.ts
+++ b/src/infrastructure-error.ts
@@ -1,30 +1,45 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import {
+	type LLMGatewayError,
+	LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE,
+	classifyLLMGatewayError,
+} from "./llm-gateway-error.js"
 
-export const KIMCHI_INFRA_ERROR_EXIT_CODE = 74
+export const KIMCHI_INFRA_ERROR_EXIT_CODE = LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE
 const KIMCHI_INFRA_ERROR_PREFIX = "KIMCHI_INFRA_ERROR"
 
-// Provider verdicts (auth, quota, rate limits, context overflow) are checked
-// first: they are answers from a working provider, not transport failures,
-// even when the surrounding message also mentions a connection problem.
-const NON_INFRA_PROVIDER_ERROR_RE =
-	/unauthorized|authentication[_\s]?(?:error|failed)|invalid api key|\b401\b|\b403\b|permission denied|account.{0,40}\b(?:terminated|suspended|deactivated|disabled)\b|context window|context overflow|maximum context|prompt too long|quota|billing|insufficient_quota|out of budget|usage limit|rate.?limit|too many requests|\b429\b/i
+/** Session-log entry type carrying the audit trail of each gateway-error classification. */
+export const GATEWAY_CLASSIFICATION_AUDIT_TYPE = "kimchi_error_classification"
 
-// Provider infrastructure failures: nothing usable came back from the provider,
-// so the run can be retried by a supervisor. Shared by the retry patch,
-// process-wide breaker, and final exit classification so they stay aligned.
-const INFRA_PROVIDER_ERROR_RE =
-	/\b5(?:00|02|03|04|24|29)\b|bad gateway|service unavailable|gateway timeout|internal server error|overloaded|cloudflare.*timeout|timeout.*cloudflare|socket(?: connection was)? closed|socket hang up|other side closed|connection closed|broken pipe|fetch failed|network.?error|connection.?error|connection.?refused|connection.?lost|upstream.?connect|reset before headers|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|\btimeout\b|\bterminated\b|unexpectedly|EPIPE|ERR_SOCKET_CLOSED|ERR_STREAM_PREMATURE_CLOSE|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|connection reset/i
+/**
+ * Append an audit-trail entry to the session log recording what the classifier
+ * was given (the raw provider error) and what it decided. Best-effort by design:
+ * audit logging must never break a run, so a failure to persist the entry is
+ * logged and swallowed rather than propagated.
+ */
+function recordClassificationAudit(pi: ExtensionAPI, rawMessage: string, error: LLMGatewayError | undefined): void {
+	try {
+		pi.appendEntry(GATEWAY_CLASSIFICATION_AUDIT_TYPE, {
+			rawMessage,
+			reason: error?.reason ?? "unclassified",
+			retryable: error?.retryable ?? false,
+			isInfrastructure: error?.isInfrastructure ?? false,
+			exitCode: error?.exitCode() ?? null,
+			httpStatusCode: error?.httpStatusCode ?? null,
+		})
+	} catch (cause) {
+		console.error(`KIMCHI: failed to record gateway classification audit entry: ${cause}`)
+	}
+}
 
 export interface InfrastructureFailure {
-	errorMessage: string
+	error: LLMGatewayError
 	consecutiveInfraErrors: number
 	sessionPath?: string
 }
 
 export function isInfrastructureProviderError(errorMessage: string): boolean {
-	if (!errorMessage) return false
-	if (NON_INFRA_PROVIDER_ERROR_RE.test(errorMessage)) return false
-	return INFRA_PROVIDER_ERROR_RE.test(errorMessage)
+	return classifyLLMGatewayError(errorMessage)?.isInfrastructure ?? false
 }
 
 export interface InfrastructureErrorTracker {
@@ -35,10 +50,10 @@ export interface InfrastructureErrorTracker {
 }
 
 /**
- * Tracks provider transport failures as they happen, via message_end events.
+ * Tracks provider failures as they happen, via message_end events.
  * A failure is only reported while it is trailing: any later assistant message
- * that is not an infra error (a successful turn, or a provider verdict such as
- * a rate limit) clears it, mirroring upstream's reset-on-success retry rule.
+ * that is not an infra exit error clears it, mirroring upstream's
+ * reset-on-success retry rule.
  */
 export function createInfrastructureErrorTracker(): InfrastructureErrorTracker {
 	let failure: InfrastructureFailure | undefined
@@ -48,14 +63,17 @@ export function createInfrastructureErrorTracker(): InfrastructureErrorTracker {
 			pi.on("message_end", (event, ctx) => {
 				const message = event.message
 				if (message.role !== "assistant") return
-				if (
-					message.stopReason === "error" &&
-					typeof message.errorMessage === "string" &&
-					isInfrastructureProviderError(message.errorMessage)
-				) {
+
+				let error: LLMGatewayError | undefined
+				if (message.stopReason === "error" && typeof message.errorMessage === "string") {
+					error = classifyLLMGatewayError(message.errorMessage)
+					recordClassificationAudit(pi, message.errorMessage, error)
+				}
+
+				if (error?.isInfrastructure) {
 					const sessionPath = ctx.sessionManager?.getSessionFile?.()
 					failure = {
-						errorMessage: message.errorMessage,
+						error,
 						consecutiveInfraErrors: (failure?.consecutiveInfraErrors ?? 0) + 1,
 						...(sessionPath ? { sessionPath } : {}),
 					}
@@ -72,7 +90,7 @@ function formatInfrastructureFailureMessage(failure: InfrastructureFailure): str
 	const countText =
 		failure.consecutiveInfraErrors > 1 ? ` after ${failure.consecutiveInfraErrors} consecutive infra errors` : ""
 	const sessionText = failure.sessionPath ? ` Session: ${failure.sessionPath}` : ""
-	return `${KIMCHI_INFRA_ERROR_PREFIX}: provider transport failure${countText}; exiting with code ${KIMCHI_INFRA_ERROR_EXIT_CODE}. Last error: ${failure.errorMessage}${sessionText}`
+	return `${KIMCHI_INFRA_ERROR_PREFIX}: provider infrastructure failure${countText}; exiting with code ${failure.error.exitCode()}. Last error: ${failure.error.rawMessage}${sessionText}`
 }
 
 /**
@@ -83,6 +101,7 @@ function formatInfrastructureFailureMessage(failure: InfrastructureFailure): str
  */
 export function applyInfrastructureExitPolicy(failure: InfrastructureFailure | undefined): boolean {
 	if (!failure) return false
+	if (!failure.error.isInfrastructure) return false
 	console.error(formatInfrastructureFailureMessage(failure))
 	process.exitCode = KIMCHI_INFRA_ERROR_EXIT_CODE
 	return true

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest"
+import { LLMGatewayError, classifyLLMGatewayError } from "./llm-gateway-error.js"
+
+describe("classifyLLMGatewayError", () => {
+	it.each([
+		{
+			name: "Kimi rate limit",
+			message: "kimi-k2.7 model is rate limited until 2026-07-09T13:18:18Z",
+			reason: "rate_limit",
+		},
+		{
+			name: "MiniMax rate limit",
+			message: "minimax-m3 model is rate limited until 2026-07-09T13:18:18Z",
+			reason: "rate_limit",
+		},
+		{
+			name: "HTTP 429",
+			message: "429 Too Many Requests",
+			reason: "rate_limit",
+			httpStatusCode: 429,
+		},
+		{
+			name: "local proxy EOF",
+			message: 'proxying request: Post "http://localhost:10000/v1/chat/completions": EOF',
+			reason: "transport_failure",
+		},
+		{
+			name: "provider proxy EOF",
+			message: 'proxying request: Post "<redacted-url>": EOF',
+			reason: "transport_failure",
+		},
+		{
+			name: "broken pipe",
+			message: 'proxying request: Post "<url>": write tcp <local>-><remote>: write: broken pipe',
+			reason: "transport_failure",
+		},
+		{
+			name: "socket closed unexpectedly",
+			message:
+				"The socket connection was closed unexpectedly. For more information, pass verbose: true in the second argument to fetch()",
+			reason: "transport_failure",
+		},
+		{
+			name: "connection reset by peer",
+			message: 'proxying request: Post "<url>": read tcp 127.0.0.1:1->127.0.0.1:2: read: connection reset by peer',
+			reason: "transport_failure",
+		},
+		{
+			name: "connection refused",
+			message: 'proxying request: Post "<url>": dial tcp 127.0.0.1:10000: connect: connection refused',
+			reason: "transport_failure",
+		},
+		{
+			name: "i/o timeout",
+			message: 'proxying request: Post "<url>": dial tcp 10.0.0.1:443: i/o timeout',
+			reason: "transport_failure",
+		},
+		{
+			name: "stream ended without finish reason",
+			message: "Stream ended without finish_reason",
+			reason: "stream_interrupted",
+		},
+		{
+			name: "provider 502",
+			message: "502 status code (no body)",
+			reason: "provider_5xx",
+			httpStatusCode: 502,
+		},
+		{
+			name: "provider 503 html",
+			message: "503 Server Error. The service you requested is not available at this time.",
+			reason: "provider_5xx",
+			httpStatusCode: 503,
+		},
+		{
+			name: "provider 500 nginx",
+			message: "500 Internal Server Error ... nginx",
+			reason: "provider_5xx",
+			httpStatusCode: 500,
+		},
+		{
+			name: "Cloudflare 524",
+			message: "Cloudflare 524 timeout",
+			reason: "provider_5xx",
+			httpStatusCode: 524,
+		},
+		{
+			name: "provider overload 529",
+			message: "529 Overloaded",
+			reason: "provider_5xx",
+			httpStatusCode: 529,
+		},
+		{
+			name: "provider overloaded_error",
+			message: "overloaded_error",
+			reason: "provider_5xx",
+		},
+		{
+			name: "gateway timeout",
+			message: "504 Gateway Timeout",
+			reason: "provider_5xx",
+			httpStatusCode: 504,
+		},
+		{
+			name: "hosted vLLM server disconnected",
+			message: "InternalServerError: Hosted_vllmException - Server disconnected",
+			reason: "provider_error",
+		},
+		{
+			name: "hosted vLLM cannot connect",
+			message:
+				"InternalServerError: Hosted_vllmException - Cannot connect to host serverless-kimi-k2-7 [Connect call failed ('34.118.225.213', 11434)]",
+			reason: "provider_error",
+		},
+		{
+			name: "hosted vLLM executor shutdown",
+			message: "Hosted_vllmException - cannot schedule new futures after shutdown, code 500",
+			reason: "provider_error",
+			httpStatusCode: 500,
+		},
+		{
+			name: "hosted vLLM upstream request",
+			message: "Internal Server Error, call_upstream_request_error, error sending request",
+			reason: "provider_error",
+		},
+	] as const)("classifies retryable gateway failure: $name", ({ message, reason, httpStatusCode }) => {
+		const error = classifyLLMGatewayError(message)
+
+		expect(error).toBeInstanceOf(LLMGatewayError)
+		expect(error).toMatchObject({
+			reason,
+			rawMessage: message,
+		})
+		expect(error?.retryable).toBe(true)
+		expect(error?.isInfrastructure).toBe(true)
+		expect(error?.exitCode()).toBe(74)
+		expect(error?.httpStatusCode).toBe(httpStatusCode)
+	})
+
+	it.each([
+		{
+			name: "empty tools array",
+			message:
+				"Value error, tools must not be an empty array. Either provide at least one tool or omit the field entirely.",
+			reason: "invalid_request_payload",
+		},
+		{
+			name: "context window exceeded",
+			message:
+				"ContextWindowExceededError: Hosted_vllmException - The input (132000 tokens) is longer than the model's context length (131072 tokens), code 400",
+			reason: "context_window_exceeded",
+			httpStatusCode: 400,
+		},
+		{
+			name: "standalone context window exceeded error class",
+			message: "ContextWindowExceededError",
+			reason: "context_window_exceeded",
+		},
+		{
+			name: "generic hosted vLLM bad request",
+			message: "BadRequestError: Hosted_vllmException - BadRequest, code 400",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+		{
+			name: "hosted vLLM bad request with JSON character offsets",
+			message:
+				"Hosted_vllmException - invalid escaped character in string: line 1 column 504 (char 503) BadRequestError code 400",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+		{
+			name: "generic HTTP bad request",
+			message: "400 Bad Request",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+	] as const)("classifies non-retryable request failure: $name", ({ message, reason, httpStatusCode }) => {
+		const error = classifyLLMGatewayError(message)
+
+		expect(error).toBeInstanceOf(LLMGatewayError)
+		expect(error).toMatchObject({
+			reason,
+			rawMessage: message,
+		})
+		expect(error?.retryable).toBe(false)
+		expect(error?.isInfrastructure).toBe(false)
+		expect(error?.exitCode()).toBe(1)
+		expect(error?.httpStatusCode).toBe(httpStatusCode)
+	})
+
+	it.each([
+		"invalid api key",
+		"insufficient_quota: billing hard limit reached",
+		"unrelated agent failure",
+		"model returned 500 tokens before stopping",
+		"tool call unexpectedly missing argument",
+		"model response terminated by safety policy",
+	])("ignores non-gateway provider verdicts: %s", (message) => {
+		expect(classifyLLMGatewayError(message)).toBeUndefined()
+	})
+
+	// A digit run equal to a status code but outside status context (an offset,
+	// a count, a timestamp fragment) must never fabricate a classification —
+	// especially not a retryable exit-74 one.
+	it.each([
+		"processed 429 files before the agent stopped",
+		"wrote 400 rows then the run ended",
+		"upstream returned 502 while proxying",
+		"failed after 503 iterations of the loop",
+	])("does not classify a bare status number outside status context: %s", (message) => {
+		expect(classifyLLMGatewayError(message)).toBeUndefined()
+	})
+})

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -41,6 +41,21 @@ describe("classifyLLMGatewayError", () => {
 			reason: "transport_failure",
 		},
 		{
+			name: "connection terminated unexpectedly",
+			message: "connection terminated unexpectedly",
+			reason: "transport_failure",
+		},
+		{
+			name: "request unexpectedly ended",
+			message: "request unexpectedly ended while reading upstream response",
+			reason: "transport_failure",
+		},
+		{
+			name: "stream terminated unexpectedly",
+			message: "provider stream terminated unexpectedly",
+			reason: "transport_failure",
+		},
+		{
 			name: "connection reset by peer",
 			message: 'proxying request: Post "<url>": read tcp 127.0.0.1:1->127.0.0.1:2: read: connection reset by peer',
 			reason: "transport_failure",
@@ -172,6 +187,24 @@ describe("classifyLLMGatewayError", () => {
 		{
 			name: "generic HTTP bad request",
 			message: "400 Bad Request",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+		{
+			name: "bad request with hosted vLLM transport wording",
+			message: "BadRequestError: Hosted_vllmException - error sending request, code 400",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+		{
+			name: "HTTP 400 with transport wording",
+			message: "HTTP 400 error sending request",
+			reason: "bad_request",
+			httpStatusCode: 400,
+		},
+		{
+			name: "status 400 with upstream connect wording",
+			message: "upstream connect error: status code 400",
 			reason: "bad_request",
 			httpStatusCode: 400,
 		},

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -1,0 +1,126 @@
+export type LLMGatewayErrorReason =
+	| "rate_limit"
+	| "transport_failure"
+	| "stream_interrupted"
+	| "provider_5xx"
+	| "provider_error"
+	| "bad_request"
+	| "context_window_exceeded"
+	| "invalid_request_payload"
+
+export const LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE = 74
+const LLM_GATEWAY_REQUEST_EXIT_CODE = 1
+
+const LLM_GATEWAY_REASON_POLICIES: Record<
+	LLMGatewayErrorReason,
+	{ readonly retryable: boolean; readonly isInfrastructure: boolean; readonly exitCode: number }
+> = {
+	rate_limit: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
+	transport_failure: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
+	stream_interrupted: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
+	provider_5xx: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
+	provider_error: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
+	bad_request: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
+	context_window_exceeded: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
+	invalid_request_payload: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
+}
+
+export class LLMGatewayError {
+	readonly name = "LLMGatewayError"
+	readonly reason: LLMGatewayErrorReason
+	readonly rawMessage: string
+	readonly httpStatusCode?: number
+
+	constructor(params: { reason: LLMGatewayErrorReason; rawMessage: string; httpStatusCode?: number }) {
+		this.reason = params.reason
+		this.rawMessage = params.rawMessage
+		this.httpStatusCode = params.httpStatusCode
+	}
+
+	get retryable(): boolean {
+		return LLM_GATEWAY_REASON_POLICIES[this.reason].retryable
+	}
+
+	get isInfrastructure(): boolean {
+		return LLM_GATEWAY_REASON_POLICIES[this.reason].isInfrastructure
+	}
+
+	exitCode(): number {
+		return LLM_GATEWAY_REASON_POLICIES[this.reason].exitCode
+	}
+}
+
+const HTTP_STATUS_RES = [
+	/"code"\s*:\s*(400|429|500|502|503|504|524|529)\b/i,
+	/\bcode\s*(?:=|:)?\s*(400|429|500|502|503|504|524|529)\b/i,
+	/\b(?:http(?:\s+status)?|status(?:\s+code)?)\s*(?:=|:)?\s*(400|429|500|502|503|504|524|529)\b/i,
+	/\b(400|429|500|502|503|504|524|529)\s+status\s+code\b/i,
+	/\b(400)\s+bad\s+request\b/i,
+	/\b(429)\s+(?:too many requests|rate.?limit(?:ed)?)\b/i,
+	/\b(500)\s+(?:internal server error|server error)\b/i,
+	/\b(502)\s+bad gateway\b/i,
+	/\b(503)\s+(?:service unavailable|server error)\b/i,
+	/\b(504)\s+gateway timeout\b/i,
+	/\b(?:cloudflare\s+)?(524)\s+timeout\b/i,
+	/\b(529)\s+overloaded\b/i,
+]
+
+const FIVE_XX_STATUS_CODES = new Set([500, 502, 503, 504, 524, 529])
+
+const INVALID_REQUEST_PAYLOAD_RE = /tools must not be an empty array/i
+const CONTEXT_WINDOW_RE =
+	/ContextWindowExceeded|context(?:\s|-)?(?:window|length|overflow)|maximum context|prompt too long|longer than the model'?s context length/i
+const NON_GATEWAY_PROVIDER_VERDICT_RE =
+	/unauthorized|authentication[_\s]?(?:error|failed)|invalid api key|\b401\b|\b403\b|permission denied|account.{0,40}\b(?:terminated|suspended|deactivated|disabled)\b|quota|billing|insufficient_quota|out of budget|usage limit/i
+
+const RATE_LIMIT_TEXT_RE = /rate.?limit|too many requests/i
+const STREAM_INTERRUPTED_RE =
+	/stream ended without finish_reason|stream ended before message_stop|ended without finish/i
+const HOSTED_VLLM_PROVIDER_ERROR_RE =
+	/Hosted_vllmException.*(?:server disconnected|cannot connect to host|connect call failed|cannot schedule new futures after shutdown|executor.*shutdown|upstream request|call_upstream_request_error)|call_upstream_request_error|error sending request/i
+const PROVIDER_5XX_TEXT_RE =
+	/bad gateway|service unavailable|gateway timeout|internal server error|overloaded|overloaded_error|cloudflare.*timeout|timeout.*cloudflare/i
+// Named-phrase forms only; numeric statuses are matched via parseHttpStatusCode.
+const TRANSPORT_FAILURE_RE =
+	/\bEOF\b|socket(?: connection was)? closed|socket hang up|other side closed|connection closed|connection reset|connection refused|connection lost|broken pipe|fetch failed|network.?error|connection.?error|upstream.?connect|reset before headers|http2 request did not get a response|i\/o timeout|(?:request|connection|socket|network|fetch|read|write|proxy|http2|tls).{0,30}(?:timeout|timed out)|timed out|EPIPE|ERR_SOCKET_CLOSED|ERR_STREAM_PREMATURE_CLOSE|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN/i
+const BAD_REQUEST_TEXT_RE = /bad request|BadRequest/i
+
+function parseHttpStatusCode(rawMessage: string): number | undefined {
+	for (const pattern of HTTP_STATUS_RES) {
+		const match = pattern.exec(rawMessage)
+		if (match?.[1]) return Number.parseInt(match[1], 10)
+	}
+	return undefined
+}
+
+function createError(
+	reason: LLMGatewayErrorReason,
+	rawMessage: string,
+	httpStatusCode: number | undefined,
+): LLMGatewayError {
+	return new LLMGatewayError({ reason, rawMessage, httpStatusCode })
+}
+
+export function classifyLLMGatewayError(rawMessage: string): LLMGatewayError | undefined {
+	if (!rawMessage) return undefined
+
+	// Parse the HTTP status once, in status context only (e.g. "code 429",
+	// "503 Service Unavailable") — never a bare number. This keeps digits that
+	// merely appear in offsets, token counts, or timestamps from fabricating a
+	// status, and gives every numeric rule below one shared source of truth.
+	const status = parseHttpStatusCode(rawMessage)
+
+	if (INVALID_REQUEST_PAYLOAD_RE.test(rawMessage)) return createError("invalid_request_payload", rawMessage, status)
+	if (CONTEXT_WINDOW_RE.test(rawMessage)) return createError("context_window_exceeded", rawMessage, status)
+	if (NON_GATEWAY_PROVIDER_VERDICT_RE.test(rawMessage)) return undefined
+
+	if (RATE_LIMIT_TEXT_RE.test(rawMessage) || status === 429) return createError("rate_limit", rawMessage, status)
+	if (STREAM_INTERRUPTED_RE.test(rawMessage)) return createError("stream_interrupted", rawMessage, status)
+	if (HOSTED_VLLM_PROVIDER_ERROR_RE.test(rawMessage)) return createError("provider_error", rawMessage, status)
+	if (PROVIDER_5XX_TEXT_RE.test(rawMessage) || (status !== undefined && FIVE_XX_STATUS_CODES.has(status)))
+		return createError("provider_5xx", rawMessage, status)
+	if (TRANSPORT_FAILURE_RE.test(rawMessage)) return createError("transport_failure", rawMessage, status)
+	if (BAD_REQUEST_TEXT_RE.test(rawMessage) || status === 400) return createError("bad_request", rawMessage, status)
+
+	return undefined
+}

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -83,6 +83,8 @@ const PROVIDER_5XX_TEXT_RE =
 // Named-phrase forms only; numeric statuses are matched via parseHttpStatusCode.
 const TRANSPORT_FAILURE_RE =
 	/\bEOF\b|socket(?: connection was)? closed|socket hang up|other side closed|connection closed|connection reset|connection refused|connection lost|broken pipe|fetch failed|network.?error|connection.?error|upstream.?connect|reset before headers|http2 request did not get a response|i\/o timeout|(?:request|connection|socket|network|fetch|read|write|proxy|http2|tls).{0,30}(?:timeout|timed out)|timed out|EPIPE|ERR_SOCKET_CLOSED|ERR_STREAM_PREMATURE_CLOSE|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN/i
+const TRANSPORT_TERMINATION_RE =
+	/\b(?:connection|request|stream|response|socket|http2 request)\b.{0,40}\b(?:terminated unexpectedly|unexpectedly (?:ended|closed|terminated)|ended unexpectedly|closed unexpectedly)\b/i
 const BAD_REQUEST_TEXT_RE = /bad request|BadRequest/i
 
 function parseHttpStatusCode(rawMessage: string): number | undefined {
@@ -113,14 +115,15 @@ export function classifyLLMGatewayError(rawMessage: string): LLMGatewayError | u
 	if (INVALID_REQUEST_PAYLOAD_RE.test(rawMessage)) return createError("invalid_request_payload", rawMessage, status)
 	if (CONTEXT_WINDOW_RE.test(rawMessage)) return createError("context_window_exceeded", rawMessage, status)
 	if (NON_GATEWAY_PROVIDER_VERDICT_RE.test(rawMessage)) return undefined
+	if (BAD_REQUEST_TEXT_RE.test(rawMessage) || status === 400) return createError("bad_request", rawMessage, status)
 
 	if (RATE_LIMIT_TEXT_RE.test(rawMessage) || status === 429) return createError("rate_limit", rawMessage, status)
 	if (STREAM_INTERRUPTED_RE.test(rawMessage)) return createError("stream_interrupted", rawMessage, status)
 	if (HOSTED_VLLM_PROVIDER_ERROR_RE.test(rawMessage)) return createError("provider_error", rawMessage, status)
 	if (PROVIDER_5XX_TEXT_RE.test(rawMessage) || (status !== undefined && FIVE_XX_STATUS_CODES.has(status)))
 		return createError("provider_5xx", rawMessage, status)
-	if (TRANSPORT_FAILURE_RE.test(rawMessage)) return createError("transport_failure", rawMessage, status)
-	if (BAD_REQUEST_TEXT_RE.test(rawMessage) || status === 400) return createError("bad_request", rawMessage, status)
+	if (TRANSPORT_FAILURE_RE.test(rawMessage) || TRANSPORT_TERMINATION_RE.test(rawMessage))
+		return createError("transport_failure", rawMessage, status)
 
 	return undefined
 }

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -5,7 +5,6 @@ import {
 	installInfrastructureRetryPatch,
 	isInfrastructureBreakerTripped,
 	isInfrastructureErrorRetryable,
-	resetInfrastructureBreaker,
 	resolveInfrastructureBreakerThreshold,
 } from "./upstream-retry-patch.js"
 
@@ -19,15 +18,17 @@ describe("upstream retry patch", () => {
 		)
 		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "503 Service Unavailable" })).toBe(true)
 		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "overloaded_error" })).toBe(true)
+		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
 		expect(isInfrastructureErrorRetryable({ stopReason: "stop", errorMessage: "524 status code (no body)" })).toBe(
 			false,
 		)
 		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "bad request" })).toBe(false)
+		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "context window exceeded" })).toBe(false)
 	})
 
 	it("wraps the upstream retry classifier once and preserves original retryable errors", () => {
 		const original = vi.fn(
-			(message: { stopReason?: string; errorMessage?: string }) => message.errorMessage === "429 rate limit",
+			(message: { stopReason?: string; errorMessage?: string }) => message.errorMessage === "upstream-only retryable",
 		)
 		const sessionClass = {
 			prototype: {
@@ -41,7 +42,7 @@ describe("upstream retry patch", () => {
 
 		expect(sessionClass.prototype._isRetryableError).toBe(wrapped)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "524 status code (no body)" })).toBe(true)
-		expect(wrapped?.({ stopReason: "error", errorMessage: "429 rate limit" })).toBe(true)
+		expect(wrapped?.({ stopReason: "error", errorMessage: "upstream-only retryable" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "invalid request" })).toBe(false)
 	})
@@ -57,10 +58,10 @@ describe("isInfrastructureErrorRetryable", () => {
 	})
 
 	it("returns false for unrelated error messages", () => {
-		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "rate limit exceeded" })).toBe(false)
+		expect(isInfrastructureErrorRetryable({ stopReason: "error", errorMessage: "insufficient_quota" })).toBe(false)
 	})
 
-	// Token-level classifier coverage lives in infrastructure-error.test.ts;
+	// Token-level classifier coverage lives in llm-gateway-error.test.ts;
 	// this pins the incident that motivated the patch (upstream misses Bun's wording).
 	it("matches Bun's mid-stream socket close verbatim", () => {
 		expect(
@@ -77,10 +78,11 @@ describe("infrastructure breaker", () => {
 	const networkError = { stopReason: "error", errorMessage: "The socket connection was closed unexpectedly" }
 	const success = { stopReason: "stop" }
 
-	function installPatchedClassifier(threshold: number) {
-		const sessionClass = {
-			prototype: { _isRetryableError: (_message: { stopReason?: string; errorMessage?: string }) => false },
-		}
+	function installPatchedClassifier(
+		threshold: number,
+		upstream: (message: { stopReason?: string; errorMessage?: string }) => boolean = () => false,
+	) {
+		const sessionClass = { prototype: { _isRetryableError: upstream } }
 		installInfrastructureRetryPatch(sessionClass, threshold)
 		// biome-ignore lint/style/noNonNullAssertion: installInfrastructureRetryPatch always wraps the classifier above
 		return sessionClass.prototype._isRetryableError!
@@ -101,50 +103,33 @@ describe("infrastructure breaker", () => {
 
 	it("trips after the threshold of consecutive infrastructure errors and stops retries", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
-		const isRetryable = installPatchedClassifier(3)
-
-		expect(isRetryable(networkError)).toBe(true)
-		expect(isRetryable(networkError)).toBe(true)
-		expect(isRetryable(networkError)).toBe(false)
-		expect(isInfrastructureBreakerTripped()).toBe(true)
-	})
-
-	it("closes again on reset, so a recovered run gets a fresh budget", () => {
-		vi.spyOn(console, "error").mockImplementation(() => {})
 		const isRetryable = installPatchedClassifier(2)
 
 		expect(isRetryable(networkError)).toBe(true)
-		resetInfrastructureBreaker()
-		expect(isRetryable(networkError)).toBe(true)
 		expect(isRetryable(networkError)).toBe(false)
 		expect(isInfrastructureBreakerTripped()).toBe(true)
 	})
 
-	it("does not count non-infrastructure errors that upstream retries (e.g. rate limits)", () => {
-		const sessionClass = {
-			prototype: {
-				_isRetryableError: (message: { stopReason?: string; errorMessage?: string }) =>
-					message.errorMessage === "429 rate limit",
-			},
-		}
-		installInfrastructureRetryPatch(sessionClass, 1)
-		const isRetryable = sessionClass.prototype._isRetryableError
+	it("does not count upstream-only retryable errors", () => {
+		const isRetryable = installPatchedClassifier(1, (message) => message.errorMessage === "upstream-only retryable")
 
-		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit" })).toBe(true)
-		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit" })).toBe(true)
+		expect(isRetryable({ stopReason: "error", errorMessage: "upstream-only retryable" })).toBe(true)
+		expect(isRetryable({ stopReason: "error", errorMessage: "upstream-only retryable" })).toBe(true)
 		expect(isInfrastructureBreakerTripped()).toBe(false)
+	})
+
+	it("counts rate limits as retryable gateway errors", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		const isRetryable = installPatchedClassifier(2)
+
+		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
+		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(false)
+		expect(isInfrastructureBreakerTripped()).toBe(true)
 	})
 
 	it("counts provider 5xx errors even when upstream retries them", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
-		const sessionClass = {
-			prototype: {
-				_isRetryableError: (message: { stopReason?: string; errorMessage?: string }) =>
-					message.errorMessage === "500 internal server error",
-			},
-		}
-		installInfrastructureRetryPatch(sessionClass, 2)
-		const isRetryable = sessionClass.prototype._isRetryableError
+		const isRetryable = installPatchedClassifier(2, (message) => message.errorMessage === "500 internal server error")
 
 		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(true)
 		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(false)

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -5,6 +5,8 @@ import {
 	installInfrastructureRetryPatch,
 	isInfrastructureBreakerTripped,
 	isInfrastructureErrorRetryable,
+	recordInfrastructureBreakerFailure,
+	resetInfrastructureBreaker,
 	resolveInfrastructureBreakerThreshold,
 } from "./upstream-retry-patch.js"
 
@@ -50,7 +52,7 @@ describe("upstream retry patch", () => {
 
 describe("isInfrastructureErrorRetryable", () => {
 	it("returns false when stopReason is not error", () => {
-		expect(isInfrastructureErrorRetryable({ stopReason: "end_turn", errorMessage: "524" })).toBe(false)
+		expect(isInfrastructureErrorRetryable({ stopReason: "stop", errorMessage: "524" })).toBe(false)
 	})
 
 	it("returns false when errorMessage is absent", () => {
@@ -101,13 +103,24 @@ describe("infrastructure breaker", () => {
 		expect(resolveInfrastructureBreakerThreshold({ [INFRA_BREAKER_THRESHOLD_ENV]: "banana" })).toBe(0)
 	})
 
+	it("does not mutate breaker state while classifying retryability", () => {
+		const isRetryable = installPatchedClassifier(1)
+
+		expect(isRetryable(networkError)).toBe(true)
+		expect(isRetryable(networkError)).toBe(true)
+		expect(isInfrastructureBreakerTripped()).toBe(false)
+	})
+
 	it("trips after the threshold of consecutive infrastructure errors and stops retries", () => {
 		vi.spyOn(console, "error").mockImplementation(() => {})
 		const isRetryable = installPatchedClassifier(2)
 
 		expect(isRetryable(networkError)).toBe(true)
-		expect(isRetryable(networkError)).toBe(false)
+		recordInfrastructureBreakerFailure()
+		expect(isRetryable(networkError)).toBe(true)
+		recordInfrastructureBreakerFailure()
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
 	})
 
 	it("does not count upstream-only retryable errors", () => {
@@ -123,8 +136,11 @@ describe("infrastructure breaker", () => {
 		const isRetryable = installPatchedClassifier(2)
 
 		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
-		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(false)
+		recordInfrastructureBreakerFailure()
+		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
+		recordInfrastructureBreakerFailure()
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(false)
 	})
 
 	it("counts provider 5xx errors even when upstream retries them", () => {
@@ -132,15 +148,34 @@ describe("infrastructure breaker", () => {
 		const isRetryable = installPatchedClassifier(2, (message) => message.errorMessage === "500 internal server error")
 
 		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(true)
-		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(false)
+		recordInfrastructureBreakerFailure()
+		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(true)
+		recordInfrastructureBreakerFailure()
 		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(false)
 	})
 
 	it("never trips when disabled", () => {
 		const isRetryable = installPatchedClassifier(0)
 
-		for (let i = 0; i < 10; i++) expect(isRetryable(networkError)).toBe(true)
+		for (let i = 0; i < 10; i++) {
+			recordInfrastructureBreakerFailure()
+			expect(isRetryable(networkError)).toBe(true)
+		}
 		expect(isInfrastructureBreakerTripped()).toBe(false)
+	})
+
+	it("resetInfrastructureBreaker clears a tripped breaker", () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		const isRetryable = installPatchedClassifier(1)
+
+		recordInfrastructureBreakerFailure()
+		expect(isInfrastructureBreakerTripped()).toBe(true)
+		expect(isRetryable(networkError)).toBe(false)
+
+		resetInfrastructureBreaker()
+		expect(isInfrastructureBreakerTripped()).toBe(false)
+		expect(isRetryable(networkError)).toBe(true)
 	})
 
 	it("stays irrelevant for successful messages", () => {

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,5 +1,5 @@
 import { AgentSession } from "@earendil-works/pi-coding-agent"
-import { isInfrastructureProviderError } from "./infrastructure-error.js"
+import { classifyLLMGatewayError } from "./llm-gateway-error.js"
 
 type RetryableMessage = { stopReason?: string; errorMessage?: string }
 type RetryableClassifier = (message: RetryableMessage) => boolean
@@ -11,7 +11,8 @@ type PatchableAgentSession = {
 }
 
 export function isInfrastructureErrorRetryable(message: RetryableMessage): boolean {
-	return message.stopReason === "error" && !!message.errorMessage && isInfrastructureProviderError(message.errorMessage)
+	if (message.stopReason !== "error" || !message.errorMessage) return false
+	return classifyLLMGatewayError(message.errorMessage)?.retryable ?? false
 }
 
 // --- Infrastructure-error circuit breaker ---
@@ -56,8 +57,14 @@ export function isInfrastructureBreakerTripped(): boolean {
 	return infrastructureBreaker.tripped
 }
 
-function infrastructureBreakerAllowsRetry(message: RetryableMessage): boolean {
-	if (infrastructureBreaker.threshold <= 0 || !isInfrastructureErrorRetryable(message)) return true
+/**
+ * Record one infrastructure-classified retryable error and report whether a
+ * retry is still allowed. Only call this for errors already classified as
+ * infrastructure errors; ordinary upstream-retryable verdicts must not draw
+ * down the budget. When disabled (threshold <= 0) nothing is counted.
+ */
+function infrastructureBreakerAllowsRetry(): boolean {
+	if (infrastructureBreaker.threshold <= 0) return true
 	infrastructureBreaker.consecutive++
 	if (infrastructureBreaker.consecutive < infrastructureBreaker.threshold) return true
 	if (!infrastructureBreaker.tripped) {
@@ -86,8 +93,12 @@ export function installInfrastructureRetryPatch(
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		if (!(original.call(this, message) || isInfrastructureErrorRetryable(message))) return false
-		return infrastructureBreakerAllowsRetry(message)
+		const infrastructure = isInfrastructureErrorRetryable(message)
+		if (!(original.call(this, message) || infrastructure)) return false
+		// Only infrastructure-classified errors draw down the breaker budget;
+		// ordinary upstream-retryable verdicts pass through uncounted.
+		if (!infrastructure) return true
+		return infrastructureBreakerAllowsRetry()
 	}
 	proto._kimchiInfrastructureRetryPatch = true
 }

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,7 +1,8 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import { classifyLLMGatewayError } from "./llm-gateway-error.js"
 
-type RetryableMessage = { stopReason?: string; errorMessage?: string }
+type RetryableMessage = Partial<Pick<AssistantMessage, "stopReason" | "errorMessage">>
 type RetryableClassifier = (message: RetryableMessage) => boolean
 type PatchableAgentSession = {
 	prototype: {
@@ -58,22 +59,20 @@ export function isInfrastructureBreakerTripped(): boolean {
 }
 
 /**
- * Record one infrastructure-classified retryable error and report whether a
- * retry is still allowed. Only call this for errors already classified as
- * infrastructure errors; ordinary upstream-retryable verdicts must not draw
- * down the budget. When disabled (threshold <= 0) nothing is counted.
+ * Record one infrastructure-classified retryable error. This is intentionally
+ * separate from _isRetryableError: Pi calls that predicate for both UI metadata
+ * and the actual retry decision, so mutating state there would double-count.
  */
-function infrastructureBreakerAllowsRetry(): boolean {
-	if (infrastructureBreaker.threshold <= 0) return true
+export function recordInfrastructureBreakerFailure(): void {
+	if (infrastructureBreaker.threshold <= 0) return
 	infrastructureBreaker.consecutive++
-	if (infrastructureBreaker.consecutive < infrastructureBreaker.threshold) return true
+	if (infrastructureBreaker.consecutive < infrastructureBreaker.threshold) return
 	if (!infrastructureBreaker.tripped) {
 		infrastructureBreaker.tripped = true
 		console.error(
 			`KIMCHI: infrastructure-error circuit breaker tripped after ${infrastructureBreaker.consecutive} consecutive provider infrastructure failures; giving up on retries.`,
 		)
 	}
-	return false
 }
 
 /**
@@ -95,10 +94,10 @@ export function installInfrastructureRetryPatch(
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
 		const infrastructure = isInfrastructureErrorRetryable(message)
 		if (!(original.call(this, message) || infrastructure)) return false
-		// Only infrastructure-classified errors draw down the breaker budget;
+		// Only infrastructure-classified errors are blocked by the breaker;
 		// ordinary upstream-retryable verdicts pass through uncounted.
 		if (!infrastructure) return true
-		return infrastructureBreakerAllowsRetry()
+		return !isInfrastructureBreakerTripped()
 	}
 	proto._kimchiInfrastructureRetryPatch = true
 }


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Adds a structured classifier for provider/gateway failures and uses it as the shared policy source for retry decisions, circuit-breaker accounting, and final infra exit classification.

- Covered gaps include rate limits, proxy/transport failures, interrupted streams, Cloudflare/5xx responses, and hosted vLLM infrastructure failures.
- Non-infra request failures remain excluded, including empty tool payloads, context-window errors, auth/quota errors, and generic bad requests.
- Existing Cloudflare/HTTP retry behavior is preserved.
- Retry-after timing is intentionally not implemented because Pi does not expose a clean retry-delay policy hook.
- Process-level tail scanning is still out of scope; this pass handles failures visible through Pi message/error paths.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
