### PR TITLE
fix(ferment): block turn_end nudges/dropdowns while plan review is pending

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -738,6 +738,56 @@ describe("turn_end error recovery in one-shot mode", () => {
 		const stored = storage.get(ferment.id)
 		expect(stored?.status).toBe("paused")
 	})
+
+	it("does not inject a continuation nudge on one-shot error when a plan review is pending", async () => {
+		const { storage, ferment } = setupScopedRunningFerment(
+			"ferment-oneshot-error-review-",
+			"One-shot Error Review Ferment",
+		)
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			isAutomatedContinuationEnabled: () => true,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+		// Defensive: a pending plan review is normally only attached to draft
+		// ferments, but if one is present we must not inject a continuation
+		// nudge that would prevent agent_end from showing the review dialog.
+		runtime.setPendingPlanReview({
+			fermentId: active.id,
+			planMarkdown: "# Plan",
+		})
+
+		const { handlers, pi } = createPi()
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockImplementation((name: string) =>
+			name === "ferment-oneshot" ? true : undefined,
+		)
+		;(pi as ExtensionAPI & { events: ExtensionAPI["events"] }).events = {
+			emit: vi.fn(),
+			on: vi.fn(),
+		} as unknown as ExtensionAPI["events"]
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const ctx = { ui: { notify: vi.fn() } }
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Connection error: socket closed",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(storage.get(ferment.id)?.status).toBe("running")
+	})
 })
 
 describe("session_shutdown one-shot recovery", () => {

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -564,7 +564,13 @@ export function registerFermentEvents(
 			if (isOneShot) {
 				const errorFerment = runtime.getActive()
 				if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
-					maybeInjectReactiveContinuationNudge(pi, runtime)
+					// Pending plan review is only attached to draft ferments, so the
+					// status check above already excludes it. Guard explicitly anyway:
+					// a continuation nudge here would start a new turn and prevent
+					// agent_end from showing the review dialog.
+					if (!hasPendingPlanReview(runtime)) {
+						maybeInjectReactiveContinuationNudge(pi, runtime)
+					}
 				}
 			}
 
@@ -583,6 +589,27 @@ export function registerFermentEvents(
 
 		const f = runtime.getActive()
 		if (!f) return
+
+		// When a pending plan review exists (propose_ferment_scoping returned
+		// "Plan ready for review"), skip ALL nudge/dropdown/compaction logic.
+		// The review dialog is shown by the agent_end handler via setTimeout(0).
+		// If we inject continuation nudges here, they trigger new turns which
+		// prevent agent_end from firing — the review dialog never appears and
+		// the ferment is stuck in draft. Similarly, maybeRunUserInputDropdown
+		// can show a competing dropdown that prematurely confirms the scope
+		// via confirmPendingScope, which then causes the plan review's
+		// confirm to fail with MISSING_PENDING_SCOPE.
+		//
+		// Apply the tool profile suppression (pi.setActiveTools([])) and return
+		// immediately so the turn ends naturally and agent_end fires.
+		//
+		// This suppression must happen in turn_end, not turn_start: pi-mono's
+		// prepareNextTurn builds the next turn's tool snapshot after turn_end
+		// but before turn_start, so turn_start is too late.
+		if (hasPendingPlanReview(runtime)) {
+			applyFermentRuntimeToolProfile(pi, runtime)
+			return
+		}
 
 		// During draft scoping, detect when the model is stuck exploring
 		// without progressing through the scoping steps. Fires for both
@@ -635,28 +662,6 @@ export function registerFermentEvents(
 		// Only acts on tool-use turns; stop/error/aborted are handled elsewhere.
 		if (event.message.role === "assistant" && event.message.stopReason === "toolUse") {
 			maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, event.message.usage?.totalTokens ?? 0)
-		}
-
-		// After a turn ends, `prepareNextTurn` in pi-mono builds the next turn's
-		// context using `this.activeToolNames` (the snapshot set by
-		// `pi.setActiveTools`). This happens AFTER `turn_end` fires but BEFORE
-		// the next `turn_start`. So to suppress tools for the next LLM call (e.g.
-		// after `propose_ferment_scoping` sets a pending plan review), we must
-		// apply the tool profile here in `turn_end` — not `turn_start`, which
-		// fires too late (the context is already built).
-		//
-		// When `propose_ferment_scoping` sets a pending review mid-turn,
-		// `applyFermentRuntimeToolProfile` suppresses all tools via
-		// `pi.setActiveTools([])`. The next LLM call sees an empty toolset,
-		// produces text-only output (stopReason: "stop"), ending the turn and
-		// firing `agent_end` which triggers the review dialog.
-		//
-		// This is placed at the end of the handler so that the nudge/dropdown
-		// logic above runs first. Those early-return paths still suppress tools
-		// when a pending review exists, which is correct — the model should not
-		// have tools until the review is resolved.
-		if (hasPendingPlanReview(runtime)) {
-			applyFermentRuntimeToolProfile(pi, runtime)
 		}
 	})
 }

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -927,6 +927,73 @@ describe("fermentExtension question dropdown", () => {
 		)
 	})
 
+	it("does not inject nudges or dropdowns on turn_end when pending plan review exists", async () => {
+		// Regression: after propose_ferment_scoping sets a pending plan review,
+		// turn_end must NOT inject continuation nudges (which prevent agent_end
+		// from firing and showing the review dialog) or show a competing
+		// dropdown (which can prematurely confirm the scope via
+		// confirmPendingScope, causing the review dialog's confirm to fail).
+		const storage = new FermentEventStore(mkdtempSync(join(tmpdir(), "ferment-index-plan-review-turn-end-guard-test-")))
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		runtime.setContinuationPolicy("automated")
+		const draft = storage.create("Turn End Guard")
+		runtime.setActive(draft)
+		runtime.setPendingScope(draft.id, {
+			goal: "Goal",
+			successCriteria: ["Works"],
+			constraints: [],
+			phases: [{ name: "Phase", goal: "Build", steps: [] }],
+		})
+		setPendingPlanReview({
+			fermentId: draft.id,
+			planMarkdown: "# Plan: Turn End Guard",
+		})
+
+		const { handlers, pi } = registerFermentExtension(runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const ctx = createContext()
+
+		// Fire a text-only turn — this is the turn where the model produced a
+		// summary after propose_ferment_scoping returned "Plan ready for review".
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "Plan submitted for review." }],
+					stopReason: "stop",
+				},
+			},
+			ctx,
+		)
+
+		// No continuation nudge should be injected — it would prevent agent_end.
+		expect(pi.sendMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "ferment_continuation_nudge" }),
+			expect.anything(),
+		)
+		// No scoping progress/stop nudge either.
+		expect(pi.sendMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "ferment_scoping_progress_nudge" }),
+			expect.anything(),
+		)
+		expect(pi.sendMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "ferment_scoping_stop_nudge" }),
+			expect.anything(),
+		)
+		// No competing dropdown — the plan review dialog is the only UI.
+		expect(ctx.ui.select).not.toHaveBeenCalled()
+		// Tools must be suppressed so the next LLM call is text-only, ending the turn.
+		expect(pi.setActiveTools).toHaveBeenCalledWith([])
+		// The pending plan review must still be set (not consumed/cleared).
+		expect(getPendingPlanReview(draft.id)).toBeDefined()
+		// The ferment must still be in draft (not prematurely scoped).
+		expect(storage.get(draft.id)?.status).toBe("draft")
+	})
+
 	it("opens pending plan review after agent_end macrotask and starts execution", async () => {
 		vi.useFakeTimers()
 		try {

--- a/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
@@ -10,10 +10,8 @@
  * confirmed in one-shot mode.
  */
 
-import { readdirSync, readFileSync } from "node:fs"
-import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, findFermentArtifact, waitForText } from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -46,32 +44,6 @@ const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
 		{ id: "P3", verdict: "pass", rationale: "tests", evidence: "n/a" },
 	],
 })
-
-/**
- * Poll for a ferment artifact with the expected status in .kimchi/ferments/.
- * Returns the parsed artifact or undefined if not found before the deadline.
- */
-async function findFermentArtifact(
-	workDir: string,
-	expectedStatus: string,
-	timeoutMs = STREAM_TIMEOUT_MS,
-): Promise<Record<string, unknown> | undefined> {
-	const fermentsDir = join(workDir, ".kimchi", "ferments")
-	const deadline = Date.now() + timeoutMs
-	while (Date.now() < deadline) {
-		try {
-			const files = readdirSync(fermentsDir).filter((f) => f.endsWith(".json"))
-			for (const f of files) {
-				const content = JSON.parse(readFileSync(join(fermentsDir, f), "utf-8"))
-				if (content.status === expectedStatus) return content
-			}
-		} catch {
-			// dir doesn't exist yet or unreadable
-		}
-		await new Promise((r) => setTimeout(r, 250))
-	}
-	return undefined
-}
 
 test("plan review dialog appears in one-shot mode after propose_ferment_scoping", async ({ terminal }) => {
 	await runKimchiSession(

--- a/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
@@ -1,0 +1,99 @@
+/**
+ * E2E TUI test: plan review dialog appears in one-shot (automated) mode.
+ *
+ * Regression coverage for the case where `propose_ferment_scoping` returns
+ * "Plan ready for review" under automated continuation policy. Before the
+ * fix, the `turn_end` handler injected a reactive continuation nudge before
+ * the pending-plan-review guard could suppress tools, starting a follow-up
+ * turn and preventing `agent_end` from firing — the review dialog never
+ * appeared. This test verifies the dialog surfaces and the ferment can be
+ * confirmed in one-shot mode.
+ */
+
+import { test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const NO_COMPACTION_MODEL = { slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 }
+
+const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "One-shot Test Feature",
+	goal: "Add a test feature to verify plan review in one-shot mode.",
+	success_criteria: ["Feature works correctly", "Tests pass"],
+	constraints: ["no new dependencies"],
+	assumptions: "Safe defaults assumed.",
+	phases: [
+		{
+			name: "Implement",
+			goal: "Build the feature",
+			steps: [
+				{
+					description: "Write the code",
+					verify: "pnpm test",
+				},
+			],
+		},
+	],
+	questions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Step has verify", evidence: "tests pass" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "tests", evidence: "n/a" },
+	],
+})
+
+test("plan review dialog appears in one-shot mode after propose_ferment_scoping", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "plan-review-oneshot",
+			gitInit: true,
+			models: [NO_COMPACTION_MODEL],
+			extraArgs: ["--ferment-oneshot=true"],
+			responses: [
+				// Turn 1: model calls propose_ferment_scoping directly (questions=[]).
+				{
+					toolCalls: [
+						{
+							function: {
+								name: "propose_ferment_scoping",
+								arguments: PROPOSE_SCOPING_PAYLOAD,
+							},
+						},
+					],
+				},
+				// Turn 2: tools suppressed → model produces text-only response.
+				{ stream: ["I've submitted the plan for your review."] },
+				// Turn 3: post-confirmation, keeps session alive.
+				{ stream: ["Starting execution now."] },
+			],
+		},
+		async (_fixture, trace) => {
+			// Stage 1: ready prompt visible.
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			// Stage 2: submit user request — one-shot mode bootstraps a draft ferment.
+			terminal.submit("Add a test feature")
+			trace.step("submitted request in one-shot mode")
+
+			// Stage 3: review dialog appears (triggered by agent_end after tool suppression).
+			// If the regression were present, a continuation nudge would fire instead and
+			// this text would never appear.
+			await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("plan-review dialog visible in one-shot mode")
+
+			// Stage 4: confirm by pressing Enter (default first option "Start execution").
+			terminal.submit("")
+			trace.step("confirmed 'Start execution'")
+
+			// Stage 5: post-confirmation response streams.
+			await waitForText(terminal, "Starting execution now", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("post-confirmation response streamed")
+		},
+	)
+})

--- a/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
@@ -10,7 +10,9 @@
  * confirmed in one-shot mode.
  */
 
-import { test } from "@microsoft/tui-test"
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
 import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
@@ -45,6 +47,32 @@ const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
 	],
 })
 
+/**
+ * Poll for a ferment artifact with the expected status in .kimchi/ferments/.
+ * Returns the parsed artifact or undefined if not found before the deadline.
+ */
+async function findFermentArtifact(
+	workDir: string,
+	expectedStatus: string,
+	timeoutMs = STREAM_TIMEOUT_MS,
+): Promise<Record<string, unknown> | undefined> {
+	const fermentsDir = join(workDir, ".kimchi", "ferments")
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		try {
+			const files = readdirSync(fermentsDir).filter((f) => f.endsWith(".json"))
+			for (const f of files) {
+				const content = JSON.parse(readFileSync(join(fermentsDir, f), "utf-8"))
+				if (content.status === expectedStatus) return content
+			}
+		} catch {
+			// dir doesn't exist yet or unreadable
+		}
+		await new Promise((r) => setTimeout(r, 250))
+	}
+	return undefined
+}
+
 test("plan review dialog appears in one-shot mode after propose_ferment_scoping", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
@@ -66,12 +94,12 @@ test("plan review dialog appears in one-shot mode after propose_ferment_scoping"
 					],
 				},
 				// Turn 2: tools suppressed → model produces text-only response.
+				// The test does not assert the exact text here; the important behavior
+				// is that agent_end fires and the review dialog surfaces.
 				{ stream: ["I've submitted the plan for your review."] },
-				// Turn 3: post-confirmation, keeps session alive.
-				{ stream: ["Starting execution now."] },
 			],
 		},
-		async (_fixture, trace) => {
+		async (fixture, trace) => {
 			// Stage 1: ready prompt visible.
 			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("ready prompt visible")
@@ -91,9 +119,13 @@ test("plan review dialog appears in one-shot mode after propose_ferment_scoping"
 			terminal.submit("")
 			trace.step("confirmed 'Start execution'")
 
-			// Stage 5: post-confirmation response streams.
-			await waitForText(terminal, "Starting execution now", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("post-confirmation response streamed")
+			// Stage 5: verify the ferment transitions to "planned" after confirmation.
+			// In automated one-shot mode, post-confirmation turns may inject continuation
+			// nudges that compete with scripted responses, so we assert on durable state
+			// rather than the next streamed message.
+			const artifact = await findFermentArtifact(fixture.workDir, "planned")
+			expect(artifact).toBeDefined()
+			trace.step("ferment artifact found with status 'planned'")
 		},
 	)
 })

--- a/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
@@ -11,7 +11,13 @@
  */
 
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, findFermentArtifact, waitForText } from "./support/assertions.js"
+import {
+	findFermentArtifact,
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	waitForText,
+} from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -14,11 +14,9 @@
  * 3. Regression — the existing zero-questions scoping flow still works.
  */
 
-import { readdirSync, readFileSync } from "node:fs"
-import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
-import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, findFermentArtifact, waitForText, viewText } from "./support/assertions.js"
+import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
@@ -77,32 +75,6 @@ const PROPOSE_SCOPING_PAYLOAD_2 = JSON.stringify({
 		{ id: "P3", verdict: "pass", rationale: "tests", evidence: "n/a" },
 	],
 })
-
-/**
- * Poll for a ferment artifact with the expected status in .kimchi/ferments/.
- * Returns the parsed artifact or undefined if not found before the deadline.
- */
-async function findFermentArtifact(
-	workDir: string,
-	expectedStatus: string,
-	timeoutMs = STREAM_TIMEOUT_MS,
-): Promise<Record<string, unknown> | undefined> {
-	const fermentsDir = join(workDir, ".kimchi", "ferments")
-	const deadline = Date.now() + timeoutMs
-	while (Date.now() < deadline) {
-		try {
-			const files = readdirSync(fermentsDir).filter((f) => f.endsWith(".json"))
-			for (const f of files) {
-				const content = JSON.parse(readFileSync(join(fermentsDir, f), "utf-8"))
-				if (content.status === expectedStatus) return content
-			}
-		} catch {
-			// dir doesn't exist yet or unreadable
-		}
-		await new Promise((r) => setTimeout(r, 250))
-	}
-	return undefined
-}
 
 // ---------------------------------------------------------------------------
 // Test 1: Full scoping flow with review confirmation

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -15,8 +15,15 @@
  */
 
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, findFermentArtifact, waitForText, viewText } from "./support/assertions.js"
-import { TUI_TEST_CONFIG, runKimchiSession } from "./support/kimchi-fixture.js"
+import {
+	findFermentArtifact,
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	viewText,
+	waitForText,
+} from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 

--- a/tests/e2e/tui/support/assertions.ts
+++ b/tests/e2e/tui/support/assertions.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
 
 /** Named timeouts, tunable in one place. */
@@ -38,6 +40,32 @@ export async function waitForText(
 		text = read()
 	}
 	throw new Error(`Timed out waiting for ${String(pattern)}.\n\nTerminal:\n${text}`)
+}
+
+/**
+ * Poll for a ferment artifact with the expected status in .kimchi/ferments/.
+ * Returns the parsed artifact or undefined if not found before the deadline.
+ */
+export async function findFermentArtifact(
+	workDir: string,
+	expectedStatus: string,
+	timeoutMs = STREAM_TIMEOUT_MS,
+): Promise<Record<string, unknown> | undefined> {
+	const fermentsDir = join(workDir, ".kimchi", "ferments")
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		try {
+			const files = readdirSync(fermentsDir).filter((f) => f.endsWith(".json"))
+			for (const f of files) {
+				const content = JSON.parse(readFileSync(join(fermentsDir, f), "utf-8"))
+				if (content.status === expectedStatus) return content
+			}
+		} catch {
+			// dir doesn't exist yet or unreadable
+		}
+		await new Promise((r) => setTimeout(r, 250))
+	}
+	return undefined
 }
 
 /**


### PR DESCRIPTION
## Problem

After `propose_ferment_scoping` returns "Plan ready for review" in TUI mode, the plan review dialog was not displayed. The agent reported that the plan was submitted but kept looping through text-only turns. Pressing ESC could eventually surface the dialog, but clicking "Start execution" then caused the session to fail.

Fixes #848.

## Root cause

The `hasPendingPlanReview` guard in `turn_end` was placed at the end of the handler, after all nudge/dropdown/compaction logic. This allowed two interfering mechanisms to fire before the guard was reached:

1. **Reactive continuation nudge** — fires on text-only turns in automated policy mode. It injects a follow-up turn (`triggerTurn: true`), which prevents `agent_end` from firing. Without `agent_end`, the deferred review dialog (shown via `setTimeout(0)` in the `agent_end` handler) never appears.

2. **User input dropdown** — `maybeRunUserInputDropdown` detects confirmation-question-shaped trailing text and shows a competing dropdown. If the user selects "Yes, this looks right", it calls `confirmPendingScope`, which consumes the pending scope buffer and transitions the ferment from `draft` to `planned`, but does **not** clear the separate `pendingPlanReview` store. Later, when the review dialog finally shows and the user clicks "Start execution", `confirmPendingScope` is called again and fails with `MISSING_PENDING_SCOPE`.

## Changes

### `src/extensions/ferment/events.ts`
- Moved the `hasPendingPlanReview` guard to the top of the nudge/dropdown/compaction section, with an early return.
- Applied `applyFermentRuntimeToolProfile(pi, runtime)` in that guard so tools are suppressed before `prepareNextTurn` builds the next turn's context.
- Hardened the one-shot `stopReason === "error"` path so it does not inject a reactive continuation nudge while a plan review is pending.
- Removed the now-unreachable end-of-handler `hasPendingPlanReview` guard and its stale comment.

### `src/extensions/ferment/index.test.ts`
- Added regression test: "does not inject nudges or dropdowns on turn_end when pending plan review exists".

### `src/extensions/ferment/events.test.ts`
- Added regression test: "does not inject a continuation nudge on one-shot error when a plan review is pending".

### `tests/e2e/tui/ferment-plan-review-suppression.test.ts`
- Added TUI E2E tests covering the interactive plan-review flow: confirm (ferment → planned), cancel (ferment stays draft, model can re-propose), and zero-questions scoping regression.

### `tests/e2e/tui/ferment-plan-review-oneshot.test.ts`
- Added TUI E2E test that launches kimchi with `--ferment-oneshot=true`, scripts `propose_ferment_scoping` followed by a text-only summary, and asserts the plan review dialog appears and the ferment transitions to `planned` (verified via filesystem artifact poll rather than a streamed message, since post-confirmation turns in automated mode consume scripted responses before they can be observed).

### `tests/e2e/tui/support/assertions.ts`
- Extracted `findFermentArtifact` (poll `.kimchi/ferments/*.json` for a given status) as a shared export, removing the duplicate local copies that existed in both plan-review test files.

## Regression validation

The oneshot TUI E2E test was verified against the buggy state by temporarily reverting `src/extensions/ferment/events.ts` to the pre-fix version and rebuilding the binary:

- **Without the fix:** test times out waiting for `"Proceed with this plan?"` on all 3 attempts. The terminal shows the reactive continuation nudge firing repeatedly (`🫧 Continuation nudge suppressed after 1 consecutive text-only assistant turns for ...`), matching the original reported failure.
- **With the fix:** all 4 plan-review tests pass (3 suppression + 1 oneshot).

## Verification

```bash
pnpm exec tsc --noEmit
pnpm run test -- --run src/extensions/ferment/events.test.ts src/extensions/ferment/index.test.ts src/extensions/ferment/tool-scope.test.ts
node scripts/run-tui-e2e.js ferment-plan-review
```

- `events.test.ts`: 22 tests pass
- `index.test.ts`: 44 tests pass
- `tool-scope.test.ts`: 20 tests pass
- `ferment-plan-review` TUI E2E (4 tests): all pass

## Type of change

- [x] Bug fix
