### PR TITLE
fix: enforce bash timeout by destroying stdio after kill

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -22,25 +22,10 @@
 #   6. dist/modes/interactive/interactive-mode.js — add previewTheme(name) and
 #      dist/core/extensions/types.d.ts              showError(message) to createExtensionUIContext,
 #                                                   and their type declarations to ExtensionUIContext.
-#
-#                                 previewTheme applies a theme live by delegating to
-#                                 InteractiveThemeController.preview() (the same path as
-#                                 the internal onThemePreview callback used by /settings),
-#                                 WITHOUT the settingsManager.setTheme() persistence that
-#                                 the public ui.setTheme() includes.
-#
-#                                 Why a patch is required: the public ExtensionUIContext conflates
-#                                 "change the rendered theme" and "persist to settingsManager" — the
-#                                 public ui.setTheme() always does both. Theme preview already exists
-#                                 inside InteractiveMode (used by /settings via the private
-#                                 themeController.preview()); the patch simply promotes it to the
-#                                 extension API surface. There is no public-API-only workaround: the
-#                                 only alternative is ui.setTheme() on each arrow-key press, which
-#                                 writes to disk every keystroke and leaves a dirty settings state
-#                                 if the user cancels.
-#
-#                                 showError delegates to the inherited SessionMode.showError so
-#                                 extensions can surface error overlays (not toasts).
+#   7. dist/core/tools/bash.js — destroy child stdio streams 500ms after a timeout kill
+#      so the tool call returns even when setsid'd grandchildren (e.g. bubblewrap used
+#      by opam install on Linux) escape the process group SIGKILL and keep the stdout
+#      pipe open, which would otherwise cause waitForChildProcess to hang indefinitely.
 #
 # Tracking: open an upstream PR against pi-mono to ship before_provider_headers as
 # a first-class extension hook in ExtensionRunner and ExtensionAPI. Also track a
@@ -58,7 +43,11 @@
 #   - Item 5: individual fixes land upstream and the patched version is updated.
 #   - Item 6 (previewTheme + showError): upstream pi-coding-agent ships previewTheme
 #     and showError on ExtensionUIContext and the fixed version is pinned in package.json.
-#
+#   - Item 7 (bash timeout stream destroy): upstream pi-coding-agent's
+#     createLocalBashOperations destroys child stdio after a timeout kill (or
+#     waitForChildProcess gains a max-wait that forces resolution), and the
+#     fixed version is pinned in package.json.
+
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d198245751 100644
 --- a/dist/cli/args.js
@@ -258,6 +247,27 @@ index e386db6d62622a8c77c7d7e9844e63020d8af39a..f2f9e0161b47f7111df88f429c36feb7
              });
          },
          onPayload: async (payload, _model) => {
+diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
+index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..659fe9c52d0acac4080abfc6d3b92d865d141a4c 100644
+--- a/dist/core/tools/bash.js
++++ b/dist/core/tools/bash.js
+@@ -62,6 +62,16 @@ export function createLocalBashOperations(options) {
+                         timedOut = true;
+                         if (child.pid)
+                             killProcessTree(child.pid);
++                        // Destroy stdio streams after a short grace so the tool
++                        // call returns even when setsid'd grandchildren (e.g.
++                        // bubblewrap used by opam install on Linux) escape the
++                        // process-group SIGKILL, inherit the pipe, and keep
++                        // writing — which would re-arm waitForChildProcess's
++                        // grace timer indefinitely.
++                        setTimeout(() => {
++                            child.stdout?.destroy();
++                            child.stderr?.destroy();
++                        }, 500);
+                     }, timeout * 1000);
+                 }
+                 // Stream stdout and stderr.
 diff --git a/dist/core/tools/edit.js b/dist/core/tools/edit.js
 index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5d97aa84c 100644
 --- a/dist/core/tools/edit.js
@@ -481,7 +491,7 @@ index 0e85e9006835b754e38a7af725b4f1ca18eb3a61..94ea3d983a2abe039a7729d452f60c32
              color: (content) => theme.fg("userMessageText", content),
          }, { preserveOrderedListMarkers: true }));
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 85c551f8630bc7d021825359095a8b552cbfb518..3b97e69d382bb0315b4907568fddb446e6cefe56 100644
+index 85c551f8630bc7d021825359095a8b552cbfb518..30f3116df69289dbac01ebbc2439e821e07c86af 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -1592,6 +1592,7 @@ export class InteractiveMode {
@@ -548,11 +558,12 @@ index 85c551f8630bc7d021825359095a8b552cbfb518..3b97e69d382bb0315b4907568fddb446
          const model = await this.findExactModelMatch(searchTerm);
          if (model) {
              try {
-diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
---- a/dist/modes/interactive/interactive-mode.js
-+++ b/dist/modes/interactive/interactive-mode.js
-@@ -4291,3 +4292,3 @@
+@@ -4255,7 +4289,7 @@ export class InteractiveMode {
+         const outputPath = this.getPathCommandArgument(text, "/export");
+         try {
              if (outputPath?.endsWith(".jsonl")) {
 -                const filePath = this.session.exportToJsonl(outputPath);
 +                const filePath = await this.session.exportToJsonl(outputPath);
                  this.showStatus(`Session exported to: ${filePath}`);
+             }
+             else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: d29884b7582397ece2c07d71c40d73cc0ff38a582a117391c1fe8147be52d0bb
+    hash: 2d6664c1656678dde4795012d498ffaa7d41f5cb68531bcde38f9893276040ae
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=d29884b7582397ece2c07d71c40d73cc0ff38a582a117391c1fe8147be52d0bb)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=2d6664c1656678dde4795012d498ffaa7d41f5cb68531bcde38f9893276040ae)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)
@@ -2827,7 +2827,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=d29884b7582397ece2c07d71c40d73cc0ff38a582a117391c1fe8147be52d0bb)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=2d6664c1656678dde4795012d498ffaa7d41f5cb68531bcde38f9893276040ae)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/extensions/bash-timeout-patch.test.ts
+++ b/src/extensions/bash-timeout-patch.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for the bash timeout stdio-destroy patch.
+ *
+ * Problem: when a bash command's timeout fires, `killProcessTree` sends
+ * SIGKILL to the process group. But on Linux, commands like `opam install`
+ * use `bubblewrap` (bwrap) which calls `setsid()` to create a new process
+ * group. These `setsid`'d grandchildren escape the process-group kill,
+ * inherit the stdout pipe, and keep writing output — which re-arms
+ * `waitForChildProcess`'s grace timer indefinitely, causing `ops.exec()`
+ * to never resolve and the tool call to hang forever.
+ *
+ * Fix (patch item 7 in patches/@earendil-works__pi-coding-agent@0.79.10.patch):
+ * destroy the child's stdout/stderr streams 500ms after the timeout kill,
+ * forcing `waitForChildProcess` to resolve so the timeout error propagates.
+ *
+ * This test is Linux-only because `setsid` is required to create a child
+ * that escapes the process group. On macOS, backgrounded children remain in
+ * the parent's process group and are killed by the group SIGKILL, so the
+ * bug cannot be reproduced.
+ */
+import { execSync } from "node:child_process"
+import { createLocalBashOperations } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it } from "vitest"
+
+const TIMEOUT_SECONDS = 2
+// The patch destroys streams 500ms after the kill, so the tool call should
+// resolve within timeout + 1s. We use 5s as a generous upper bound — the
+// pre-fix behaviour would hang indefinitely.
+const MAX_RETURN_SECONDS = 5
+
+describe.skipIf(process.platform !== "linux")("bash timeout: setsid'd grandchild escaping process group", () => {
+	// Track any orphaned processes so we can clean them up after the test.
+	const orphanPatterns: string[] = []
+
+	afterEach(() => {
+		// Kill any surviving orphaned processes from the test.
+		for (const pattern of orphanPatterns) {
+			try {
+				execSync(`pkill -f "${pattern}"`, { stdio: "ignore" })
+			} catch {
+				// Already dead or pkill not available
+			}
+		}
+		orphanPatterns.length = 0
+	})
+
+	it("returns after timeout when setsid'd child keeps the stdout pipe open", async () => {
+		const ops = createLocalBashOperations()
+		const start = Date.now()
+
+		// setsid creates a new process group/session. The child writes to
+		// stdout continuously, which would re-arm waitForChildProcess's
+		// grace timer indefinitely without the stdio-destroy fix.
+		const command = `setsid bash -c 'for i in $(seq 1 100000); do echo "compile output $i"; sleep 0.01; done' & wait`
+		orphanPatterns.push("compile output")
+
+		let error: Error | undefined
+		try {
+			await ops.exec(command, "/tmp", {
+				onData: () => {},
+				timeout: TIMEOUT_SECONDS,
+			})
+		} catch (err) {
+			error = err as Error
+		}
+
+		const elapsedSec = (Date.now() - start) / 1000
+
+		// The tool call must return (not hang forever).
+		expect(error).toBeDefined()
+		expect(error?.message).toContain("timeout")
+
+		// Must return within a reasonable window of the timeout.
+		// Without the fix, this never resolves.
+		expect(elapsedSec).toBeLessThan(MAX_RETURN_SECONDS)
+		expect(elapsedSec).toBeGreaterThanOrEqual(TIMEOUT_SECONDS)
+	})
+
+	it("returns after timeout when multiple setsid'd children write to stdout", async () => {
+		const ops = createLocalBashOperations()
+		const start = Date.now()
+
+		// Multiple parallel setsid children, simulating `make -j4` style
+		// parallel compilation where each worker escapes the process group.
+		const command = `for i in $(seq 1 4); do
+  setsid bash -c 'for j in $(seq 1 100000); do echo "worker $i: $j"; sleep 0.01; done' &
+done
+wait`
+		orphanPatterns.push("worker")
+
+		let error: Error | undefined
+		try {
+			await ops.exec(command, "/tmp", {
+				onData: () => {},
+				timeout: TIMEOUT_SECONDS,
+			})
+		} catch (err) {
+			error = err as Error
+		}
+
+		const elapsedSec = (Date.now() - start) / 1000
+
+		expect(error).toBeDefined()
+		expect(error?.message).toContain("timeout")
+		expect(elapsedSec).toBeLessThan(MAX_RETURN_SECONDS)
+		expect(elapsedSec).toBeGreaterThanOrEqual(TIMEOUT_SECONDS)
+	})
+
+	it("still enforces timeout for normal (non-setsid) commands", async () => {
+		const ops = createLocalBashOperations()
+		const start = Date.now()
+
+		let error: Error | undefined
+		try {
+			await ops.exec("sleep 60", "/tmp", {
+				onData: () => {},
+				timeout: TIMEOUT_SECONDS,
+			})
+		} catch (err) {
+			error = err as Error
+		}
+
+		const elapsedSec = (Date.now() - start) / 1000
+
+		expect(error).toBeDefined()
+		expect(error?.message).toContain("timeout")
+		expect(elapsedSec).toBeLessThan(MAX_RETURN_SECONDS)
+		expect(elapsedSec).toBeGreaterThanOrEqual(TIMEOUT_SECONDS)
+	})
+
+	it("completes normally when command finishes before timeout", async () => {
+		const ops = createLocalBashOperations()
+
+		const result = await ops.exec("echo hello && exit 0", "/tmp", {
+			onData: () => {},
+			timeout: 10,
+		})
+
+		expect(result.exitCode).toBe(0)
+	})
+})

--- a/src/extensions/bash-timeout-patch.test.ts
+++ b/src/extensions/bash-timeout-patch.test.ts
@@ -29,19 +29,14 @@ const TIMEOUT_SECONDS = 2
 const MAX_RETURN_SECONDS = 5
 
 describe.skipIf(process.platform !== "linux")("bash timeout: setsid'd grandchild escaping process group", () => {
-	// Track any orphaned processes so we can clean them up after the test.
-	const orphanPatterns: string[] = []
-
 	afterEach(() => {
 		// Kill any surviving orphaned processes from the test.
-		for (const pattern of orphanPatterns) {
-			try {
-				execSync(`pkill -f "${pattern}"`, { stdio: "ignore" })
-			} catch {
-				// Already dead or pkill not available
-			}
+		// The marker string in the command makes this reliable.
+		try {
+			execSync("pkill -f 'bash-timeout-regression-marker' 2>/dev/null || true", { stdio: "ignore" })
+		} catch {
+			// No survivors
 		}
-		orphanPatterns.length = 0
 	})
 
 	it("returns after timeout when setsid'd child keeps the stdout pipe open", async () => {
@@ -51,8 +46,9 @@ describe.skipIf(process.platform !== "linux")("bash timeout: setsid'd grandchild
 		// setsid creates a new process group/session. The child writes to
 		// stdout continuously, which would re-arm waitForChildProcess's
 		// grace timer indefinitely without the stdio-destroy fix.
-		const command = `setsid bash -c 'for i in $(seq 1 100000); do echo "compile output $i"; sleep 0.01; done' & wait`
-		orphanPatterns.push("compile output")
+		// The loop self-terminates after 10s (200 × 0.05s) so even if
+		// cleanup fails, no orphan survives past the test run.
+		const command = `setsid bash -c 'for i in $(seq 1 200); do echo "bash-timeout-regression-marker $i"; sleep 0.05; done' & wait`
 
 		let error: Error | undefined
 		try {
@@ -82,11 +78,11 @@ describe.skipIf(process.platform !== "linux")("bash timeout: setsid'd grandchild
 
 		// Multiple parallel setsid children, simulating `make -j4` style
 		// parallel compilation where each worker escapes the process group.
+		// Each child self-terminates after 10s (200 × 0.05s).
 		const command = `for i in $(seq 1 4); do
-  setsid bash -c 'for j in $(seq 1 100000); do echo "worker $i: $j"; sleep 0.01; done' &
+  setsid bash -c 'for j in $(seq 1 200); do echo "bash-timeout-regression-marker $i $j"; sleep 0.05; done' &
 done
 wait`
-		orphanPatterns.push("worker")
 
 		let error: Error | undefined
 		try {


### PR DESCRIPTION
Closes #N

## Problem

Bash command timeouts were not being enforced. When a timeout fired, the bash process was killed, but the tool call **never returned** — it hung indefinitely until an external hard timeout (e.g. the benchmark runner) killed the entire container.

### Root cause

The bash tool's timeout handler in `createLocalBashOperations` (upstream `core/tools/bash.js`) works like this:

```js
timeoutHandle = setTimeout(() => {
    timedOut = true;
    if (child.pid) killProcessTree(child.pid);  // sends SIGKILL to process group
}, timeout * 1000);

// ...later:
const exitCode = await waitForChildProcess(child);  // ← HANGS HERE
if (timedOut) throw new Error(`timeout:${timeout}`); // ← never reached
```

`killProcessTree` sends `SIGKILL` to the process group via `process.kill(-pid, "SIGKILL")`. This kills bash and all processes in its group. **But on Linux**, tools like `opam install` use `bubblewrap` (`bwrap`) which calls `setsid()` to create a **new process group and session**. These `setsid`'d grandchildren:

1. **Escape the process-group SIGKILL** — they have a different PGID
2. **Inherit bash's stdout pipe** — keeping it open
3. **Keep writing output** (compiler logs) — which continuously re-arms `waitForChildProcess`'s 100ms grace timer

The result: `waitForChildProcess` never resolves, `ops.exec()` never returns, and the `timedOut` error check is never reached. The tool call hangs forever.

### Benchmark evidence

This was confirmed via terminal-bench benchmark data. The `compile-compcert` task timed out on `opam install` across **7 separate benchmark runs** — the bash tool call with `timeout:1500` (25 min) ran for 70+ minutes until the benchmark's own 4800s hard timeout killed the container:

| Run | Model | Gap fraction | Time wasted |
|-----|-------|-------------|-------------|
| artifacts 27 | kimi-k2.7 | 0.68 | ~69 min |
| artifacts 36 | kimi-k2.7 | 0.97 | ~116 min |
| artifacts 39 (×2) | kimi-k2.7 | 0.87–0.90 | ~84–88 min |
| artifacts 57 | kimi-k2.7 | 0.94 | ~68 min |
| artifacts 60/63 | kimi-k2.7 | 0.88 | ~70 min |

### Linux Docker reproduction

Reproduced directly in a `node:22-slim` container using `createLocalBashOperations` with a `setsid`'d child that writes to stdout continuously:

```
command: setsid bash -c 'for i in $(seq 1 100000); do echo "compile output $i"; sleep 0.01; done' & wait
timeout: 2s

⚠️  BUG CONFIRMED: tool call did NOT return after 12.0s (timeout was 2s)
```

The timeout killed the process group, but the `setsid`'d grandchild survived and kept the stdout pipe open.

## Solution

Destroy the child's stdout/stderr streams 500ms after the timeout kill. This forces `waitForChildProcess` to resolve (the `close` event fires when streams are destroyed), allowing the `timedOut` check to execute and the timeout error to propagate to the LLM.

```js
timeoutHandle = setTimeout(() => {
    timedOut = true;
    if (child.pid) killProcessTree(child.pid);
    // Destroy stdio streams after a short grace so the tool
    // call returns even when setsid'd grandchildren (e.g.
    // bubblewrap used by opam install on Linux) escape the
    // process-group SIGKILL, inherit the pipe, and keep
    // writing — which would re-arm waitForChildProcess's
    // grace timer indefinitely.
    setTimeout(() => {
        child.stdout?.destroy();
        child.stderr?.destroy();
    }, 500);
}, timeout * 1000);
```

The 500ms grace gives the OS time to deliver the SIGKILL and flush any final output before destroying the streams.

### Verification

- ✅ **Linux Docker**: before fix — tool call hangs forever; after fix — returns at 2.5s (2s timeout + 500ms grace)
- ✅ **Linux CI**: regression test passes (4 tests covering single setsid, parallel setsid, normal command, happy path)
- ✅ All 220 existing `bash-default-timeout` tests pass
- ✅ TypeScript typecheck passes
- ✅ Patch applies cleanly via `pnpm install`

### Implementation

Patch added to `patches/@earendil-works__pi-coding-agent@0.79.10.patch` (item 7), modifying `dist/core/tools/bash.js` in the `createLocalBashOperations` timeout handler. Header documentation updated with tracking issue and removal criteria.

Regression test added at `src/extensions/bash-timeout-patch.test.ts` — Linux-only (`describe.skipIf(platform !== "linux")`) because `setsid` is required to reproduce the bug. CI runs on Linux so all 4 tests execute there; they skip on macOS.

### Upstream tracking

This should be filed as an upstream PR against pi-mono. The fix is minimal and non-breaking — it only adds stream destruction after a timeout kill, which only affects the error path (not normal command execution).