### PR TITLE
fix(terminal-bench-2): select multi-model mode via model alias

### DIFF
--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -182,13 +182,13 @@ Do not use `--agent-kwarg disable-multi-model=true`; the adapter accepts that le
 
 ### Multi-model run (orchestrator)
 
-To run kimchi's multi-model orchestrator, opt into the adapter-level kwarg. In this mode the adapter intentionally does not pass `--model` to kimchi, because an explicit model flag is what disables orchestration in the kimchi CLI.
+To run kimchi's default multi-model role configuration, select the adapter's virtual `multi-model` model. In this mode the adapter intentionally does not pass `--model` to kimchi, because an explicit model flag is what disables orchestration in the kimchi CLI.
 
 ```bash
-./scripts/run-local.sh -n 8 -k 3 --agent-kwarg multi-model=true
+MODEL=multi-model ./scripts/run-local.sh -n 8 -k 3
 ```
 
-With no custom role config in the task container, the orchestrator model defaults to `kimchi-dev/kimi-k2.6`. The adapter writes `{"multiModel":true}` to the in-container harness settings before launching kimchi so orchestration is enabled even in a fresh benchmark image.
+With no custom role config in the task container, the tested Kimchi revision supplies its default role configuration. The adapter writes `{"multiModel":true}` to the in-container harness settings before launching kimchi so orchestration is enabled even in a fresh benchmark image.
 
 ### One-shot ferment per task
 

--- a/benchmark/terminal-bench-2/scripts/run-local.sh
+++ b/benchmark/terminal-bench-2/scripts/run-local.sh
@@ -6,7 +6,7 @@
 # Usage examples:
 #   ./scripts/run-local.sh -i terminal-bench/fix-git
 #   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
-#   ./scripts/run-local.sh -i terminal-bench/fix-git -k 3 --agent-kwarg multi-model=true
+#   MODEL=multi-model ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"

--- a/benchmark/terminal-bench-2/scripts/run-release.sh
+++ b/benchmark/terminal-bench-2/scripts/run-release.sh
@@ -6,7 +6,7 @@
 # Usage examples:
 #   ./scripts/run-release.sh -i terminal-bench/fix-git
 #   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-release.sh -i terminal-bench/fix-git
-#   ./scripts/run-release.sh -i terminal-bench/fix-git -k 3 --agent-kwarg multi-model=true
+#   MODEL=multi-model ./scripts/run-release.sh -i terminal-bench/fix-git -k 3
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -39,6 +39,7 @@ CONTAINER_HARNESS_SETTINGS_DIR = "~/.config/kimchi/harness"
 CONTAINER_HARNESS_SETTINGS = f"{CONTAINER_HARNESS_SETTINGS_DIR}/settings.json"
 CONTAINER_HARNESS_SKILLS_DIR = f"{CONTAINER_HARNESS_SETTINGS_DIR}/skills"
 KIMCHI_API_KEY_ENV = "KIMCHI_API_KEY"
+MULTI_MODEL = "multi-model"
 KIMCHI_INFRA_BREAKER_THRESHOLD_ENV = "KIMCHI_INFRA_BREAKER_THRESHOLD"
 KIMCHI_BENCHMARK_INFRA_BREAKER_DEFAULT_ATTEMPTS = "3"
 KIMCHI_EXIT_OUTPUT_TAIL_LINES = 20
@@ -145,17 +146,25 @@ class Kimchi(BaseInstalledAgent):
     ]
 
     def __init__(self, *args, **kwargs):
-        multi_model = _coerce_bool_kwarg(kwargs.pop("multi-model", False), "multi-model")
+        multi_model_kwarg = kwargs.pop("multi-model", None)
         disable_multi_model = _coerce_bool_kwarg(
             kwargs.pop("disable-multi-model", False), "disable-multi-model"
         )
-        if multi_model and disable_multi_model:
-            raise ValueError(
-                "'multi-model=true' conflicts with legacy 'disable-multi-model=true'"
-            )
 
         super().__init__(*args, **kwargs)
-        self._multi_model_enabled = multi_model
+        selected_multi_model = self.model_name == MULTI_MODEL
+        legacy_multi_model = (
+            _coerce_bool_kwarg(multi_model_kwarg, "multi-model")
+            if multi_model_kwarg is not None
+            else False
+        )
+        if multi_model_kwarg is not None and legacy_multi_model != selected_multi_model:
+            raise ValueError("the 'multi-model' agent kwarg must match model_name='multi-model'")
+        if selected_multi_model and disable_multi_model:
+            raise ValueError(
+                "multi-model selection conflicts with legacy 'disable-multi-model=true'"
+            )
+        self._multi_model_enabled = selected_multi_model
         config_kwargs = {}
         api_key = self._get_env(KIMCHI_API_KEY_ENV)
         if api_key is not None:

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -89,8 +89,7 @@ async def test_single_model_run_passes_model_without_multi_model_cli_flag(tmp_pa
 async def test_multi_model_run_omits_model_and_enables_harness_setting(tmp_path: Path) -> None:
     agent = RecordingKimchi(
         logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
-        model_name="kimchi-dev/kimi-k2.6",
-        **{"multi-model": True},
+        model_name="multi-model",
     )
 
     with pytest.raises(asyncio.CancelledError):
@@ -107,16 +106,22 @@ async def test_multi_model_run_omits_model_and_enables_harness_setting(tmp_path:
     assert agent.to_agent_info().model_info.name == "multi-model"
 
 
-async def test_multi_model_run_does_not_require_model_name(tmp_path: Path) -> None:
-    agent = RecordingKimchi(
-        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
-        **{"multi-model": "true"},
-    )
+def test_legacy_multi_model_kwarg_cannot_enable_mode(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must match model_name='multi-model'"):
+        RecordingKimchi(
+            logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+            model_name="kimchi-dev/kimi-k2.6",
+            **{"multi-model": "true"},
+        )
 
-    with pytest.raises(asyncio.CancelledError):
-        await agent.run("hello", object(), AgentContext())
 
-    assert "--model" not in agent.agent_commands[0]
+def test_multi_model_virtual_selection_rejects_explicit_false_kwarg(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must match model_name='multi-model'"):
+        RecordingKimchi(
+            logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+            model_name="multi-model",
+            **{"multi-model": False},
+        )
 
 
 async def test_run_copies_harbor_skills_dir_into_kimchi_harness_skills_dir(tmp_path: Path) -> None:
@@ -237,8 +242,8 @@ def test_multi_model_and_legacy_disable_multi_model_conflict(tmp_path: Path) -> 
     with pytest.raises(ValueError):
         RecordingKimchi(
             logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
-            model_name="kimchi-dev/kimi-k2.6",
-            **{"multi-model": True, "disable-multi-model": True},
+            model_name="multi-model",
+            **{"disable-multi-model": True},
         )
 
 


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Multi-model configuration is now managed by Kimchi roles. Drive the adapter's multi-model mode by passing `model_name='multi-model'` instead of `--agent-kwarg multi-model=true`. The legacy `multi-model` kwarg is still accepted but must agree with the selected model name.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
