### PR TITLE
fix(ferment): honor /settings Auto-compact toggle in ferment compaction

### DIFF
--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -10,6 +10,7 @@
 import type { CompactionResult, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { getCompactionEnabled } from "../../settings-watcher.js"
 import {
 	buildCustomInstructions,
 	buildHandoffDetails,
@@ -22,6 +23,13 @@ import {
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
 import { clearPendingCompaction, type PendingCompaction, setPendingCompaction } from "./state.js"
+
+// Mock the settings-watcher so the /settings Auto-compact toggle can be
+// controlled per-test. Default factory returns `true` so every existing test
+// keeps passing unchanged (backward compatible).
+vi.mock("../../settings-watcher.js", () => ({
+	getCompactionEnabled: vi.fn(() => true),
+}))
 
 // ─── Mock the dynamic require of engine.js in auto-compaction.ts ───────────────
 // auto-compaction.ts uses require() inside buildNextActionDescription to avoid
@@ -162,6 +170,24 @@ function makeSessionMessageEntry(message: unknown): SessionEntry {
 		timestamp: NOW,
 		message,
 	} as unknown as SessionEntry
+}
+
+const CONTEXT_WINDOW = 100_000
+
+function makeMidTurnRuntime(ferment: Ferment): FermentRuntime {
+	const runtime = makeRuntime()
+	runtime.getActive = vi.fn(() => ferment)
+	runtime.getStorage = vi.fn(
+		() => makeMockStorage(new Map([[ferment.id, ferment]])) as unknown as ReturnType<typeof runtime.getStorage>,
+	)
+	return runtime
+}
+
+function makeMidTurnCtx(): ExtensionContext {
+	return {
+		...makeCtx(),
+		model: { contextWindow: CONTEXT_WINDOW },
+	} as unknown as ExtensionContext
 }
 
 // ─── Test suite ───────────────────────────────────────────────────────────────
@@ -616,22 +642,6 @@ describe("buildMidTurnCustomInstructions", () => {
 describe("maybeTriggerMidTurnFermentCompaction", () => {
 	const CONTEXT_WINDOW = 100_000
 
-	function makeMidTurnRuntime(ferment: Ferment): FermentRuntime {
-		const runtime = makeRuntime()
-		runtime.getActive = vi.fn(() => ferment)
-		runtime.getStorage = vi.fn(
-			() => makeMockStorage(new Map([[ferment.id, ferment]])) as unknown as ReturnType<typeof runtime.getStorage>,
-		)
-		return runtime
-	}
-
-	function makeMidTurnCtx(): ExtensionContext {
-		return {
-			...makeCtx(),
-			model: { contextWindow: CONTEXT_WINDOW },
-		} as unknown as ExtensionContext
-	}
-
 	it("no-ops when total tokens are below the threshold", () => {
 		const ferment = makeFermentWithPhase()
 		ferment.phases[0].status = "active"
@@ -928,5 +938,81 @@ describe("in-flight tool-call guard", () => {
 			expect(ctx.compact).toHaveBeenCalledOnce()
 			expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
 		})
+	})
+})
+
+// ─── /settings Auto-compact toggle regression ──────────────────────────────
+// These blocks prove the global compaction.enabled setting (read by
+// getCompactionEnabled) gates BOTH ferment compaction paths. When the toggle
+// is disabled, neither maybeTriggerFermentCompaction nor
+// maybeTriggerMidTurnFermentCompaction should call ctx.compact().
+
+describe("maybeTriggerFermentCompaction — /settings Auto-compact toggle", () => {
+	let storageMap: Map<string, Ferment>
+	let mockStorage: ReturnType<typeof makeMockStorage>
+	let runtime: FermentRuntime
+	let pi: ExtensionAPI
+	let ctx: ExtensionContext
+
+	beforeEach(() => {
+		storageMap = new Map()
+		mockStorage = makeMockStorage(storageMap)
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+		})
+		pi = makePi()
+		ctx = makeCtx()
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	afterEach(() => {
+		runtime.clearCompactionInFlight("ferment-1")
+		clearPendingCompaction("ferment-1")
+		vi.restoreAllMocks()
+		// restoreAllMocks does not reliably reset module-mock implementations, so
+		// re-pin the enabled default to avoid leaking a `false` into other blocks.
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	it("does NOT compact when the Auto-compact toggle is disabled", () => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(false)
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+
+		maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
+		// The pending compaction must be left untouched (not drained).
+		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
+	})
+})
+
+describe("maybeTriggerMidTurnFermentCompaction — /settings Auto-compact toggle", () => {
+	beforeEach(() => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	it("does NOT compact when the Auto-compact toggle is disabled", () => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(false)
+		const ferment = makeFermentWithPhase()
+		ferment.phases[0].status = "active"
+		ferment.phases[0].steps[0].status = "running"
+		const runtime = makeMidTurnRuntime(ferment)
+		const pi = makePi()
+		const ctx = makeMidTurnCtx()
+
+		maybeTriggerMidTurnFermentCompaction(pi, ctx, runtime, CONTEXT_WINDOW - 1)
+
+		expect(ctx.compact).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -20,6 +20,7 @@
 import type { CompactionResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
+import { getCompactionEnabled } from "../../settings-watcher.js"
 import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
 import type { FermentRuntime } from "./runtime.js"
 import { safeSendMessage, tryPiAction } from "./safe-send.js"
@@ -323,6 +324,9 @@ function isExpectedCompactionError(error: Error): boolean {
 export function maybeTriggerFermentCompaction(pi: ExtensionAPI, ctx: ExtensionContext, runtime: FermentRuntime): void {
 	if (pi.getFlag?.("ferment-oneshot") === true) return
 
+	// /settings Auto-compact toggle (settings.json compaction.enabled).
+	if (!getCompactionEnabled()) return
+
 	// Root-cause guard: defer compaction while a tool call is in flight (the
 	// trailing assistant toolCall has no matching toolResult yet). Compacting
 	// now would summarise away the toolCall and orphan the toolResult appended
@@ -462,6 +466,9 @@ export function maybeTriggerMidTurnFermentCompaction(
 		}
 		return
 	}
+
+	// /settings Auto-compact toggle — see maybeTriggerFermentCompaction.
+	if (!getCompactionEnabled()) return
 
 	const model = ctx.model
 	if (!model) return

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -32,6 +32,11 @@ vi.mock("../shared-status-line.js", () => ({
 	requestSharedStatusLineRender: requestSharedStatusLineRenderMock,
 }))
 
+// Default the /settings Auto-compact toggle to enabled (independent of dev machine's settings.json).
+vi.mock("../../settings-watcher.js", () => ({
+	getCompactionEnabled: () => true,
+}))
+
 // Stub the journey-grade judge so completeFerment doesn't try to call a real
 // Opus endpoint during tests. Returns a clean A by default.
 vi.mock("./judge.js", async () => {

--- a/src/settings-watcher.test.ts
+++ b/src/settings-watcher.test.ts
@@ -7,7 +7,7 @@ vi.mock("node:fs", () => ({
 }))
 
 import { readFileSync, watch } from "node:fs"
-import { getActiveThemeName, onThemeChange } from "./settings-watcher.js"
+import { getActiveThemeName, getCompactionEnabled, onThemeChange } from "./settings-watcher.js"
 
 const mockReadFileSync = vi.mocked(readFileSync)
 const mockWatch = vi.mocked(watch)
@@ -55,6 +55,35 @@ describe("getActiveThemeName", () => {
 	it("returns undefined when KIMCHI_CODING_AGENT_DIR is unset", () => {
 		delete process.env.KIMCHI_CODING_AGENT_DIR
 		expect(getActiveThemeName()).toBeUndefined()
+	})
+})
+
+describe("getCompactionEnabled", () => {
+	it("returns true when compaction.enabled is true", () => {
+		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: true } }))
+		expect(getCompactionEnabled()).toBe(true)
+	})
+
+	it("returns false when compaction.enabled is false", () => {
+		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: false } }))
+		expect(getCompactionEnabled()).toBe(false)
+	})
+
+	it("returns true (default) when compaction key is absent", () => {
+		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
+		expect(getCompactionEnabled()).toBe(true)
+	})
+
+	it("returns true when settings.json is malformed JSON", () => {
+		mockReadFileSync.mockReturnValue("{ not valid json")
+		expect(getCompactionEnabled()).toBe(true)
+	})
+
+	it("returns true when settings.json is missing", () => {
+		mockReadFileSync.mockImplementation(() => {
+			throw new Error("ENOENT")
+		})
+		expect(getCompactionEnabled()).toBe(true)
 	})
 })
 

--- a/src/settings-watcher.test.ts
+++ b/src/settings-watcher.test.ts
@@ -7,7 +7,12 @@ vi.mock("node:fs", () => ({
 }))
 
 import { readFileSync, watch } from "node:fs"
-import { getActiveThemeName, getCompactionEnabled, onThemeChange } from "./settings-watcher.js"
+import {
+	__resetCompactionCacheForTest,
+	getActiveThemeName,
+	getCompactionEnabled,
+	onThemeChange,
+} from "./settings-watcher.js"
 
 const mockReadFileSync = vi.mocked(readFileSync)
 const mockWatch = vi.mocked(watch)
@@ -22,6 +27,7 @@ function getWatchCallback(): (() => void) | undefined {
 
 beforeEach(() => {
 	process.env.KIMCHI_CODING_AGENT_DIR = "/fake/agent/dir"
+	__resetCompactionCacheForTest()
 	mockReadFileSync.mockReset()
 	mockWatch.mockReset()
 	mockWatch.mockReturnValue(createMockWatcher() as unknown as ReturnType<typeof watch>)
@@ -84,6 +90,25 @@ describe("getCompactionEnabled", () => {
 			throw new Error("ENOENT")
 		})
 		expect(getCompactionEnabled()).toBe(true)
+	})
+
+	it("caches the value and re-reads after the watcher fires", () => {
+		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: false } }))
+		expect(getCompactionEnabled()).toBe(false)
+
+		// Second call should NOT hit disk (cache hit).
+		mockReadFileSync.mockClear()
+		getCompactionEnabled()
+		expect(mockReadFileSync).not.toHaveBeenCalled()
+
+		// Simulate settings.json change → watcher fires → cache invalidated.
+		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: true } }))
+		const unsub = onThemeChange(vi.fn())
+		getWatchCallback()?.()
+		vi.runAllTimers()
+
+		expect(getCompactionEnabled()).toBe(true)
+		unsub()
 	})
 })
 

--- a/src/settings-watcher.ts
+++ b/src/settings-watcher.ts
@@ -22,7 +22,16 @@ export function getActiveThemeName(): string | undefined {
 	}
 }
 
+let cachedCompactionEnabled: boolean | undefined
+
 export function getCompactionEnabled(): boolean {
+	if (cachedCompactionEnabled !== undefined) return cachedCompactionEnabled
+	cachedCompactionEnabled = readCompactionEnabledFromDisk()
+	ensureWatcher()
+	return cachedCompactionEnabled
+}
+
+function readCompactionEnabledFromDisk(): boolean {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
 	if (!agentDir) return true
 	try {
@@ -31,6 +40,20 @@ export function getCompactionEnabled(): boolean {
 		return enabled !== false
 	} catch {
 		return true
+	}
+}
+
+/** @internal Test-only: reset the compaction cache and close the watcher so tests get a clean state. */
+export function __resetCompactionCacheForTest(): void {
+	cachedCompactionEnabled = undefined
+	if (watcher) {
+		watcher.close()
+		watcher = undefined
+	}
+	listeners.clear()
+	if (debounceTimer) {
+		clearTimeout(debounceTimer)
+		debounceTimer = undefined
 	}
 }
 
@@ -43,6 +66,7 @@ let debounceTimer: NodeJS.Timeout | undefined
 
 function fire(): void {
 	debounceTimer = undefined
+	cachedCompactionEnabled = undefined
 	const current = getActiveThemeName()
 	if (current === lastSeenTheme) return
 	const previous = lastSeenTheme
@@ -83,7 +107,7 @@ export function onThemeChange(listener: ThemeChangeListener): () => void {
 	listeners.add(listener)
 	return () => {
 		listeners.delete(listener)
-		if (listeners.size === 0 && watcher) {
+		if (listeners.size === 0 && cachedCompactionEnabled === undefined && watcher) {
 			watcher.close()
 			watcher = undefined
 		}

--- a/src/settings-watcher.ts
+++ b/src/settings-watcher.ts
@@ -22,6 +22,18 @@ export function getActiveThemeName(): string | undefined {
 	}
 }
 
+export function getCompactionEnabled(): boolean {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) return true
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(resolve(agentDir, "settings.json"), "utf-8"))
+		const enabled = (parsed as { compaction?: { enabled?: unknown } })?.compaction?.enabled
+		return enabled !== false
+	} catch {
+		return true
+	}
+}
+
 type ThemeChangeListener = (newName: string | undefined, oldName: string | undefined) => void
 
 let watcher: FSWatcher | undefined


### PR DESCRIPTION
The ferment extension's own compaction paths (maybeTriggerFermentCompaction at turn_end/agent_end, and maybeTriggerMidTurnFermentCompaction mid-turn) bypassed the upstream autoCompactionEnabled setting — disabling auto-compact in /settings only stopped upstream compaction, not ferment-driven compaction.

Add getCompactionEnabled() to settings-watcher.ts, which reads the same global settings.json the /settings UI writes (key compaction.enabled, via KIMCHI_CODING_AGENT_DIR). Both trigger functions now early-return when the toggle is false, skipping silently. Defaults to true on any read/parse error so a missing/broken file never spuriously disables compaction.

Tests:
- 5 unit tests in settings-watcher.test.ts (enabled, disabled, key-absent, malformed JSON, missing file)
- 2 regression tests in auto-compaction.test.ts (disabled path skips ctx.compact for both trigger functions)
- index.test.ts: added default-true settings-watcher mock to decouple integration tests from the dev machine's global compaction.enabled

## Linked issue

Closes #123456
