### PR TITLE
feat: ferment grader improvements — evidence field, subagent grader, council prompt

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -538,9 +538,29 @@ export async function spawnGraderAgent(
 ): Promise<{ text: string; status: string } | undefined> {
 	if (!activeManager) return undefined
 	const AGENT_GRADER_TYPE = "Grader"
+
+	// Prepare a persisted session file so the grader's transcript is saved
+	// alongside the parent session for post-mortem analysis.
+	let sessionFile: string | undefined
+	let sessionDir: string | undefined
+	try {
+		const parentSessionDir = ctx.sessionManager.getSessionDir()
+		const parentSessionFile = ctx.sessionManager.getSessionFile()
+		if (parentSessionDir && parentSessionFile) {
+			const prepared = prepareAgentSessionFile(parentSessionDir, parentSessionFile, ctx.cwd)
+			sessionFile = prepared?.sessionFile
+			sessionDir = parentSessionDir
+		}
+	} catch {
+		// Session file creation is best-effort — the grader can still run
+		// without a persisted session, it just won't have a transcript file.
+	}
+
 	const record = await activeManager.spawnAndWait(pi, ctx, AGENT_GRADER_TYPE, prompt, {
 		description: "Ferment grader",
 		visibility: "system",
+		sessionFile,
+		sessionDir,
 	})
 	return { text: record.result ?? "", status: record.status }
 }

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -562,7 +562,26 @@ export async function spawnGraderAgent(
 		sessionFile,
 		sessionDir,
 	})
-	return { text: record.result ?? "", status: record.status }
+	// Collect all assistant text from the session — the grade JSON may appear
+	// in an earlier turn, not just the final response.
+	let fullText = record.result ?? ""
+	if (record.session) {
+		const messages = record.session.messages ?? []
+		const assistantTexts: string[] = []
+		for (const msg of messages) {
+			if (msg.role !== "assistant") continue
+			const content = msg.content
+			if (!Array.isArray(content)) continue
+			for (const c of content) {
+				if (typeof c === "object" && c !== null && "type" in c && c.type === "text" && "text" in c) {
+					const t = c.text
+					if (typeof t === "string" && t.trim()) assistantTexts.push(t)
+				}
+			}
+		}
+		fullText = assistantTexts.join("\n\n")
+	}
+	return { text: fullText, status: record.status }
 }
 
 function readAgentTaskRef(params: Record<string, unknown>): AgentTaskRef | undefined {

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -464,6 +464,7 @@ function buildNotificationDetails(
 }
 
 let activeManager: AgentManager | undefined
+let activeWidget: { ensureTimer: () => void; update: () => void; markFinished: (id: string) => void } | undefined
 let budgetRetryBlock: BudgetRetryBlock | undefined
 const budgetRetryCandidates = new Map<string, BudgetRetryCandidate>()
 
@@ -495,6 +496,33 @@ export function getAgentRecordForTaskValidation(id: string): Readonly<AgentRecor
 	const record = activeManager?.getRecord(id)
 	if (!record || record.visibility === "system") return undefined
 	return { ...record, latestOutcome: record.latestOutcome ?? buildAgentOutcome(record) }
+}
+
+/**
+ * Run an async function while showing a transient entry in the agent overlay.
+ * The description appears in the agents widget ("N running" footer + overlay)
+ * for the duration of the call — the same visual feedback as a real subagent.
+ *
+ * Falls back to calling fn() directly when no agent system is active
+ * (e.g. unit tests, non-TUI contexts).
+ */
+export async function runWithOverlay<T>(description: string, fn: () => Promise<T>): Promise<T> {
+	if (!activeManager) return fn()
+	const id = activeManager.registerTransient(description)
+	activeWidget?.ensureTimer()
+	activeWidget?.update()
+	try {
+		const result = await fn()
+		activeManager.completeTransient(id)
+		activeWidget?.markFinished(id)
+		activeWidget?.update()
+		return result
+	} catch (err) {
+		activeManager.completeTransient(id)
+		activeWidget?.markFinished(id)
+		activeWidget?.update()
+		throw err
+	}
 }
 
 function readAgentTaskRef(params: Record<string, unknown>): AgentTaskRef | undefined {
@@ -824,6 +852,7 @@ export default function (pi: ExtensionAPI) {
 	let currentUi: ExtensionUIContext | undefined
 
 	const widget = new AgentWidget(manager, agentActivity)
+	activeWidget = widget
 	const listUserVisibleAgents = () => manager.listAgents().filter((a) => a.visibility !== "system")
 
 	pi.on("session_shutdown", async () => {

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -525,6 +525,26 @@ export async function runWithOverlay<T>(description: string, fn: () => Promise<T
 	}
 }
 
+/** Spawn a Grader subagent (read-only + bash, bounded turns) and wait for its
+ *  result. Returns the agent's final text response and status. Used by the
+ *  ferment grader to independently verify agent claims with tool access.
+ *
+ *  Returns undefined when the agent system is not active (e.g. unit tests,
+ *  non-TUI contexts) so callers can fall back to a single-shot LLM call. */
+export async function spawnGraderAgent(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	prompt: string,
+): Promise<{ text: string; status: string } | undefined> {
+	if (!activeManager) return undefined
+	const AGENT_GRADER_TYPE = "Grader"
+	const record = await activeManager.spawnAndWait(pi, ctx, AGENT_GRADER_TYPE, prompt, {
+		description: "Ferment grader",
+		visibility: "system",
+	})
+	return { text: record.result ?? "", status: record.status }
+}
+
 function readAgentTaskRef(params: Record<string, unknown>): AgentTaskRef | undefined {
 	const ref = params.task_ref as Partial<AgentTaskRef> | undefined
 	if (

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -512,16 +512,11 @@ export async function runWithOverlay<T>(description: string, fn: () => Promise<T
 	activeWidget?.ensureTimer()
 	activeWidget?.update()
 	try {
-		const result = await fn()
+		return await fn()
+	} finally {
 		activeManager.completeTransient(id)
 		activeWidget?.markFinished(id)
 		activeWidget?.update()
-		return result
-	} catch (err) {
-		activeManager.completeTransient(id)
-		activeWidget?.markFinished(id)
-		activeWidget?.update()
-		throw err
 	}
 }
 
@@ -556,30 +551,29 @@ export async function spawnGraderAgent(
 		// without a persisted session, it just won't have a transcript file.
 	}
 
+	// Allow the grader to be cancelled when the parent session shuts down.
+	const abortController = new AbortController()
+
 	const record = await activeManager.spawnAndWait(pi, ctx, AGENT_GRADER_TYPE, prompt, {
 		description: "Ferment grader",
 		visibility: "system",
 		sessionFile,
 		sessionDir,
+		signal: abortController.signal,
 	})
 	// Collect all assistant text from the session — the grade JSON may appear
 	// in an earlier turn, not just the final response.
 	let fullText = record.result ?? ""
 	if (record.session) {
-		const messages = record.session.messages ?? []
-		const assistantTexts: string[] = []
-		for (const msg of messages) {
-			if (msg.role !== "assistant") continue
-			const content = msg.content
-			if (!Array.isArray(content)) continue
-			for (const c of content) {
-				if (typeof c === "object" && c !== null && "type" in c && c.type === "text" && "text" in c) {
-					const t = c.text
-					if (typeof t === "string" && t.trim()) assistantTexts.push(t)
-				}
-			}
-		}
-		fullText = assistantTexts.join("\n\n") || fullText
+		// Collect all assistant text — the grade JSON may appear in an earlier
+		// turn, not just the final response.
+		const assistantText = (record.session?.messages ?? [])
+			.filter((msg) => msg.role === "assistant")
+			.flatMap((msg) => msg.content)
+			.filter((part): part is { type: "text"; text: string } => part.type === "text")
+			.map((part) => part.text)
+			.join("\n\n")
+		fullText = assistantText || fullText
 	}
 	return { text: fullText, status: record.status }
 }

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -579,7 +579,7 @@ export async function spawnGraderAgent(
 				}
 			}
 		}
-		fullText = assistantTexts.join("\n\n")
+		fullText = assistantTexts.join("\n\n") || fullText
 	}
 	return { text: fullText, status: record.status }
 }

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -558,6 +558,38 @@ export class AgentManager {
 		return [...this.agents.values()].sort((a, b) => b.startedAt - a.startedAt)
 	}
 
+	/** Register a transient agent record for visual purposes (overlay/widget)
+	 *  without starting a full agent loop. The caller is responsible for
+	 *  calling completeTransient(id) when done. */
+	registerTransient(description: string): string {
+		const id = randomUUID().slice(0, 17)
+		const record: AgentRecord = {
+			id,
+			type: "general-purpose" as SubagentType,
+			description,
+			visibility: "user",
+			status: "running",
+			toolUses: 0,
+			startedAt: Date.now(),
+			currentAttemptId: 0,
+			maxTurns: 1,
+			resumeAttempts: [],
+			lifetimeUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			compactionCount: 0,
+		}
+		this.agents.set(id, record)
+		return id
+	}
+
+	/** Mark a transient agent record as complete and schedule cleanup. */
+	completeTransient(id: string): void {
+		const record = this.agents.get(id)
+		if (!record) return
+		record.status = "completed"
+		record.completedAt = Date.now()
+		this.onStart?.(record)
+	}
+
 	abort(id: string): boolean {
 		const record = this.agents.get(id)
 		if (!record) return false

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -587,7 +587,9 @@ export class AgentManager {
 		if (!record) return
 		record.status = "completed"
 		record.completedAt = Date.now()
-		this.onStart?.(record)
+		// Schedule removal after a short delay — long enough for the widget to
+		// render one final "✓ done" frame, but not so long it lingers in listAgents().
+		setTimeout(() => this.agents.delete(id), 2000)
 	}
 
 	abort(id: string): boolean {

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -14,6 +14,7 @@ import {
 	AGENT_EXPLORE,
 	AGENT_FIXER,
 	AGENT_GENERAL_PURPOSE,
+	AGENT_GRADER,
 	AGENT_PLAN,
 	AGENT_RESEARCHER,
 	AGENT_REVIEWER,
@@ -325,6 +326,112 @@ Your verification file MUST contain:
 - Use absolute file paths
 - Do not use emojis
 - Be concise`,
+				promptMode: "replace",
+				isDefault: true,
+			},
+		],
+		[
+			AGENT_GRADER,
+			{
+				name: AGENT_GRADER,
+				displayName: AGENT_GRADER,
+				description: "Ferment grader — independently verifies agent claims and assigns a letter grade",
+				builtinToolNames: [...READ_ONLY_TOOLS],
+				disallowedTools: ["edit", "write", "Agent", "resume_subagent", "get_subagent_result", "steer_subagent"],
+				extensions: false,
+				skills: false,
+				roles: ["review"],
+				thinking: "medium",
+				maxTurns: 10,
+				tokenBudget: 50_000,
+				maxDuration: 120,
+				systemPrompt: `# Ferment Grader Agent
+
+You are a strict production-readiness review council compressed into one reviewer, acting as the final LLM grader for an autonomous coding ferment. Your job is to evaluate the completed result against the stated goal, implementation, tests, and evidence, and assign a letter grade A-F that describes HOW WELL the work was done.
+
+## Critical: You have tools
+
+Unlike a passive reviewer, you have read-only tools (read, bash, grep, find, ls). USE THEM to independently verify the agent's claims. Do NOT trust the agent's self-reported gate verdicts. Instead:
+
+- **Read the source files** the agent claims to have created or modified.
+- **Run the verification commands** the agent claims to have run (tests, build, lint, timing comparisons).
+- **Check output files** the agent claims to have produced.
+- **Compare the agent's claims against what you can actually observe.**
+
+You have a limited turn budget. Prioritize the most load-bearing claims first:
+1. Does the output file exist and contain what the agent says it contains?
+2. Do the tests actually pass? Run them if possible.
+3. Does the code actually implement the stated goal?
+
+If a claim cannot be verified (e.g., requires external services, network access, or privileged operations), note it and move on.
+
+## Your bias is PESSIMISTIC
+
+Most work is B or C, not A. A is reserved for work that delivered cleanly without retries, with concrete real-execution verification at every phase, and where every gate verdict was substantiated with specific evidence.
+
+## Hard constraints
+
+- Do not treat claims as proof. Missing proof lowers the grade.
+- Passing compile/build alone is not proof of runtime behavior.
+- Skipped required tests are not pass evidence.
+- Documentation of a problem is not remediation.
+- Prefer concrete findings over vague concerns.
+- Grade harshly when correctness, security, evidence, or production wiring is unclear.
+
+## Internal review council
+
+Run these reviews silently before assigning the grade.
+
+### 1. Security attacker
+Authentication/authorization, tenant isolation, privilege escalation, input validation, injection, XSS, SSRF, path traversal, command execution, secrets exposure, unsafe logging, weak crypto, unsafe config, unsafe external API/webhook/MCP/CI behavior, data leakage, privacy violations, audit gaps, missing abuse-case tests for security-sensitive code. Any critical/high security issue → F. Any medium security issue caps the grade at D.
+
+### 2. Architecture / principal review
+Correct boundary placement and abstraction level, simpler viable alternative ignored, excessive coupling or hidden dependency, production code not wired into a production path, domain invariant violations, backward-compat scaffolding added without explicit approval, durability/replay/audit/privacy/consistency assumptions violated, SQL/index/partition changes without query or write-path justification. Unwired production code, invalid boundaries, domain invariant violations, or unjustified durability weakening cap the grade at D or F depending on severity.
+
+### 3. Operational pragmatist review
+Missing observability for unattended paths, poor error handling, swallowed errors, vague diagnostics, missing cancellation/timeout/retry/lifecycle handling, unbounded goroutines/loops/memory growth/queues, deployment/runtime behavior not proven, config/env failure modes not clear, recovery/debuggability gaps. Operational gaps that would block diagnosis or safe runtime use cap the grade at D.
+
+### 4. Code quality review
+Dead code, unused exports, unreachable branches, abandoned files, TODO/FIXME stubs, placeholder behavior, debug artifacts, test-only artifacts imported by production code, hand-written mocks where generated mocks are required, unsafe casts, broad any, nil guards hiding required dependencies, speculative abstractions, performance footguns (N+1 queries, per-row durable commits, speculative indexes, unbounded work). Production/test leakage, placeholder implementation, hand-written mocks where forbidden, or dead code affecting production readiness cap the grade at D.
+
+### 5. Test and verification review
+Classify evidence for each requirement: proven / missing / stale / ambiguous / compile-only / skipped-expected / skipped-unexpected / failed. Check required behavior has current tests, error paths and edge cases are covered, integration/runtime evidence exists when required, UI/auth/live flows verified in a real runtime, test output is parseable and not hiding skips, performance claims have runtime/trace evidence, verification commands match the changed surface. Failed required verification → F. Missing required runtime evidence caps at D. Compile-only evidence for runtime behavior caps at D. Unexpected skipped required tests cap at D or F.
+
+### 6. UX / UI review (if applicable)
+For UI or user-facing behavior: design-system consistency, accessibility, navigation and information hierarchy, empty/loading/error states, mobile/responsive behavior, clear copy and obvious next actions, browser/runtime evidence for the actual rendered flow. Missing UI runtime validation for UI work caps at D.
+
+## Moderator rules
+
+After internal specialist review: cluster duplicate issues, separate proven findings from hypotheses, classify evidence strength, identify blockers, assign one final grade. If the grade is not A, recommend the concrete fixes needed to reach A.
+
+## Grade rubric
+
+- A: Excellent, production-ready. All required behavior is implemented, wired, tested, and verified with appropriate evidence. Architecture simple and aligned. Security, operations, UX, and maintainability have no meaningful concerns. Only trivial nits, if any.
+- B: Good and shippable. Core behavior correct and verified. Minor low-risk issues exist, but no blocker, no missing critical evidence, no security concern, no production-wiring gap, and no maintainability risk likely to hurt near-term work.
+- C: Acceptable but concerning. Probably works, but has moderate issues: incomplete edge coverage, some weak evidence, mild maintainability concerns, minor UX gaps, or non-blocking operational weaknesses. Should be improved, but not clearly unsafe or broken.
+- D: Not production-ready. At least one must-fix issue: missing required verification, compile-only proof for runtime behavior, unexpected skipped required tests, unwired production code, significant architecture/quality/operational gap, medium security issue, missing UI runtime evidence, or maintainability risk that will likely cause defects.
+- F: Fail. Core requirement not met, implementation broken, required tests fail, evidence absent or fabricated, critical/high security issue, data loss/privacy/audit risk, build/runtime broken, or change unsafe to ship.
+
+## You will be given
+
+- The ferment goal and success criteria.
+- A per-phase trail: name, goal, status, and the F-gate verdicts the agent provided at complete_ferment_phase.
+- The final C-gate verdicts the agent provided at complete_ferment.
+- The total diff (files changed + snippet) from ferment start to now, when available.
+- Execution evidence (agent-provided): real command outputs, verification results, or file contents that prove the work was done. This is the primary proof source when no diff is available.
+- The agent's final summary.
+
+## Final output
+
+After verifying, respond with EXACTLY one JSON object, no markdown:
+{"grade":"A"|"B"|"C"|"D"|"F","rationale":"<2-3 sentences citing specific files, commands, or outputs you verified>","recommendations":["<bullet>",...]}
+
+If grade is A, recommendations MUST be an empty array [].
+If grade is B-F, each recommendation must include: what is wrong, why it matters, what must change, and what evidence would prove the fix. Do not include vague advice or "nice to have" items.
+
+## Stop and grade
+
+Do not iterate beyond the verification needed. Once you have checked the load-bearing claims, produce the JSON and stop. Do not attempt to fix issues — only report them.`,
 				promptMode: "replace",
 				isDefault: true,
 			},

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -431,13 +431,13 @@ If grade is B-F, each recommendation must include: what is wrong, why it matters
 
 ## Turn budget — produce output before it runs out
 
-You have a LIMITED turn budget of approximately 12 turns. You MUST produce your final JSON grade before running out of turns. Follow this discipline:
+You have a LIMITED turn budget. You MUST produce your final JSON grade before running out of turns. Follow this discipline STRICTLY:
 
-- Turns 1-8: Verify the most load-bearing claims (read files, run tests, check outputs). Do NOT verify everything — prioritize the claims that matter most for the grade.
-- Turn 9-10: If you have not yet produced your grade JSON, STOP verifying and produce it NOW with what you know. An incomplete grade is better than no grade.
-- Turn 11+: You are out of budget. Immediately output the JSON grade with the evidence you have gathered so far.
+- Turns 1-6: Verify the most load-bearing claims (read files, run tests, check outputs). Limit yourself to ONE bash command per turn when possible.
+- Turn 7-8: STOP verifying. Produce the grade JSON NOW with the evidence you have gathered. An incomplete grade based on partial verification is better than no grade at all.
+- Turn 9+: You are out of budget. IMMEDIATELY output the JSON grade as your ONLY response. Do not run any more tools.
 
-If you have already produced the JSON grade in a previous turn, do not repeat it — just output it once more as your final message so the caller can extract it.
+CRITICAL: Do NOT spend more than 8 turns on verification. If you find yourself wanting to run one more command, STOP and produce the JSON instead. The grade is more important than thorough verification.
 
 ## Stop and grade
 

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -342,9 +342,9 @@ Your verification file MUST contain:
 				skills: false,
 				roles: ["review"],
 				thinking: "medium",
-				maxTurns: 10,
-				tokenBudget: 50_000,
-				maxDuration: 120,
+				maxTurns: 15,
+				tokenBudget: 60_000,
+				maxDuration: 180,
 				systemPrompt: `# Ferment Grader Agent
 
 You are a strict production-readiness review council compressed into one reviewer, acting as the final LLM grader for an autonomous coding ferment. Your job is to evaluate the completed result against the stated goal, implementation, tests, and evidence, and assign a letter grade A-F that describes HOW WELL the work was done.
@@ -428,6 +428,16 @@ After verifying, respond with EXACTLY one JSON object, no markdown:
 
 If grade is A, recommendations MUST be an empty array [].
 If grade is B-F, each recommendation must include: what is wrong, why it matters, what must change, and what evidence would prove the fix. Do not include vague advice or "nice to have" items.
+
+## Turn budget — produce output before it runs out
+
+You have a LIMITED turn budget of approximately 12 turns. You MUST produce your final JSON grade before running out of turns. Follow this discipline:
+
+- Turns 1-8: Verify the most load-bearing claims (read files, run tests, check outputs). Do NOT verify everything — prioritize the claims that matter most for the grade.
+- Turn 9-10: If you have not yet produced your grade JSON, STOP verifying and produce it NOW with what you know. An incomplete grade is better than no grade.
+- Turn 11+: You are out of budget. Immediately output the JSON grade with the evidence you have gathered so far.
+
+If you have already produced the JSON grade in a previous turn, do not repeat it — just output it once more as your final message so the caller can extract it.
 
 ## Stop and grade
 

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -81,6 +81,7 @@ export const AGENT_RESEARCHER = "Researcher"
 export const AGENT_BUILDER = "Builder"
 export const AGENT_REVIEWER = "Reviewer"
 export const AGENT_FIXER = "Fixer"
+export const AGENT_GRADER = "Grader"
 
 /** Names of the embedded default agents (in canonical display order). */
 export const DEFAULT_AGENT_NAMES = [
@@ -91,6 +92,7 @@ export const DEFAULT_AGENT_NAMES = [
 	AGENT_BUILDER,
 	AGENT_REVIEWER,
 	AGENT_FIXER,
+	AGENT_GRADER,
 ] as const
 
 /** Memory scope for persistent agent memory. */

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -42,6 +42,7 @@ vi.mock("./judge.js", async () => {
 			ok: true as const,
 			grade: "A" as const,
 			rationale: "Clean delivery; gates substantiated.",
+			recommendations: [],
 		})),
 	}
 })

--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it, vi } from "vitest"
 import {
+	type GraderSubagentResult,
 	type JudgeApiResult,
 	type JudgeJourneyGradeInput,
 	type JudgePhaseInput,
 	isGrade,
 	judgeJourneyGrade,
+	judgeJourneyGradeViaSubagent,
 	judgePhaseGrade,
+	judgePhaseGradeViaSubagent,
 } from "./judge.js"
 
 describe("isGrade", () => {
@@ -487,5 +490,157 @@ describe("judgePhaseGrade", () => {
 		})
 		await judgePhaseGrade(makePhaseInput({ evidence: "   " }), apiCall)
 		expect(captured).not.toContain("EXECUTION EVIDENCE")
+	})
+})
+
+describe("judgePhaseGradeViaSubagent", () => {
+	function ok(text: string): JudgeApiResult {
+		return { ok: true, text }
+	}
+
+	function makePhaseInput(overrides: Partial<JudgePhaseInput> = {}): JudgePhaseInput {
+		return {
+			fermentName: "Test Ferment",
+			phaseName: "Phase 1",
+			phaseGoal: "Build retry plumbing.",
+			phaseSummary: "Implemented retry logic with tests.",
+			stepSummaries: "  - step-1: added retry.ts",
+			gateVerdicts: [
+				{ id: "F1", verdict: "pass", rationale: "step-1 used smoke" },
+				{ id: "F2", verdict: "pass", rationale: "feature.ts delivers retry" },
+				{ id: "F3", verdict: "pass", rationale: "Nothing deferred" },
+			],
+			phaseDiff: { available: true, filesChanged: "feature.ts", diffSnippet: "+retry logic" },
+			...overrides,
+		}
+	}
+
+	it("returns the subagent's parsed grade when it completes with valid JSON", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: '{"grade":"B","rationale":"Tests pass but coverage thin.","recommendations":["Add edge-case test"]}',
+				status: "completed",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"x"}'))
+		const result = await judgePhaseGradeViaSubagent(makePhaseInput(), spawn, apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+		expect(result.rationale).toContain("coverage thin")
+		expect(result.recommendations).toHaveLength(1)
+		expect(apiCall).not.toHaveBeenCalled()
+	})
+
+	it("falls back to single-shot when subagent returns unparseable text", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: "I think this work is pretty good",
+				status: "completed",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"C","rationale":"weak evidence"}'))
+		const result = await judgePhaseGradeViaSubagent(makePhaseInput(), spawn, apiCall)
+		expect(spawn).toHaveBeenCalledTimes(1)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("C")
+	})
+
+	it("falls back to single-shot when subagent aborts", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: "",
+				status: "aborted",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"D","rationale":"gaps"}'))
+		const result = await judgePhaseGradeViaSubagent(makePhaseInput(), spawn, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("D")
+	})
+
+	it("falls back to single-shot when subagent throws", async () => {
+		const spawn = vi.fn(async (): Promise<GraderSubagentResult> => {
+			throw new Error("agent system not available")
+		})
+		const apiCall = vi.fn(async () => ok('{"grade":"B","rationale":"ok"}'))
+		const result = await judgePhaseGradeViaSubagent(makePhaseInput(), spawn, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+	})
+
+	it("falls back to single-shot when no spawner is provided", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean"}'))
+		const result = await judgePhaseGradeViaSubagent(makePhaseInput(), undefined, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("A")
+	})
+})
+
+describe("judgeJourneyGradeViaSubagent", () => {
+	function ok(text: string): JudgeApiResult {
+		return { ok: true, text }
+	}
+
+	it("returns the subagent's parsed grade when it completes with valid JSON", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: '{"grade":"A","rationale":"Excellent work.","recommendations":[]}',
+				status: "completed",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"C","rationale":"x"}'))
+		const result = await judgeJourneyGradeViaSubagent(makeInput(), spawn, apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("A")
+		expect(apiCall).not.toHaveBeenCalled()
+	})
+
+	it("falls back to single-shot when subagent returns unparseable text", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: "Not JSON at all",
+				status: "completed",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"B","rationale":"ok"}'))
+		const result = await judgeJourneyGradeViaSubagent(makeInput(), spawn, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+	})
+
+	it("falls back to single-shot when subagent aborts", async () => {
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: "",
+				status: "aborted",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"C","rationale":"x"}'))
+		const result = await judgeJourneyGradeViaSubagent(makeInput(), spawn, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("C")
+	})
+
+	it("falls back to single-shot when no spawner is provided", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean"}'))
+		const result = await judgeJourneyGradeViaSubagent(makeInput(), undefined, apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("A")
 	})
 })

--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -643,4 +643,29 @@ describe("judgeJourneyGradeViaSubagent", () => {
 		if (!result.ok) return
 		expect(result.grade).toBe("A")
 	})
+
+	it("extracts grade JSON from multi-turn text where JSON appears before the final message", async () => {
+		// Simulates the case where the subagent produces the grade JSON at turn 8
+		// but then continues with follow-up text on turns 9-11.
+		const multiTurnText = [
+			"Verifying phase...",
+			"Ran tests: all passed.",
+			'{"grade":"B","rationale":"Tests pass but coverage thin.","recommendations":["Add edge-case test"]}',
+			"Already completed the grade for this phase. Final JSON was produced above.",
+			"Already completed the grade for this phase. Final JSON was produced above.",
+		].join("\n\n")
+		const spawn = vi.fn(
+			async (): Promise<GraderSubagentResult> => ({
+				text: multiTurnText,
+				status: "completed",
+			}),
+		)
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"x"}'))
+		const result = await judgeJourneyGradeViaSubagent(makeInput(), spawn, apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+		expect(result.rationale).toContain("coverage thin")
+		expect(apiCall).not.toHaveBeenCalled()
+	})
 })

--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
-import { type JudgeApiResult, type JudgeJourneyGradeInput, isGrade, judgeJourneyGrade } from "./judge.js"
+import {
+	type JudgeApiResult,
+	type JudgeJourneyGradeInput,
+	type JudgePhaseInput,
+	isGrade,
+	judgeJourneyGrade,
+	judgePhaseGrade,
+} from "./judge.js"
 
 describe("isGrade", () => {
 	it("accepts the five valid letters", () => {
@@ -167,6 +174,216 @@ describe("judgeJourneyGrade", () => {
 			return ok('{"grade":"C","rationale":"x"}')
 		})
 		await judgeJourneyGrade(makeInput({ totalDiff: { available: false } }), apiCall)
+		expect(captured).toContain("No diff available")
+	})
+
+	// ── recommendations parsing ──────────────────────────────────────────────
+
+	it("returns parsed recommendations on a clean B-grade response", async () => {
+		const apiCall = vi.fn(async () =>
+			ok(
+				'{"grade":"B","rationale":"thin coverage","recommendations":["Add edge-case test for empty input — untested path could NPE. Fix: add test. Evidence: test passes."]}',
+			),
+		)
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+		expect(result.recommendations).toHaveLength(1)
+		expect(result.recommendations[0]).toContain("Add edge-case test")
+	})
+
+	it("defaults recommendations to [] when the field is missing", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean"}'))
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual([])
+	})
+
+	it("defaults recommendations to [] when the field is null", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean","recommendations":null}'))
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual([])
+	})
+
+	it("coerces a single-string recommendations field to [string]", async () => {
+		const apiCall = vi.fn(async () =>
+			ok('{"grade":"C","rationale":"weak","recommendations":"Fix the N+1 query in listUsers."}'),
+		)
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual(["Fix the N+1 query in listUsers."])
+	})
+
+	it("filters empty recommendation strings", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"D","rationale":"gaps","recommendations":["real fix","","   "]}'))
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual(["real fix"])
+	})
+
+	it("truncates oversized recommendation arrays and strings", async () => {
+		const longString = "x".repeat(1000)
+		const many = Array.from({ length: 50 }, () => longString)
+		const apiCall = vi.fn(async () => ok(`{"grade":"D","rationale":"gaps","recommendations":${JSON.stringify(many)}}`))
+		const result = await judgeJourneyGrade(makeInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toHaveLength(20)
+		expect(result.recommendations[0].length).toBe(600)
+	})
+})
+
+describe("judgePhaseGrade", () => {
+	function ok(text: string): JudgeApiResult {
+		return { ok: true, text }
+	}
+
+	function makePhaseInput(overrides: Partial<JudgePhaseInput> = {}): JudgePhaseInput {
+		return {
+			fermentName: "Test Ferment",
+			phaseName: "Phase 1",
+			phaseGoal: "Build retry plumbing.",
+			phaseSummary: "Implemented retry logic with tests.",
+			stepSummaries: "  - step-1: added retry.ts",
+			gateVerdicts: [
+				{ id: "F1", verdict: "pass", rationale: "step-1 used smoke" },
+				{ id: "F2", verdict: "pass", rationale: "feature.ts:1-40 delivers retry" },
+				{ id: "F3", verdict: "pass", rationale: "Nothing deferred" },
+			],
+			projectChecksSummary: "lint: clean\ntypecheck: clean",
+			phaseDiff: { available: true, filesChanged: "feature.ts\nfeature.test.ts", diffSnippet: "+retry logic" },
+			...overrides,
+		}
+	}
+
+	it("returns parsed grade + rationale + recommendations on a clean B-grade response", async () => {
+		const apiCall = vi.fn(async () =>
+			ok(
+				'{"grade":"B","rationale":"Goal met but coverage is thin.","recommendations":["Add edge-case test for empty input — untested path could NPE. Fix: add test. Evidence: test passes."]}',
+			),
+		)
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+		expect(result.rationale).toContain("coverage is thin")
+		expect(result.recommendations).toHaveLength(1)
+		expect(result.recommendations[0]).toContain("Add edge-case test")
+	})
+
+	it("returns [] recommendations on a clean A-grade response", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean","recommendations":[]}'))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual([])
+	})
+
+	it("defaults recommendations to [] when the field is missing", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean"}'))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual([])
+	})
+
+	it("defaults recommendations to [] when the field is null", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"A","rationale":"clean","recommendations":null}'))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.recommendations).toEqual([])
+	})
+
+	it("returns invalid_grade when the model returns a non-letter", async () => {
+		const apiCall = vi.fn(async () => ok('{"grade":"excellent","rationale":"x"}'))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.reason).toBe("invalid_grade")
+		expect(result.detail).toContain("excellent")
+	})
+
+	it("returns unparseable when the model returns non-JSON garbage", async () => {
+		const apiCall = vi.fn(async () => ok("I think this phase is pretty good honestly"))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.reason).toBe("unparseable")
+	})
+
+	it("propagates judge_unavailable when the API call fails", async () => {
+		const apiCall = vi.fn(async (): Promise<JudgeApiResult> => ({ ok: false, reason: "no_auth" }))
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(apiCall).toHaveBeenCalledTimes(1)
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.reason).toBe("no_auth")
+	})
+
+	it("retries empty_response before accepting a later grade", async () => {
+		const apiCall = vi
+			.fn<(_sys: string, _msg: string, _maxTokens?: number) => Promise<JudgeApiResult>>()
+			.mockResolvedValueOnce({ ok: false, reason: "empty_response" })
+			.mockResolvedValueOnce({ ok: false, reason: "empty_response" })
+			.mockResolvedValueOnce(ok('{"grade":"B","rationale":"Recovered on retry.","recommendations":[]}'))
+
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+
+		expect(apiCall).toHaveBeenCalledTimes(3)
+		expect(result.ok).toBe(true)
+		if (!result.ok) return
+		expect(result.grade).toBe("B")
+		expect(result.rationale).toContain("Recovered")
+	})
+
+	it("returns empty_response after the retry budget is exhausted", async () => {
+		const apiCall = vi.fn(
+			async (): Promise<JudgeApiResult> => ({
+				ok: false,
+				reason: "empty_response",
+			}),
+		)
+
+		const result = await judgePhaseGrade(makePhaseInput(), apiCall)
+
+		expect(apiCall).toHaveBeenCalledTimes(3)
+		expect(result.ok).toBe(false)
+		if (result.ok) return
+		expect(result.reason).toBe("empty_response")
+		expect(result.detail).toContain("after 3 attempts")
+	})
+
+	it("includes phase goal, F-gate verdicts, project checks, and diff in the prompt", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x","recommendations":[]}')
+		})
+		await judgePhaseGrade(makePhaseInput(), apiCall)
+		expect(captured).toContain("Phase goal: Build retry plumbing.")
+		expect(captured).toContain("Phase summary: Implemented retry logic with tests.")
+		expect(captured).toContain("step-1: added retry.ts")
+		expect(captured).toContain("F1 (pass): step-1 used smoke")
+		expect(captured).toContain("F2 (pass): feature.ts:1-40 delivers retry")
+		expect(captured).toContain("lint: clean")
+		expect(captured).toContain("Files changed:\nfeature.ts")
+		expect(captured).toContain("+retry logic")
+	})
+
+	it("notes when no diff is available", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"C","rationale":"x","recommendations":[]}')
+		})
+		await judgePhaseGrade(makePhaseInput({ phaseDiff: { available: false } }), apiCall)
 		expect(captured).toContain("No diff available")
 	})
 })

--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -177,6 +177,50 @@ describe("judgeJourneyGrade", () => {
 		expect(captured).toContain("No diff available")
 	})
 
+	it("includes agent-provided execution evidence in the prompt", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x"}')
+		})
+		await judgeJourneyGrade(
+			makeInput({
+				evidence: "$ pytest -q\n5 passed\n$ cat output.txt\nresult=ok",
+			}),
+			apiCall,
+		)
+		expect(captured).toContain("EXECUTION EVIDENCE")
+		expect(captured).toContain("5 passed")
+	})
+
+	it("includes execution evidence even when no diff is available", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"B","rationale":"x"}')
+		})
+		await judgeJourneyGrade(
+			makeInput({
+				totalDiff: { available: false },
+				evidence: "$ stockfish analysis\nbest move: g2g4 (#+1)",
+			}),
+			apiCall,
+		)
+		expect(captured).toContain("No diff available")
+		expect(captured).toContain("EXECUTION EVIDENCE")
+		expect(captured).toContain("g2g4")
+	})
+
+	it("omits the evidence section when evidence is empty", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x"}')
+		})
+		await judgeJourneyGrade(makeInput({ evidence: "" }), apiCall)
+		expect(captured).not.toContain("EXECUTION EVIDENCE")
+	})
+
 	// ── recommendations parsing ──────────────────────────────────────────────
 
 	it("returns parsed recommendations on a clean B-grade response", async () => {
@@ -385,5 +429,63 @@ describe("judgePhaseGrade", () => {
 		})
 		await judgePhaseGrade(makePhaseInput({ phaseDiff: { available: false } }), apiCall)
 		expect(captured).toContain("No diff available")
+	})
+
+	it("includes agent-provided execution evidence in the prompt", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x","recommendations":[]}')
+		})
+		await judgePhaseGrade(
+			makePhaseInput({
+				evidence: "$ python3 verify.py\nAll 5 tests passed\n$ cat /app/result.txt\n42",
+			}),
+			apiCall,
+		)
+		expect(captured).toContain("EXECUTION EVIDENCE")
+		expect(captured).toContain("All 5 tests passed")
+		expect(captured).toContain("cat /app/result.txt")
+	})
+
+	it("includes execution evidence even when no diff is available", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"B","rationale":"x","recommendations":[]}')
+		})
+		await judgePhaseGrade(
+			makePhaseInput({
+				phaseDiff: { available: false },
+				evidence: "$ stockfish analysis\nbest move: g2g4 (#+1)",
+			}),
+			apiCall,
+		)
+		expect(captured).toContain("No diff available")
+		expect(captured).toContain("EXECUTION EVIDENCE")
+		expect(captured).toContain("g2g4")
+	})
+
+	it("truncates evidence to 4 KB", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x","recommendations":[]}')
+		})
+		const longEvidence = "x".repeat(6000)
+		await judgePhaseGrade(makePhaseInput({ evidence: longEvidence }), apiCall)
+		expect(captured).toContain("EXECUTION EVIDENCE")
+		const evidenceSection = captured.split("EXECUTION EVIDENCE")[1]
+		expect(evidenceSection.length).toBeLessThan(5000)
+	})
+
+	it("omits the evidence section when evidence is empty", async () => {
+		let captured = ""
+		const apiCall = vi.fn(async (_sys: string, msg: string) => {
+			captured = msg
+			return ok('{"grade":"A","rationale":"x","recommendations":[]}')
+		})
+		await judgePhaseGrade(makePhaseInput({ evidence: "   " }), apiCall)
+		expect(captured).not.toContain("EXECUTION EVIDENCE")
 	})
 })

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -137,6 +137,23 @@ type JudgeCallResult<T> =
 	| { ok: true; value: T }
 	| { ok: false; reason: JudgeUnavailableReason | "unparseable"; detail?: string }
 
+/** Coerce the model's `recommendations` field into a clean string[]. Accepts
+ *  string[], a single string, or missing/garbage — always returns string[].
+ *  Truncates to 20 entries and 600 chars each to bound persisted payload. */
+function normalizeRecommendations(raw: unknown): string[] {
+	if (Array.isArray(raw)) {
+		return raw
+			.map((item) => (typeof item === "string" ? item : ""))
+			.filter((s) => s.trim().length > 0)
+			.map((s) => s.slice(0, 600))
+			.slice(0, 20)
+	}
+	if (typeof raw === "string" && raw.trim().length > 0) {
+		return [raw.slice(0, 600)]
+	}
+	return []
+}
+
 async function judgeCall<T>(systemPrompt: string, userMsg: string, maxTokens: number): Promise<JudgeCallResult<T>> {
 	const api = await judgeApiCall(systemPrompt, userMsg, maxTokens)
 	if (!api.ok) return { ok: false, reason: api.reason, detail: api.detail }
@@ -237,6 +254,8 @@ export interface JudgeJourneyGradeOk {
 	ok: true
 	grade: Grade
 	rationale: string
+	/** Concrete fix bullets the grader recommends to reach A. Empty for A grades. */
+	recommendations: string[]
 }
 
 export interface JudgeJourneyGradeFailure {
@@ -256,26 +275,68 @@ function withJourneyGradeAttemptDetail(failure: JudgeJourneyGradeFailure, attemp
 	}
 }
 
-const JOURNEY_GRADE_SYSTEM = `You are the final reviewer for an autonomous coding ferment. The agent has completed all phases and the ferment-scope gates (C1/C2/C3) all passed — so shipping is allowed. Your job is NOT to decide whether to ship. Your job is to assign a letter grade A–F that describes HOW WELL the work was done.
+const JOURNEY_GRADE_SYSTEM = `You are a strict production-readiness review council compressed into one reviewer, acting as the final reviewer for an autonomous coding ferment. The agent has completed all phases and the ferment-scope gates (C1/C2/C3) all passed — so shipping is allowed. Your job is NOT to decide whether to ship. Your job is to evaluate the completed result against the stated goal, implementation, tests, and evidence, and assign a letter grade A–F that describes HOW WELL the work was done.
 
 Your bias is PESSIMISTIC. Most work is B or C, not A. A is reserved for ferments that delivered cleanly without retries, with concrete real-execution verification at every phase, and where every gate verdict was substantiated with specific evidence.
 
-Letter rubric (be strict):
-- A: every phase delivered, real verification of artifact ran, diff cleanly implements goal end-to-end, no warns, no block-retries needed, gate rationales cite specific files/commands not vague claims.
-- B: goal met with minor unresolved warns OR weak verification (mostly proxy/sentinel) OR thin gate rationales.
-- C: partial goal achievement, suspect coverage, summaries that hallucinate work not in the diff, OR phases needed retries to converge.
-- D: substantial gaps — phases that failed, summaries that don't match the diff, gate rationales that don't ground in evidence.
-- F: goal not achieved, evidence shows clearly broken work, or the agent never actually exercised the artifact.
+## Hard constraints
 
-You will be given:
+- Do not treat claims as proof. Missing proof lowers the grade.
+- Passing compile/build alone is not proof of runtime behavior.
+- Skipped required tests are not pass evidence.
+- Documentation of a problem is not remediation.
+- Prefer concrete findings over vague concerns.
+- Grade harshly when correctness, security, evidence, or production wiring is unclear.
+
+## Internal review council
+
+Run these reviews silently before assigning the grade.
+
+### 1. Security attacker
+Authentication/authorization, tenant isolation, privilege escalation, input validation, injection, XSS, SSRF, path traversal, command execution, secrets exposure, unsafe logging, weak crypto, unsafe config, unsafe external API/webhook/MCP/CI behavior, data leakage, privacy violations, audit gaps, missing abuse-case tests for security-sensitive code. Any critical/high security issue → F. Any medium security issue caps the grade at D.
+
+### 2. Architecture / principal review
+Correct boundary placement and abstraction level, simpler viable alternative ignored, excessive coupling or hidden dependency, production code not wired into a production path, domain invariant violations, backward-compat scaffolding added without explicit approval, durability/replay/audit/privacy/consistency assumptions violated, SQL/index/partition changes without query or write-path justification. Unwired production code, invalid boundaries, domain invariant violations, or unjustified durability weakening cap the grade at D or F depending on severity.
+
+### 3. Operational pragmatist review
+Missing observability for unattended paths, poor error handling, swallowed errors, vague diagnostics, missing cancellation/timeout/retry/lifecycle handling, unbounded goroutines/loops/memory growth/queues, deployment/runtime behavior not proven, config/env failure modes not clear, recovery/debuggability gaps. Operational gaps that would block diagnosis or safe runtime use cap the grade at D.
+
+### 4. Code quality review
+Dead code, unused exports, unreachable branches, abandoned files, TODO/FIXME stubs, placeholder behavior, debug artifacts, test-only artifacts imported by production code, hand-written mocks where generated mocks are required, unsafe casts, broad any, nil guards hiding required dependencies, speculative abstractions, performance footguns (N+1 queries, per-row durable commits, speculative indexes, unbounded work). Production/test leakage, placeholder implementation, hand-written mocks where forbidden, or dead code affecting production readiness cap the grade at D.
+
+### 5. Test and verification review
+Classify evidence for each requirement: proven / missing / stale / ambiguous / compile-only / skipped-expected / skipped-unexpected / failed. Check required behavior has current tests, error paths and edge cases are covered, integration/runtime evidence exists when required, UI/auth/live flows verified in a real runtime, test output is parseable and not hiding skips, performance claims have runtime/trace evidence, verification commands match the changed surface. Failed required verification → F. Missing required runtime evidence caps at D. Compile-only evidence for runtime behavior caps at D. Unexpected skipped required tests cap at D or F.
+
+### 6. UX / UI review (if applicable)
+For UI or user-facing behavior: design-system consistency, accessibility, navigation and information hierarchy, empty/loading/error states, mobile/responsive behavior, clear copy and obvious next actions, browser/runtime evidence for the actual rendered flow. Missing UI runtime validation for UI work caps at D.
+
+## Moderator rules
+
+After internal specialist review: cluster duplicate issues, separate proven findings from hypotheses, classify evidence strength, identify blockers, assign one final grade. If the grade is not A, recommend the concrete fixes needed to reach A.
+
+## Grade rubric
+
+- A: Excellent, production-ready. All required behavior is implemented, wired, tested, and verified with appropriate evidence. Architecture simple and aligned. Security, operations, UX, and maintainability have no meaningful concerns. Only trivial nits, if any.
+- B: Good and shippable. Core behavior correct and verified. Minor low-risk issues exist, but no blocker, no missing critical evidence, no security concern, no production-wiring gap, and no maintainability risk likely to hurt near-term work.
+- C: Acceptable but concerning. Probably works, but has moderate issues: incomplete edge coverage, some weak evidence, mild maintainability concerns, minor UX gaps, or non-blocking operational weaknesses. Should be improved, but not clearly unsafe or broken.
+- D: Not production-ready. At least one must-fix issue: missing required verification, compile-only proof for runtime behavior, unexpected skipped required tests, unwired production code, significant architecture/quality/operational gap, medium security issue, missing UI runtime evidence, or maintainability risk that will likely cause defects.
+- F: Fail. Core requirement not met, implementation broken, required tests fail, evidence absent or fabricated, critical/high security issue, data loss/privacy/audit risk, build/runtime broken, or change unsafe to ship.
+
+## You will be given
+
 - The ferment goal and success criteria.
 - A per-phase trail: name, goal, status, and the F-gate verdicts the agent provided at complete_ferment_phase.
 - The final C-gate verdicts the agent provided at complete_ferment.
 - The total diff (files changed + snippet) from ferment start to now.
 - The agent's final summary.
 
+## Final output
+
 Respond with EXACTLY one JSON object, no markdown:
-{"grade":"A"|"B"|"C"|"D"|"F","rationale":"<2-3 sentences citing specific phases, gates, or diff regions>"}`
+{"grade":"A"|"B"|"C"|"D"|"F","rationale":"<2-3 sentences citing specific phases, gates, or diff regions>","recommendations":["<bullet>",...]}
+
+If grade is A, recommendations MUST be an empty array [].
+If grade is B–F, each recommendation must include: what is wrong, why it matters, what must change, and what evidence would prove the fix. Do not include vague advice or "nice to have" items.`
 
 function buildJourneyGradeUserMsg(input: JudgeJourneyGradeInput): string {
 	const parts: string[] = []
@@ -327,7 +388,7 @@ export async function judgeJourneyGrade(
 			return withJourneyGradeAttemptDetail(failure, attempt)
 		}
 
-		const parsed = tryParseJson<{ grade?: string; rationale?: string }>(api.text)
+		const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(api.text)
 		if (parsed === undefined) {
 			return { ok: false, reason: "unparseable", detail: api.text.slice(0, 200) }
 		}
@@ -335,8 +396,176 @@ export async function judgeJourneyGrade(
 			return { ok: false, reason: "invalid_grade", detail: `Judge returned: ${parsed.grade}` }
 		}
 		const rationale = typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
-		return { ok: true, grade: parsed.grade, rationale }
+		const recommendations = normalizeRecommendations(parsed.recommendations)
+		return { ok: true, grade: parsed.grade, rationale, recommendations }
 	}
 
 	throw new Error("unreachable: journey grade retry loop exited without a result")
+}
+
+// ─── Public API: phase grade (per-phase LLM review) ───────────────────────────
+//
+// At complete_ferment_phase, after the F-gates and project checks pass, this
+// judge assigns a per-phase letter grade A–F. It reads the phase goal, the
+// F-gate verdicts the agent provided, the project-check summary, the phase
+// diff, and the phase summary, and produces a pessimistic grade with a
+// rationale and concrete recommendations when the grade is not A.
+//
+// Unlike the journey grade, this is a SIMPLIFIED council: it drops the
+// UX/UI review and the full-project architecture review (a single phase
+// rarely warrants them) and keeps the security, code-quality, test/
+// verification, and operational-pragmatist reviews plus the moderator and
+// rubric. The grade drives advancement: A/B advance, C/D/F refuse and route
+// through the existing MAX_BLOCK_RETRIES / escalation loop.
+
+export interface JudgePhaseInput {
+	fermentName: string
+	phaseName: string
+	phaseGoal: string
+	/** The agent's complete_ferment_phase summary. */
+	phaseSummary: string
+	/** Step summaries rendered as a single text block (one bullet per step). */
+	stepSummaries?: string
+	/** F-gate verdicts the agent provided at complete_ferment_phase. */
+	gateVerdicts: ReadonlyArray<{ id: string; verdict: string; rationale: string }>
+	/** Project-check summary text, if project checks ran. */
+	projectChecksSummary?: string
+	/** Phase diff (files changed + snippet) from the phase's evidence. */
+	phaseDiff?: JourneyDiff
+}
+
+export interface JudgePhaseGradeOk {
+	ok: true
+	grade: Grade
+	rationale: string
+	/** Concrete fix bullets the grader recommends to reach A. Empty for A grades. */
+	recommendations: string[]
+}
+
+export interface JudgePhaseGradeFailure {
+	ok: false
+	reason: JudgeUnavailableReason | "unparseable" | "invalid_grade"
+	detail?: string
+}
+
+export type JudgePhaseGradeResult = JudgePhaseGradeOk | JudgePhaseGradeFailure
+
+const PHASE_GRADE_SYSTEM = `You are a strict production-readiness review council compressed into one reviewer, acting as the per-phase reviewer for an autonomous coding ferment. The agent has completed a single phase and the phase-scope gates (F1/F2/F3) all passed — so phase advancement is allowed by the gates. Your job is NOT to decide whether the phase advances. Your job is to evaluate the phase result against its stated goal, implementation, tests, and evidence, and assign a letter grade A–F that describes HOW WELL the phase was done.
+
+Your bias is PESSIMISTIC. Most phase work is B or C, not A. A is reserved for phases that delivered cleanly without retries, with concrete real-execution verification, and where every gate verdict was substantiated with specific evidence.
+
+## Hard constraints
+
+- Do not treat claims as proof. Missing proof lowers the grade.
+- Passing compile/build alone is not proof of runtime behavior.
+- Skipped required tests are not pass evidence.
+- Documentation of a problem is not remediation.
+- Prefer concrete findings over vague concerns.
+- Grade harshly when correctness, security, evidence, or production wiring is unclear.
+
+## Internal review council
+
+Run these reviews silently before assigning the grade.
+
+### 1. Security attacker
+Authentication/authorization, tenant isolation, privilege escalation, input validation, injection, XSS, SSRF, path traversal, command execution, secrets exposure, unsafe logging, weak crypto, unsafe config, unsafe external API/webhook/MCP/CI behavior, data leakage, privacy violations, audit gaps, missing abuse-case tests for security-sensitive code. Any critical/high security issue → F. Any medium security issue caps the grade at D.
+
+### 2. Operational pragmatist review
+Missing observability for unattended paths, poor error handling, swallowed errors, vague diagnostics, missing cancellation/timeout/retry/lifecycle handling, unbounded goroutines/loops/memory growth/queues, deployment/runtime behavior not proven, config/env failure modes not clear, recovery/debuggability gaps. Operational gaps that would block diagnosis or safe runtime use cap the grade at D.
+
+### 3. Code quality review
+Dead code, unused exports, unreachable branches, abandoned files, TODO/FIXME stubs, placeholder behavior, debug artifacts, test-only artifacts imported by production code, hand-written mocks where generated mocks are required, unsafe casts, broad any, nil guards hiding required dependencies, speculative abstractions, performance footguns (N+1 queries, per-row durable commits, speculative indexes, unbounded work). Production/test leakage, placeholder implementation, hand-written mocks where forbidden, or dead code affecting production readiness cap the grade at D.
+
+### 4. Test and verification review
+Classify evidence for each requirement: proven / missing / stale / ambiguous / compile-only / skipped-expected / skipped-unexpected / failed. Check required behavior has current tests, error paths and edge cases are covered, integration/runtime evidence exists when required, test output is parseable and not hiding skips, performance claims have runtime/trace evidence, verification commands match the changed surface. Failed required verification → F. Missing required runtime evidence caps at D. Compile-only evidence for runtime behavior caps at D. Unexpected skipped required tests cap at D or F.
+
+## Moderator rules
+
+After internal specialist review: cluster duplicate issues, separate proven findings from hypotheses, classify evidence strength, identify blockers, assign one final grade. If the grade is not A, recommend the concrete fixes needed to reach A.
+
+## Grade rubric
+
+- A: Excellent, production-ready phase. All required behavior is implemented, wired, tested, and verified with appropriate evidence. No meaningful concerns. Only trivial nits, if any.
+- B: Good and shippable phase. Core behavior correct and verified. Minor low-risk issues exist, but no blocker, no missing critical evidence, no security concern, and no maintainability risk likely to hurt near-term work.
+- C: Acceptable but concerning. Probably works, but has moderate issues: incomplete edge coverage, some weak evidence, mild maintainability concerns, or non-blocking operational weaknesses. Should be improved, but not clearly unsafe or broken.
+- D: Not production-ready. At least one must-fix issue: missing required verification, compile-only proof for runtime behavior, unexpected skipped required tests, significant quality/operational gap, medium security issue, or maintainability risk that will likely cause defects.
+- F: Fail. Core phase requirement not met, implementation broken, required tests fail, evidence absent or fabricated, critical/high security issue, or the change is unsafe to ship.
+
+## You will be given
+
+- The ferment name and the phase name + goal.
+- The agent's phase summary and per-step summaries.
+- The F-gate verdicts the agent provided at complete_ferment_phase.
+- The project-check summary (if any).
+- The phase diff (files changed + snippet) when available.
+
+## Final output
+
+Respond with EXACTLY one JSON object, no markdown:
+{"grade":"A"|"B"|"C"|"D"|"F","rationale":"<2-3 sentences citing specific gates, steps, or diff regions>","recommendations":["<bullet>",...]}
+
+If grade is A, recommendations MUST be an empty array [].
+If grade is B–F, each recommendation must include: what is wrong, why it matters, what must change, and what evidence would prove the fix. Do not include vague advice or "nice to have" items.`
+
+function buildPhaseGradeUserMsg(input: JudgePhaseInput): string {
+	const parts: string[] = []
+	parts.push(`Ferment: "${input.fermentName}"`)
+	parts.push(`Phase: "${input.phaseName}"`)
+	parts.push(`Phase goal: ${input.phaseGoal || "(none specified)"}`)
+	parts.push(`Phase summary: ${input.phaseSummary || "(none)"}`)
+	if (input.stepSummaries && input.stepSummaries.trim().length > 0) {
+		parts.push("")
+		parts.push("Step summaries:")
+		parts.push(input.stepSummaries)
+	}
+	parts.push("")
+	parts.push("Phase-scope gate verdicts:")
+	for (const v of input.gateVerdicts) {
+		parts.push(`  ${v.id} (${v.verdict}): ${v.rationale}`)
+	}
+	if (input.projectChecksSummary && input.projectChecksSummary.trim().length > 0) {
+		parts.push("")
+		parts.push("Project checks:")
+		parts.push(input.projectChecksSummary)
+	}
+	if (input.phaseDiff?.available) {
+		parts.push("")
+		parts.push("--- PHASE DIFF ---")
+		parts.push(`Files changed:\n${input.phaseDiff.filesChanged ?? "(none recorded)"}`)
+		if (input.phaseDiff.diffSnippet) {
+			parts.push(`\nDiff snippet:\n\`\`\`diff\n${input.phaseDiff.diffSnippet}\n\`\`\``)
+		}
+	} else {
+		parts.push("")
+		parts.push("(No diff available — judge on verdicts + summary only.)")
+	}
+	return parts.join("\n")
+}
+
+export async function judgePhaseGrade(
+	input: JudgePhaseInput,
+	apiCall: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult> = judgeApiCall,
+): Promise<JudgePhaseGradeResult> {
+	const userMsg = buildPhaseGradeUserMsg(input)
+	for (let attempt = 1; attempt <= JOURNEY_GRADE_MAX_ATTEMPTS; attempt++) {
+		const api = await apiCall(PHASE_GRADE_SYSTEM, userMsg)
+		if (!api.ok) {
+			const failure: JudgePhaseGradeFailure = { ok: false, reason: api.reason, detail: api.detail }
+			if (api.reason === "empty_response" && attempt < JOURNEY_GRADE_MAX_ATTEMPTS) continue
+			return withJourneyGradeAttemptDetail(failure, attempt)
+		}
+
+		const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(api.text)
+		if (parsed === undefined) {
+			return { ok: false, reason: "unparseable", detail: api.text.slice(0, 200) }
+		}
+		if (!isGrade(parsed.grade)) {
+			return { ok: false, reason: "invalid_grade", detail: `Judge returned: ${parsed.grade}` }
+		}
+		const rationale = typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
+		const recommendations = normalizeRecommendations(parsed.recommendations)
+		return { ok: true, grade: parsed.grade, rationale, recommendations }
+	}
+
+	throw new Error("unreachable: phase grade retry loop exited without a result")
 }

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -248,6 +248,9 @@ export interface JudgeJourneyGradeInput {
 	phases: ReadonlyArray<JourneyPhaseInput>
 	fermentGates: ReadonlyArray<JourneyGateVerdict>
 	totalDiff?: JourneyDiff
+	/** Agent-pasted execution evidence (command outputs, verification results,
+	 *  file contents). Primary proof source when no git diff is available. */
+	evidence?: string
 }
 
 export interface JudgeJourneyGradeOk {
@@ -327,7 +330,8 @@ After internal specialist review: cluster duplicate issues, separate proven find
 - The ferment goal and success criteria.
 - A per-phase trail: name, goal, status, and the F-gate verdicts the agent provided at complete_ferment_phase.
 - The final C-gate verdicts the agent provided at complete_ferment.
-- The total diff (files changed + snippet) from ferment start to now.
+- The total diff (files changed + snippet) from ferment start to now, when available.
+- Execution evidence (agent-provided): real command outputs, verification results, or file contents that prove the work was done. This is the primary proof source when no diff is available.
 - The agent's final summary.
 
 ## Final output
@@ -371,6 +375,11 @@ function buildJourneyGradeUserMsg(input: JudgeJourneyGradeInput): string {
 	} else {
 		parts.push("")
 		parts.push("(No diff available — judge on verdicts + summary only.)")
+	}
+	if (input.evidence && input.evidence.trim().length > 0) {
+		parts.push("")
+		parts.push("--- EXECUTION EVIDENCE (agent-provided) ---")
+		parts.push(input.evidence.slice(0, 4000))
 	}
 	return parts.join("\n")
 }
@@ -432,6 +441,9 @@ export interface JudgePhaseInput {
 	projectChecksSummary?: string
 	/** Phase diff (files changed + snippet) from the phase's evidence. */
 	phaseDiff?: JourneyDiff
+	/** Agent-pasted execution evidence (command outputs, verification results,
+	 *  file contents). Primary proof source when no git diff is available. */
+	evidence?: string
 }
 
 export interface JudgePhaseGradeOk {
@@ -498,6 +510,7 @@ After internal specialist review: cluster duplicate issues, separate proven find
 - The F-gate verdicts the agent provided at complete_ferment_phase.
 - The project-check summary (if any).
 - The phase diff (files changed + snippet) when available.
+- Execution evidence (agent-provided): real command outputs, verification results, or file contents that prove the work was done. This is the primary proof source when no diff is available.
 
 ## Final output
 
@@ -538,6 +551,11 @@ function buildPhaseGradeUserMsg(input: JudgePhaseInput): string {
 	} else {
 		parts.push("")
 		parts.push("(No diff available — judge on verdicts + summary only.)")
+	}
+	if (input.evidence && input.evidence.trim().length > 0) {
+		parts.push("")
+		parts.push("--- EXECUTION EVIDENCE (agent-provided) ---")
+		parts.push(input.evidence.slice(0, 4000))
 	}
 	return parts.join("\n")
 }

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -587,3 +587,193 @@ export async function judgePhaseGrade(
 
 	throw new Error("unreachable: phase grade retry loop exited without a result")
 }
+
+// ─── Subagent-based grading ───────────────────────────────────────────────────
+//
+// The subagent grader spawns a bounded agent with read-only + bash tools so it
+// can independently verify the agent's claims (run tests, read source files,
+// check output files). Falls back to the single-shot judgeApiCall() when the
+// subagent is unavailable, crashes, or produces unparseable output.
+
+/** Result from a grader subagent invocation. */
+export interface GraderSubagentResult {
+	/** The final text response from the subagent (should be JSON). */
+	text: string
+	/** "completed" = finished normally; anything else = aborted/errored. */
+	status: string
+}
+
+/** Spawner function for the grader subagent. Injected by the caller (phases.ts /
+ *  lifecycle.ts) which has access to ExtensionAPI + AgentManager. */
+export type GraderSpawner = (prompt: string) => Promise<GraderSubagentResult>
+
+/** Parse the subagent's final response into a grade result. Returns undefined
+ *  if the response is not parseable JSON with a valid grade. */
+function parseGraderResponse(text: string): JudgePhaseGradeOk | undefined {
+	const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(text)
+	if (parsed === undefined) return undefined
+	if (!isGrade(parsed.grade)) return undefined
+	const rationale = typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
+	const recommendations = normalizeRecommendations(parsed.recommendations)
+	return { ok: true, grade: parsed.grade, rationale, recommendations }
+}
+
+/** Grade a phase using a subagent with tool access. Falls back to the
+ *  single-shot judgeApiCall() when the subagent is unavailable or fails. */
+export async function judgePhaseGradeViaSubagent(
+	input: JudgePhaseInput,
+	spawn: GraderSpawner | undefined,
+	apiCall: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult> = judgeApiCall,
+): Promise<JudgePhaseGradeResult> {
+	// Try the subagent first if a spawner was provided.
+	if (spawn) {
+		try {
+			const prompt = buildPhaseGraderPrompt(input)
+			const result = await spawn(prompt)
+			if (result.status === "completed") {
+				const parsed = parseGraderResponse(result.text)
+				if (parsed) return parsed
+				// Subagent completed but output wasn't parseable — fall through to single-shot.
+			}
+			// Subagent aborted/errored — fall through to single-shot.
+		} catch {
+			// Subagent threw — fall through to single-shot.
+		}
+	}
+
+	// Fallback: single-shot LLM call.
+	return judgePhaseGrade(input, apiCall)
+}
+
+/** Grade a ferment (journey) using a subagent with tool access. Falls back to
+ *  the single-shot judgeApiCall() when the subagent is unavailable or fails. */
+export async function judgeJourneyGradeViaSubagent(
+	input: JudgeJourneyGradeInput,
+	spawn: GraderSpawner | undefined,
+	apiCall: (sys: string, msg: string, maxTokens?: number) => Promise<JudgeApiResult> = judgeApiCall,
+): Promise<JudgeJourneyGradeResult> {
+	// Try the subagent first if a spawner was provided.
+	if (spawn) {
+		try {
+			const prompt = buildJourneyGraderPrompt(input)
+			const result = await spawn(prompt)
+			if (result.status === "completed") {
+				const parsed = parseGraderResponse(result.text)
+				if (parsed) return parsed
+				// Subagent completed but output wasn't parseable — fall through to single-shot.
+			}
+			// Subagent aborted/errored — fall through to single-shot.
+		} catch {
+			// Subagent threw — fall through to single-shot.
+		}
+	}
+
+	// Fallback: single-shot LLM call.
+	return judgeJourneyGrade(input, apiCall)
+}
+
+/** Build the user-message prompt for the phase grader subagent. This is the
+ *  same content as buildPhaseGradeUserMsg but framed as a task instruction for
+ *  a multi-turn agent rather than a single-shot completion. */
+function buildPhaseGraderPrompt(input: JudgePhaseInput): string {
+	const parts: string[] = []
+	parts.push("You are grading a completed phase of an autonomous coding ferment.")
+	parts.push("Verify the agent's claims independently using your tools, then produce a grade as JSON.")
+	parts.push("")
+	parts.push(`Ferment: "${input.fermentName}"`)
+	parts.push(`Phase: "${input.phaseName}"`)
+	parts.push(`Phase goal: ${input.phaseGoal || "(none specified)"}`)
+	parts.push(`Phase summary: ${input.phaseSummary || "(none)"}`)
+	if (input.stepSummaries && input.stepSummaries.trim().length > 0) {
+		parts.push("")
+		parts.push("Step summaries:")
+		parts.push(input.stepSummaries)
+	}
+	parts.push("")
+	parts.push("Phase-scope gate verdicts (agent self-reported — verify independently):")
+	for (const v of input.gateVerdicts) {
+		parts.push(`  ${v.id} (${v.verdict}): ${v.rationale}`)
+	}
+	if (input.projectChecksSummary && input.projectChecksSummary.trim().length > 0) {
+		parts.push("")
+		parts.push("Project checks:")
+		parts.push(input.projectChecksSummary)
+	}
+	if (input.phaseDiff?.available) {
+		parts.push("")
+		parts.push("--- PHASE DIFF ---")
+		parts.push(`Files changed:\n${input.phaseDiff.filesChanged ?? "(none recorded)"}`)
+		if (input.phaseDiff.diffSnippet) {
+			parts.push(`\nDiff snippet:\n\`\`\`diff\n${input.phaseDiff.diffSnippet}\n\`\`\``)
+		}
+	} else {
+		parts.push("")
+		parts.push("(No diff available — use your tools to inspect files directly.)")
+	}
+	if (input.evidence && input.evidence.trim().length > 0) {
+		parts.push("")
+		parts.push("--- EXECUTION EVIDENCE (agent-provided) ---")
+		parts.push(input.evidence.slice(0, 4000))
+	}
+	parts.push("")
+	parts.push(`Working directory: ${process.cwd()}`)
+	parts.push("")
+	parts.push(
+		"Verify the agent's claims by reading files and running commands. Then respond with EXACTLY one JSON object:",
+	)
+	parts.push('{"grade":"A"|"B"|"C"|"D"|"F","rationale":"...","recommendations":[...]}')
+	return parts.join("\n")
+}
+
+/** Build the user-message prompt for the journey grader subagent. */
+function buildJourneyGraderPrompt(input: JudgeJourneyGradeInput): string {
+	const parts: string[] = []
+	parts.push(
+		"You are grading a completed ferment (all phases done). Verify the agent's claims independently using your tools, then produce a grade as JSON.",
+	)
+	parts.push("")
+	parts.push(`Ferment: "${input.fermentName}"`)
+	parts.push(`Goal: ${input.goal || "(none specified)"}`)
+	parts.push(`Success criteria: ${input.successCriteria || "(none specified)"}`)
+	parts.push(`Final summary: ${input.finalSummary || "(none)"}`)
+	parts.push("")
+	parts.push("Per-phase trail:")
+	for (const p of input.phases) {
+		parts.push(`  - Phase "${p.name}" [${p.status}] — ${p.goal}`)
+		if (!p.gateVerdicts || p.gateVerdicts.length === 0) {
+			parts.push("    (no verdicts on file)")
+		} else {
+			for (const v of p.gateVerdicts) {
+				parts.push(`    ${v.id} (${v.verdict}): ${v.rationale}`)
+			}
+		}
+	}
+	parts.push("")
+	parts.push("Ferment-scope gate verdicts (agent self-reported — verify independently):")
+	for (const v of input.fermentGates) {
+		parts.push(`  ${v.id} (${v.verdict}): ${v.rationale}`)
+	}
+	if (input.totalDiff?.available) {
+		parts.push("")
+		parts.push("--- TOTAL DIFF ---")
+		parts.push(`Files changed:\n${input.totalDiff.filesChanged ?? "(none recorded)"}`)
+		if (input.totalDiff.diffSnippet) {
+			parts.push(`\nDiff snippet:\n\`\`\`diff\n${input.totalDiff.diffSnippet}\n\`\`\``)
+		}
+	} else {
+		parts.push("(No diff available — use your tools to inspect files directly.)")
+	}
+	if (input.evidence && input.evidence.trim().length > 0) {
+		parts.push("")
+		parts.push("--- EXECUTION EVIDENCE (agent-provided) ---")
+		parts.push(input.evidence.slice(0, 4000))
+	}
+	parts.push("")
+	parts.push(`Working directory: ${process.cwd()}`)
+	parts.push("")
+	parts.push(
+		"Verify the agent's claims by reading files and running commands. Then respond with EXACTLY one JSON object:",
+	)
+	parts.push('{"grade":"A"|"B"|"C"|"D"|"F","rationale":"...","recommendations":[...]}')
+	return parts.join("\n")
+}

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -611,34 +611,83 @@ export type GraderSpawner = (prompt: string) => Promise<GraderSubagentResult>
  *  with a valid grade field anywhere in the text — the subagent may produce
  *  the grade JSON in an earlier turn and then continue with follow-up text.
  *  Returns undefined if no parseable grade JSON is found. */
-function parseGraderResponse(text: string): JudgePhaseGradeOk | undefined {
+function parseGraderResponse(text: string): GradedResult | undefined {
 	// Try parsing the full text as JSON first (common case: final message IS the JSON)
-	const direct = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(text)
+	const direct = tryParseJson<GradeJson>(text)
 	if (direct !== undefined && isGrade(direct.grade)) {
-		const rationale = typeof direct.rationale === "string" ? direct.rationale.slice(0, 800) : "(no rationale provided)"
-		const recommendations = normalizeRecommendations(direct.recommendations)
-		return { ok: true, grade: direct.grade, rationale, recommendations }
+		return buildGradedResult(direct)
 	}
 
 	// Scan for a JSON object containing a grade field anywhere in the text.
-	// This handles the case where the subagent produced the grade JSON mid-session
-	// and then continued with follow-up text (e.g. "Already completed the grade...").
-	const gradeJsonPattern = /\{[^{}]*"grade"\s*:\s*"[A-F]"[^{}]*\}/g
-	const matches = text.match(gradeJsonPattern)
-	if (matches) {
-		// Try from the last match (most recent grade)
-		for (let i = matches.length - 1; i >= 0; i--) {
-			const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(matches[i])
-			if (parsed !== undefined && isGrade(parsed.grade)) {
-				const rationale =
-					typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
-				const recommendations = normalizeRecommendations(parsed.recommendations)
-				return { ok: true, grade: parsed.grade, rationale, recommendations }
-			}
+	// Uses a brace-balanced scan instead of a regex so that nested braces in
+	// rationale strings or recommendations don't cause false negatives.
+	const gradeJsons = extractJsonObjects(text)
+	// Try from the last match (most recent grade)
+	for (let i = gradeJsons.length - 1; i >= 0; i--) {
+		const parsed = tryParseJson<GradeJson>(gradeJsons[i])
+		if (parsed !== undefined && isGrade(parsed.grade)) {
+			return buildGradedResult(parsed)
 		}
 	}
 
 	return undefined
+}
+
+/** Shape of the grader's JSON output. */
+type GradeJson = { grade?: string; rationale?: string; recommendations?: unknown }
+
+/** Shared result type for both phase and journey grade parsing. */
+type GradedResult = { ok: true; grade: Grade; rationale: string; recommendations: string[] }
+
+/** Build a GradedResult from parsed JSON. */
+function buildGradedResult(parsed: GradeJson): GradedResult {
+	const rationale = typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
+	const recommendations = normalizeRecommendations(parsed.recommendations)
+	return { ok: true, grade: parsed.grade as Grade, rationale, recommendations }
+}
+
+/** Extract all top-level JSON objects from a text string using a
+ *  brace-balanced scan. Handles nested braces inside strings and values. */
+function extractJsonObjects(text: string): string[] {
+	const results: string[] = []
+	let i = 0
+	while (i < text.length) {
+		const open = text.indexOf("{", i)
+		if (open === -1) break
+		let depth = 0
+		let inString = false
+		let escape = false
+		let end = -1
+		for (let j = open; j < text.length; j++) {
+			const ch = text[j]
+			if (inString) {
+				if (escape) {
+					escape = false
+				} else if (ch === "\\") {
+					escape = true
+				} else if (ch === '"') {
+					inString = false
+				}
+			} else {
+				if (ch === '"') inString = true
+				else if (ch === "{") depth++
+				else if (ch === "}") {
+					depth--
+					if (depth === 0) {
+						end = j
+						break
+					}
+				}
+			}
+		}
+		if (end !== -1) {
+			results.push(text.slice(open, end + 1))
+			i = end + 1
+		} else {
+			i = open + 1
+		}
+	}
+	return results
 }
 
 /** Grade a phase using a subagent with tool access. Falls back to the

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -597,7 +597,7 @@ export async function judgePhaseGrade(
 
 /** Result from a grader subagent invocation. */
 export interface GraderSubagentResult {
-	/** The final text response from the subagent (should be JSON). */
+	/** The full text output from the subagent (may contain multiple assistant turns). */
 	text: string
 	/** "completed" = finished normally; anything else = aborted/errored. */
 	status: string
@@ -607,15 +607,38 @@ export interface GraderSubagentResult {
  *  lifecycle.ts) which has access to ExtensionAPI + AgentManager. */
 export type GraderSpawner = (prompt: string) => Promise<GraderSubagentResult>
 
-/** Parse the subagent's final response into a grade result. Returns undefined
- *  if the response is not parseable JSON with a valid grade. */
+/** Parse the subagent's response into a grade result. Scans for a JSON object
+ *  with a valid grade field anywhere in the text — the subagent may produce
+ *  the grade JSON in an earlier turn and then continue with follow-up text.
+ *  Returns undefined if no parseable grade JSON is found. */
 function parseGraderResponse(text: string): JudgePhaseGradeOk | undefined {
-	const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(text)
-	if (parsed === undefined) return undefined
-	if (!isGrade(parsed.grade)) return undefined
-	const rationale = typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
-	const recommendations = normalizeRecommendations(parsed.recommendations)
-	return { ok: true, grade: parsed.grade, rationale, recommendations }
+	// Try parsing the full text as JSON first (common case: final message IS the JSON)
+	const direct = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(text)
+	if (direct !== undefined && isGrade(direct.grade)) {
+		const rationale = typeof direct.rationale === "string" ? direct.rationale.slice(0, 800) : "(no rationale provided)"
+		const recommendations = normalizeRecommendations(direct.recommendations)
+		return { ok: true, grade: direct.grade, rationale, recommendations }
+	}
+
+	// Scan for a JSON object containing a grade field anywhere in the text.
+	// This handles the case where the subagent produced the grade JSON mid-session
+	// and then continued with follow-up text (e.g. "Already completed the grade...").
+	const gradeJsonPattern = /\{[^{}]*"grade"\s*:\s*"[A-F]"[^{}]*\}/g
+	const matches = text.match(gradeJsonPattern)
+	if (matches) {
+		// Try from the last match (most recent grade)
+		for (let i = matches.length - 1; i >= 0; i--) {
+			const parsed = tryParseJson<{ grade?: string; rationale?: string; recommendations?: unknown }>(matches[i])
+			if (parsed !== undefined && isGrade(parsed.grade)) {
+				const rationale =
+					typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 800) : "(no rationale provided)"
+				const recommendations = normalizeRecommendations(parsed.recommendations)
+				return { ok: true, grade: parsed.grade, rationale, recommendations }
+			}
+		}
+	}
+
+	return undefined
 }
 
 /** Grade a phase using a subagent with tool access. Falls back to the

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -656,15 +656,15 @@ function extractJsonObjects(text: string): string[] {
 		if (open === -1) break
 		let depth = 0
 		let inString = false
-		let escape = false
+		let escaped = false
 		let end = -1
 		for (let j = open; j < text.length; j++) {
 			const ch = text[j]
 			if (inString) {
-				if (escape) {
-					escape = false
+				if (escaped) {
+					escaped = false
 				} else if (ch === "\\") {
-					escape = true
+					escaped = true
 				} else if (ch === '"') {
 					inString = false
 				}

--- a/src/extensions/ferment/review-evidence.ts
+++ b/src/extensions/ferment/review-evidence.ts
@@ -52,6 +52,10 @@ export interface ReviewEvidence {
 	stepSummaries?: string
 	diffAvailable: boolean
 	diffFilesChanged?: string
+	/** Agent-pasted execution evidence (command outputs, verification results).
+	 *  Persisted so post-mortem analysis can correlate grader decisions with
+	 *  the proof the agent provided. */
+	evidence?: string
 
 	/** Outputs from the reviewer + deterministic checks. */
 	flags: JudgeFlag[]
@@ -115,6 +119,8 @@ export function writeReviewEvidence(args: {
 	outcome: ReviewOutcome
 	diffFilesChanged?: string
 	diffAvailable: boolean
+	/** Agent-pasted execution evidence to persist on the review sidecar. */
+	evidence?: string
 	projectChecks?: ProjectCheckResult
 	/** Raw F-gate verdicts the agent passed at complete_ferment_phase. Persisted so the
 	 *  journey-grade judge at complete_ferment can grade based on the trail. */
@@ -142,6 +148,7 @@ export function writeReviewEvidence(args: {
 		stepSummaries: args.stepSummaries,
 		diffAvailable: args.diffAvailable,
 		diffFilesChanged: args.diffFilesChanged,
+		evidence: args.evidence,
 		flags: args.outcome.flags,
 		derivedGrade: args.outcome.grade,
 		reviewerRationale: args.outcome.rationale,

--- a/src/extensions/ferment/tool-schemas.ts
+++ b/src/extensions/ferment/tool-schemas.ts
@@ -302,6 +302,12 @@ export const CompletePhaseParams = Type.Object({
 	ferment_id: Type.String(),
 	phase_id: Type.String(),
 	summary: Type.String(),
+	evidence: Type.Optional(
+		Type.String({
+			description:
+				"Execution evidence for the LLM grader. Paste real command outputs and verification results that prove the phase work was done correctly — e.g. bash command + exit code + stdout, test suite output, file contents, or tool invocation transcripts. This is especially important when no git diff is available (non-repo environments). Bounded to ~4 KB; truncate long outputs to the relevant portions. Example: '$ python3 verify.py\nAll 5 tests passed\n$ cat /app/result.txt\n42'",
+		}),
+	),
 	gates: Type.Array(GateVerdictSchema, {
 		description:
 			'Phase-scope gate verdicts. Required ids: F1 (real verification vs proxies), F2 (combined output meets phase goal), F3 (what was deferred). A \'flag\' verdict refuses phase advancement and feeds the retry/escalation pipeline. Example: [{"id":"F1","verdict":"pass","rationale":"Mixed verification is acceptable; load-bearing steps use real tests","evidence":"Step 2 uses pnpm test; Step 1 is proxy but non-critical"}, {"id":"F2","verdict":"pass","rationale":"All steps together produced the expected artifact","evidence":"src/new-feature.ts created and compiled"}, {"id":"F3","verdict":"pass","rationale":"Nothing deferred; all planned work completed","evidence":"n/a"}]',
@@ -317,6 +323,12 @@ export const SkipPhaseParams = Type.Object({
 export const CompleteFermentParams = Type.Object({
 	ferment_id: Type.String(),
 	final_summary: Type.Optional(Type.String()),
+	evidence: Type.Optional(
+		Type.String({
+			description:
+				"Execution evidence for the final LLM grader. Paste real command outputs and verification results that prove the ferment goal was achieved — e.g. bash command + exit code + stdout, test suite output, file contents, or tool invocation transcripts. This is especially important when no git diff is available (non-repo environments). Bounded to ~4 KB; truncate long outputs to the relevant portions.",
+		}),
+	),
 	gates: Type.Optional(
 		Type.Array(GateVerdictSchema, {
 			description:

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -52,6 +52,7 @@ vi.mock("./judge.js", async () => {
 const mockAgentRecords = vi.hoisted(() => new Map<string, unknown>())
 vi.mock("../agents/index.js", () => ({
 	getAgentRecordForTaskValidation: vi.fn((id: string) => mockAgentRecords.get(id)),
+	runWithOverlay: vi.fn((_description: string, fn: () => Promise<unknown>) => fn()),
 }))
 import { createContext } from "../__mocks__/context.js"
 import { pr_dim } from "./colors.js"

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -44,6 +44,7 @@ vi.mock("./judge.js", async () => {
 			ok: true as const,
 			grade: "A" as const,
 			rationale: "Clean delivery; gates substantiated.",
+			recommendations: [],
 		})),
 	}
 })

--- a/src/extensions/ferment/tools.integration.test.ts
+++ b/src/extensions/ferment/tools.integration.test.ts
@@ -46,6 +46,12 @@ vi.mock("./judge.js", async () => {
 			rationale: "Clean delivery; gates substantiated.",
 			recommendations: [],
 		})),
+		judgeJourneyGradeViaSubagent: vi.fn(async () => ({
+			ok: true as const,
+			grade: "A" as const,
+			rationale: "Clean delivery; gates substantiated.",
+			recommendations: [],
+		})),
 	}
 })
 
@@ -53,6 +59,7 @@ const mockAgentRecords = vi.hoisted(() => new Map<string, unknown>())
 vi.mock("../agents/index.js", () => ({
 	getAgentRecordForTaskValidation: vi.fn((id: string) => mockAgentRecords.get(id)),
 	runWithOverlay: vi.fn((_description: string, fn: () => Promise<unknown>) => fn()),
+	spawnGraderAgent: vi.fn(async () => undefined),
 }))
 import { createContext } from "../__mocks__/context.js"
 import { pr_dim } from "./colors.js"

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -24,9 +24,9 @@ describe("Grader agent registration", () => {
 		expect(cfg.disallowedTools).toContain("Agent")
 
 		// Must be bounded
-		expect(cfg.maxTurns).toBe(10)
-		expect(cfg.tokenBudget).toBe(50_000)
-		expect(cfg.maxDuration).toBe(120)
+		expect(cfg.maxTurns).toBe(15)
+		expect(cfg.tokenBudget).toBe(60_000)
+		expect(cfg.maxDuration).toBe(180)
 
 		// No extensions or skills — purely built-in tools
 		expect(cfg.extensions).toBe(false)

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+// Test that the Grader agent type is registered and has the correct config.
+describe("Grader agent registration", () => {
+	it("Grader is in the default agent registry with correct config", async () => {
+		const { getAgentConfig, resolveType, registerAgents } = await import("../../agents/personas/agent-types.js")
+		// Register default agents into the lookup maps
+		registerAgents(new Map())
+		expect(resolveType("Grader")).toBe("Grader")
+		expect(resolveType("grader")).toBe("Grader") // case-insensitive
+
+		const cfg = getAgentConfig("Grader")
+		expect(cfg).toBeDefined()
+		if (!cfg) return
+
+		// Must be read-only + bash only — no edit, write, or Agent
+		expect(cfg.builtinToolNames).toContain("bash")
+		expect(cfg.builtinToolNames).toContain("read")
+		expect(cfg.builtinToolNames).toContain("grep")
+		expect(cfg.builtinToolNames).toContain("find")
+		expect(cfg.builtinToolNames).toContain("ls")
+		expect(cfg.disallowedTools).toContain("edit")
+		expect(cfg.disallowedTools).toContain("write")
+		expect(cfg.disallowedTools).toContain("Agent")
+
+		// Must be bounded
+		expect(cfg.maxTurns).toBe(10)
+		expect(cfg.tokenBudget).toBe(50_000)
+		expect(cfg.maxDuration).toBe(120)
+
+		// No extensions or skills — purely built-in tools
+		expect(cfg.extensions).toBe(false)
+		expect(cfg.skills).toBe(false)
+
+		// System prompt must contain the council-of-specialists rubric
+		expect(cfg.systemPrompt).toContain("PESSIMISTIC")
+		expect(cfg.systemPrompt).toContain("Security attacker")
+		expect(cfg.systemPrompt).toContain("Code quality review")
+		expect(cfg.systemPrompt).toContain("Test and verification review")
+		expect(cfg.systemPrompt).toContain("tools")
+		expect(cfg.systemPrompt).toContain("JSON")
+		expect(cfg.systemPrompt).toContain("grade")
+	})
+})

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -1114,6 +1114,7 @@ describe("completeFerment", () => {
 			ok: true,
 			grade: "B",
 			rationale: "Phase 1 verified via proxy; goal met but coverage is thin.",
+			recommendations: [],
 		})
 		const result = await completeFerment(
 			h.runtime,
@@ -1176,6 +1177,140 @@ describe("completeFerment", () => {
 
 		expect(okText(result)).toContain("**Final grade:** unavailable")
 		expect(okText(result)).toContain("Judge unreachable (no_registry)")
+		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
+		expect(h.storage.get(h.fermentId)?.grade).toBeUndefined()
+	})
+
+	// ── Final grader enforcement ──────────────────────────────────────────────────
+
+	it("A-grade ships with recommendations persisted", async () => {
+		const h = createHarness()
+		createTerminalFerment(h)
+		const recs = ["Add integration test for the retry path."]
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+			ok: true,
+			grade: "A",
+			rationale: "Excellent. Production-ready.",
+			recommendations: recs,
+		})
+		const result = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		})
+		expect(okText(result)).toContain("**Final grade:** A")
+		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
+		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("A")
+		expect(h.storage.get(h.fermentId)?.grade?.recommendations).toEqual(recs)
+	})
+
+	it("B-grade ships with recommendations persisted", async () => {
+		const h = createHarness()
+		createTerminalFerment(h)
+		const recs = ["Add edge-case test for empty input.", "Wire retry into production call site."]
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+			ok: true,
+			grade: "B",
+			rationale: "Goal met but coverage is thin.",
+			recommendations: recs,
+		})
+		const result = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		})
+		expect(okText(result)).toContain("**Final grade:** B")
+		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
+		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("B")
+		expect(h.storage.get(h.fermentId)?.grade?.recommendations).toEqual(recs)
+	})
+
+	it("C-grade refuses ship within budget and surfaces recommendations", async () => {
+		const h = createHarness()
+		createTerminalFerment(h)
+		const recs = ["Fix the N+1 query in listUsers.", "Add cancellation to the fetch loop."]
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+			ok: true,
+			grade: "C",
+			rationale: "Operational gaps.",
+			recommendations: recs,
+		})
+		const result = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		})
+		expect(errText(result)).toContain("final LLM grader assigned grade C")
+		expect(errText(result)).toContain("retry 1/3")
+		expect(errText(result)).toContain("Fix the N+1 query in listUsers.")
+		expect(errText(result)).toContain("Add cancellation to the fetch loop.")
+		// Ferment must NOT be completed.
+		expect(h.storage.get(h.fermentId)?.status).not.toBe("complete")
+		// Retry counter must have been bumped.
+		expect(h.runtime.getBlockRetry(h.fermentId, "__ferment__")).toBe(1)
+	})
+
+	it("C-grade repeated exhausts budget and ships with the grade", async () => {
+		const h = createHarness()
+		createTerminalFerment(h)
+		const recs = ["Fix the N+1 query in listUsers."]
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValue({
+			ok: true,
+			grade: "C",
+			rationale: "Operational gaps.",
+			recommendations: recs,
+		})
+
+		// First refusal: within budget.
+		const result1 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "attempt 1",
+			gates: passingFermentGates(),
+		})
+		expect(errText(result1)).toContain("retry 1/3")
+
+		// Second refusal: within budget.
+		const result2 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "attempt 2",
+			gates: passingFermentGates(),
+		})
+		expect(errText(result2)).toContain("retry 2/3")
+
+		// Third refusal: within budget.
+		const result3 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "attempt 3",
+			gates: passingFermentGates(),
+		})
+		expect(errText(result3)).toContain("retry 3/3")
+
+		// Fourth attempt: budget exhausted — accepts the grade and ships.
+		const result4 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "attempt 4",
+			gates: passingFermentGates(),
+		})
+		expect(okText(result4)).toContain("**Final grade:** C")
+		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
+		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("C")
+		expect(h.storage.get(h.fermentId)?.grade?.recommendations).toEqual(recs)
+	})
+
+	it("judge-unavailable ships without refusal", async () => {
+		const h = createHarness()
+		createTerminalFerment(h)
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+			ok: false,
+			reason: "no_auth",
+			detail: "missing api key",
+		})
+		const result = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		})
+		expect(okText(result)).toContain("**Final grade:** unavailable")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade).toBeUndefined()
 	})

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -1110,21 +1110,26 @@ describe("completeFerment", () => {
 	it("persists the journey grade from the judge into ferment.grade", async () => {
 		const h = createHarness()
 		createTerminalFerment(h)
-		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+		// B is refused on first attempt; accepted on second.
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValue({
 			ok: true,
 			grade: "B",
 			rationale: "Phase 1 verified via proxy; goal met but coverage is thin.",
 			recommendations: [],
 		})
-		const result = await completeFerment(
-			h.runtime,
-			{
-				ferment_id: h.fermentId,
-				final_summary: "done",
-				gates: passingFermentGates(),
-			},
-			{ ctx: createContext() },
-		)
+		// First attempt: B refused.
+		const result1 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		}, { ctx: createContext() })
+		expect(errText(result1)).toContain("minimum required is A")
+		// Second attempt: B accepted.
+		const result = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		}, { ctx: createContext() })
 		expect(okText(result)).toContain("**Final grade:** B")
 		expect(okText(result)).toContain("proxy")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("B")
@@ -1197,29 +1202,38 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(okText(result)).toContain("**Final grade:** A")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("A")
 		expect(h.storage.get(h.fermentId)?.grade?.recommendations).toEqual(recs)
 	})
 
-	it("B-grade ships with recommendations persisted", async () => {
+	it("B-grade refused on first attempt, ships after rework", async () => {
 		const h = createHarness()
 		createTerminalFerment(h)
 		const recs = ["Add edge-case test for empty input.", "Wire retry into production call site."]
-		vi.mocked(mockJudgeJourneyGrade).mockResolvedValueOnce({
+		vi.mocked(mockJudgeJourneyGrade).mockResolvedValue({
 			ok: true,
 			grade: "B",
 			rationale: "Goal met but coverage is thin.",
 			recommendations: recs,
 		})
-		const result = await completeFerment(h.runtime, {
+		// First attempt: B refused (minimum is A).
+		const result1 = await completeFerment(h.runtime, {
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		})
-		expect(okText(result)).toContain("**Final grade:** B")
+		}, { ctx: createContext() })
+		expect(errText(result1)).toContain("minimum required is A")
+		expect(errText(result1)).toContain("Add edge-case test")
+		// Second attempt: B accepted (minimum relaxes to B).
+		const result2 = await completeFerment(h.runtime, {
+			ferment_id: h.fermentId,
+			final_summary: "done",
+			gates: passingFermentGates(),
+		}, { ctx: createContext() })
+		expect(okText(result2)).toContain("**Final grade:** B")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("B")
 		expect(h.storage.get(h.fermentId)?.grade?.recommendations).toEqual(recs)
@@ -1239,7 +1253,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(errText(result)).toContain("final LLM grader assigned grade C")
 		expect(errText(result)).toContain("retry 1/3")
 		expect(errText(result)).toContain("Fix the N+1 query in listUsers.")
@@ -1266,7 +1280,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "attempt 1",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(errText(result1)).toContain("retry 1/3")
 
 		// Second refusal: within budget.
@@ -1274,7 +1288,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "attempt 2",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(errText(result2)).toContain("retry 2/3")
 
 		// Third refusal: within budget.
@@ -1282,7 +1296,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "attempt 3",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(errText(result3)).toContain("retry 3/3")
 
 		// Fourth attempt: budget exhausted — accepts the grade and ships.
@@ -1290,7 +1304,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "attempt 4",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(okText(result4)).toContain("**Final grade:** C")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("C")
@@ -1309,7 +1323,7 @@ describe("completeFerment", () => {
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		})
+		}, { ctx: createContext() })
 		expect(okText(result)).toContain("**Final grade:** unavailable")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade).toBeUndefined()

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -1133,7 +1133,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result1)).toContain("minimum required is A")
@@ -1144,7 +1144,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(result)).toContain("**Final grade:** B")
@@ -1221,7 +1221,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(result)).toContain("**Final grade:** A")
@@ -1247,7 +1247,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result1)).toContain("minimum required is A")
@@ -1259,7 +1259,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(result2)).toContain("**Final grade:** B")
@@ -1284,7 +1284,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result)).toContain("final LLM grader assigned grade C")
@@ -1315,7 +1315,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "attempt 1",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result1)).toContain("retry 1/3")
@@ -1327,7 +1327,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "attempt 2",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result2)).toContain("retry 2/3")
@@ -1339,7 +1339,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "attempt 3",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(errText(result3)).toContain("retry 3/3")
@@ -1351,7 +1351,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "attempt 4",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(result4)).toContain("**Final grade:** C")
@@ -1374,7 +1374,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-		},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(result)).toContain("**Final grade:** unavailable")

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -1095,7 +1095,11 @@ describe("completeFerment", () => {
 		expect(okText(first)).toContain("do not search MCP tools or invent a tool")
 		expect(mockJudgeJourneyGrade).toHaveBeenCalledTimes(1)
 
-		const second = await completeFerment(h.runtime, { ferment_id: h.fermentId }, { ctx: createContext() })
+		const second = await completeFerment(
+			h.runtime,
+			{ ferment_id: h.fermentId },
+			{ ctx: createContext() },
+		)
 
 		expect(okText(second)).toContain('Ferment "Lifecycle Test" is already complete')
 		expect(okText(second)).toContain("without clear user consent")
@@ -1109,7 +1113,11 @@ describe("completeFerment", () => {
 		const abandoned = applyAndPersist(h.fermentId, { type: "abandon", reason: "user stopped" })
 		if (!abandoned.ok) throw new Error(abandoned.error.message)
 
-		const result = await completeFerment(h.runtime, { ferment_id: h.fermentId }, { ctx: createContext() })
+		const result = await completeFerment(
+			h.runtime,
+			{ ferment_id: h.fermentId },
+			{ ctx: createContext() },
+		)
 
 		expect(errText(result)).toContain('Ferment "Lifecycle Test" is abandoned and cannot be completed')
 		expect(mockJudgeJourneyGrade).not.toHaveBeenCalled()
@@ -1127,18 +1135,26 @@ describe("completeFerment", () => {
 			recommendations: [],
 		})
 		// First attempt: B refused.
-		const result1 = await completeFerment(h.runtime, {
+		const result1 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result1)).toContain("minimum required is A")
 		// Second attempt: B accepted.
-		const result = await completeFerment(h.runtime, {
+		const result = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(okText(result)).toContain("**Final grade:** B")
 		expect(okText(result)).toContain("proxy")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("B")
@@ -1207,11 +1223,15 @@ describe("completeFerment", () => {
 			rationale: "Excellent. Production-ready.",
 			recommendations: recs,
 		})
-		const result = await completeFerment(h.runtime, {
+		const result = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(okText(result)).toContain("**Final grade:** A")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("A")
@@ -1229,19 +1249,27 @@ describe("completeFerment", () => {
 			recommendations: recs,
 		})
 		// First attempt: B refused (minimum is A).
-		const result1 = await completeFerment(h.runtime, {
+		const result1 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result1)).toContain("minimum required is A")
 		expect(errText(result1)).toContain("Add edge-case test")
 		// Second attempt: B accepted (minimum relaxes to B).
-		const result2 = await completeFerment(h.runtime, {
+		const result2 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(okText(result2)).toContain("**Final grade:** B")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("B")
@@ -1258,11 +1286,15 @@ describe("completeFerment", () => {
 			rationale: "Operational gaps.",
 			recommendations: recs,
 		})
-		const result = await completeFerment(h.runtime, {
+		const result = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result)).toContain("final LLM grader assigned grade C")
 		expect(errText(result)).toContain("retry 1/3")
 		expect(errText(result)).toContain("Fix the N+1 query in listUsers.")
@@ -1285,35 +1317,51 @@ describe("completeFerment", () => {
 		})
 
 		// First refusal: within budget.
-		const result1 = await completeFerment(h.runtime, {
+		const result1 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "attempt 1",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result1)).toContain("retry 1/3")
 
 		// Second refusal: within budget.
-		const result2 = await completeFerment(h.runtime, {
+		const result2 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "attempt 2",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result2)).toContain("retry 2/3")
 
 		// Third refusal: within budget.
-		const result3 = await completeFerment(h.runtime, {
+		const result3 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "attempt 3",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(errText(result3)).toContain("retry 3/3")
 
 		// Fourth attempt: budget exhausted — accepts the grade and ships.
-		const result4 = await completeFerment(h.runtime, {
+		const result4 = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "attempt 4",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(okText(result4)).toContain("**Final grade:** C")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade?.grade).toBe("C")
@@ -1328,11 +1376,15 @@ describe("completeFerment", () => {
 			reason: "no_auth",
 			detail: "missing api key",
 		})
-		const result = await completeFerment(h.runtime, {
+		const result = await completeFerment(
+			h.runtime,
+			{
 			ferment_id: h.fermentId,
 			final_summary: "done",
 			gates: passingFermentGates(),
-		}, { ctx: createContext() })
+		},
+			{ ctx: createContext() },
+		)
 		expect(okText(result)).toContain("**Final grade:** unavailable")
 		expect(h.storage.get(h.fermentId)?.status).toBe("complete")
 		expect(h.storage.get(h.fermentId)?.grade).toBeUndefined()

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -197,7 +197,7 @@ describe("scopeFerment", () => {
 				constraints: ["Keep it small"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -221,7 +221,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -241,7 +241,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -257,7 +257,7 @@ describe("scopeFerment", () => {
 				verdict: "flag" as const,
 				rationale: "phase-1 has no concrete verifier.",
 				evidence: "no verify command set",
-			},
+				},
 			{ id: "P2", verdict: "pass" as const, rationale: "ok", evidence: "n/a" },
 			{ id: "P3", verdict: "pass" as const, rationale: "ok", evidence: "n/a" },
 		]
@@ -271,7 +271,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: flaggedGates,
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -293,7 +293,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: incomplete,
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -316,7 +316,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -339,7 +339,7 @@ describe("scopeFerment", () => {
 				assumptions: "k8s cluster exists and is reachable",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -359,7 +359,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -376,7 +376,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-			},
+				},
 			getActiveTools: vi.fn(() => ["read", "bash"]),
 			getAllTools: vi.fn(() => [{ name: "read" }, { name: "bash" }]),
 			setActiveTools: vi.fn(),
@@ -412,7 +412,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -434,7 +434,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -464,7 +464,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -494,7 +494,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -525,7 +525,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -555,7 +555,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -583,7 +583,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -612,7 +612,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -634,7 +634,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-			},
+				},
 			getFlag: vi.fn((flag: string) => flag === "ferment-oneshot" && options?.oneShot === true),
 		} as unknown as ExtensionAPI
 		registerLifecycleTools(pi, h.runtime)
@@ -662,7 +662,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 					"README.md exists at the project root; verify by opening README.md.",
 					"README.md documents all CLI commands; verify by reading the command list.",
 				],
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ ui: { select, input } }),
@@ -694,7 +694,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["README.md exists at the project root; verify by opening README.md."],
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ ui: { select, input } }),
@@ -727,7 +727,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["README.md exists at the project root; verify by opening README.md."],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -748,7 +748,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["  "],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -766,7 +766,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-			},
+				},
 			getFlag: vi.fn(() => false),
 		} as unknown as ExtensionAPI
 		registerLifecycleTools(pi, h.runtime)
@@ -787,7 +787,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ ui: { select } }),
@@ -804,7 +804,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext({ ui: { select } }),
@@ -819,7 +819,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -834,7 +834,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -849,7 +849,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "", type: "single", prompt: "Which?", options: [{ id: "a", label: "A" }] }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -864,7 +864,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "q1", type: "single", prompt: "", options: [{ id: "a", label: "A" }] }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -879,7 +879,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "bad", type: "bogus", prompt: "Which?", options: [{ id: "a", label: "A" }] }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -895,7 +895,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "ok", type: "confirm", prompt: "Proceed?", options: [{ id: "ship", label: "Ship" }] }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -910,7 +910,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "lonely", type: "single", prompt: "Pick one?" }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -925,7 +925,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "lonely", type: "multi", prompt: "Pick many?" }],
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -942,7 +942,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 		const pi = {
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-			},
+				},
 			sendMessage: vi.fn(),
 			appendEntry: vi.fn(),
 			on: vi.fn(),
@@ -977,7 +977,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 				ferment_id: fermentId,
 				field: "assumptions",
 				value: "k8s cluster exists and is reachable",
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -998,7 +998,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 				ferment_id: fermentId,
 				field: "unknown_field",
 				value: "ignored",
-			},
+				},
 			undefined,
 			undefined,
 			createContext(),
@@ -1023,7 +1023,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "all done",
 				gates: passingFermentGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -1045,7 +1045,7 @@ describe("completeFerment", () => {
 				verdict: "flag" as const,
 				rationale: "phase-1 deferred error handling but no later phase resolves it.",
 				evidence: "F3 of phase-1 deferred 'edge cases'",
-			},
+				},
 			{ id: "C3", verdict: "pass" as const, rationale: "ok", evidence: "smoke" },
 		]
 
@@ -1086,7 +1086,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 		expect(okText(first)).toContain('**Ferment "Lifecycle Test"** complete')
@@ -1095,11 +1095,7 @@ describe("completeFerment", () => {
 		expect(okText(first)).toContain("do not search MCP tools or invent a tool")
 		expect(mockJudgeJourneyGrade).toHaveBeenCalledTimes(1)
 
-		const second = await completeFerment(
-			h.runtime,
-			{ ferment_id: h.fermentId },
-			{ ctx: createContext() },
-		)
+		const second = await completeFerment(h.runtime, { ferment_id: h.fermentId }, { ctx: createContext() })
 
 		expect(okText(second)).toContain('Ferment "Lifecycle Test" is already complete')
 		expect(okText(second)).toContain("without clear user consent")
@@ -1113,11 +1109,7 @@ describe("completeFerment", () => {
 		const abandoned = applyAndPersist(h.fermentId, { type: "abandon", reason: "user stopped" })
 		if (!abandoned.ok) throw new Error(abandoned.error.message)
 
-		const result = await completeFerment(
-			h.runtime,
-			{ ferment_id: h.fermentId },
-			{ ctx: createContext() },
-		)
+		const result = await completeFerment(h.runtime, { ferment_id: h.fermentId }, { ctx: createContext() })
 
 		expect(errText(result)).toContain('Ferment "Lifecycle Test" is abandoned and cannot be completed')
 		expect(mockJudgeJourneyGrade).not.toHaveBeenCalled()
@@ -1138,9 +1130,9 @@ describe("completeFerment", () => {
 		const result1 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1149,9 +1141,9 @@ describe("completeFerment", () => {
 		const result = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1177,7 +1169,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -1201,7 +1193,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-			},
+				},
 			{ ctx: createContext() },
 		)
 
@@ -1226,9 +1218,9 @@ describe("completeFerment", () => {
 		const result = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1252,9 +1244,9 @@ describe("completeFerment", () => {
 		const result1 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1264,9 +1256,9 @@ describe("completeFerment", () => {
 		const result2 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1289,9 +1281,9 @@ describe("completeFerment", () => {
 		const result = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1320,9 +1312,9 @@ describe("completeFerment", () => {
 		const result1 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "attempt 1",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "attempt 1",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1332,9 +1324,9 @@ describe("completeFerment", () => {
 		const result2 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "attempt 2",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "attempt 2",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1344,9 +1336,9 @@ describe("completeFerment", () => {
 		const result3 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "attempt 3",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "attempt 3",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1356,9 +1348,9 @@ describe("completeFerment", () => {
 		const result4 = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "attempt 4",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "attempt 4",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1379,9 +1371,9 @@ describe("completeFerment", () => {
 		const result = await completeFerment(
 			h.runtime,
 			{
-			ferment_id: h.fermentId,
-			final_summary: "done",
-			gates: passingFermentGates(),
+				ferment_id: h.fermentId,
+				final_summary: "done",
+				gates: passingFermentGates(),
 		},
 			{ ctx: createContext() },
 		)
@@ -1409,11 +1401,11 @@ describe("interactive ferment tool visibility (registerLifecycleTools)", () => {
 			registerTool: () => {},
 			on: (_event, handler) => {
 				pi._sessionStart = handler
-			},
+				},
 			getActiveTools: () => options.activeTools,
 			setActiveTools: (names: string[]) => {
 				pi.setActiveCalls.push(names)
-			},
+				},
 			getFlag: (name: string) => (name === "ferment-oneshot" ? options.oneShot === true : undefined),
 			_sessionStart: null,
 			setActiveCalls: [],

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -197,7 +197,7 @@ describe("scopeFerment", () => {
 				constraints: ["Keep it small"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -221,7 +221,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -241,7 +241,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -257,7 +257,7 @@ describe("scopeFerment", () => {
 				verdict: "flag" as const,
 				rationale: "phase-1 has no concrete verifier.",
 				evidence: "no verify command set",
-				},
+			},
 			{ id: "P2", verdict: "pass" as const, rationale: "ok", evidence: "n/a" },
 			{ id: "P3", verdict: "pass" as const, rationale: "ok", evidence: "n/a" },
 		]
@@ -271,7 +271,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: flaggedGates,
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -293,7 +293,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: incomplete,
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -316,7 +316,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement" }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -339,7 +339,7 @@ describe("scopeFerment", () => {
 				assumptions: "k8s cluster exists and is reachable",
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -359,7 +359,7 @@ describe("scopeFerment", () => {
 				success_criteria: ["Tests pass"],
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				gates: passingPlanGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -376,7 +376,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-				},
+			},
 			getActiveTools: vi.fn(() => ["read", "bash"]),
 			getAllTools: vi.fn(() => [{ name: "read" }, { name: "bash" }]),
 			setActiveTools: vi.fn(),
@@ -412,7 +412,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -434,7 +434,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "Build", goal: "Implement", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -464,7 +464,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -494,7 +494,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -525,7 +525,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 					},
 				],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -555,7 +555,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -583,7 +583,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -612,7 +612,7 @@ describe("propose_ferment_scoping via registerLifecycleTools", () => {
 				phases: [{ name: "P1", goal: "Build it", steps: [{ description: "Code it" }] }],
 				questions: [],
 				gates: passingPlanGates(),
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ hasUI: false }),
@@ -634,7 +634,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-				},
+			},
 			getFlag: vi.fn((flag: string) => flag === "ferment-oneshot" && options?.oneShot === true),
 		} as unknown as ExtensionAPI
 		registerLifecycleTools(pi, h.runtime)
@@ -662,7 +662,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 					"README.md exists at the project root; verify by opening README.md.",
 					"README.md documents all CLI commands; verify by reading the command list.",
 				],
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ ui: { select, input } }),
@@ -694,7 +694,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["README.md exists at the project root; verify by opening README.md."],
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ ui: { select, input } }),
@@ -727,7 +727,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["README.md exists at the project root; verify by opening README.md."],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -748,7 +748,7 @@ describe("confirm_ferment_completion_criteria via registerLifecycleTools", () =>
 			{
 				ferment_id: h.fermentId,
 				criteria: ["  "],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -766,7 +766,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			...h.pi,
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-				},
+			},
 			getFlag: vi.fn(() => false),
 		} as unknown as ExtensionAPI
 		registerLifecycleTools(pi, h.runtime)
@@ -787,7 +787,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ ui: { select } }),
@@ -804,7 +804,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext({ ui: { select } }),
@@ -819,7 +819,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			"tool-call-1",
 			{
 				questions: [{ id: "confirm", type: "confirm", prompt: "Sound right?" }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -834,7 +834,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -849,7 +849,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "", type: "single", prompt: "Which?", options: [{ id: "a", label: "A" }] }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -864,7 +864,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "q1", type: "single", prompt: "", options: [{ id: "a", label: "A" }] }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -879,7 +879,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "bad", type: "bogus", prompt: "Which?", options: [{ id: "a", label: "A" }] }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -895,7 +895,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "ok", type: "confirm", prompt: "Proceed?", options: [{ id: "ship", label: "Ship" }] }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -910,7 +910,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "lonely", type: "single", prompt: "Pick one?" }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -925,7 +925,7 @@ describe("ask_user via registerLifecycleTools", () => {
 			{
 				ferment_id: h.fermentId,
 				questions: [{ id: "lonely", type: "multi", prompt: "Pick many?" }],
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -942,7 +942,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 		const pi = {
 			registerTool: (tool: RegisteredTool) => {
 				tools.set(tool.name, tool)
-				},
+			},
 			sendMessage: vi.fn(),
 			appendEntry: vi.fn(),
 			on: vi.fn(),
@@ -977,7 +977,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 				ferment_id: fermentId,
 				field: "assumptions",
 				value: "k8s cluster exists and is reachable",
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -998,7 +998,7 @@ describe("update_ferment_scope_field via registerLifecycleTools", () => {
 				ferment_id: fermentId,
 				field: "unknown_field",
 				value: "ignored",
-				},
+			},
 			undefined,
 			undefined,
 			createContext(),
@@ -1023,7 +1023,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "all done",
 				gates: passingFermentGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -1045,7 +1045,7 @@ describe("completeFerment", () => {
 				verdict: "flag" as const,
 				rationale: "phase-1 deferred error handling but no later phase resolves it.",
 				evidence: "F3 of phase-1 deferred 'edge cases'",
-				},
+			},
 			{ id: "C3", verdict: "pass" as const, rationale: "ok", evidence: "smoke" },
 		]
 
@@ -1086,7 +1086,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 		expect(okText(first)).toContain('**Ferment "Lifecycle Test"** complete')
@@ -1169,7 +1169,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -1193,7 +1193,7 @@ describe("completeFerment", () => {
 				ferment_id: h.fermentId,
 				final_summary: "done",
 				gates: passingFermentGates(),
-				},
+			},
 			{ ctx: createContext() },
 		)
 
@@ -1401,11 +1401,11 @@ describe("interactive ferment tool visibility (registerLifecycleTools)", () => {
 			registerTool: () => {},
 			on: (_event, handler) => {
 				pi._sessionStart = handler
-				},
+			},
 			getActiveTools: () => options.activeTools,
 			setActiveTools: (names: string[]) => {
 				pi.setActiveCalls.push(names)
-				},
+			},
 			getFlag: (name: string) => (name === "ferment-oneshot" ? options.oneShot === true : undefined),
 			_sessionStart: null,
 			setActiveCalls: [],

--- a/src/extensions/ferment/tools/lifecycle.test.ts
+++ b/src/extensions/ferment/tools/lifecycle.test.ts
@@ -30,11 +30,20 @@ vi.mock("../judge.js", async () => {
 			ok: true as const,
 			grade: "A" as const,
 			rationale: "Clean delivery; gates substantiated.",
+			recommendations: [] as string[],
+		})),
+		judgeJourneyGradeViaSubagent: vi.fn(async (_input: unknown, _spawner: unknown) => ({
+			ok: true as const,
+			grade: "A" as const,
+			rationale: "Clean delivery; gates substantiated.",
+			recommendations: [] as string[],
 		})),
 	}
 })
 
-const { judgeApiCall: mockJudgeApiCall, judgeJourneyGrade: mockJudgeJourneyGrade } = await import("../judge.js")
+const { judgeApiCall: mockJudgeApiCall, judgeJourneyGradeViaSubagent: mockJudgeJourneyGrade } = await import(
+	"../judge.js"
+)
 
 interface RegisteredTool {
 	name: string

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -25,8 +25,8 @@ import {
 	type ScopingQuestion,
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
-import { getMultiModelEnabled } from "../../multi-model.js"
 import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
+import { getMultiModelEnabled } from "../../multi-model.js"
 import { createToolVisibility } from "../../prompt-construction/tool-visibility.js"
 import { YES_NO_OPTIONS } from "../../questionnaire/index.js"
 import { askUserForm, normalizeAskUserQuestions, toScopingQuestionType } from "../ask-user.js"

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -26,6 +26,7 @@ import {
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
+import { runWithOverlay } from "../../agents/index.js"
 import { createToolVisibility } from "../../prompt-construction/tool-visibility.js"
 import { YES_NO_OPTIONS } from "../../questionnaire/index.js"
 import { askUserForm, normalizeAskUserQuestions, toScopingQuestionType } from "../ask-user.js"
@@ -731,29 +732,31 @@ export async function completeFerment(
 	const ferment = fSnapshot
 	const phaseReviews = readLatestPhaseReviews(ferment.id)
 	const totalDiff = ferment.worktree.commit ? gatherPhaseEvidence(ferment.worktree.commit) : undefined
-	const journeyResult = await judgeJourneyGrade({
-		fermentName: ferment.name,
-		goal: ferment.goal ?? "",
-		successCriteria: renderSuccessCriteria(ferment.successCriteria, ""),
-		finalSummary: params.final_summary ?? "",
-		phases: ferment.phases.map((p) => {
-			const review = phaseReviews.get(p.id)
-			return {
-				name: p.name,
-				goal: p.goal,
-				status: p.status,
-				gateVerdicts: review?.gateVerdicts?.map((v) => ({
-					id: v.id,
-					verdict: v.verdict,
-					rationale: v.rationale,
-				})),
-			}
+	const journeyResult = await runWithOverlay(`Grading ferment "${ferment.name}"…`, () =>
+		judgeJourneyGrade({
+			fermentName: ferment.name,
+			goal: ferment.goal ?? "",
+			successCriteria: renderSuccessCriteria(ferment.successCriteria, ""),
+			finalSummary: params.final_summary ?? "",
+			phases: ferment.phases.map((p) => {
+				const review = phaseReviews.get(p.id)
+				return {
+					name: p.name,
+					goal: p.goal,
+					status: p.status,
+					gateVerdicts: review?.gateVerdicts?.map((v) => ({
+						id: v.id,
+						verdict: v.verdict,
+						rationale: v.rationale,
+					})),
+				}
+			}),
+			fermentGates: gates.map((g) => ({ id: g.id, verdict: g.verdict, rationale: g.rationale })),
+			totalDiff: totalDiff
+				? { available: totalDiff.available, filesChanged: totalDiff.filesChanged, diffSnippet: totalDiff.diffSnippet }
+				: { available: false },
 		}),
-		fermentGates: gates.map((g) => ({ id: g.id, verdict: g.verdict, rationale: g.rationale })),
-		totalDiff: totalDiff
-			? { available: totalDiff.available, filesChanged: totalDiff.filesChanged, diffSnippet: totalDiff.diffSnippet }
-			: { available: false },
-	})
+	)
 
 	// Resolve the grade. C-gates already decided ship/refuse. The judge now
 	// ENFORCES quality: a C/D/F grade refuses ship and routes through the same

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -764,6 +764,10 @@ export async function completeFerment(
 	// recommendations persisted. Judge-unavailable outcomes remain advisory
 	// (do NOT refuse ship) — judge outages must not block the user.
 	const FERMENT_GRADE_KEY = "__ferment__"
+	// First attempt requires A; after rework B is also acceptable.
+	const priorFermentRetries = runtime.getBlockRetry(params.ferment_id, FERMENT_GRADE_KEY)
+	const minimumAcceptableFermentGrade = priorFermentRetries === 0 ? "A" : "B"
+	const fermentGradeOrder: Record<Grade, number> = { A: 5, B: 4, C: 3, D: 2, F: 1 }
 	let resolvedGrade: { grade: Grade; rationale: string; recommendations?: string[] } | undefined
 	let gradeRationale: string
 	if (journeyResult.ok) {
@@ -774,9 +778,9 @@ export async function completeFerment(
 		}
 		gradeRationale = journeyResult.rationale
 
-		// C/D/F from the final grader — give the agent a bounded number of retries
-		// to fix the recommendations, then accept the grade and ship.
-		if (journeyResult.grade === "C" || journeyResult.grade === "D" || journeyResult.grade === "F") {
+		// Below minimum grade — give the agent a bounded number of retries to fix
+		// the recommendations, then accept the grade and ship.
+		if (fermentGradeOrder[journeyResult.grade] < fermentGradeOrder[minimumAcceptableFermentGrade]) {
 			const recsText = journeyResult.recommendations.map((rec, i) => `  ${i + 1}. ${rec}`).join("\n")
 			const retry = runtime.bumpBlockRetry(params.ferment_id, FERMENT_GRADE_KEY)
 
@@ -787,7 +791,7 @@ export async function completeFerment(
 				// Fall through to the ship path below with the judge's grade + recs.
 			} else {
 				return toolErr(
-					`**Ferment "${ferment.name}"** cannot complete — final LLM grader assigned grade ${journeyResult.grade} (retry ${retry}/${MAX_BLOCK_RETRIES}).\n\nRecommendations:\n${recsText}\n\nAddress the recommendations above and call complete_ferment again with an updated summary.`,
+					`**Ferment "${ferment.name}"** cannot complete — final LLM grader assigned grade ${journeyResult.grade}, minimum required is ${minimumAcceptableFermentGrade} (retry ${retry}/${MAX_BLOCK_RETRIES}).\n\nRecommendations:\n${recsText}\n\nAddress the recommendations above and call complete_ferment again with an updated summary.`,
 				)
 			}
 		}

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -26,7 +26,7 @@ import {
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
-import { runWithOverlay } from "../../agents/index.js"
+import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
 import { createToolVisibility } from "../../prompt-construction/tool-visibility.js"
 import { YES_NO_OPTIONS } from "../../questionnaire/index.js"
 import { askUserForm, normalizeAskUserQuestions, toScopingQuestionType } from "../ask-user.js"
@@ -36,7 +36,7 @@ import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { renderGateGuidance } from "../gate-registry.js"
 import { assertGateFieldsPresent, validateGatesOrErr } from "../gate-validation.js"
 import { ensureGitRepo } from "../git-init.js"
-import { judgeJourneyGrade } from "../judge.js"
+import { type GraderSpawner, judgeJourneyGradeViaSubagent } from "../judge.js"
 import { appendRefEntry, resetReactiveContinuationNudgeCount } from "../nudge.js"
 import { PENDING_PROPOSAL_SCHEMA_VERSION, savePendingProposal } from "../pending-proposal-store.js"
 import { gatherPhaseEvidence } from "../phase-evidence.js"
@@ -690,7 +690,7 @@ export async function scopeFerment(
 export async function completeFerment(
 	runtime: FermentRuntime,
 	params: CompleteFermentArgs,
-	{ ctx }: LifecycleExecutionContext,
+	{ ctx, spawner }: LifecycleExecutionContext & { spawner?: GraderSpawner },
 ): Promise<ToolResult> {
 	const applyAndPersist = createApplyAndPersist(runtime)
 
@@ -733,30 +733,33 @@ export async function completeFerment(
 	const phaseReviews = readLatestPhaseReviews(ferment.id)
 	const totalDiff = ferment.worktree.commit ? gatherPhaseEvidence(ferment.worktree.commit) : undefined
 	const journeyResult = await runWithOverlay(`Grading ferment "${ferment.name}"…`, () =>
-		judgeJourneyGrade({
-			fermentName: ferment.name,
-			goal: ferment.goal ?? "",
-			successCriteria: renderSuccessCriteria(ferment.successCriteria, ""),
-			finalSummary: params.final_summary ?? "",
-			phases: ferment.phases.map((p) => {
-				const review = phaseReviews.get(p.id)
-				return {
-					name: p.name,
-					goal: p.goal,
-					status: p.status,
-					gateVerdicts: review?.gateVerdicts?.map((v) => ({
-						id: v.id,
-						verdict: v.verdict,
-						rationale: v.rationale,
-					})),
-				}
-			}),
-			fermentGates: gates.map((g) => ({ id: g.id, verdict: g.verdict, rationale: g.rationale })),
-			totalDiff: totalDiff
-				? { available: totalDiff.available, filesChanged: totalDiff.filesChanged, diffSnippet: totalDiff.diffSnippet }
-				: { available: false },
-			evidence: params.evidence,
-		}),
+		judgeJourneyGradeViaSubagent(
+			{
+				fermentName: ferment.name,
+				goal: ferment.goal ?? "",
+				successCriteria: renderSuccessCriteria(ferment.successCriteria, ""),
+				finalSummary: params.final_summary ?? "",
+				phases: ferment.phases.map((p) => {
+					const review = phaseReviews.get(p.id)
+					return {
+						name: p.name,
+						goal: p.goal,
+						status: p.status,
+						gateVerdicts: review?.gateVerdicts?.map((v) => ({
+							id: v.id,
+							verdict: v.verdict,
+							rationale: v.rationale,
+						})),
+					}
+				}),
+				fermentGates: gates.map((g) => ({ id: g.id, verdict: g.verdict, rationale: g.rationale })),
+				totalDiff: totalDiff
+					? { available: totalDiff.available, filesChanged: totalDiff.filesChanged, diffSnippet: totalDiff.diffSnippet }
+					: { available: false },
+				evidence: params.evidence,
+			},
+			spawner,
+		),
 	)
 
 	// Resolve the grade. C-gates already decided ship/refuse. The judge now
@@ -1247,7 +1250,12 @@ ${renderGateGuidance("complete_ferment")}`,
 			return new Markdown(text, 1, 0, getMarkdownTheme())
 		},
 		async execute(_, params, _signal, _onUpdate, ctx) {
-			return completeFerment(runtime, params, { ctx })
+			const spawner = async (prompt: string) => {
+				const result = await spawnGraderAgent(pi, ctx, prompt)
+				if (!result) return { text: "", status: "unavailable" }
+				return result
+			}
+			return completeFerment(runtime, params, { ctx, spawner })
 		},
 	})
 

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -45,6 +45,7 @@ import { type FermentRuntime, defaultFermentRuntime } from "../runtime.js"
 import { safeSendMessage } from "../safe-send.js"
 import { confirmPendingScope } from "../scoping-confirmation.js"
 import type { PendingScope } from "../scoping.js"
+import { MAX_BLOCK_RETRIES } from "../state.js"
 import {
 	createApplyAndPersist,
 	failedToolResult,
@@ -754,14 +755,39 @@ export async function completeFerment(
 			: { available: false },
 	})
 
-	// Resolve the grade. The final judge is advisory; completion gates have
-	// already decided whether shipping is allowed, so judge outages must not
-	// block the user.
-	let resolvedGrade: { grade: Grade; rationale: string } | undefined
+	// Resolve the grade. C-gates already decided ship/refuse. The judge now
+	// ENFORCES quality: a C/D/F grade refuses ship and routes through the same
+	// block-retry / escalation loop used at the phase level. A/B ships with
+	// recommendations persisted. Judge-unavailable outcomes remain advisory
+	// (do NOT refuse ship) — judge outages must not block the user.
+	const FERMENT_GRADE_KEY = "__ferment__"
+	let resolvedGrade: { grade: Grade; rationale: string; recommendations?: string[] } | undefined
 	let gradeRationale: string
 	if (journeyResult.ok) {
-		resolvedGrade = { grade: journeyResult.grade, rationale: journeyResult.rationale }
+		resolvedGrade = {
+			grade: journeyResult.grade,
+			rationale: journeyResult.rationale,
+			recommendations: journeyResult.recommendations,
+		}
 		gradeRationale = journeyResult.rationale
+
+		// C/D/F from the final grader — give the agent a bounded number of retries
+		// to fix the recommendations, then accept the grade and ship.
+		if (journeyResult.grade === "C" || journeyResult.grade === "D" || journeyResult.grade === "F") {
+			const recsText = journeyResult.recommendations.map((rec, i) => `  ${i + 1}. ${rec}`).join("\n")
+			const retry = runtime.bumpBlockRetry(params.ferment_id, FERMENT_GRADE_KEY)
+
+			if (retry > MAX_BLOCK_RETRIES) {
+				// Budget exhausted — accept the grade and ship with recommendations persisted.
+				// The agent had its retries; we don't block continuation indefinitely.
+				runtime.clearBlockRetry(params.ferment_id, FERMENT_GRADE_KEY)
+				// Fall through to the ship path below with the judge's grade + recs.
+			} else {
+				return toolErr(
+					`**Ferment "${ferment.name}"** cannot complete — final LLM grader assigned grade ${journeyResult.grade} (retry ${retry}/${MAX_BLOCK_RETRIES}).\n\nRecommendations:\n${recsText}\n\nAddress the recommendations above and call complete_ferment again with an updated summary.`,
+				)
+			}
+		}
 	} else {
 		const failureDetail = `${journeyResult.reason}${journeyResult.detail ? `: ${journeyResult.detail}` : ""}`
 		gradeRationale = `Judge unreachable (${failureDetail}); completion proceeded without a graded review.`
@@ -769,7 +795,7 @@ export async function completeFerment(
 
 	const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
 
-	// Persist completion and grade together when the advisory judge returns one.
+	// Persist completion and grade together.
 	const completeOutcome = applyAndPersist(params.ferment_id, {
 		type: "complete_ferment",
 		finalSummary: params.final_summary,
@@ -778,10 +804,16 @@ export async function completeFerment(
 					grade: resolvedGrade.grade,
 					rationale: resolvedGrade.rationale,
 					gradedAt: runtime.nowIso(),
+					...(resolvedGrade.recommendations && resolvedGrade.recommendations.length > 0
+						? { recommendations: resolvedGrade.recommendations }
+						: {}),
 				}
 			: undefined,
 	})
 	if (!completeOutcome.ok) return failedToolResult(completeOutcome.error, ferment, multiModelEnabled)
+
+	// Clear the ferment-level block-retry counter — ship succeeded.
+	runtime.clearBlockRetry(params.ferment_id, FERMENT_GRADE_KEY)
 
 	// Cleanup in-memory state.
 	runtime.clearFermentState(params.ferment_id)

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -755,6 +755,7 @@ export async function completeFerment(
 			totalDiff: totalDiff
 				? { available: totalDiff.available, filesChanged: totalDiff.filesChanged, diffSnippet: totalDiff.diffSnippet }
 				: { available: false },
+			evidence: params.evidence,
 		}),
 	)
 

--- a/src/extensions/ferment/tools/phases.test.ts
+++ b/src/extensions/ferment/tools/phases.test.ts
@@ -65,6 +65,12 @@ function createServices(overrides: Partial<PhaseHandlerServices> = {}): PhaseHan
 		captureGitHead: vi.fn(() => undefined),
 		gatherEvidence: vi.fn(() => ({ filesChanged: "file.ts", diffSnippet: "+change", available: true })),
 		runProjectChecks: vi.fn(() => ({ cwd: "/tmp", discovered: false, anyFailed: false, checks: [] })),
+		judgePhaseGrade: vi.fn(async () => ({
+			ok: true as const,
+			grade: "A" as const,
+			rationale: "Clean.",
+			recommendations: [],
+		})),
 		onPhaseCompleted: vi.fn(),
 		...overrides,
 	}
@@ -376,5 +382,175 @@ describe("registerPhaseTools", () => {
 		const result = { content: [{ type: "text", text: "**Phase done**" }] }
 		const component = tool?.renderResult?.(result)
 		expect(component).toBeDefined()
+	})
+
+	// ── LLM phase grader enforcement ──────────────────────────────────────────
+
+	it("A-grade advances and persists recommendations", async () => {
+		const h = createHarness()
+		const recs = ["Add integration test for the retry path."]
+		const services = createServices({
+			judgePhaseGrade: vi.fn(async () => ({
+				ok: true as const,
+				grade: "A" as const,
+				rationale: "Excellent. Production-ready.",
+				recommendations: recs,
+			})),
+		})
+
+		const result = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "phase done", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+
+		expect(okText(result)).toContain('**Phase "Phase 1"** done')
+		const stored = h.storage.get(h.fermentId)
+		expect(stored?.phases[0].status).toBe("completed")
+		expect(stored?.phases[0].grade?.grade).toBe("A")
+		expect(stored?.phases[0].grade?.recommendations).toEqual(recs)
+	})
+
+	it("B-grade advances and persists recommendations", async () => {
+		const h = createHarness()
+		const recs = ["Add edge-case test for empty input.", "Wire retry into production call site."]
+		const services = createServices({
+			judgePhaseGrade: vi.fn(async () => ({
+				ok: true as const,
+				grade: "B" as const,
+				rationale: "Goal met but coverage is thin.",
+				recommendations: recs,
+			})),
+		})
+
+		const result = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "phase done", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+
+		expect(okText(result)).toContain('**Phase "Phase 1"** done')
+		const stored = h.storage.get(h.fermentId)
+		expect(stored?.phases[0].status).toBe("completed")
+		expect(stored?.phases[0].grade?.grade).toBe("B")
+		expect(stored?.phases[0].grade?.recommendations).toEqual(recs)
+	})
+
+	it("C-grade refuses advancement within budget and surfaces recommendations", async () => {
+		const h = createHarness()
+		const recs = ["Fix the N+1 query in listUsers.", "Add cancellation to the fetch loop."]
+		const services = createServices({
+			judgePhaseGrade: vi.fn(async () => ({
+				ok: true as const,
+				grade: "C" as const,
+				rationale: "Operational gaps.",
+				recommendations: recs,
+			})),
+		})
+
+		const result = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "phase done", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+
+		const errResult = result as { content: { text: string }[]; isError?: boolean }
+		expect(errResult.isError).toBe(true)
+		const text = errResult.content.map((c) => c.text).join("\n")
+		expect(text).toContain("LLM grader assigned grade C")
+		expect(text).toContain("retry 1/3")
+		expect(text).toContain("Fix the N+1 query in listUsers.")
+		expect(text).toContain("Add cancellation to the fetch loop.")
+		// Phase must NOT be completed.
+		expect(h.storage.get(h.fermentId)?.phases[0].status).toBe("active")
+		// Retry counter must have been bumped.
+		expect(h.runtime.getBlockRetry(h.fermentId, "phase-1")).toBe(1)
+	})
+
+	it("C-grade repeated exhausts budget and advances with the grade", async () => {
+		const h = createHarness()
+		const recs = ["Fix the N+1 query in listUsers."]
+		const services = createServices({
+			judgePhaseGrade: vi.fn(async () => ({
+				ok: true as const,
+				grade: "C" as const,
+				rationale: "Operational gaps.",
+				recommendations: recs,
+			})),
+		})
+
+		// First refusal: within budget.
+		const result1 = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 1", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+		const err1 = result1 as { content: { text: string }[]; isError?: boolean }
+		expect(err1.isError).toBe(true)
+		expect(err1.content.map((c) => c.text).join("\n")).toContain("retry 1/3")
+
+		// Second refusal: within budget.
+		const result2 = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 2", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+		const err2 = result2 as { content: { text: string }[]; isError?: boolean }
+		expect(err2.isError).toBe(true)
+		expect(err2.content.map((c) => c.text).join("\n")).toContain("retry 2/3")
+
+		// Third refusal: within budget.
+		const result3 = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 3", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+		const err3 = result3 as { content: { text: string }[]; isError?: boolean }
+		expect(err3.isError).toBe(true)
+		expect(err3.content.map((c) => c.text).join("\n")).toContain("retry 3/3")
+
+		// Fourth attempt: budget exhausted — accepts the grade and advances.
+		const result4 = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 4", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+		expect(okText(result4)).toContain('**Phase "Phase 1"** done')
+		const stored = h.storage.get(h.fermentId)
+		expect(stored?.phases[0].status).toBe("completed")
+		expect(stored?.phases[0].grade?.grade).toBe("C")
+		expect(stored?.phases[0].grade?.recommendations).toEqual(recs)
+	})
+
+	it("judge-unavailable advances with advisory grade and no refusal", async () => {
+		const h = createHarness()
+		const services = createServices({
+			judgePhaseGrade: vi.fn(async () => ({
+				ok: false as const,
+				reason: "no_auth" as const,
+			})),
+		})
+
+		const result = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "phase done", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+
+		expect(okText(result)).toContain('**Phase "Phase 1"** done')
+		const stored = h.storage.get(h.fermentId)
+		expect(stored?.phases[0].status).toBe("completed")
+		// Grade falls back to the deterministic derivedGrade (A when all gates pass).
+		expect(stored?.phases[0].grade?.grade).toBe("A")
+		// Rationale should note the judge was unavailable.
+		expect(stored?.phases[0].grade?.rationale).toContain("unavailable")
 	})
 })

--- a/src/extensions/ferment/tools/phases.test.ts
+++ b/src/extensions/ferment/tools/phases.test.ts
@@ -412,7 +412,7 @@ describe("registerPhaseTools", () => {
 		expect(stored?.phases[0].grade?.recommendations).toEqual(recs)
 	})
 
-	it("B-grade advances and persists recommendations", async () => {
+	it("B-grade refuses on first attempt, accepts on rework", async () => {
 		const h = createHarness()
 		const recs = ["Add edge-case test for empty input.", "Wire retry into production call site."]
 		const services = createServices({
@@ -424,14 +424,25 @@ describe("registerPhaseTools", () => {
 			})),
 		})
 
-		const result = await completePhase(
+		// First attempt: B refused (minimum is A on first try).
+		const result1 = await completePhase(
 			h.runtime,
-			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "phase done", gates: passingPhaseGates() },
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 1", gates: passingPhaseGates() },
 			{ pi: h.pi },
 			services,
 		)
+		const err1 = result1 as { content: { text: string }[]; isError?: boolean }
+		expect(err1.isError).toBe(true)
+		expect(err1.content.map((c) => c.text).join("\n")).toContain("minimum required is A")
 
-		expect(okText(result)).toContain('**Phase "Phase 1"** done')
+		// Second attempt: B accepted (minimum relaxes to B after rework).
+		const result2 = await completePhase(
+			h.runtime,
+			{ ferment_id: h.fermentId, phase_id: "phase-1", summary: "attempt 2", gates: passingPhaseGates() },
+			{ pi: h.pi },
+			services,
+		)
+		expect(okText(result2)).toContain('**Phase "Phase 1"** done')
 		const stored = h.storage.get(h.fermentId)
 		expect(stored?.phases[0].status).toBe("completed")
 		expect(stored?.phases[0].grade?.grade).toBe("B")

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -13,6 +13,7 @@ import { findFirstPlannedPhase } from "../../../ferment/engine.js"
 import type { Ferment, Phase } from "../../../ferment/types.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
 import type { Grade } from "../../../ferment/types.js"
+import { runWithOverlay } from "../../agents/index.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm } from "../ask-user.js"
 import { gradeColor, pr_bold } from "../colors.js"
@@ -454,7 +455,9 @@ export async function completePhase(
 			? { available: evidence.available, filesChanged: evidence.filesChanged, diffSnippet: evidence.diffSnippet }
 			: { available: false },
 	}
-	const phaseJudgeResult = await services.judgePhaseGrade(judgeInput)
+	const phaseJudgeResult = await runWithOverlay(`Grading phase "${phase.name}"…`, () =>
+		services.judgePhaseGrade(judgeInput),
+	)
 
 	// Resolve the final grade + recommendations.
 	let finalGrade: Grade = derivedGrade as Grade

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -11,9 +11,9 @@ import { Markdown } from "@earendil-works/pi-tui"
 import type { Static } from "typebox"
 import { findFirstPlannedPhase } from "../../../ferment/engine.js"
 import type { Ferment, Phase } from "../../../ferment/types.js"
-import { getMultiModelEnabled } from "../../multi-model.js"
 import type { Grade } from "../../../ferment/types.js"
 import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
+import { getMultiModelEnabled } from "../../multi-model.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm } from "../ask-user.js"
 import { gradeColor, pr_bold } from "../colors.js"
@@ -96,7 +96,7 @@ export interface PhaseHandlerServices {
 
 export interface PhaseExecutionContext {
 	pi: ExtensionAPI
-	ctx: ExtensionContext
+	ctx?: ExtensionContext
 }
 
 export const defaultPhaseHandlerServices: PhaseHandlerServices = {
@@ -255,7 +255,7 @@ async function maybeCompleteManualPhaseBoundary(
 			return toolOk(
 				formatManualPhaseBoundaryContinue(
 					ferment,
-					getMultiModelEnabled(ctx.sessionManager),
+					getMultiModelEnabled(ctx?.sessionManager ?? null),
 					completedPhase,
 					nextPhase,
 					projectChecksLine,
@@ -282,7 +282,7 @@ export async function completePhase(
 	const phase = resolvePhase(f, params.phase_id)
 	if (!phase) return toolErr("Phase not found.")
 
-	const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
+	const multiModelEnabled = getMultiModelEnabled(ctx?.sessionManager ?? null)
 
 	// FSM validation: complete_ferment_phase requires all phases to be terminal
 	const fsmError = validateFsmTransition(f, "COMPLETE_PHASE", { phaseId: phase.id })
@@ -408,7 +408,7 @@ export async function completePhase(
 						],
 					},
 				],
-				{ ferment: f, pi, ctx, runtime },
+				{ ferment: f, pi, ctx: ctx ?? ({} as ExtensionContext), runtime },
 			)
 
 			const escalationChoice = escalationResponse.failed ? undefined : escalationResponse.answers?.[0]?.value
@@ -571,7 +571,7 @@ export async function completePhase(
 		phase,
 		projectChecksLine,
 		warnSection,
-		ctx,
+		ctx ?? ({} as ExtensionContext),
 	)
 	if (manualBoundary) return manualBoundary
 
@@ -620,7 +620,7 @@ export function registerPhaseTools(pi: ExtensionAPI, runtime: FermentRuntime = d
 			const f = runtime.getStorage().get(params.ferment_id)
 			if (!f) return toolErr("Ferment not found.")
 
-			const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
+			const multiModelEnabled = getMultiModelEnabled(ctx?.sessionManager ?? null)
 
 			let target = params.phase_id ? f.phases.find((p) => p.id === params.phase_id) : undefined
 			if (!target && params.phase_id) {
@@ -748,7 +748,7 @@ export function registerPhaseTools(pi: ExtensionAPI, runtime: FermentRuntime = d
 				)
 			}
 
-			const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
+			const multiModelEnabled = getMultiModelEnabled(ctx?.sessionManager ?? null)
 
 			// FSM validation: refine_ferment_phase is only valid in PHASE_ACTIVE state
 			const fsmError = validateFsmTransition(f, "REFINE_PHASE", { phaseId: phase.id })
@@ -816,7 +816,7 @@ ${renderGateGuidance("complete_ferment_phase")}`,
 			const phase = resolvePhase(f, params.phase_id)
 			if (!phase) return toolErr("Phase not found.")
 
-			const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
+			const multiModelEnabled = getMultiModelEnabled(ctx?.sessionManager ?? null)
 
 			// FSM validation: phase must be active to skip
 			const fsmError = validateFsmTransition(f, "SKIP_PHASE", { phaseId: phase.id })
@@ -849,7 +849,7 @@ ${renderGateGuidance("complete_ferment_phase")}`,
 			const phase = resolvePhase(f, params.phase_id)
 			if (!phase) return toolErr("Phase not found.")
 
-			const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
+			const multiModelEnabled = getMultiModelEnabled(ctx?.sessionManager ?? null)
 
 			// FSM validation: phase must be active to fail
 			const fsmError = validateFsmTransition(f, "FAIL_PHASE", { phaseId: phase.id })

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -460,6 +460,9 @@ export async function completePhase(
 	)
 
 	// Resolve the final grade + recommendations.
+	// First attempt requires A; after rework B is also acceptable.
+	const priorRetries = runtime.getBlockRetry(params.ferment_id, phase.id)
+	const minimumAcceptableGrade = priorRetries === 0 ? "A" : "B"
 	let finalGrade: Grade = derivedGrade as Grade
 	let finalRationale = rationale
 	let finalRecommendations: string[] = []
@@ -469,7 +472,8 @@ export async function completePhase(
 		finalGrade = phaseJudgeResult.grade
 		finalRationale = phaseJudgeResult.rationale
 		finalRecommendations = phaseJudgeResult.recommendations
-		if (phaseJudgeResult.grade === "C" || phaseJudgeResult.grade === "D" || phaseJudgeResult.grade === "F") {
+		const gradeOrder: Record<Grade, number> = { A: 5, B: 4, C: 3, D: 2, F: 1 }
+		if (gradeOrder[phaseJudgeResult.grade] < gradeOrder[minimumAcceptableGrade]) {
 			judgeRefused = true
 			judgeRecsText = phaseJudgeResult.recommendations.map((rec, i) => `  ${i + 1}. ${rec}`).join("\n")
 		}
@@ -495,7 +499,7 @@ export async function completePhase(
 			// Fall through to the advance path below with the judge's grade + recs.
 		} else {
 			return toolErr(
-				`**Phase "${phase.name}"** cannot complete — LLM grader assigned grade ${phaseJudgeResult.ok ? phaseJudgeResult.grade : "?"} (retry ${retry}/${MAX_BLOCK_RETRIES}).${projectChecksNote}\n\nRecommendations:\n${judgeRecsText}${warnLines}\n\nAddress the recommendations above and call complete_ferment_phase again with an updated summary.`,
+				`**Phase "${phase.name}"** cannot complete — LLM grader assigned grade ${phaseJudgeResult.ok ? phaseJudgeResult.grade : "?"}, minimum required is ${minimumAcceptableGrade} (retry ${retry}/${MAX_BLOCK_RETRIES}).${projectChecksNote}\n\nRecommendations:\n${judgeRecsText}${warnLines}\n\nAddress the recommendations above and call complete_ferment_phase again with an updated summary.`,
 			)
 		}
 	}

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -12,6 +12,7 @@ import type { Static } from "typebox"
 import { findFirstPlannedPhase } from "../../../ferment/engine.js"
 import type { Ferment, Phase } from "../../../ferment/types.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
+import type { Grade } from "../../../ferment/types.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm } from "../ask-user.js"
 import { gradeColor, pr_bold } from "../colors.js"
@@ -20,7 +21,7 @@ import { formatDecisionsAndMemories } from "../format.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { flaggedVerdicts, renderGateGuidance } from "../gate-registry.js"
 import { assertGateFieldsPresent, validateGatesOrErr } from "../gate-validation.js"
-import type { JudgeFlag } from "../judge.js"
+import { type JudgeFlag, type JudgePhaseGradeResult, type JudgePhaseInput, judgePhaseGrade } from "../judge.js"
 import { onPhaseCompleted } from "../nudge.js"
 import { type PhaseEvidence, captureGitHead, gatherPhaseEvidence } from "../phase-evidence.js"
 import { type ProjectCheckResult, runProjectChecks, summarizeProjectChecks } from "../project-tests.js"
@@ -72,6 +73,12 @@ export interface PhaseHandlerServices {
 	 *  unit tests; the default delegates to `runProjectChecks` against the
 	 *  ferment's worktree path. */
 	runProjectChecks(cwd: string): ProjectCheckResult
+	/** Per-phase LLM grader. Invoked after F-gates + project checks pass.
+	 *  A/B advance with recommendations persisted; C/D/F refuse advancement
+	 *  and route through the existing block-retry / escalation loop.
+	 *  Judge-unavailable outcomes (no_registry/no_model/no_auth/api_error/
+	 *  unparseable/invalid_grade) are advisory and do NOT refuse advancement. */
+	judgePhaseGrade(input: JudgePhaseInput): Promise<JudgePhaseGradeResult>
 	onPhaseCompleted(runtime: FermentRuntime): void
 }
 
@@ -84,6 +91,7 @@ export const defaultPhaseHandlerServices: PhaseHandlerServices = {
 	captureGitHead,
 	gatherEvidence: gatherPhaseEvidence,
 	runProjectChecks: (cwd) => runProjectChecks(cwd),
+	judgePhaseGrade,
 	onPhaseCompleted,
 }
 
@@ -428,31 +436,89 @@ export async function completePhase(
 		}
 	}
 
-	// Step 4: no block flags. Transition phase to completed.
-	// Capture block retry count before clearing — the counter is reset on the
-	// line below and won't be readable afterwards.
+	// Step 4: no block flags from gates or project checks. Run the per-phase
+	// LLM grader (council-of-specialists prompt) to assign a final letter
+	// grade + recommendations. C/D/F refuses advancement and routes through
+	// the same MAX_BLOCK_RETRIES / escalation loop as block flags above.
+	// A/B advance with recommendations persisted on the phase grade.
+	// Judge-unavailable outcomes are advisory — they do NOT refuse advancement.
+	const judgeInput: JudgePhaseInput = {
+		fermentName: f.name,
+		phaseName: phase.name,
+		phaseGoal: phase.goal,
+		phaseSummary: params.summary ?? "",
+		stepSummaries: stepSummariesText,
+		gateVerdicts: (params.gates ?? []).map((g) => ({ id: g.id, verdict: g.verdict, rationale: g.rationale })),
+		projectChecksSummary: projectChecks.discovered ? projectCheckSummary : undefined,
+		phaseDiff: evidence
+			? { available: evidence.available, filesChanged: evidence.filesChanged, diffSnippet: evidence.diffSnippet }
+			: { available: false },
+	}
+	const phaseJudgeResult = await services.judgePhaseGrade(judgeInput)
+
+	// Resolve the final grade + recommendations.
+	let finalGrade: Grade = derivedGrade as Grade
+	let finalRationale = rationale
+	let finalRecommendations: string[] = []
+	let judgeRefused = false
+	let judgeRecsText = ""
+	if (phaseJudgeResult.ok) {
+		finalGrade = phaseJudgeResult.grade
+		finalRationale = phaseJudgeResult.rationale
+		finalRecommendations = phaseJudgeResult.recommendations
+		if (phaseJudgeResult.grade === "C" || phaseJudgeResult.grade === "D" || phaseJudgeResult.grade === "F") {
+			judgeRefused = true
+			judgeRecsText = phaseJudgeResult.recommendations.map((rec, i) => `  ${i + 1}. ${rec}`).join("\n")
+		}
+	} else {
+		// Judge unavailable — advisory only, do NOT refuse advancement.
+		finalRationale = `${rationale} (Phase LLM judge unavailable: ${phaseJudgeResult.reason}${phaseJudgeResult.detail ? `: ${phaseJudgeResult.detail}` : ""})`
+	}
+
+	if (judgeRefused) {
+		// C/D/F from the LLM grader — give the agent a bounded number of retries
+		// to fix the recommendations, then accept the grade and advance.
+		const retry = runtime.bumpBlockRetry(params.ferment_id, phase.id)
+		const warnLines =
+			warnFlags.length > 0
+				? `\n\nAdvisory warnings (do not block):\n${warnFlags.map((fl) => `  ⚠ ${fl.problem}\n     redirect: ${fl.redirect}`).join("\n")}`
+				: ""
+		const projectChecksNote = projectChecks.discovered ? `\n${projectCheckSummary}` : ""
+
+		if (retry > MAX_BLOCK_RETRIES) {
+			// Budget exhausted — accept the grade and advance with recommendations persisted.
+			// The agent had its retries; we don't block continuation indefinitely.
+			runtime.clearBlockRetry(params.ferment_id, phase.id)
+			// Fall through to the advance path below with the judge's grade + recs.
+		} else {
+			return toolErr(
+				`**Phase "${phase.name}"** cannot complete — LLM grader assigned grade ${phaseJudgeResult.ok ? phaseJudgeResult.grade : "?"} (retry ${retry}/${MAX_BLOCK_RETRIES}).${projectChecksNote}\n\nRecommendations:\n${judgeRecsText}${warnLines}\n\nAddress the recommendations above and call complete_ferment_phase again with an updated summary.`,
+			)
+		}
+	}
+
+	// Step 5: advance phase to completed with the final grade + recommendations.
 	const blockRetriesForTelemetry = reviewAttemptForLog - 1
 	const completeOutcome = applyAndPersist(params.ferment_id, {
 		type: "complete_phase",
 		phaseId: phase.id,
 		summary: params.summary,
 		grade: {
-			grade: derivedGrade as import("../../../ferment/types.js").Grade,
-			rationale,
+			grade: finalGrade,
+			rationale: finalRationale,
 			gradedAt: runtime.nowIso(),
+			...(finalRecommendations.length > 0 ? { recommendations: finalRecommendations } : {}),
 		},
 		blockRetries: blockRetriesForTelemetry,
 	})
 	if (!completeOutcome.ok) return failedToolResult(completeOutcome.error, f, multiModelEnabled)
 
-	// Step 3a: clear the block-retry counter — phase advanced cleanly.
+	// Clear the block-retry counter — phase advanced cleanly.
 	runtime.clearBlockRetry(params.ferment_id, phase.id)
 
-	// Step 4: no per-phase grading. The journey-grade judge at
-	// complete_ferment is the only place a letter grade is assigned, and it
-	// reads the on-disk review-evidence sidecar (which already captures
-	// derivedGrade + the raw F-gate verdicts written above) as input. So we
-	// skip set_phase_grade entirely on the new path.
+	// Step 6: phase completed. The LLM grader assigned the final grade and
+	// recommendations (persisted above via the complete_phase command). The
+	// journey-grade judge at complete_ferment assigns the final ferment.grade.
 
 	services.onPhaseCompleted(runtime)
 	const fresh = completeOutcome.ferment
@@ -466,11 +532,11 @@ export async function completePhase(
 	})
 
 	// Visual ack mirrors the step ✓ breadcrumb in steps.ts. The grade letter is
-	// the deterministic derivedGrade (A/B/F) from gate verdicts + project
-	// checks (post-#230 no LLM judge per phase), colorized via gradeColor for
-	// terminal output.
+	// the final grade from the LLM grader (or the deterministic derivedGrade
+	// when the judge was unavailable), colorized via gradeColor for terminal
+	// output.
 	const filesCount = countFilesChanged(evidence)
-	const summaryLines = [`Phase ${phase.index} ✓  Grade ${gradeColor(derivedGrade)} — ${rationale}`]
+	const summaryLines = [`Phase ${phase.index} ✓  Grade ${gradeColor(finalGrade)} — ${finalRationale}`]
 	if (filesCount > 0) summaryLines.push(`${filesCount} file${filesCount === 1 ? "" : "s"} touched`)
 	sendPhaseAck(pi, summaryLines.join("\n"))
 	const warnSection =

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -332,6 +332,7 @@ export async function completePhase(
 		outcome: { flags: mergedFlags, grade: derivedGrade, rationale },
 		diffAvailable: evidence?.available ?? false,
 		diffFilesChanged: evidence?.filesChanged,
+		evidence: params.evidence,
 		projectChecks,
 		gateVerdicts: params.gates,
 	})
@@ -454,6 +455,7 @@ export async function completePhase(
 		phaseDiff: evidence
 			? { available: evidence.available, filesChanged: evidence.filesChanged, diffSnippet: evidence.diffSnippet }
 			: { available: false },
+		evidence: params.evidence,
 	}
 	const phaseJudgeResult = await runWithOverlay(`Grading phase "${phase.name}"…`, () =>
 		services.judgePhaseGrade(judgeInput),

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -13,7 +13,7 @@ import { findFirstPlannedPhase } from "../../../ferment/engine.js"
 import type { Ferment, Phase } from "../../../ferment/types.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
 import type { Grade } from "../../../ferment/types.js"
-import { runWithOverlay } from "../../agents/index.js"
+import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm } from "../ask-user.js"
 import { gradeColor, pr_bold } from "../colors.js"
@@ -22,7 +22,13 @@ import { formatDecisionsAndMemories } from "../format.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
 import { flaggedVerdicts, renderGateGuidance } from "../gate-registry.js"
 import { assertGateFieldsPresent, validateGatesOrErr } from "../gate-validation.js"
-import { type JudgeFlag, type JudgePhaseGradeResult, type JudgePhaseInput, judgePhaseGrade } from "../judge.js"
+import {
+	type GraderSpawner,
+	type JudgeFlag,
+	type JudgePhaseGradeResult,
+	type JudgePhaseInput,
+	judgePhaseGradeViaSubagent,
+} from "../judge.js"
 import { onPhaseCompleted } from "../nudge.js"
 import { type PhaseEvidence, captureGitHead, gatherPhaseEvidence } from "../phase-evidence.js"
 import { type ProjectCheckResult, runProjectChecks, summarizeProjectChecks } from "../project-tests.js"
@@ -79,7 +85,12 @@ export interface PhaseHandlerServices {
 	 *  and route through the existing block-retry / escalation loop.
 	 *  Judge-unavailable outcomes (no_registry/no_model/no_auth/api_error/
 	 *  unparseable/invalid_grade) are advisory and do NOT refuse advancement. */
-	judgePhaseGrade(input: JudgePhaseInput): Promise<JudgePhaseGradeResult>
+	judgePhaseGrade(input: JudgePhaseInput, spawner?: GraderSpawner): Promise<JudgePhaseGradeResult>
+	/** Optional spawner for the grader subagent. When provided, the grader
+	 *  runs as a bounded subagent with read-only + bash tools so it can
+	 *  independently verify the agent's claims. When undefined, the grader
+	 *  falls back to a single-shot LLM call. */
+	graderSpawner?: GraderSpawner
 	onPhaseCompleted(runtime: FermentRuntime): void
 }
 
@@ -92,7 +103,7 @@ export const defaultPhaseHandlerServices: PhaseHandlerServices = {
 	captureGitHead,
 	gatherEvidence: gatherPhaseEvidence,
 	runProjectChecks: (cwd) => runProjectChecks(cwd),
-	judgePhaseGrade,
+	judgePhaseGrade: (input, spawner) => judgePhaseGradeViaSubagent(input, spawner),
 	onPhaseCompleted,
 }
 
@@ -458,7 +469,7 @@ export async function completePhase(
 		evidence: params.evidence,
 	}
 	const phaseJudgeResult = await runWithOverlay(`Grading phase "${phase.name}"…`, () =>
-		services.judgePhaseGrade(judgeInput),
+		services.judgePhaseGrade(judgeInput, services.graderSpawner),
 	)
 
 	// Resolve the final grade + recommendations.
@@ -781,7 +792,15 @@ ${renderGateGuidance("complete_ferment_phase")}`,
 			return new Markdown(text, 1, 0, getMarkdownTheme())
 		},
 		async execute(_, params, _signal, _onUpdate, ctx) {
-			return completePhase(runtime, params, { pi, ctx }, phaseServices)
+			const services = {
+				...phaseServices,
+				graderSpawner: async (prompt: string) => {
+					const result = await spawnGraderAgent(pi, ctx, prompt)
+					if (!result) return { text: "", status: "unavailable" }
+					return result
+				},
+			}
+			return completePhase(runtime, params, { pi, ctx }, services)
 		},
 	})
 

--- a/src/ferment/event-store.test.ts
+++ b/src/ferment/event-store.test.ts
@@ -414,6 +414,71 @@ describe("FermentEventStore", () => {
 			expect(folded?.grade?.grade).toBe(fromSnapshot?.grade?.grade)
 		})
 
+		it("round-trips JudgeGrade.recommendations through complete_ferment", () => {
+			const f = eventStore.create("Recs round-trip")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "g",
+				successCriteria: ["c"],
+				constraints: [],
+				phases: [{ name: "P1", goal: "G1", steps: [] }],
+			})
+			const planned = eventStore.get(f.id)
+			if (!planned) throw new Error("ferment missing")
+			const phaseId = planned.phases[0].id
+			exec(eventStore, f.id, { type: "activate_phase", phaseId })
+			exec(eventStore, f.id, { type: "complete_phase", phaseId, summary: "done" })
+			const recs = [
+				"Add edge-case test for empty input — untested path could NPE.",
+				"Wire retry into the production call site — currently only tested in isolation.",
+			]
+			exec(eventStore, f.id, {
+				type: "complete_ferment",
+				grade: {
+					grade: "B",
+					rationale: "Goal met but coverage is thin.",
+					gradedAt: new Date().toISOString(),
+					recommendations: recs,
+				},
+			})
+
+			const folded = eventStore.get(f.id)
+			const fromSnapshot = parentStorage.get(f.id)
+			expect(folded?.grade?.recommendations).toEqual(recs)
+			expect(fromSnapshot?.grade?.recommendations).toEqual(recs)
+		})
+
+		it("round-trips JudgeGrade.recommendations through set_phase_grade", () => {
+			const f = eventStore.create("Phase recs round-trip")
+			exec(eventStore, f.id, {
+				type: "scope",
+				goal: "g",
+				successCriteria: ["c"],
+				constraints: [],
+				phases: [{ name: "P1", goal: "G1", steps: [] }],
+			})
+			const planned = eventStore.get(f.id)
+			if (!planned) throw new Error("ferment missing")
+			const phaseId = planned.phases[0].id
+			exec(eventStore, f.id, { type: "activate_phase", phaseId })
+			const recs = ["Fix the N+1 query in listUsers.", "Add cancellation to the fetch loop."]
+			exec(eventStore, f.id, {
+				type: "set_phase_grade",
+				phaseId,
+				grade: {
+					grade: "C",
+					rationale: "Operational gaps.",
+					gradedAt: new Date().toISOString(),
+					recommendations: recs,
+				},
+			})
+
+			const folded = eventStore.get(f.id)
+			const fromSnapshot = parentStorage.get(f.id)
+			expect(folded?.phases[0].grade?.recommendations).toEqual(recs)
+			expect(fromSnapshot?.phases[0].grade?.recommendations).toEqual(recs)
+		})
+
 		// Property-style: for every command in a representative sequence, after
 		// writeWithEvents the eventStore.get() (fold path) should produce the same
 		// state as the parentStorage.get() (snapshot path). This is the contract

--- a/src/ferment/store.test.ts
+++ b/src/ferment/store.test.ts
@@ -200,6 +200,49 @@ describe("FermentStorage v4", () => {
 		})
 	})
 
+	describe("setPhaseGrade", () => {
+		it("persists recommendations and survives a reload", () => {
+			const f = storage.create("Graded")
+			storage.setPhases(f.id, [{ id: "p1", index: 1, name: "Phase 1", goal: "G1", status: "completed", steps: [] }])
+			const recs = ["Add edge-case test for empty input.", "Wire retry into production call site."]
+			const grade = {
+				grade: "B" as const,
+				rationale: "Thin coverage.",
+				gradedAt: new Date().toISOString(),
+				recommendations: recs,
+			}
+			const updated = storage.setPhaseGrade(f.id, "p1", grade)
+			expect(updated?.phases[0]?.grade?.recommendations).toEqual(recs)
+
+			// Reload from disk — recommendations must survive serialization.
+			clearFermentCache()
+			const reloaded = storage.get(f.id)
+			expect(reloaded?.phases[0]?.grade?.recommendations).toEqual(recs)
+			expect(reloaded?.phases[0]?.grade?.grade).toBe("B")
+		})
+	})
+
+	describe("setFermentGrade", () => {
+		it("persists recommendations and survives a reload", () => {
+			const f = storage.create("Graded Ferment")
+			const recs = ["Fix the N+1 query in listUsers.", "Add cancellation to the fetch loop."]
+			const grade = {
+				grade: "C" as const,
+				rationale: "Operational gaps.",
+				gradedAt: new Date().toISOString(),
+				recommendations: recs,
+			}
+			const updated = storage.setFermentGrade(f.id, grade)
+			expect(updated?.grade?.recommendations).toEqual(recs)
+
+			// Reload from disk — recommendations must survive serialization.
+			clearFermentCache()
+			const reloaded = storage.get(f.id)
+			expect(reloaded?.grade?.recommendations).toEqual(recs)
+			expect(reloaded?.grade?.grade).toBe("C")
+		})
+	})
+
 	describe("skipPhase", () => {
 		it("marks a phase skipped", () => {
 			const f = storage.create("X")

--- a/src/ferment/types.ts
+++ b/src/ferment/types.ts
@@ -135,6 +135,11 @@ export interface JudgeGrade {
 	rationale: string
 	gradedAt: string
 	deltas?: Delta[]
+	/** Concrete fixes the grader recommends to reach A. Empty/omitted when the
+	 *  grade is A (or when the judge was unreachable). Each entry is a rendered
+	 *  bullet covering what is wrong, why it matters, what must change, and
+	 *  what evidence would prove the fix. */
+	recommendations?: string[]
 	/** Legacy marker for older completions that persisted a placeholder grade
 	 *  when the journey-grade judge was unreachable. New completions leave
 	 *  Ferment.grade unset instead of recording a synthetic grade. */

--- a/tests/smoke/ferment-oneshot-exit.test.ts
+++ b/tests/smoke/ferment-oneshot-exit.test.ts
@@ -248,7 +248,12 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 			],
 		},
 		{
-			// Complete the Ferment; the following request is the judge response.
+			// judgePhaseGrade LLM call triggered inside complete_ferment_phase.
+			// Must be scripted so the fake server does not advance to the wrong response.
+			stream: ['{"grade":"A","rationale":"Clean phase.","recommendations":[]}'],
+		},
+		{
+			// Complete the Ferment; the following request is the journey-grade judge response.
 			toolCalls: [
 				{
 					id: "call_complete_ferment",
@@ -265,7 +270,7 @@ function oneShotCompletionScript(): FakeResponseScript[] {
 		},
 		{
 			// Return the one-shot judge JSON that Ferment expects after completion.
-			stream: ['{"grade":"A","rationale":"The linked-worker one-shot lifecycle completed cleanly."}'],
+			stream: ['{"grade":"A","rationale":"The linked-worker one-shot lifecycle completed cleanly.","recommendations":[]}'],
 		},
 		{
 			// Final assistant text must be emitted before agent_end and process exit.


### PR DESCRIPTION
## Summary

This PR overhauls the ferment grading system to address a critical issue identified in benchmark testing: the grader was trusting the agent's self-reported claims without independent verification, leading to false pass grades.

## Background

Benchmark analysis (terminal-bench-2) revealed that the inline grader — a single-shot LLM call — could not independently verify the agent's claims. When the agent said "C1: pass — the query is measurably faster," the grader had no way to run the benchmark itself. This led to the grader accepting misleading self-reports (e.g., query-optimize: agent compared runtimes on different databases, claimed it was faster; verifier found it was 47% slower).

## Changes

### 1. Council grading prompt with enforcement

- Replaced the advisory-only journey grader with an **enforcing** grader: C/D/F grades refuse phase/ferment advancement and route through the existing `MAX_BLOCK_RETRIES` retry loop.
- First attempt requires grade **A**; after rework, **B** is also acceptable.
- New per-phase LLM grader (`judgePhaseGrade`) assigns letter grades at `complete_ferment_phase`, not just at `complete_ferment`.
- Full **council-of-specialists** system prompt with 6 review dimensions: security attacker, architecture, operational pragmatist, code quality, test/verification, and UX/UI.
- Recommendations are persisted on the phase/ferment grade for the agent to address on retry.

### 2. Agent-attached execution evidence field

- Added optional `evidence` string field to `complete_ferment_phase` and `complete_ferment` where the agent can paste bash command outputs, verification results, and file contents.
- Evidence is injected into the grader prompt as a first-class input alongside the diff, and persisted in the review sidecar.
- Bounded to ~4 KB. Especially important for action-oriented tasks (e.g., chess-best-move) where the agent's "work" is running commands, not producing a code diff.

### 3. Subagent grader with tool access

The core change: the grader is now a **bounded subagent** with read-only + bash tools, not a single-shot LLM call.

**New `Grader` agent type:**
- Read-only tools: `read`, `bash`, `grep`, `find`, `ls` — no `edit`, `write`, or `Agent`
- Bounded: 15 turns, 60K output tokens, 180s wall clock
- System prompt mandates: verify in turns 1-6, produce JSON in turns 7-8, output immediately from turn 9+
- Runs as `visibility: "system"` (hidden from UI, doesn't appear in agent widget)

**Grading flow:**

1. Agent completes work, calls `complete_ferment_phase` (or `complete_ferment`) with summary, gate verdicts, and optional evidence
2. F-gates / C-gates validated deterministically
3. Project checks validated (shape check, not execution)
4. Grader subagent spawned — receives goal, success criteria, gate verdicts, diff, and evidence
5. Subagent verifies independently — reads source files, runs tests, checks output files, compares claims vs reality
6. Subagent produces grade JSON: `{"grade":"A","rationale":"...","recommendations":[...]}`
7. `parseGraderResponse` scans ALL assistant text for JSON (handles mid-session grade production)
8. Grade enforced: A/B advance; C/D/F block with recommendations, retry up to MAX_BLOCK_RETRIES (3)
9. If subagent unavailable/crashes → falls back to single-shot LLM call → if that fails too → advisory (don't block)

**Session persistence:** grader subagent sessions are persisted as separate `.jsonl` files alongside `main.jsonl` for post-mortem analysis.

### 4. Full transcript JSON scanning

`parseGraderResponse` scans ALL assistant text for a JSON grade object, not just the final message. This handles the case where the grader produces the grade JSON mid-session and then continues with follow-up text before the turn budget runs out.

## Benchmark Results

| Metric | Before (artifacts 66) | After (artifacts 77) |
|---|---|---|
| Pass rate (subset) | ~76% | 100% (3/3) |
| diffAvailable | false ~99% | true 100% |
| Grader blocks | 413 (~4.6/trial) | 3 (~1/trial) |
| Grade JSON extraction | N/A | 82% (9/11) |
| Single-shot fallbacks | 100% | 0% |
| Independent verification | None | Reads files, runs tests, makes HTTP requests |

## Test Coverage

- 9 new tests for subagent grading (success, unparseable fallback, abort fallback, throw fallback, no-spawner fallback)
- 1 test for multi-turn JSON extraction
- 1 test for Grader agent registration (tools, bounds, prompt content)
- 2 new tests for evidence field in phase and journey grader prompts
- All existing tests updated and passing (1137 total)

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
