### PR TITLE
feat(acp): multi-model via config options and availableModels

### DIFF
--- a/src/extensions/model-catalog/ref-utils.ts
+++ b/src/extensions/model-catalog/ref-utils.ts
@@ -1,3 +1,12 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+
+/**
+ * Combines model provider and id into a ref string.
+ */
+export function refFromModel(model: Model<Api>): string {
+	return `${model.provider}/${model.id}`
+}
+
 /**
  * Extract just the model ID from a "provider/model-id" string.
  * Returns the full string if no slash is present.

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -33,7 +33,7 @@ interface Harness {
 	getAvailable: ReturnType<typeof vi.fn>
 	exec: (
 		model: string,
-		opts?: { omitRegistry?: boolean; currentModel?: ModelEntry; imagesPresent?: boolean },
+		opts?: { currentModel?: ModelEntry; imagesPresent?: boolean },
 	) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
 }
 
@@ -77,19 +77,17 @@ function createHarness(options: { setModelResult?: boolean } = {}): Harness {
 	const tool = registered
 
 	const exec: Harness["exec"] = (model, opts = {}) => {
-		const ctx = opts.omitRegistry
-			? createContext({ getContextUsage: () => undefined, model: undefined })
-			: createContext({
-					modelRegistry: { find, getAvailable },
-					getContextUsage: () => undefined,
-					model: opts.currentModel
-						? {
-								id: opts.currentModel.id,
-								provider: opts.currentModel.provider,
-								input: opts.currentModel.input ?? ["text", "image"],
-							}
-						: { id: MODELS[0].id, provider: MODELS[0].provider, input: ["text", "image"] },
-				})
+		const ctx = createContext({
+			modelRegistry: { find, getAvailable },
+			getContextUsage: () => undefined,
+			model: opts.currentModel
+				? {
+						id: opts.currentModel.id,
+						provider: opts.currentModel.provider,
+						input: opts.currentModel.input ?? ["text", "image"],
+					}
+				: { id: MODELS[0].id, provider: MODELS[0].provider, input: ["text", "image"] },
+		})
 		return tool.execute("test-call-id", { model }, undefined, undefined, ctx)
 	}
 
@@ -194,10 +192,10 @@ describe("modelSwitchExtension", () => {
 			expect(idxMinimax).toBeGreaterThan(idxKimi)
 		})
 
-		it("handles missing modelRegistry on invalid format (empty available list)", async () => {
+		it("handles invalid model format", async () => {
 			const h = createHarness()
-			const result = await h.exec("no-slash", { omitRegistry: true })
-			expect(textOf(result)).toContain('Invalid model format: "no-slash"')
+			const result = await h.exec("kimi-k2.6")
+			expect(textOf(result)).toContain('Invalid model format: "kimi-k2.6"')
 			expect(textOf(result)).toContain("Available models:")
 			expect(h.setModel).not.toHaveBeenCalled()
 		})
@@ -214,14 +212,6 @@ describe("modelSwitchExtension", () => {
 			expect(textOf(result)).toContain("kimchi-dev/kimi-k2.6")
 			expect(h.setModel).not.toHaveBeenCalled()
 			expect(result.details).toBeNull()
-		})
-
-		it("handles missing modelRegistry on lookup (empty available list)", async () => {
-			const h = createHarness()
-			const result = await h.exec("kimchi-dev/kimi-k2.6", { omitRegistry: true })
-
-			expect(textOf(result)).toContain("Model not found: kimchi-dev/kimi-k2.6")
-			expect(h.setModel).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
+import { refFromModel } from "./model-catalog/ref-utils.js"
 import {
 	contextFitsModel,
 	getLatestMessages,
@@ -12,7 +13,7 @@ import {
 import { setMultiModelEnabled } from "./multi-model.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
-import { getOrchestratorModelId, getOrchestratorModelRef, splitModelRef } from "./orchestration/model-roles.js"
+import { getOrchestratorModel, getOrchestratorModelRef } from "./orchestration/model-roles.js"
 
 /** Prevents model_select handler from re-checking what set_model tool already validated. */
 let suppressModelSelectGuard = false
@@ -65,10 +66,11 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 			const { model } = params
 
 			if (model === "multi-model") {
-				const orchRef = getOrchestratorModelRef(sessionId)
-				const orchId = getOrchestratorModelId(sessionId)
-				const parsed = splitModelRef(orchRef)
-				const orchestrator = parsed ? ctx.modelRegistry?.find(parsed.provider, parsed.modelId) : undefined
+				const {
+					model: orchestrator,
+					modelId: orchId,
+					modelRef: orchRef,
+				} = getOrchestratorModel(sessionId, ctx.modelRegistry)
 				if (!orchestrator) {
 					return {
 						content: [{ type: "text" as const, text: `Multi-model orchestrator (${orchRef}) is not available.` }],
@@ -95,11 +97,10 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 
 			const parts = model.split("/")
 			if (parts.length !== 2 || !parts[0] || !parts[1]) {
-				const available =
-					ctx.modelRegistry
-						?.getAvailable()
-						?.map((m) => `${m.provider}/${m.id}`)
-						?.sort() ?? []
+				const available = ctx.modelRegistry
+					.getAvailable()
+					.map((m) => refFromModel(m))
+					.sort()
 				return {
 					content: [
 						{
@@ -112,14 +113,12 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 			}
 
 			const [provider, modelId] = parts
-			const target = ctx.modelRegistry?.find(provider, modelId)
-
+			const target = ctx.modelRegistry.find(provider, modelId)
 			if (!target) {
-				const available =
-					ctx.modelRegistry
-						?.getAvailable()
-						?.map((m) => `${m.provider}/${m.id}`)
-						?.sort() ?? []
+				const available = ctx.modelRegistry
+					.getAvailable()
+					.map((m) => refFromModel(m))
+					.sort()
 				return {
 					content: [
 						{
@@ -180,7 +179,7 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 					content: [
 						{
 							type: "text" as const,
-							text: `Failed to switch to ${provider}/${modelId} — no API key available for this model's provider.`,
+							text: `Failed to switch to ${refFromModel(target)} — no API key available for this model's provider.`,
 						},
 					],
 					details: null,
@@ -191,7 +190,7 @@ export default function modelSwitchExtension(pi: ExtensionAPI) {
 				content: [
 					{
 						type: "text" as const,
-						text: `Switched to model ${target.provider}/${target.id} (${target.name})`,
+						text: `Switched to model ${refFromModel(target)} (${target.name})`,
 					},
 				],
 				details: null,

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -37,6 +37,8 @@
  * ```
  */
 
+import type { Api, Model } from "@earendil-works/pi-ai"
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import {
 	type ModelCustomMetadata,
 	getModelMetadata,
@@ -45,7 +47,7 @@ import {
 export { modelIdFromRef, splitModelRef } from "./model-ref-utils.js"
 import { readConfigSetting, writeConfigSetting } from "../../config/settings.js"
 import { getProcessOrchestratorRef } from "../kimchi-process.js"
-import { modelIdFromRef } from "./model-ref-utils.js"
+import { modelIdFromRef, splitModelRef } from "./model-ref-utils.js"
 
 /** Task-type affinity tag used to match an agent persona to a model role. */
 export type ModelRole = "review" | "build" | "plan" | "explore" | "research"
@@ -320,4 +322,18 @@ export function getOrchestratorModelRef(sessionId: string | null): string {
 		if (ref) return ref
 	}
 	return getModelRoles().orchestrator
+}
+
+export function getOrchestratorModel(
+	sessionId: string,
+	modelRegistry: ModelRegistry,
+): { model: Model<Api> | undefined; modelId: string; modelRef: string } {
+	const orchRef = getOrchestratorModelRef(sessionId)
+	const orchId = modelIdFromRef(orchRef)
+	const parsed = splitModelRef(orchRef)
+	return {
+		model: parsed ? modelRegistry.find(parsed.provider, parsed.modelId) : undefined,
+		modelId: orchId,
+		modelRef: orchRef,
+	}
 }

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -72,6 +72,8 @@ class FakeAgentSession {
 						},
 					]
 				: [],
+		find: (provider: string, id: string) =>
+			this.modelRegistry.getAvailable().find((m) => m.provider === provider && m.id === id),
 	}
 	promptImpl: (text: string, opts?: { images?: unknown[] }) => Promise<void> = async () => {}
 	abortImpl: () => Promise<void> = async () => {}
@@ -83,6 +85,8 @@ class FakeAgentSession {
 	branch: unknown[] = []
 	sessionManager = {
 		getBranch: () => this.branch,
+		getSessionId: () => this.sessionId,
+		getEntries: () => this.branch,
 	}
 	// Captures whatever setUIContext the agent installs so tests can assert
 	// on it. The real AgentSession exposes this via its extensionRunner
@@ -1627,24 +1631,38 @@ describe("initializeHeadlessTheme", () => {
 	})
 })
 
-describe("buildSessionModelState", () => {
-	it("returns null when model is missing", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = undefined
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
-		expect(result).toBeNull()
-	})
+function modelConfigOption(
+	currentValue: string,
+	options: { value: string; name: string }[],
+): {
+	id: "model"
+	name: string
+	type: "select"
+	category: string
+	description: string
+	currentValue: string
+	options: { value: string; name: string }[]
+} {
+	return {
+		id: "model",
+		name: "Model",
+		type: "select",
+		category: "model",
+		description: "",
+		currentValue,
+		options,
+	}
+}
 
-	it("returns currentModelId and availableModels when model is present", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = { provider: "openai", id: "gpt-4" }
-		fake.modelRegistry = {
-			getAvailable: () => [
-				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
-				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
-			],
-		}
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+describe("buildSessionModelState", () => {
+	it("returns currentModelId and availableModels from the model config option", () => {
+		const configOptions = [
+			modelConfigOption("openai/gpt-4", [
+				{ value: "openai/gpt-4", name: "GPT-4" },
+				{ value: "anthropic/claude-3", name: "Claude 3" },
+			]),
+		]
+		const result = buildSessionModelState(configOptions as unknown as Parameters<typeof buildSessionModelState>[0])
 		expect(result).toEqual({
 			currentModelId: "openai/gpt-4",
 			availableModels: [
@@ -1654,11 +1672,9 @@ describe("buildSessionModelState", () => {
 		})
 	})
 
-	it("returns empty availableModels when registry has no models", () => {
-		const fake = new FakeAgentSession("s1")
-		fake.model = { provider: "openai", id: "gpt-4" }
-		fake.modelRegistry = { getAvailable: () => [] }
-		const result = buildSessionModelState(fake as unknown as Parameters<typeof buildSessionModelState>[0])
+	it("returns empty availableModels when the model config option has no entries", () => {
+		const configOptions = [modelConfigOption("openai/gpt-4", [])]
+		const result = buildSessionModelState(configOptions as unknown as Parameters<typeof buildSessionModelState>[0])
 		expect(result).toEqual({
 			currentModelId: "openai/gpt-4",
 			availableModels: [],
@@ -1671,6 +1687,7 @@ describe("newSession model state", () => {
 		const fake = new FakeAgentSession("session-model")
 		fake.model = { provider: "openai", id: "gpt-4" }
 		fake.modelRegistry = {
+			...fake.modelRegistry,
 			getAvailable: () => [
 				{ provider: "openai", id: "gpt-4", name: "GPT-4" },
 				{ provider: "anthropic", id: "claude-3", name: "Claude 3" },
@@ -1686,7 +1703,7 @@ describe("newSession model state", () => {
 		expect(res.sessionId).toBe("session-model")
 		expect(res.models).toBeDefined()
 		expect(res.models?.currentModelId).toBe("openai/gpt-4")
-		expect(res.models?.availableModels).toHaveLength(2)
+		expect(res.models?.availableModels).toHaveLength(3)
 		expect(res.models?.availableModels[0]).toEqual({
 			modelId: "openai/gpt-4",
 			name: "GPT-4",
@@ -1695,6 +1712,8 @@ describe("newSession model state", () => {
 			modelId: "anthropic/claude-3",
 			name: "Claude 3",
 		})
+		expect(res.models?.availableModels[2]?.modelId).toBe("multi-model")
+		expect(res.models?.availableModels[2]?.name).toMatch(/^Multi-model \(/)
 	})
 
 	it("rejects with authRequired when no model is active", async () => {
@@ -1722,10 +1741,12 @@ describe("newSession model state", () => {
 		const res = await agent.newSession({ cwd: "/tmp", mcpServers: [] })
 
 		expect(res.configOptions).toBeDefined()
-		expect(res.configOptions).toHaveLength(1)
+		expect(res.configOptions).toHaveLength(2)
 		expect(res.configOptions?.[0].id).toBe("permissions-mode")
 		expect(res.configOptions?.[0].type).toBe("select")
 		expect(res.configOptions?.[0].currentValue).toBeDefined()
+		expect(res.configOptions?.[1].id).toBe("model")
+		expect(res.configOptions?.[1].type).toBe("select")
 	})
 })
 
@@ -1785,6 +1806,7 @@ describe("unstable_setSessionModel", () => {
 		const fake = new FakeAgentSession("switch-session")
 		fake.model = { provider: "provider-a", id: "model-a" }
 		fake.modelRegistry = {
+			...fake.modelRegistry,
 			getAvailable: () => [
 				{ provider: "provider-a", id: "model-a", name: "Model A" },
 				{ provider: "provider-b", id: "model-b", name: "Model B" },
@@ -1810,6 +1832,7 @@ describe("unstable_setSessionModel", () => {
 		const fake = new FakeAgentSession("switch-session")
 		fake.model = { provider: "provider-a", id: "model-a" }
 		fake.modelRegistry = {
+			...fake.modelRegistry,
 			getAvailable: () => [{ provider: "provider-a", id: "model-a", name: "Model A" }],
 		}
 		const factory: AcpSessionFactory = async () => asSession(fake)
@@ -1831,6 +1854,7 @@ describe("unstable_setSessionModel", () => {
 		const fake = new FakeAgentSession("switch-session")
 		fake.model = { provider: "provider-a", id: "model-a" }
 		fake.modelRegistry = {
+			...fake.modelRegistry,
 			getAvailable: () => [
 				{ provider: "provider-a", id: "model-a", name: "Model A" },
 				{ provider: "provider-b", id: "model-b", name: "Model B" },
@@ -1891,9 +1915,10 @@ describe("setSessionConfigOption", () => {
 			value: "plan",
 		})
 
-		expect(res.configOptions).toHaveLength(1)
+		expect(res.configOptions).toHaveLength(2)
 		expect(res.configOptions[0].id).toBe("permissions-mode")
 		expect(res.configOptions[0].currentValue).toBe("plan")
+		expect(res.configOptions[1].id).toBe("model")
 	})
 
 	it("sets all valid permission modes", async () => {
@@ -1913,8 +1938,9 @@ describe("setSessionConfigOption", () => {
 				configId: "permissions-mode",
 				value: mode,
 			})
-			expect(res.configOptions).toHaveLength(1)
+			expect(res.configOptions).toHaveLength(2)
 			expect(res.configOptions[0].currentValue).toBe(mode)
+			expect(res.configOptions[1].id).toBe("model")
 		}
 	})
 
@@ -2002,6 +2028,199 @@ describe("setSessionConfigOption", () => {
 		const selectOption = res.configOptions[0] as any
 		expect(selectOption.options).toHaveLength(4)
 		expect(selectOption.options.map((o: { value: string }) => o.value)).toEqual(PERMISSION_MODES)
+	})
+
+	describe("model config option", () => {
+		it("switches to a valid single model", async () => {
+			const fake = new FakeAgentSession("test-session-model-single")
+			fake.model = { provider: "provider-a", id: "model-a" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "provider-b", id: "model-b", name: "Model B" },
+				],
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			const res = await agent.setSessionConfigOption({
+				sessionId: "test-session-model-single",
+				configId: "model",
+				value: "provider-b/model-b",
+			})
+
+			expect(fake.model).toMatchObject({ provider: "provider-b", id: "model-b" })
+			const modelOption = res.configOptions?.find((o) => o.id === "model")
+			expect(modelOption?.currentValue).toBe("provider-b/model-b")
+		})
+
+		it("switches to multi-model when orchestrator is available", async () => {
+			const fake = new FakeAgentSession("test-session-model-multi")
+			fake.model = { provider: "kimchi-dev", id: "kimi-k2.7", name: "Kimi K2.7" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "kimchi-dev", id: "kimi-k2.7", name: "Kimi K2.7" },
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+				],
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			const res = await agent.setSessionConfigOption({
+				sessionId: "test-session-model-multi",
+				configId: "model",
+				value: "multi-model",
+			})
+
+			expect(fake.model).toMatchObject({ provider: "kimchi-dev", id: "kimi-k2.7" })
+			const modelOption = res.configOptions?.find((o) => o.id === "model")
+			expect(modelOption?.currentValue).toBe("multi-model")
+		})
+
+		it("rejects multi-model when orchestrator is not available", async () => {
+			const fake = new FakeAgentSession("test-session-model-multi-missing")
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [{ provider: "provider-a", id: "model-a", name: "Model A" }],
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId: "test-session-model-multi-missing",
+					configId: "model",
+					value: "multi-model",
+				}),
+			).rejects.toThrow(/multi-model orchestrator .* is not available/)
+		})
+
+		it("rejects invalid model format", async () => {
+			const fake = new FakeAgentSession("test-session-model-format")
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId: "test-session-model-format",
+					configId: "model",
+					value: "not-a-valid-ref",
+				}),
+			).rejects.toThrow(/invalid model format/)
+		})
+
+		it("rejects unknown single model", async () => {
+			const fake = new FakeAgentSession("test-session-model-unknown")
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [{ provider: "provider-a", id: "model-a", name: "Model A" }],
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId: "test-session-model-unknown",
+					configId: "model",
+					value: "provider-b/model-b",
+				}),
+			).rejects.toThrow(/model not found/)
+		})
+
+		it("returns updated configOptions when model changes", async () => {
+			const fake = new FakeAgentSession("test-session-model-return")
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "provider-b", id: "model-b", name: "Model B" },
+				],
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			const res = await agent.setSessionConfigOption({
+				sessionId: "test-session-model-return",
+				configId: "model",
+				value: "provider-b/model-b",
+			})
+
+			const modelOption = res.configOptions?.find((o) => o.id === "model")
+			expect(modelOption?.currentValue).toBe("provider-b/model-b")
+		})
+
+		it("rejects model change when a prompt is in progress", async () => {
+			const fake = new FakeAgentSession("test-session-model-busy")
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "provider-b", id: "model-b", name: "Model B" },
+				],
+			}
+			let releasePrompt!: () => void
+			const promptReleased = new Promise<void>((resolve) => {
+				releasePrompt = resolve
+			})
+			fake.promptImpl = async () => {
+				fake.emit({ type: "agent_start" })
+				await promptReleased
+			}
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			const promptP = agent.prompt({
+				sessionId: "test-session-model-busy",
+				prompt: [{ type: "text", text: "x" }],
+			})
+			await delay(10)
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId: "test-session-model-busy",
+					configId: "model",
+					value: "provider-b/model-b",
+				}),
+			).rejects.toThrow(/prompt is already in progress/)
+
+			// Release the prompt so the test runner doesn't wait on it.
+			releasePrompt()
+			await promptP
+		})
 	})
 
 	it("emits config_option_update when permission mode changes", async () => {
@@ -3281,8 +3500,9 @@ describe("KimchiAcpAgent loadSession", () => {
 			})
 
 			expect(res.configOptions).toBeDefined()
-			expect(res.configOptions).toHaveLength(1)
+			expect(res.configOptions).toHaveLength(2)
 			expect(res.configOptions?.[0].id).toBe("permissions-mode")
+			expect(res.configOptions?.[1].id).toBe("model")
 		} finally {
 			rmSync(tmpDir, { recursive: true, force: true })
 		}
@@ -3381,6 +3601,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		// "live" while loadSession rejects — blocking re-load with invalidRequest.
 		const fake = new FakeAgentSession("replay-boom")
 		fake.sessionManager = {
+			...fake.sessionManager,
 			getBranch: () => {
 				throw new Error("branch read failed")
 			},
@@ -3395,7 +3616,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		).rejects.toThrow(/branch read failed/)
 		expect(fake.disposed).toBe(true)
 		// Re-load must not see the failed session as already-live.
-		fake.sessionManager = { getBranch: () => [] }
+		fake.sessionManager = { ...fake.sessionManager, getBranch: () => [] }
 		fake.disposed = false
 		await expect(
 			agent.loadSession({
@@ -3410,6 +3631,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		const fake = new FakeAgentSession("loaded-1")
 		fake.model = { provider: "test", id: "test-model", name: "Test Model" }
 		fake.modelRegistry = {
+			...fake.modelRegistry,
 			getAvailable: () => [{ provider: "test", id: "test-model", name: "Test Model" }],
 		}
 		fake.branch = [
@@ -3466,7 +3688,10 @@ describe("KimchiAcpAgent loadSession", () => {
 		})
 		expect(res.models).toMatchObject({
 			currentModelId: "test/test-model",
-			availableModels: [{ modelId: "test/test-model", name: "Test Model" }],
+			availableModels: [
+				{ modelId: "test/test-model", name: "Test Model" },
+				{ modelId: "multi-model", name: expect.stringMatching(/^Multi-model \(/) },
+			],
 		})
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -26,7 +26,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
-import { setMultiModelEnabled } from "../../extensions/multi-model.js"
+import { setProcessOrchestratorRef } from "../../extensions/kimchi-process.js"
+import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { PERMISSIONS_ENV_KEY } from "../../extensions/permissions/constants.js"
 import { PERMISSION_MODES } from "../../extensions/permissions/constants.js"
 import { getSessionPermissionFlagController } from "../../extensions/permissions/mode-controller-registry.js"
@@ -2065,16 +2066,55 @@ describe("setSessionConfigOption", () => {
 			expect(modelOption?.currentValue).toBe("provider-b/model-b")
 		})
 
-		it("switches to multi-model when orchestrator is available", async () => {
-			const fake = new FakeAgentSession("test-session-model-multi")
-			fake.model = { provider: "kimchi-dev", id: "kimi-k2.7", name: "Kimi K2.7" }
+		it("restores previous multi-model state when switching to a single model fails", async () => {
+			const sessionId = "test-session-model-restore"
+			const fake = new FakeAgentSession(sessionId)
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
 			fake.modelRegistry = {
 				...fake.modelRegistry,
 				getAvailable: () => [
-					{ provider: "kimchi-dev", id: "kimi-k2.7", name: "Kimi K2.7" },
 					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "provider-b", id: "model-b", name: "Model B" },
 				],
 			}
+			fake.setModel = async () => {
+				throw new Error("auth failed")
+			}
+			// Start in multi-model mode so we can verify the flag is restored on failure.
+			setMultiModelEnabled(sessionId, true)
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId,
+					configId: "model",
+					value: "provider-b/model-b",
+				}),
+			).rejects.toThrow(/model provider-b\/model-b is not available: auth required/)
+
+			expect(getMultiModelEnabled(fake.sessionManager as Pick<SessionManager, "getEntries" | "getSessionId">)).toBe(
+				true,
+			)
+		})
+
+		it("switches to multi-model when orchestrator is available", async () => {
+			const sessionId = "test-session-model-multi"
+			const fake = new FakeAgentSession(sessionId)
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "orchestrator-provider", id: "orchestrator-model", name: "Orchestrator Model" },
+				],
+			}
+			// Wire the orchestrator model explicitly instead of relying on the global default role.
+			setProcessOrchestratorRef(sessionId, "orchestrator-provider/orchestrator-model")
 			const agent = new KimchiAcpAgent(makeConn(), {
 				extensionFactories: [],
 				agentDir: "/tmp/fake-agent-dir",
@@ -2083,14 +2123,50 @@ describe("setSessionConfigOption", () => {
 			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
 
 			const res = await agent.setSessionConfigOption({
-				sessionId: "test-session-model-multi",
+				sessionId,
 				configId: "model",
 				value: "multi-model",
 			})
 
-			expect(fake.model).toMatchObject({ provider: "kimchi-dev", id: "kimi-k2.7" })
+			expect(fake.model).toMatchObject({ provider: "orchestrator-provider", id: "orchestrator-model" })
 			const modelOption = res.configOptions?.find((o) => o.id === "model")
 			expect(modelOption?.currentValue).toBe("multi-model")
+		})
+
+		it("restores previous multi-model state when switching to multi-model fails", async () => {
+			const sessionId = "test-session-model-multi-restore"
+			const fake = new FakeAgentSession(sessionId)
+			fake.model = { provider: "provider-a", id: "model-a", name: "Model A" }
+			fake.modelRegistry = {
+				...fake.modelRegistry,
+				getAvailable: () => [
+					{ provider: "provider-a", id: "model-a", name: "Model A" },
+					{ provider: "orchestrator-provider", id: "orchestrator-model", name: "Orchestrator Model" },
+				],
+			}
+			fake.setModel = async () => {
+				throw new Error("auth failed")
+			}
+			// Wire the orchestrator model explicitly instead of relying on the global default role.
+			setProcessOrchestratorRef(sessionId, "orchestrator-provider/orchestrator-model")
+			const agent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/fake-agent-dir",
+				sessionFactory: async () => asSession(fake),
+			})
+			await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+			await expect(
+				agent.setSessionConfigOption({
+					sessionId,
+					configId: "model",
+					value: "multi-model",
+				}),
+			).rejects.toThrow(/orchestrator model orchestrator-provider\/orchestrator-model is not available: auth required/)
+
+			expect(getMultiModelEnabled(fake.sessionManager as Pick<SessionManager, "getEntries" | "getSessionId">)).toBe(
+				false,
+			)
 		})
 
 		it("rejects multi-model when orchestrator is not available", async () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1658,16 +1658,16 @@ describe("buildSessionModelState", () => {
 	it("returns currentModelId and availableModels from the model config option", () => {
 		const configOptions = [
 			modelConfigOption("openai/gpt-4", [
-				{ value: "openai/gpt-4", name: "GPT-4" },
 				{ value: "anthropic/claude-3", name: "Claude 3" },
+				{ value: "openai/gpt-4", name: "GPT-4" },
 			]),
 		]
 		const result = buildSessionModelState(configOptions as unknown as Parameters<typeof buildSessionModelState>[0])
 		expect(result).toEqual({
 			currentModelId: "openai/gpt-4",
 			availableModels: [
-				{ modelId: "openai/gpt-4", name: "GPT-4" },
 				{ modelId: "anthropic/claude-3", name: "Claude 3" },
+				{ modelId: "openai/gpt-4", name: "GPT-4" },
 			],
 		})
 	})
@@ -1705,15 +1705,17 @@ describe("newSession model state", () => {
 		expect(res.models?.currentModelId).toBe("openai/gpt-4")
 		expect(res.models?.availableModels).toHaveLength(3)
 		expect(res.models?.availableModels[0]).toEqual({
-			modelId: "openai/gpt-4",
-			name: "GPT-4",
+			modelId: "multi-model",
+			name: "Multi-model (kimi-k2.7)",
 		})
 		expect(res.models?.availableModels[1]).toEqual({
 			modelId: "anthropic/claude-3",
 			name: "Claude 3",
 		})
-		expect(res.models?.availableModels[2]?.modelId).toBe("multi-model")
-		expect(res.models?.availableModels[2]?.name).toMatch(/^Multi-model \(/)
+		expect(res.models?.availableModels[2]).toEqual({
+			modelId: "openai/gpt-4",
+			name: "GPT-4",
+		})
 	})
 
 	it("rejects with authRequired when no model is active", async () => {
@@ -3689,8 +3691,8 @@ describe("KimchiAcpAgent loadSession", () => {
 		expect(res.models).toMatchObject({
 			currentModelId: "test/test-model",
 			availableModels: [
-				{ modelId: "test/test-model", name: "Test Model" },
 				{ modelId: "multi-model", name: expect.stringMatching(/^Multi-model \(/) },
+				{ modelId: "test/test-model", name: "Test Model" },
 			],
 		})
 	})

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
+import { setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { PERMISSIONS_ENV_KEY } from "../../extensions/permissions/constants.js"
 import { PERMISSION_MODES } from "../../extensions/permissions/constants.js"
 import { getSessionPermissionFlagController } from "../../extensions/permissions/mode-controller-registry.js"
@@ -105,6 +106,9 @@ class FakeAgentSession {
 
 	constructor(sessionId: string) {
 		this.sessionId = sessionId
+		// Tests assume deterministic single-model state by default. The global
+		// multi-model default may differ between local and CI, so pin it here.
+		setMultiModelEnabled(sessionId, false)
 	}
 
 	subscribe(listener: AgentSessionEventListener): () => void {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -263,9 +263,7 @@ export class KimchiAcpAgent implements Agent {
 
 			const sessionId = session.sessionId
 			const uiContext = this.createUiContext(session)
-			const permissionFlagController = registerPermissionFlagController(sessionId, initialMode, (params) =>
-				this.send(params),
-			)
+			registerPermissionFlagController(session, initialMode, (params) => this.send(params))
 			registerAcpPrompter(sessionId, createAcpPermissionPrompter(this.conn, sessionId, uiContext, buildToolCallUpdate))
 			await this.bindAcpExtensions(session, uiContext)
 
@@ -282,7 +280,7 @@ export class KimchiAcpAgent implements Agent {
 			return {
 				sessionId,
 				models: buildSessionModelState(session),
-				configOptions: [buildPermissionsConfigOption(permissionFlagController.getMode()?.mode)],
+				configOptions: buildConfigOptions(session, () => this.resolveInitialMode(params.cwd)),
 			}
 		} catch (err) {
 			unregisterAcpPrompter(session.sessionId)
@@ -316,18 +314,57 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
-		const entry = this.sessions.get(params.sessionId)
-		if (!entry) {
+		await this.setModel(params.sessionId, params.modelId)
+		return {}
+	}
+
+	async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
+		const session = this.sessions.get(params.sessionId)?.session
+		if (!session) {
 			throw RequestError.invalidParams(undefined, `unknown sessionId ${params.sessionId}`)
+		}
+		switch (params.configId) {
+			case "permissions-mode": {
+				this.setPermissionMode(params.sessionId, params.value ? `${params.value}` : "")
+				break
+			}
+			case "model": {
+				await this.setModel(params.sessionId, params.value ? `${params.value}` : "")
+				break
+			}
+			default:
+				throw RequestError.invalidParams(undefined, `unknown config option ${params.configId}`)
+		}
+		return {
+			configOptions: buildConfigOptions(session, () => this.resolveInitialMode(session.sessionManager.getSessionDir())),
+		}
+	}
+
+	private setPermissionMode(sessionId: string, mode: string): PermissionMode {
+		const permissionMode = mode as PermissionMode
+		if (!PERMISSION_MODES.includes(permissionMode)) {
+			throw RequestError.invalidParams(undefined, `invalid mode ${permissionMode}`)
+		}
+		setPermissionMode(sessionId, permissionMode, "user")
+		return permissionMode
+	}
+
+	private async setModel(sessionId: string, modelId: string): Promise<string> {
+		const entry = this.sessions.get(sessionId)
+		if (!entry) {
+			throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
 		}
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
+		if (!modelId) {
+			throw RequestError.invalidParams(undefined, "modelId is required")
+		}
 		const { session } = entry
 		const availableModels = session.modelRegistry.getAvailable()
-		const selectedModel = availableModels.find((m) => getAcpModelId(m) === params.modelId)
+		const selectedModel = availableModels.find((m) => getAcpModelId(m) === modelId)
 		if (!selectedModel) {
-			throw RequestError.invalidParams(undefined, `Unknown or unavailable model: ${params.modelId}`)
+			throw RequestError.invalidParams(undefined, `unknown or unavailable model: ${modelId}`)
 		}
 		try {
 			await session.setModel(selectedModel)
@@ -340,29 +377,7 @@ export class KimchiAcpAgent implements Agent {
 				`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`,
 			)
 		}
-		return {}
-	}
-
-	async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
-		const entry = this.sessions.get(params.sessionId)
-		if (!entry) {
-			throw RequestError.invalidParams(undefined, `unknown sessionId ${params.sessionId}`)
-		}
-
-		switch (params.configId) {
-			case "permissions-mode": {
-				const value = params.value as PermissionMode
-				if (!PERMISSION_MODES.includes(value)) {
-					throw RequestError.invalidParams(undefined, `invalid mode ${value}`)
-				}
-				setPermissionMode(params.sessionId, value, "user")
-				return {
-					configOptions: [buildPermissionsConfigOption(value)],
-				}
-			}
-			default:
-				throw RequestError.invalidParams(undefined, `unknown config option ${params.configId}`)
-		}
+		return modelId
 	}
 
 	async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
@@ -384,10 +399,8 @@ export class KimchiAcpAgent implements Agent {
 			this.sendAvailableCommandsUpdate(sessionId)
 
 			return {
-				models: this.modelStateForSession(existing.session),
-				configOptions: [
-					buildPermissionsConfigOption(getPermissionMode(sessionId)?.mode ?? this.resolveInitialMode(params.cwd)),
-				],
+				models: buildSessionModelState(existing.session),
+				configOptions: buildConfigOptions(existing.session, () => this.resolveInitialMode(params.cwd)),
 			}
 		}
 		const loading = this.loadingSessions.get(sessionId)
@@ -432,7 +445,7 @@ export class KimchiAcpAgent implements Agent {
 			assertSessionHasModel(session)
 
 			const uiContext = this.createUiContext(session)
-			const permissionFlagController = registerPermissionFlagController(sid, initialMode, (params) => this.send(params))
+			registerPermissionFlagController(session, initialMode, (params) => this.send(params))
 			registerAcpPrompter(sid, createAcpPermissionPrompter(this.conn, sid, uiContext, buildToolCallUpdate))
 			await this.bindAcpExtensions(session, uiContext)
 
@@ -458,8 +471,8 @@ export class KimchiAcpAgent implements Agent {
 			this.sendAvailableCommandsUpdate(sid)
 
 			return {
-				models: this.modelStateForSession(session),
-				configOptions: [buildPermissionsConfigOption(permissionFlagController.getMode()?.mode)],
+				models: buildSessionModelState(session),
+				configOptions: buildConfigOptions(session, () => this.resolveInitialMode(params.cwd)),
 			}
 		} catch (err) {
 			unregisterAcpPrompter(sid)
@@ -948,10 +961,6 @@ export class KimchiAcpAgent implements Agent {
 		flushText()
 	}
 
-	private modelStateForSession(session: AgentSession): SessionModelState | null {
-		return buildSessionModelState(session)
-	}
-
 	private send(params: SessionNotification): void {
 		// Fire-and-forget is safe here because the ACP SDK chains every outbound
 		// message onto a shared writeQueue Promise (see @agentclientprotocol/sdk
@@ -996,6 +1005,7 @@ export class KimchiAcpAgent implements Agent {
  * Builds a SessionConfigOption for the permissions mode setting.
  * Exposes the four permission modes (default, plan, auto, yolo) as a select
  * option that ACP clients can read and modify.
+ * Exported for testing.
  */
 export function buildPermissionsConfigOption(currentMode: PermissionMode): SessionConfigOption {
 	return {
@@ -1012,6 +1022,37 @@ export function buildPermissionsConfigOption(currentMode: PermissionMode): Sessi
 			description,
 		})),
 	}
+}
+
+/**
+ * Builds a SessionConfigOption for the model setting.
+ * ???
+ * Exported for testing.
+ */
+export function buildModelConfigOption(session: Pick<AgentSession, "model" | "modelRegistry">): SessionConfigOption {
+	const availableModels = session.modelRegistry.getAvailable().map((m) => ({
+		value: getAcpModelId(m),
+		name: m.name,
+	}))
+	const currentValue = session.model ? getAcpModelId(session.model) : availableModels[0].value
+	return {
+		id: "model",
+		name: "Model",
+		type: "select",
+		category: "model",
+		description: "",
+		currentValue,
+		options: availableModels,
+	}
+}
+
+function buildConfigOptions(
+	session: AgentSession,
+	defaultMode: PermissionMode | (() => PermissionMode),
+): SessionConfigOption[] {
+	const mode =
+		getPermissionMode(session.sessionId)?.mode ?? (typeof defaultMode === "function" ? defaultMode() : defaultMode)
+	return [buildPermissionsConfigOption(mode), buildModelConfigOption(session)]
 }
 
 // Exported for testing. In practice the only way model is missing here is a
@@ -1054,26 +1095,25 @@ export function initializeHeadlessTheme(settingsManager: Pick<SettingsManager, "
 }
 
 function registerPermissionFlagController(
-	sessionId: string,
+	session: AgentSession,
 	initialMode: PermissionMode,
 	send: (params: SessionNotification) => void,
-): SessionPermissionFlagController {
+): void {
 	const permissionFlagController = createSessionPermissionFlagController({
 		mode: { mode: initialMode, source: "user" },
 	})
 	// Register with permissions extension so tool gating uses session-scoped mode
-	registerSessionPermissionFlagController(sessionId, permissionFlagController)
+	registerSessionPermissionFlagController(session.sessionId, permissionFlagController)
 	permissionFlagController.subscribe(({ mode }) => {
 		if (mode === undefined) return
 		send({
-			sessionId,
+			sessionId: session.sessionId,
 			update: {
 				sessionUpdate: "config_option_update",
-				configOptions: [buildPermissionsConfigOption(mode.mode)],
+				configOptions: buildConfigOptions(session, initialMode),
 			},
 		})
 	})
-	return permissionFlagController
 }
 
 // Title falls back to the truncated first user message when the session has no

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1072,14 +1072,19 @@ export function buildModelConfigOption(
 		modelId: orchId,
 	} = getOrchestratorModel(session.sessionId, session.modelRegistry)
 	const orchName = orchestrator?.name ?? orchId ?? orchRef
-	const options = session.modelRegistry.getAvailable().map((m) => ({
-		value: refFromModel(m),
-		name: m.name,
-	}))
-	options.push({
-		value: "multi-model",
-		name: `Multi-model (${orchName})`,
-	})
+	const options = [
+		{
+			value: "multi-model",
+			name: `Multi-model (${orchName})`,
+		},
+		...session.modelRegistry
+			.getAvailable()
+			.map((m) => ({
+				value: refFromModel(m),
+				name: m.name,
+			}))
+			.sort((a, b) => a.value.localeCompare(b.value)),
+	]
 	// biome-ignore lint/style/noNonNullAssertion: we assert model availability before session is created/loaded via assertSessionHasModel.
 	const currentValue = multiModelEnabled ? "multi-model" : refFromModel(session.model!)
 	return {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -57,7 +57,7 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import type { AgentSessionEvent, ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
-import { setMultiModelEnabled } from "../../extensions/multi-model.js"
+import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
 import { loadConfig } from "../../extensions/permissions/config.js"
 import {
@@ -77,6 +77,7 @@ import {
 } from "../../extensions/permissions/mode-controller.js"
 import { resolveMode } from "../../extensions/permissions/mode.js"
 import type { PermissionMode } from "../../extensions/permissions/types.js"
+import { SLASH_COMMANDS } from "../../extensions/slash-commands.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
@@ -371,8 +372,14 @@ export class KimchiAcpAgent implements Agent {
 			if (!orchestrator) {
 				throw RequestError.invalidParams(undefined, `multi-model orchestrator (${orchRef}) is not available`)
 			}
-			void setMultiModelEnabled(sessionId, true)
-			await session.setModel(orchestrator)
+			const previousMultiModelEnabled = getMultiModelEnabled(session.sessionManager)
+			setMultiModelEnabled(sessionId, true)
+			try {
+				await session.setModel(orchestrator)
+			} catch {
+				setMultiModelEnabled(sessionId, previousMultiModelEnabled)
+				throw RequestError.authRequired(undefined, `orchestrator model ${orchRef} is not available: auth required`)
+			}
 			return value
 		}
 
@@ -380,7 +387,7 @@ export class KimchiAcpAgent implements Agent {
 		if (!provider || !modelId) {
 			throw RequestError.invalidParams(
 				undefined,
-				`invalid model format: "${modelId}". expected "provider/modelId" or "multi-model".`,
+				`invalid model format: "${value}". expected "provider/modelId" or "multi-model".`,
 			)
 		}
 		const target = session.modelRegistry.find(provider, modelId)
@@ -395,8 +402,12 @@ export class KimchiAcpAgent implements Agent {
 			)
 		}
 
-		void setMultiModelEnabled(sessionId, false)
-		await session.setModel(target)
+		setMultiModelEnabled(sessionId, false)
+		try {
+			await session.setModel(target)
+		} catch (err) {
+			throw RequestError.authRequired(undefined, `model ${refFromModel(target)} is not available: auth required`)
+		}
 		return value
 	}
 
@@ -1048,12 +1059,13 @@ export function buildPermissionsConfigOption(currentMode: PermissionMode): Sessi
 
 /**
  * Builds a SessionConfigOption for the model setting.
- * ???
+ * Combines the orchestrator model with multi-model support into a single select UI.
  * Exported for testing.
  */
 export function buildModelConfigOption(
-	session: Pick<AgentSession, "model" | "modelRegistry" | "sessionId">,
+	session: Pick<AgentSession, "model" | "modelRegistry" | "sessionId" | "sessionManager">,
 ): SessionConfigOption {
+	const multiModelEnabled = getMultiModelEnabled(session.sessionManager)
 	const {
 		model: orchestrator,
 		modelRef: orchRef,
@@ -1069,13 +1081,13 @@ export function buildModelConfigOption(
 		name: `Multi-model (${orchName})`,
 	})
 	// biome-ignore lint/style/noNonNullAssertion: we assert model availability before session is created/loaded via assertSessionHasModel.
-	const currentValue = refFromModel(session.model!)
+	const currentValue = multiModelEnabled ? "multi-model" : refFromModel(session.model!)
 	return {
 		id: "model",
 		name: "Model",
 		type: "select",
 		category: "model",
-		description: "",
+		description: "Select the active AI model: single-model or multi-model (orchestrator + workers).",
 		currentValue,
 		options,
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -77,7 +77,6 @@ import {
 } from "../../extensions/permissions/mode-controller.js"
 import { resolveMode } from "../../extensions/permissions/mode.js"
 import type { PermissionMode } from "../../extensions/permissions/types.js"
-import { SLASH_COMMANDS } from "../../extensions/slash-commands.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
@@ -378,6 +377,7 @@ export class KimchiAcpAgent implements Agent {
 				await session.setModel(orchestrator)
 			} catch {
 				setMultiModelEnabled(sessionId, previousMultiModelEnabled)
+				// Pi's setModel only throws "if no auth is configured for the model"
 				throw RequestError.authRequired(undefined, `orchestrator model ${orchRef} is not available: auth required`)
 			}
 			return value
@@ -402,10 +402,13 @@ export class KimchiAcpAgent implements Agent {
 			)
 		}
 
+		const previousMultiModelEnabled = getMultiModelEnabled(session.sessionManager)
 		setMultiModelEnabled(sessionId, false)
 		try {
 			await session.setModel(target)
 		} catch (err) {
+			setMultiModelEnabled(sessionId, previousMultiModelEnabled)
+			// Pi's setModel only throws "if no auth is configured for the model"
 			throw RequestError.authRequired(undefined, `model ${refFromModel(target)} is not available: auth required`)
 		}
 		return value

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -319,7 +319,7 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
-		await this.setModel(params.sessionId, params.modelId)
+		await this.doSetModel(params.sessionId, params.modelId)
 		return {}
 	}
 
@@ -330,11 +330,11 @@ export class KimchiAcpAgent implements Agent {
 		}
 		switch (params.configId) {
 			case "permissions-mode": {
-				this.setPermissionMode(params.sessionId, params.value ? `${params.value}` : "")
+				this.doSetPermissionMode(params.sessionId, params.value ? `${params.value}` : "")
 				break
 			}
 			case "model": {
-				await this.setModel(params.sessionId, params.value ? `${params.value}` : "")
+				await this.doSetModel(params.sessionId, params.value ? `${params.value}` : "")
 				break
 			}
 			default:
@@ -345,7 +345,7 @@ export class KimchiAcpAgent implements Agent {
 		}
 	}
 
-	private setPermissionMode(sessionId: string, mode: string): PermissionMode {
+	private doSetPermissionMode(sessionId: string, mode: string): PermissionMode {
 		const permissionMode = mode as PermissionMode
 		if (!PERMISSION_MODES.includes(permissionMode)) {
 			throw RequestError.invalidParams(undefined, `invalid mode ${permissionMode}`)
@@ -354,7 +354,7 @@ export class KimchiAcpAgent implements Agent {
 		return permissionMode
 	}
 
-	private async setModel(sessionId: string, value: string): Promise<string> {
+	private async doSetModel(sessionId: string, value: string): Promise<string> {
 		const entry = this.sessions.get(sessionId)
 		if (!entry) {
 			throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -28,6 +28,7 @@ import {
 	type PromptResponse,
 	RequestError,
 	type SessionConfigOption,
+	type SessionConfigSelectOption,
 	type SessionModelState,
 	type SessionNotification,
 	type SetSessionConfigOptionRequest,
@@ -55,7 +56,9 @@ import {
 	initTheme,
 } from "@earendil-works/pi-coding-agent"
 import type { AgentSessionEvent, ExtensionUIContext } from "@earendil-works/pi-coding-agent"
-
+import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
+import { setMultiModelEnabled } from "../../extensions/multi-model.js"
+import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
 import { loadConfig } from "../../extensions/permissions/config.js"
 import {
 	PERMISSIONS_ENV_KEY,
@@ -73,7 +76,7 @@ import {
 	setPermissionMode,
 } from "../../extensions/permissions/mode-controller.js"
 import { resolveMode } from "../../extensions/permissions/mode.js"
-import type { PermissionMode, SessionPermissionFlagController } from "../../extensions/permissions/types.js"
+import type { PermissionMode } from "../../extensions/permissions/types.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
@@ -277,10 +280,11 @@ export class KimchiAcpAgent implements Agent {
 
 			this.sendAvailableCommandsUpdate(sessionId)
 
+			const configOptions = buildConfigOptions(session, () => this.resolveInitialMode(params.cwd))
 			return {
 				sessionId,
-				models: buildSessionModelState(session),
-				configOptions: buildConfigOptions(session, () => this.resolveInitialMode(params.cwd)),
+				configOptions,
+				models: buildSessionModelState(configOptions),
 			}
 		} catch (err) {
 			unregisterAcpPrompter(session.sessionId)
@@ -349,7 +353,7 @@ export class KimchiAcpAgent implements Agent {
 		return permissionMode
 	}
 
-	private async setModel(sessionId: string, modelId: string): Promise<string> {
+	private async setModel(sessionId: string, value: string): Promise<string> {
 		const entry = this.sessions.get(sessionId)
 		if (!entry) {
 			throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
@@ -357,27 +361,43 @@ export class KimchiAcpAgent implements Agent {
 		if (entry.turn) {
 			throw RequestError.invalidRequest(undefined, "a prompt is already in progress for this session")
 		}
-		if (!modelId) {
+		if (!value) {
 			throw RequestError.invalidParams(undefined, "modelId is required")
 		}
+
 		const { session } = entry
-		const availableModels = session.modelRegistry.getAvailable()
-		const selectedModel = availableModels.find((m) => getAcpModelId(m) === modelId)
-		if (!selectedModel) {
-			throw RequestError.invalidParams(undefined, `unknown or unavailable model: ${modelId}`)
-		}
-		try {
-			await session.setModel(selectedModel)
-		} catch (err) {
-			if (err instanceof RequestError) {
-				throw err
+		if (value === "multi-model") {
+			const { model: orchestrator, modelRef: orchRef } = getOrchestratorModel(session.sessionId, session.modelRegistry)
+			if (!orchestrator) {
+				throw RequestError.invalidParams(undefined, `multi-model orchestrator (${orchRef}) is not available`)
 			}
+			void setMultiModelEnabled(sessionId, true)
+			await session.setModel(orchestrator)
+			return value
+		}
+
+		const { provider, modelId } = splitModelRef(value) || {}
+		if (!provider || !modelId) {
 			throw RequestError.invalidParams(
 				undefined,
-				`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`,
+				`invalid model format: "${modelId}". expected "provider/modelId" or "multi-model".`,
 			)
 		}
-		return modelId
+		const target = session.modelRegistry.find(provider, modelId)
+		if (!target) {
+			const available = session.modelRegistry
+				.getAvailable()
+				.map((m) => refFromModel(m))
+				.sort()
+			throw RequestError.invalidParams(
+				undefined,
+				`model not found: "${value}". available models: multi-model, ${available.join(", ")}`,
+			)
+		}
+
+		void setMultiModelEnabled(sessionId, false)
+		await session.setModel(target)
+		return value
 	}
 
 	async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
@@ -398,9 +418,10 @@ export class KimchiAcpAgent implements Agent {
 			this.replayTranscript(existing.session)
 			this.sendAvailableCommandsUpdate(sessionId)
 
+			const configOptions = buildConfigOptions(existing.session, () => this.resolveInitialMode(params.cwd))
 			return {
-				models: buildSessionModelState(existing.session),
-				configOptions: buildConfigOptions(existing.session, () => this.resolveInitialMode(params.cwd)),
+				configOptions,
+				models: buildSessionModelState(configOptions),
 			}
 		}
 		const loading = this.loadingSessions.get(sessionId)
@@ -470,9 +491,10 @@ export class KimchiAcpAgent implements Agent {
 			this.replayTranscript(session)
 			this.sendAvailableCommandsUpdate(sid)
 
+			const configOptions = buildConfigOptions(session, () => this.resolveInitialMode(params.cwd))
 			return {
-				models: buildSessionModelState(session),
-				configOptions: buildConfigOptions(session, () => this.resolveInitialMode(params.cwd)),
+				configOptions,
+				models: buildSessionModelState(configOptions),
 			}
 		} catch (err) {
 			unregisterAcpPrompter(sid)
@@ -1029,12 +1051,25 @@ export function buildPermissionsConfigOption(currentMode: PermissionMode): Sessi
  * ???
  * Exported for testing.
  */
-export function buildModelConfigOption(session: Pick<AgentSession, "model" | "modelRegistry">): SessionConfigOption {
-	const availableModels = session.modelRegistry.getAvailable().map((m) => ({
-		value: getAcpModelId(m),
+export function buildModelConfigOption(
+	session: Pick<AgentSession, "model" | "modelRegistry" | "sessionId">,
+): SessionConfigOption {
+	const {
+		model: orchestrator,
+		modelRef: orchRef,
+		modelId: orchId,
+	} = getOrchestratorModel(session.sessionId, session.modelRegistry)
+	const orchName = orchestrator?.name ?? orchId ?? orchRef
+	const options = session.modelRegistry.getAvailable().map((m) => ({
+		value: refFromModel(m),
 		name: m.name,
 	}))
-	const currentValue = session.model ? getAcpModelId(session.model) : availableModels[0].value
+	options.push({
+		value: "multi-model",
+		name: `Multi-model (${orchName})`,
+	})
+	// biome-ignore lint/style/noNonNullAssertion: we assert model availability before session is created/loaded via assertSessionHasModel.
+	const currentValue = refFromModel(session.model!)
 	return {
 		id: "model",
 		name: "Model",
@@ -1042,7 +1077,7 @@ export function buildModelConfigOption(session: Pick<AgentSession, "model" | "mo
 		category: "model",
 		description: "",
 		currentValue,
-		options: availableModels,
+		options,
 	}
 }
 
@@ -1055,30 +1090,17 @@ function buildConfigOptions(
 	return [buildPermissionsConfigOption(mode), buildModelConfigOption(session)]
 }
 
-// Exported for testing. In practice the only way model is missing here is a
-// missing / unusable credential: loadConfig() already threw on an absent
-// KIMCHI_API_KEY before we ever spawned the ACP loop, and updateModelsConfig
-// falls back to defaults rather than failing. authRequired (-32000) nudges
-// Zed toward an auth prompt instead of showing a generic "internal error".
-export function buildSessionModelState(
-	session: Pick<AgentSession, "model" | "modelRegistry">,
-): SessionModelState | null {
-	const currentModel = session.model
-	if (!currentModel) {
-		return null
-	}
-	const availableModels = session.modelRegistry.getAvailable()
+export function buildSessionModelState(configOptions: SessionConfigOption[]): SessionModelState | null {
+	// biome-ignore lint/style/noNonNullAssertion: model config option is static, it is always available
+	const configOption = configOptions.find((opt) => opt.id === "model")!
+	const options = (configOption as SessionConfigOption & { type: "select" }).options as SessionConfigSelectOption[]
 	return {
-		currentModelId: getAcpModelId(currentModel),
-		availableModels: availableModels.map((m) => ({
-			modelId: getAcpModelId(m),
+		currentModelId: configOption.currentValue as string,
+		availableModels: options.map((m) => ({
+			modelId: m.value,
 			name: m.name,
 		})),
 	}
-}
-
-function getAcpModelId(model: Pick<NonNullable<AgentSession["model"]>, "provider" | "id">): string {
-	return `${model.provider}/${model.id}`
 }
 
 export function assertSessionHasModel(session: Pick<AgentSession, "model">): void {


### PR DESCRIPTION
## Linked issue

Closes #0 (LLM-2472)

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

This PR exposes multi-model support in the ACP (Agent Connection Protocol) surface, allowing ACP clients to discover and select both single models and multi-model mode.

## What's changed

- **Multi-model in the models list:** The legacy `availableModels` response now includes a `"multi-model"` entry alongside the regular single models, so ACP clients can discover and select multi-model mode.
- **Config options for model selection:** A new `"model"` config option is exposed via `configOptions` / `setSessionConfigOption`. It appears as a select control containing every available model plus the `"multi-model"` choice, with the current value reflecting whether multi-model is active.
- **Code cleanup:** Refactored ACP and model-switching code to use shared helpers — `getOrchestratorModel` and `refFromModel` — instead of duplicating orchestrator-model resolution logic.

## Net effect

ACP clients can now see, read, and change the active model (including toggling multi-model on/off) through the standard session config-option flow.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
