### PR TITLE
fix(e2e): flaky e2e ferment tests

### DIFF
--- a/tests/e2e/tui/ask-user-form.test.ts
+++ b/tests/e2e/tui/ask-user-form.test.ts
@@ -19,7 +19,7 @@ import {
 	submitFermentCommand,
 	waitForText,
 } from "./support/assertions.js"
-import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+import { TUI_TEST_CONFIG, type TuiScenarioTrace, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
@@ -58,11 +58,11 @@ const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
  */
 async function startFerment(
 	terminal: import("@microsoft/tui-test").Terminal,
-	trace: import("./support/kimchi-fixture.js").TuiScenarioTrace,
+	trace: TuiScenarioTrace,
 	nextStream: string,
 ) {
 	// Stage 1: enter ferment.
-	await submitFermentCommand(terminal)
+	await submitFermentCommand(terminal, trace)
 	trace.step("ran /ferment")
 
 	await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })

--- a/tests/e2e/tui/ask-user-form.test.ts
+++ b/tests/e2e/tui/ask-user-form.test.ts
@@ -12,7 +12,13 @@
  */
 
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -56,7 +62,7 @@ async function startFerment(
 	nextStream: string,
 ) {
 	// Stage 1: enter ferment.
-	terminal.submit("/ferment")
+	await submitFermentCommand(terminal)
 	trace.step("ran /ferment")
 
 	await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })

--- a/tests/e2e/tui/ask-user-form.test.ts
+++ b/tests/e2e/tui/ask-user-form.test.ts
@@ -55,12 +55,8 @@ async function startFerment(
 	trace: import("./support/kimchi-fixture.js").TuiScenarioTrace,
 	nextStream: string,
 ) {
-	// Stage 1: enter ferment. Type then Enter separately — one-shot "/ferment\r" can
-	// race startup and skip the intent prompt.
-	terminal.write("/ferment")
-	await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-	trace.step("typed /ferment")
-	terminal.submit("")
+	// Stage 1: enter ferment.
+	terminal.submit("/ferment")
 	trace.step("ran /ferment")
 
 	await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })

--- a/tests/e2e/tui/background-agents.test.ts
+++ b/tests/e2e/tui/background-agents.test.ts
@@ -163,6 +163,10 @@ test("Ctrl+X kills background agents one by one", async ({ terminal }) => {
 			await waitForText(terminal, "ctrl+x to kill", { timeoutMs: 5_000, full: false })
 			trace.step("two background agents running")
 
+			// Give both agents a moment to fully detach their streams before killing;
+			// without this the first kill can race with the second agent startup.
+			await new Promise((resolve) => setTimeout(resolve, 200))
+
 			// Kill the most recent one (second bg — listAgents sorts by startedAt desc)
 			terminal.keyPress("x", { ctrl: true })
 			await waitForText(terminal, "Stopped", { timeoutMs: 5_000, full: false })

--- a/tests/e2e/tui/ferment-new-runs-planning.test.ts
+++ b/tests/e2e/tui/ferment-new-runs-planning.test.ts
@@ -105,12 +105,8 @@ test("/ferment new runs planning and produces a scoped ferment artifact", async 
 			})
 			trace.step("ready prompt visible")
 
-			// Stage 2: enter ferment. Type then Enter separately — one-shot
-			// "/ferment\r" can race startup (ferment-phase-review.test.ts:42-48).
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			// Stage 2: enter ferment.
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/ferment-new-runs-planning.test.ts
+++ b/tests/e2e/tui/ferment-new-runs-planning.test.ts
@@ -18,7 +18,13 @@
 import { readFileSync, readdirSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { Key, expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -106,7 +112,10 @@ test("/ferment new runs planning and produces a scoped ferment artifact", async 
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			// submitFermentCommand types "/ferment", waits for it to render, then
+			// presses return. A one-shot submit("/ferment") can race with the editor
+			// prompt and submit "/ferment" as the intent, skipping the prompt.
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/ferment-new-runs-planning.test.ts
+++ b/tests/e2e/tui/ferment-new-runs-planning.test.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync, readdirSync, statSync } from "node:fs"
 import { join } from "node:path"
-import { Key, expect, test } from "@microsoft/tui-test"
+import { expect, test } from "@microsoft/tui-test"
 import {
 	INPUT_TIMEOUT_MS,
 	STARTUP_TIMEOUT_MS,
@@ -115,7 +115,7 @@ test("/ferment new runs planning and produces a scoped ferment artifact", async 
 			// submitFermentCommand types "/ferment", waits for it to render, then
 			// presses return. A one-shot submit("/ferment") can race with the editor
 			// prompt and submit "/ferment" as the intent, skipping the prompt.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/ferment-phase-review.test.ts
+++ b/tests/e2e/tui/ferment-phase-review.test.ts
@@ -1,5 +1,11 @@
 import { test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -44,7 +50,7 @@ test.fail("ferment phase-review separator is not selectable", async ({ terminal 
 		},
 		async (_fixture, trace) => {
 			// Stage 1: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("intent prompt visible")

--- a/tests/e2e/tui/ferment-phase-review.test.ts
+++ b/tests/e2e/tui/ferment-phase-review.test.ts
@@ -43,12 +43,8 @@ test.fail("ferment phase-review separator is not selectable", async ({ terminal 
 			],
 		},
 		async (_fixture, trace) => {
-			// Stage 1: enter ferment. Type then Enter separately — one-shot "/ferment\r" can
-			// race startup and skip the intent prompt.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			// Stage 1: enter ferment.
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("intent prompt visible")

--- a/tests/e2e/tui/ferment-phase-review.test.ts
+++ b/tests/e2e/tui/ferment-phase-review.test.ts
@@ -50,7 +50,7 @@ test.fail("ferment phase-review separator is not selectable", async ({ terminal 
 		},
 		async (_fixture, trace) => {
 			// Stage 1: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 			await waitForText(terminal, "would you like to ferment", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("intent prompt visible")

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -17,7 +17,14 @@
 import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText, viewText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	viewText,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -141,7 +148,7 @@ test("plan review: model stops after propose, review dialog appears, user confir
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -238,7 +245,7 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.
@@ -339,7 +346,7 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -141,10 +141,7 @@ test("plan review: model stops after propose, review dialog appears, user confir
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -241,10 +238,7 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.
@@ -345,10 +339,7 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -148,7 +148,7 @@ test("plan review: model stops after propose, review dialog appears, user confir
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -245,7 +245,7 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.
@@ -346,7 +346,7 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/ferment-progress-overlay.test.ts
+++ b/tests/e2e/tui/ferment-progress-overlay.test.ts
@@ -30,7 +30,9 @@ import {
 	INPUT_TIMEOUT_MS,
 	STARTUP_TIMEOUT_MS,
 	STREAM_TIMEOUT_MS,
+	viewText,
 	waitForText,
+	waitForTurnToSettle,
 } from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
@@ -125,7 +127,7 @@ test("/ferment progress overlay shows ferment name, progress bar, phase list, an
 				}
 			},
 		},
-		async (_fixture, trace) => {
+		async (fixture, trace) => {
 			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("ready prompt visible")
 
@@ -135,13 +137,32 @@ test("/ferment progress overlay shows ferment name, progress bar, phase list, an
 			await waitForText(terminal, "Waiting.", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("resume-nudge turn rendered — terminal stable")
 
+			// Drain any in-flight LLM activity so a domain event cannot abort the
+			// overlay immediately after it opens.
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("llm activity settled")
+
 			terminal.submit("/ferment progress")
 			trace.step("submitted /ferment progress")
 
 			// "human:" always appears in the overlay header and is absent from
 			// the status line and all scrollback. Once visible, the full overlay is
 			// rendered and all field assertions are reliable.
-			await waitForText(terminal, "human:", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
+			//
+			// Defensive: on fast CI runners the trailing return from submit()
+			// can occasionally leak into the overlay's select and auto-select the
+			// active phase, leaving us on L2 instead of L1. If we see the L2-only
+			// "Back" option, press Escape to cancel back to the L1 phase list.
+			try {
+				await waitForText(terminal, "human:", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
+			} catch (err) {
+				if (viewText(terminal).includes("Back")) {
+					terminal.keyEscape()
+					await waitForText(terminal, "human:", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
+				} else {
+					throw err
+				}
+			}
 			trace.step("overlay open")
 
 			await waitForText(terminal, "Progress Overlay Test", { timeoutMs: INPUT_TIMEOUT_MS, full: false })

--- a/tests/e2e/tui/ferment-progress-overlay.test.ts
+++ b/tests/e2e/tui/ferment-progress-overlay.test.ts
@@ -25,7 +25,7 @@
 import { randomUUID } from "node:crypto"
 import { mkdirSync, realpathSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { test } from "@microsoft/tui-test"
+import { expect, test } from "@microsoft/tui-test"
 import {
 	INPUT_TIMEOUT_MS,
 	STARTUP_TIMEOUT_MS,
@@ -149,18 +149,29 @@ test("/ferment progress overlay shows ferment name, progress bar, phase list, an
 			// the status line and all scrollback. Once visible, the full overlay is
 			// rendered and all field assertions are reliable.
 			//
-			// Defensive: on fast CI runners the trailing return from submit()
-			// can occasionally leak into the overlay's select and auto-select the
-			// active phase, leaving us on L2 instead of L1. If we see the L2-only
-			// "Back" option, press Escape to cancel back to the L1 phase list.
+			// Defensive: a fast CI runner may process submit()'s trailing return
+			// before the overlay finishes opening, leaving us on L2. Only recover
+			// when we can prove L2 ("Back" visible, "human:" absent), and assert
+			// Escape actually returns us to L1.
 			try {
 				await waitForText(terminal, "human:", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
 			} catch (err) {
-				if (viewText(terminal).includes("Back")) {
+				const originalError = err
+				let text: string
+				try {
+					text = viewText(terminal)
+				} catch {
+					throw originalError
+				}
+				const onL2 = text.includes("Back") && !text.includes("human:")
+				if (!onL2) throw originalError
+
+				try {
 					terminal.keyEscape()
 					await waitForText(terminal, "human:", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
-				} else {
-					throw err
+					expect(viewText(terminal)).not.toContain("Back")
+				} catch {
+					throw originalError
 				}
 			}
 			trace.step("overlay open")

--- a/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
@@ -97,8 +97,11 @@ test("ferment status-line segment updates after activate_ferment_phase tool call
 					],
 				},
 				// Extra text-only responses to absorb continuation nudges.
-				{ stream: ["Waiting."] }, { stream: ["Waiting."] }, { stream: ["Waiting."] },
-				{ stream: ["Waiting."] }, { stream: ["Waiting."] },
+				{ stream: ["Waiting."] },
+				{ stream: ["Waiting."] },
+				{ stream: ["Waiting."] },
+				{ stream: ["Waiting."] },
+				{ stream: ["Waiting."] },
 			],
 		},
 		async (_fixture, trace) => {
@@ -107,9 +110,7 @@ test("ferment status-line segment updates after activate_ferment_phase tool call
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
@@ -116,7 +116,7 @@ test("ferment status-line segment updates after activate_ferment_phase tool call
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
@@ -15,7 +15,13 @@
  */
 
 import { test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -110,7 +116,7 @@ test("ferment status-line segment updates after activate_ferment_phase tool call
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt.

--- a/tests/e2e/tui/plan-review-dismissal.test.ts
+++ b/tests/e2e/tui/plan-review-dismissal.test.ts
@@ -139,12 +139,8 @@ test("plan review dialog does not re-appear after Esc dismissal", async ({ termi
 				timeoutMs: STARTUP_TIMEOUT_MS,
 			})
 
-			// Stage 2: enter ferment. Type then Enter separately — one-shot
-			// "/ferment\r" can race startup.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			// Stage 2: enter ferment.
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -235,10 +231,7 @@ test("plan review dialog does not re-appear after feedback", async ({ terminal }
 			})
 
 			// Stage 2: enter ferment.
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/plan-review-dismissal.test.ts
+++ b/tests/e2e/tui/plan-review-dismissal.test.ts
@@ -19,7 +19,14 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { join } from "node:path"
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	viewText,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -140,7 +147,7 @@ test("plan review dialog does not re-appear after Esc dismissal", async ({ termi
 			})
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -231,7 +238,7 @@ test("plan review dialog does not re-appear after feedback", async ({ terminal }
 			})
 
 			// Stage 2: enter ferment.
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/plan-review-dismissal.test.ts
+++ b/tests/e2e/tui/plan-review-dismissal.test.ts
@@ -147,7 +147,7 @@ test("plan review dialog does not re-appear after Esc dismissal", async ({ termi
 			})
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.
@@ -238,7 +238,7 @@ test("plan review dialog does not re-appear after feedback", async ({ terminal }
 			})
 
 			// Stage 2: enter ferment.
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/support/assertions.ts
+++ b/tests/e2e/tui/support/assertions.ts
@@ -45,6 +45,22 @@ export async function waitForText(
  * follow-up completions. Polls request count until stable for settleForMs.
  * Shared across TUI E2E tests that need to wait for the agent to fully settle.
  */
+/**
+ * Types `/ferment` into the main prompt and submits it.
+ *
+ * A one-shot `terminal.submit("/ferment")` can race with the editor prompt
+ * that opens immediately after the command runs: the trailing return may be
+ * processed by the editor, causing it to submit the literal `/ferment` as the
+ * intent and skip the "What would you like to ferment?" prompt. Splitting the
+ * write and the return, and waiting for the slash text to render first, keeps
+ * the return in the main input.
+ */
+export async function submitFermentCommand(terminal: Terminal): Promise<void> {
+	terminal.write("/ferment")
+	await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+	terminal.submit("")
+}
+
 export async function waitForTurnToSettle(requests: { length: number }): Promise<void> {
 	const settleForMs = 1_200
 	const timeoutMs = 30_000

--- a/tests/e2e/tui/support/assertions.ts
+++ b/tests/e2e/tui/support/assertions.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
+import type { TuiScenarioTrace } from "./kimchi-fixture"
 
 /** Named timeouts, tunable in one place. */
 export const STARTUP_TIMEOUT_MS = 10_000
@@ -55,9 +56,10 @@ export async function waitForText(
  * write and the return, and waiting for the slash text to render first, keeps
  * the return in the main input.
  */
-export async function submitFermentCommand(terminal: Terminal): Promise<void> {
+export async function submitFermentCommand(terminal: Terminal, trace: TuiScenarioTrace): Promise<void> {
 	terminal.write("/ferment")
 	await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+	trace.step("typed /ferment")
 	terminal.submit("")
 }
 

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -1,17 +1,12 @@
 import { execFileSync } from "node:child_process"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { dirname, join, resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Shell } from "@microsoft/tui-test"
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
 import { STARTUP_TIMEOUT_MS, fullText, viewText, waitForText } from "./assertions.js"
-import {
-	type FakeOllamaModel,
-	type FakeOllamaServer,
-	type StartFakeOllamaServerOptions,
-	startFakeOllamaServer,
-} from "./fake-ollama-server.js"
+import { type StartFakeOllamaServerOptions, startFakeOllamaServer } from "./fake-ollama-server.js"
 import {
 	DEFAULT_MODEL,
 	type FakeModel,

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -165,7 +165,7 @@ test("todo tools are available during ferment execution", async ({ terminal }) =
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment (same entry path as ferment-new-runs-planning).
-			await submitFermentCommand(terminal)
+			await submitFermentCommand(terminal, trace)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -1,11 +1,5 @@
 import { expect, test } from "@microsoft/tui-test"
-import {
-	INPUT_TIMEOUT_MS,
-	STARTUP_TIMEOUT_MS,
-	STREAM_TIMEOUT_MS,
-	viewText,
-	waitForText,
-} from "./support/assertions.js"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -54,7 +48,10 @@ test("todo widget renders global scope with status symbols", async ({ terminal }
 			trace.step("todo items visible")
 
 			// Status symbols: ▶ for in_progress, ○ for pending.
-			const text = terminal.getViewableBuffer().map((r) => r.join("")).join("\n")
+			const text = terminal
+				.getViewableBuffer()
+				.map((r) => r.join(""))
+				.join("\n")
 			expect(text).toContain("▶")
 			expect(text).toContain("○")
 		},
@@ -99,9 +96,7 @@ test("todo tools are available during ferment execution", async ({ terminal }) =
 										{
 											name: "Implementation",
 											goal: "Call update_todos during the ferment.",
-											steps: [
-												{ description: "Write a todo list via update_todos.", verify: "true" },
-											],
+											steps: [{ description: "Write a todo list via update_todos.", verify: "true" }],
 										},
 									],
 									questions: [],
@@ -163,10 +158,7 @@ test("todo tools are available during ferment execution", async ({ terminal }) =
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment (same entry path as ferment-new-runs-planning).
-			terminal.write("/ferment")
-			await waitForText(terminal, "/ferment", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("typed /ferment")
-			terminal.submit("")
+			terminal.submit("/ferment")
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import {
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	submitFermentCommand,
+	viewText,
+	waitForText,
+} from "./support/assertions.js"
 import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -158,7 +165,7 @@ test("todo tools are available during ferment execution", async ({ terminal }) =
 			trace.step("ready prompt visible")
 
 			// Stage 2: enter ferment (same entry path as ferment-new-runs-planning).
-			terminal.submit("/ferment")
+			await submitFermentCommand(terminal)
 			trace.step("ran /ferment")
 
 			// Stage 3: intent prompt appears.


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Fixes a couple of issues with ferment tests:
* Simplify /ferment invocation logic (probably addressed upstream already, but tests not updated)
* Flakiness of `tests/e2e/tui/ferment-progress-overlay.test.ts` due to test-specific input race causing the test to fail ~2/3 times

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
