### PR TITLE
feat: steer agent on bash timeout to avoid repeated wasted runs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import activityExtension from "./extensions/activity.js"
 import agentsExtension from "./extensions/agents/index.js"
 import assistantPrefixExtension from "./extensions/assistant-prefix.js"
 import bashDefaultTimeoutExtension from "./extensions/bash-default-timeout.js"
+import bashTimeoutGuidanceExtension from "./extensions/bash-timeout-guidance.js"
 import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
 import branchCommandExtension from "./extensions/branch-command.js"
@@ -534,6 +535,7 @@ try {
 			// takes effect immediately without a process restart.
 			bashDefaultTimeoutExtension,
 			bashToolGuardExtension,
+			bashTimeoutGuidanceExtension,
 			...enabledExtensionFactories([
 				{ id: "plugins.mcp-apps", factory: mcpAdapterExtension },
 			] satisfies ManagedExtensionFactory[]),

--- a/src/extensions/bash-timeout-guidance.test.ts
+++ b/src/extensions/bash-timeout-guidance.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { extractTimeoutSeconds, isBashTimeoutResult } from "./bash-timeout-guidance.js"
+
+function makeToolResult(
+	overrides: Partial<{
+		toolName: string
+		isError: boolean
+		content: Array<{ type: "text"; text: string }>
+	}>,
+): {
+	type: "tool_result"
+	toolCallId: string
+	toolName: string
+	input: Record<string, unknown>
+	content: Array<{ type: "text"; text: string }>
+	isError: boolean
+	details: unknown
+} {
+	return {
+		type: "tool_result",
+		toolCallId: "call-1",
+		toolName: "bash",
+		input: {},
+		content: [{ type: "text", text: "" }],
+		isError: true,
+		details: undefined,
+		...overrides,
+	}
+}
+
+describe("extractTimeoutSeconds", () => {
+	it("extracts the timeout value from the error message", () => {
+		expect(extractTimeoutSeconds("some output\n\nCommand timed out after 300 seconds")).toBe(300)
+	})
+
+	it("returns undefined when there is no timeout message", () => {
+		expect(extractTimeoutSeconds("Command exited with code 1")).toBeUndefined()
+	})
+
+	it("returns undefined for empty text", () => {
+		expect(extractTimeoutSeconds("")).toBeUndefined()
+	})
+})
+
+describe("isBashTimeoutResult", () => {
+	it("returns true for a bash result containing a timeout error", () => {
+		const event = makeToolResult({
+			toolName: "bash",
+			isError: true,
+			content: [{ type: "text", text: "Progress: 50%\n\nCommand timed out after 600 seconds" }],
+		})
+		expect(isBashTimeoutResult(event)).toBe(true)
+	})
+
+	it("returns false when the result is not an error", () => {
+		const event = makeToolResult({
+			toolName: "bash",
+			isError: false,
+			content: [{ type: "text", text: "Command timed out after 600 seconds" }],
+		})
+		expect(isBashTimeoutResult(event)).toBe(false)
+	})
+
+	it("returns false for a non-timeout error", () => {
+		const event = makeToolResult({
+			toolName: "bash",
+			isError: true,
+			content: [{ type: "text", text: "Command exited with code 1" }],
+		})
+		expect(isBashTimeoutResult(event)).toBe(false)
+	})
+
+	it("returns false for non-bash tool results", () => {
+		const event = makeToolResult({
+			toolName: "read",
+			isError: true,
+			content: [{ type: "text", text: "Command timed out after 600 seconds" }],
+		})
+		expect(isBashTimeoutResult(event)).toBe(false)
+	})
+})

--- a/src/extensions/bash-timeout-guidance.ts
+++ b/src/extensions/bash-timeout-guidance.ts
@@ -1,0 +1,83 @@
+/**
+ * Bash timeout guidance
+ *
+ * When a bash command times out, the upstream error message is just:
+ *
+ *     Command timed out after N seconds
+ *
+ * This gives the LLM no guidance on what to do differently. The natural
+ * response is to retry with a larger timeout — which wastes time and
+ * budget without changing the outcome (the benchmark data shows agents
+ * burning 2+ hours on repeated timeouts with increasingly large timeouts).
+ *
+ * This extension intercepts bash tool results that contain a timeout error
+ * and appends actionable guidance: run a single iteration to estimate
+ * timing, break batched work into smaller calls, or change approach.
+ *
+ * The guidance is generic — it doesn't know about ML training, compilation,
+ * or any specific workload. It applies to any command that batches multiple
+ * operations (loops, `&&` chains, scripts that iterate) and times out.
+ *
+ * Implementation: hooks `tool_result`, checks if the result is a bash
+ * timeout error, and returns modified content with appended guidance.
+ * Uses `pi.sendMessage` with `deliverAs: "steer"` so the guidance lands
+ * as a separate steering message rather than mutating the tool result
+ * itself (which could confuse the model about what the command produced).
+ */
+
+import type { TextContent } from "@earendil-works/pi-ai"
+import type { ExtensionAPI, ToolResultEvent } from "@earendil-works/pi-coding-agent"
+
+const TIMEOUT_PATTERN = /Command timed out after (\d+) seconds/
+
+const STEER_MESSAGE =
+	"A bash command timed out. Before retrying: " +
+	"(1) If the command runs multiple operations in sequence (loops, &&, batch scripts), " +
+	"run a single iteration first to measure how long each one takes, then set a realistic timeout. " +
+	"(2) Break batched work into smaller bash calls so partial results are not lost on timeout. " +
+	"(3) If a single operation genuinely needs more time, increase the timeout — but do not " +
+	"repeatedly increase it without changing approach."
+
+export function extractTimeoutSeconds(text: string): number | undefined {
+	const match = text.match(TIMEOUT_PATTERN)
+	if (!match) return undefined
+	const seconds = Number.parseInt(match[1], 10)
+	return Number.isNaN(seconds) ? undefined : seconds
+}
+
+export function isBashTimeoutResult(event: ToolResultEvent): boolean {
+	if (event.toolName !== "bash") return false
+	if (!event.isError) return false
+	for (const block of event.content) {
+		if (block.type === "text" && TIMEOUT_PATTERN.test(block.text)) {
+			return true
+		}
+	}
+	return false
+}
+
+export default function bashTimeoutGuidanceExtension(pi: ExtensionAPI): void {
+	pi.on("tool_result", (event) => {
+		if (!isBashTimeoutResult(event)) return
+
+		const timeoutSecs = extractTimeoutSeconds(
+			event.content
+				.filter((b): b is TextContent => b.type === "text")
+				.map((b) => b.text)
+				.join("\n"),
+		)
+
+		const message = timeoutSecs
+			? `${STEER_MESSAGE} (The command was killed after ${timeoutSecs}s — the partial output above was captured before the timeout.)`
+			: STEER_MESSAGE
+
+		pi.sendMessage(
+			{
+				customType: "bash-timeout-guidance",
+				content: [{ type: "text", text: message }],
+				display: false,
+			},
+			{ deliverAs: "steer" },
+		)
+	})
+}


### PR DESCRIPTION
## Problem

When a bash command times out, the upstream error message is just `Command timed out after N seconds` — no guidance on what to do differently. Benchmark data (terminal-bench-2-1) shows the agent's natural response is to retry with a larger timeout, burning 2+ hours on repeated timeouts without changing strategy.

For example, the `train-fasttext` task had 7 consecutive hyperparameter sweeps that each timed out — the agent kept batching multiple training runs in a single bash call, underestimating the total time, and increasing the timeout instead of breaking the work into smaller pieces.

## Solution

New `bash-timeout-guidance` extension that hooks `tool_result`, detects bash timeout errors, and sends a steering message with generic, actionable guidance:

1. Run a single iteration first to measure how long each one takes, then set a realistic timeout
2. Break batched work into smaller bash calls so partial results are not lost on timeout
3. Don't repeatedly increase the timeout without changing approach

The guidance is fully generic — no knowledge of ML training, compilation, or any specific workload. It applies to any command that batches multiple operations (loops, `&&` chains, scripts that iterate) and times out.

## Verification

- ✅ 7 unit tests pass (`extractTimeoutSeconds` + `isBashTimeoutResult`)
- ✅ TypeScript typecheck passes
- ✅ Lint passes
- ✅ Manual test: agent runs `sleep 30` with `timeout=5`, receives the steering message, and acknowledges the guidance instead of blindly retrying

- [x] Tests added