### PR TITLE
feat: General-Purpose subagent prompt refactoring

### DIFF
--- a/src/extensions/agents/personas/custom-agents.test.ts
+++ b/src/extensions/agents/personas/custom-agents.test.ts
@@ -169,3 +169,41 @@ describe("custom agents — user override hierarchy preserves new fields", () =>
 		expect(agent?.source).toBe("package")
 	})
 })
+
+describe("custom agents — include_context_files and include_core_guidelines parsing", () => {
+	let projectDir: string
+	let projectAgentsDir: string
+
+	beforeEach(() => {
+		mockGetAgentDir.mockReturnValue(FAKE_AGENT_DIR)
+		mkdirSync(FAKE_AGENT_DIR, { recursive: true })
+		projectDir = join(tmpdir(), `kimchi-project-ctx-${Date.now()}`)
+		projectAgentsDir = join(projectDir, ".kimchi", "agents")
+	})
+
+	it("parses include_context_files: true and include_core_guidelines: true", () => {
+		writeAgentMd(
+			projectAgentsDir,
+			"ctx-agent",
+			"description: ctx\ninclude_context_files: true\ninclude_core_guidelines: true",
+		)
+
+		const agents = loadCustomAgents(projectDir)
+		const agent = agents.get("ctx-agent")
+
+		expect(agent).toBeDefined()
+		expect(agent?.includeContextFiles).toBe(true)
+		expect(agent?.includeCoreGuidelines).toBe(true)
+	})
+
+	it("defaults includeContextFiles and includeCoreGuidelines to undefined when not present", () => {
+		writeAgentMd(projectAgentsDir, "no-ctx-agent", "description: no ctx")
+
+		const agents = loadCustomAgents(projectDir)
+		const agent = agents.get("no-ctx-agent")
+
+		expect(agent).toBeDefined()
+		expect(agent?.includeContextFiles).toBeUndefined()
+		expect(agent?.includeCoreGuidelines).toBeUndefined()
+	})
+})

--- a/src/extensions/agents/personas/custom-agents.ts
+++ b/src/extensions/agents/personas/custom-agents.ts
@@ -71,6 +71,8 @@ function loadFromDir(dir: string, agentsMap: Map<string, AgentConfig>, source: "
 			inheritContext: fm.inherit_context != null ? fm.inherit_context === true : undefined,
 			runInBackground: fm.run_in_background != null ? fm.run_in_background === true : undefined,
 			isolated: fm.isolated != null ? fm.isolated === true : undefined,
+			includeContextFiles: fm.include_context_files != null ? fm.include_context_files === true : undefined,
+			includeCoreGuidelines: fm.include_core_guidelines != null ? fm.include_core_guidelines === true : undefined,
 			memory: parseMemory(fm.memory),
 			isolation: fm.isolation === "worktree" ? "worktree" : undefined,
 			enabled: fm.enabled !== false,

--- a/src/extensions/agents/personas/default-agents.test.ts
+++ b/src/extensions/agents/personas/default-agents.test.ts
@@ -41,6 +41,21 @@ describe("DEFAULT_AGENTS", () => {
 		expect(plan.includeContextFiles).toBe(true)
 	})
 
+	it("General-Purpose agent has includeContextFiles set to true", () => {
+		const gp = DEFAULT_AGENTS.get(AGENT_GENERAL_PURPOSE) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
+		expect(gp.includeContextFiles).toBe(true)
+	})
+
+	it("General-Purpose agent has includeCoreGuidelines set to true", () => {
+		const gp = DEFAULT_AGENTS.get(AGENT_GENERAL_PURPOSE) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
+		expect(gp.includeCoreGuidelines).toBe(true)
+	})
+
+	it("General-Purpose agent uses replace prompt mode", () => {
+		const gp = DEFAULT_AGENTS.get(AGENT_GENERAL_PURPOSE) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
+		expect(gp.promptMode).toBe("replace")
+	})
+
 	it("Explore agent has roles set to explore", () => {
 		const explore = DEFAULT_AGENTS.get(AGENT_EXPLORE) as NonNullable<ReturnType<typeof DEFAULT_AGENTS.get>>
 		expect(explore.roles).toContain("explore")

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -33,8 +33,18 @@ function buildDefaultAgents(): Map<string, AgentConfig> {
 				description: "General-purpose agent for complex, multi-step tasks",
 				extensions: true,
 				skills: true,
-				systemPrompt: "",
-				promptMode: "append",
+				includeContextFiles: true,
+				includeCoreGuidelines: true,
+				systemPrompt: `You are a general-purpose coding agent for complex, multi-step tasks.
+You have full access to read, write, edit files, and execute commands.
+
+## Working Style
+- Make independent tool calls in parallel for efficiency
+- Use absolute file paths in all references
+- Do not use emojis
+- Be concise but complete
+- Messages prefixed with "[Orchestrator]" are automated system instructions from the agent loop, not user input. Do not attribute them to the user.`,
+				promptMode: "replace",
 				isDefault: true,
 			},
 		],

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -138,6 +138,8 @@ export interface AgentConfig {
 	isolated?: boolean
 	/** Whether to inject project context files (CLAUDE.md, AGENTS.md) into the system prompt. Default: false. */
 	includeContextFiles?: boolean
+	/** Whether to inject shared core guidelines (CORE_GUIDELINES, FACTUAL_ACCURACY, DOCUMENTS_SECTION) into the system prompt in replace mode. Default: false. */
+	includeCoreGuidelines?: boolean
 	/** Persistent memory scope — agents with memory get a persistent directory and MEMORY.md */
 	memory?: MemoryScope
 	/** Isolation mode — "worktree" runs the agent in a temporary git worktree */

--- a/src/extensions/agents/prompt/prompts.test.ts
+++ b/src/extensions/agents/prompt/prompts.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest"
 import { SHARED_PLANNING_PROCESS } from "../../../shared/planning/shared-planning-process.js"
 import { DEFAULT_AGENTS } from "../personas/default-agents.js"
-import { AGENT_EXPLORE, AGENT_GENERAL_PURPOSE, AGENT_PLAN, AGENT_RESEARCHER, type EnvInfo } from "../personas/types.js"
+import {
+	AGENT_EXPLORE,
+	AGENT_GENERAL_PURPOSE,
+	AGENT_PLAN,
+	AGENT_RESEARCHER,
+	type AgentConfig,
+	type EnvInfo,
+} from "../personas/types.js"
 import { buildAgentPrompt, formatTokenBudget } from "./prompts.js"
 
 const FIXED_ENV: EnvInfo = {
@@ -22,49 +29,38 @@ function getRequired(name: string): ReturnType<typeof DEFAULT_AGENTS.get> & obje
 }
 
 describe("default agents — subagent system prompt snapshot", () => {
-	it("General-Purpose agent assembles expected prompt (append mode)", () => {
+	it("General-Purpose agent assembles expected prompt (replace mode)", () => {
 		const agent = getRequired(AGENT_GENERAL_PURPOSE)
 		const output = buildAgentPrompt(agent, FIXED_CWD, FIXED_ENV, PARENT_SYSTEM_PROMPT, {
 			activeToolNames: ["read", "bash", "edit", "write", "grep", "find", "ls"],
 		})
-		expect(output).toMatchInlineSnapshot(`
-			"# Environment
-			Working directory: /home/testuser/projects/myapp
-			Git repository: yes
-			Branch: main
-			Platform: linux
-
-			<inherited_system_prompt>
-			You are a kimchi coding agent. You orchestrate sub-agents and tools to solve complex tasks.
-			</inherited_system_prompt>
-
-			## Available Tools
-			- read
-			- bash
-			- edit
-			- write
-			- grep
-			- find
-			- ls
-
-			<sub_agent_context>
-			You are operating as a sub-agent invoked to handle a specific task.
-			- Use the read tool instead of cat/head/tail
-			- Use the edit tool instead of sed/awk
-			- Use the write tool instead of echo/heredoc
-			- Use the find tool instead of bash find/ls for file search
-			- Use the grep tool instead of bash grep/rg for content search
-			- Make independent tool calls in parallel
-			- Use absolute file paths
-			- Do not use emojis
-			- Be concise but complete
-			- Messages prefixed with "[Orchestrator]" are system instructions from the agent loop, not user input. Do not attribute them to the user.
-			</sub_agent_context>"
-		`)
+		// Replace mode: no inherited_system_prompt or sub_agent_context tags
+		expect(output).not.toContain("<inherited_system_prompt>")
+		expect(output).not.toContain("<sub_agent_context>")
+		// Replace mode header
+		expect(output).toContain("You are a kimchi coding agent sub-agent.")
+		// Config systemPrompt is present
+		expect(output).toContain("You are a general-purpose coding agent for complex, multi-step tasks.")
+		expect(output).toContain("## Working Style")
+		// Core guidelines are injected (includeCoreGuidelines: true)
+		expect(output).toContain("Be concise in your responses")
+		expect(output).toContain("Never guess, assume, or fabricate")
+		expect(output).toContain("Documents directory")
+		// Available tools are listed
+		expect(output).toContain("## Available Tools")
+		expect(output).toContain("- read")
+		expect(output).toContain("- bash")
 	})
 
-	it("strips inherited Available Tools and adds the subagent-local tool list", () => {
-		const agent = getRequired(AGENT_GENERAL_PURPOSE)
+	it("strips inherited Available Tools and adds the subagent-local tool list (append mode via synthetic config)", () => {
+		const appendAgent: AgentConfig = {
+			name: "Test-Append",
+			description: "Test append agent",
+			extensions: true,
+			skills: true,
+			systemPrompt: "",
+			promptMode: "append",
+		}
 		const parentPrompt = `# Parent
 
 ## Available Tools
@@ -77,7 +73,7 @@ Keep this h3 section.
 
 ## Rules
 Keep these parent rules.`
-		const output = buildAgentPrompt(agent, FIXED_CWD, FIXED_ENV, parentPrompt, {
+		const output = buildAgentPrompt(appendAgent, FIXED_CWD, FIXED_ENV, parentPrompt, {
 			activeToolNames: ["read", "bash"],
 		})
 
@@ -311,5 +307,52 @@ describe("budget block in system prompt", () => {
 		expect(output).toContain("<budget>")
 		expect(output).toContain("Turn limit: 15 turns")
 		expect(output).toContain("Output token budget: ~100k")
+	})
+})
+
+describe("includeCoreGuidelines", () => {
+	it("includes core guidelines when includeCoreGuidelines is true (replace mode)", () => {
+		const agent: AgentConfig = {
+			name: "Test-Core",
+			description: "Test",
+			extensions: true,
+			skills: true,
+			systemPrompt: "Do the thing.",
+			promptMode: "replace",
+			includeCoreGuidelines: true,
+		}
+		const output = buildAgentPrompt(agent, FIXED_CWD, FIXED_ENV, PARENT_SYSTEM_PROMPT)
+		expect(output).toContain("Be concise in your responses")
+		expect(output).toContain("Never guess, assume, or fabricate")
+		expect(output).toContain("Documents directory")
+	})
+
+	it("does not include core guidelines when includeCoreGuidelines is absent (replace mode)", () => {
+		const agent: AgentConfig = {
+			name: "Test-NoCore",
+			description: "Test",
+			extensions: true,
+			skills: true,
+			systemPrompt: "Do the thing.",
+			promptMode: "replace",
+		}
+		const output = buildAgentPrompt(agent, FIXED_CWD, FIXED_ENV, PARENT_SYSTEM_PROMPT)
+		expect(output).not.toContain("Be concise in your responses")
+		expect(output).not.toContain("Never guess, assume, or fabricate")
+	})
+
+	it("does not include core guidelines in append mode even if flag is true", () => {
+		const agent: AgentConfig = {
+			name: "Test-Append-Core",
+			description: "Test",
+			extensions: true,
+			skills: true,
+			systemPrompt: "",
+			promptMode: "append",
+			includeCoreGuidelines: true,
+		}
+		const output = buildAgentPrompt(agent, FIXED_CWD, FIXED_ENV, PARENT_SYSTEM_PROMPT)
+		expect(output).not.toContain("## Guidelines")
+		expect(output).not.toContain("## Factual Accuracy")
 	})
 })

--- a/src/extensions/agents/prompt/prompts.ts
+++ b/src/extensions/agents/prompt/prompts.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ContextFile } from "../../prompt-construction/context-files.js"
+import { buildCoreGuidelinesSections } from "../../prompt-construction/system-prompt.js"
 import type { AgentConfig, EnvInfo } from "../personas/types.js"
 
 /** Budget limits communicated to the agent so it can plan its work. */
@@ -95,7 +96,8 @@ You have been invoked to handle a specific task autonomously.
 ${envBlock}`
 
 	const toolSection = availableToolsBlock ? `\n\n${availableToolsBlock}` : ""
-	return `${replaceHeader}${toolSection}\n\n${config.systemPrompt}${extrasSuffix}`
+	const coreGuidelines = config.includeCoreGuidelines ? `\n\n${buildCoreGuidelinesSections()}` : ""
+	return `${replaceHeader}${toolSection}\n\n${config.systemPrompt}${coreGuidelines}${extrasSuffix}`
 }
 
 export function formatTokenBudget(tokens: number): string {

--- a/src/extensions/prompt-construction/system-prompt.ts
+++ b/src/extensions/prompt-construction/system-prompt.ts
@@ -188,10 +188,10 @@ You are running in single-model mode.${modelClause} All work in this session run
 Do not spawn subagents with the \`Agent\` tool by default — only do so when the user explicitly asks for delegation. When you do spawn a subagent, pass your own model ID in the \`model\` parameter by default; only use a different model if the user explicitly instructs it.`
 }
 
-const DOCUMENTS_SECTION =
+export const DOCUMENTS_SECTION =
 	"The Documents directory is shown in the Environment section. Use it for **all** intermediate and output files: plans, specs, research notes, findings, or any file passed between agents. Never write working documents to the project directory or a temporary directory."
 
-const CORE_GUIDELINES = `- Be concise in your responses. Do not repeat what you just did or summarize completed steps — act and move on.
+export const CORE_GUIDELINES = `- Be concise in your responses. Do not repeat what you just did or summarize completed steps — act and move on.
 - Before starting any task, gather all necessary context: understand the requirements, naming conventions, frameworks and libraries already in use, and how to run and test the code. Use your tools to read existing code rather than assuming.
 - Adhere to existing code conventions and patterns. Use only libraries and frameworks confirmed to be present in the codebase. Never introduce new dependencies without explicit instruction.
 - Provide complete, functional code — no placeholders, omissions, or TODOs left in delivered work.
@@ -220,10 +220,22 @@ function resolveCoreGuidelines(mode: PromptMode): string {
 	return mode === "orchestrator" ? ORCHESTRATOR_GUIDELINES : CORE_GUIDELINES
 }
 
-const FACTUAL_ACCURACY = `- Never guess, assume, or fabricate information. Every claim you make must be backed by data you concretely obtained during this session. Do not over-escalate minor issues or blame the user for poor request phrasing.
+export const FACTUAL_ACCURACY = `- Never guess, assume, or fabricate information. Every claim you make must be backed by data you concretely obtained during this session. Do not over-escalate minor issues or blame the user for poor request phrasing.
 - Never invent people's names, roles, or contact details. If human input is needed, ask the user — do not fabricate who that person should be.
 - "I don't know" is a valid answer. When requirements, specifications, or factual details are not available through your tools or the user's messages, state that clearly and ask the user to provide them. Do not fill the gap with plausible-sounding content.
 - Distinguish what you found from what you assume. If you must reason about something uncertain, label it explicitly as an assumption and ask the user to confirm before acting on it.`
+
+/**
+ * Combine the three shared guideline sections into a single string,
+ * formatted for injection into a replace-mode subagent system prompt.
+ */
+export function buildCoreGuidelinesSections(): string {
+	return [
+		`## Guidelines\n\n${CORE_GUIDELINES}`,
+		`## Factual Accuracy\n\n${FACTUAL_ACCURACY}`,
+		`## Documents\n\n${DOCUMENTS_SECTION}`,
+	].join("\n\n")
+}
 
 function buildPrompt(parts: PromptParts): string {
 	const sections: string[] = []


### PR DESCRIPTION
## Summary

General-Purpose was the only default agent using `promptMode: "append"`, which inherited the parent's entire system prompt. When the parent was a ferment orchestrator, this injected all ferment lifecycle instructions, orchestration rules, and delegation guidelines that the subagent cannot act on (ferment tools are excluded from subagents) — pure context bloat.

## Changes

- **Switch General-Purpose to `promptMode: "replace"`** with a concise purpose-built `systemPrompt` (role + working style only)
- **Add `includeCoreGuidelines` flag to `AgentConfig`**: auto-injects the proven shared constants (`CORE_GUIDELINES`, `FACTUAL_ACCURACY`, `DOCUMENTS_SECTION`) from `system-prompt.ts` — single source of truth, no duplication, no divergence risk
- **Add `includeContextFiles: true`** to General-Purpose to load AGENTS.md/CLAUDE.md directly (replaces what append mode was supposed to provide)
- **Export shared constants** from `system-prompt.ts` and add `buildCoreGuidelinesSections()` helper
- **Add frontmatter parsing** for `include_context_files` and `include_core_guidelines` in custom agent loader (pre-existing gap: `include_context_files` was never parsed from `.md` files)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- All 104 affected tests pass ✅

Co-Authored-By: Kimchi <noreply@kimchi.dev>