### PR TITLE
fix(bash-tool-guard): document cd persistence

### DIFF
--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -4,7 +4,7 @@
  * using a mock ExtensionAPI.
  */
 import { afterEach, describe, expect, it, vi } from "vitest"
-import bashToolGuardExtension, { STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
+import bashToolGuardExtension, { BASH_TOOL_DESCRIPTION, STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
 import { BASH_TOOL_GUARD_EVENTS } from "./bash-tool-guard-events.js"
 
 let mockMode: string | undefined = "default"
@@ -23,9 +23,41 @@ afterEach(() => {
 	mockResourceEnabled = true
 })
 
+// Capture what session_start actually passes to createBashToolDefinition
+// (and the real definition it gets back) so tests can assert the
+// description override preserves upstream's execute/renderCall/
+// renderResult/parameters, and that cwd comes from the session_start ctx
+// rather than being hardcoded.
+let capturedCwd: string | undefined
+let capturedBase: Record<string, unknown> | undefined
+
+vi.mock("@earendil-works/pi-coding-agent", async () => {
+	const actual = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>(
+		"@earendil-works/pi-coding-agent",
+	)
+	return {
+		...actual,
+		createBashToolDefinition: (cwd: string) => {
+			capturedCwd = cwd
+			const real = actual.createBashToolDefinition(cwd)
+			capturedBase = { ...real }
+			return real
+		},
+	}
+})
+
 interface BlockResult {
 	block: true
 	reason: string
+}
+
+interface RegisteredTool {
+	name: string
+	description: string
+	execute: unknown
+	renderCall: unknown
+	renderResult: unknown
+	parameters: unknown
 }
 
 interface MockExtensionAPI {
@@ -35,19 +67,14 @@ interface MockExtensionAPI {
 	events: { emit: ReturnType<typeof vi.fn> }
 	_blockResult?: BlockResult
 	_emittedEvents: Array<{ channel: string; payload: unknown }>
-	/** getAllTools() returns the live bash tool list. The integration tests
-	 *  don't exercise the preference description override, so the default
-	 *  empty array is fine — the session_start hook only needs the call to
-	 *  not throw. Override via `setTools()` for tests that need a specific
-	 *  tool list. */
-	getAllTools: () => Array<{ name: string; description: string }>
-	setTools: (tools: Array<{ name: string; description: string }>) => void
+	registeredTools: Map<string, RegisteredTool>
+	registerTool: (tool: RegisteredTool) => void
 }
 
 function createMockPI(): MockExtensionAPI {
 	const handlers: MockExtensionAPI["handlers"] = {}
 	const _emittedEvents: MockExtensionAPI["_emittedEvents"] = []
-	let tools: Array<{ name: string; description: string }> = []
+	const registeredTools = new Map<string, RegisteredTool>()
 	return {
 		handlers,
 		on(event: string, handler) {
@@ -61,11 +88,9 @@ function createMockPI(): MockExtensionAPI {
 			}),
 		},
 		_emittedEvents,
-		getAllTools() {
-			return tools
-		},
-		setTools(t) {
-			tools = t
+		registeredTools,
+		registerTool(tool) {
+			registeredTools.set(tool.name, tool)
 		},
 	}
 }
@@ -86,13 +111,16 @@ function emit(pi: MockExtensionAPI, event: string, payload: Record<string, unkno
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PI = import("@earendil-works/pi-coding-agent").ExtensionAPI
 
-function fakeCtx(sessionId = "test-session"): { sessionManager: { getSessionId: () => string } } {
-	return { sessionManager: { getSessionId: () => sessionId } }
+function fakeCtx(
+	sessionId = "test-session",
+	cwd = "/repo",
+): { sessionManager: { getSessionId: () => string }; cwd: string } {
+	return { sessionManager: { getSessionId: () => sessionId }, cwd }
 }
 
-function fireSessionStart(pi: MockExtensionAPI): void {
+function fireSessionStart(pi: MockExtensionAPI, ctx: ReturnType<typeof fakeCtx> = fakeCtx()): void {
 	const handlers = pi.handlers.session_start ?? []
-	for (const h of handlers) h({}, fakeCtx())
+	for (const h of handlers) h({}, ctx)
 }
 
 describe("bashToolGuardExtension wiring", () => {
@@ -767,5 +795,50 @@ describe("bashToolGuardExtension — per-category thresholds", () => {
 			input: { command: "sed -i 's/a/b/' a.ts" },
 		})
 		expect(rEdit?.block).toBe(true)
+	})
+})
+
+describe("bashToolGuardExtension - description override", () => {
+	it("registers the bash tool with the overridden description on session_start", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+
+		fireSessionStart(pi)
+
+		expect(pi.registeredTools.size).toBe(1)
+		expect(pi.registeredTools.get("bash")?.description).toBe(BASH_TOOL_DESCRIPTION)
+	})
+
+	it("preserves the upstream execute/renderCall/renderResult/parameters", () => {
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+
+		fireSessionStart(pi)
+
+		const tool = pi.registeredTools.get("bash")
+		expect(capturedBase).toBeDefined()
+		expect(tool?.execute).toBe(capturedBase?.execute)
+		expect(tool?.renderCall).toBe(capturedBase?.renderCall)
+		expect(tool?.renderResult).toBe(capturedBase?.renderResult)
+		expect(tool?.parameters).toBe(capturedBase?.parameters)
+	})
+
+	it("resolves cwd from the session_start ctx and re-registers on every session_start", () => {
+		// Resumed/forked sessions can start in a different directory than
+		// the one the extension factory originally loaded in. Re-running
+		// registerTool() on every session_start (instead of once at
+		// factory-load time) keeps the bash tool's cwd correct.
+		const pi = createMockPI()
+		bashToolGuardExtension(pi as unknown as PI)
+
+		fireSessionStart(pi, fakeCtx("test-session", "/repo-a"))
+		expect(capturedCwd).toBe("/repo-a")
+		const first = pi.registeredTools.get("bash")
+
+		fireSessionStart(pi, fakeCtx("test-session", "/repo-b"))
+		expect(capturedCwd).toBe("/repo-b")
+		const second = pi.registeredTools.get("bash")
+		expect(second).not.toBe(first)
+		expect(second?.description).toBe(BASH_TOOL_DESCRIPTION)
 	})
 })

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -1,5 +1,13 @@
+/**
+ * Pure-function unit tests for bash-tool-guard.ts: command classification,
+ * the BashToolGuard class, and description-override helpers.
+ *
+ * Tests that exercise the wired `bashToolGuardExtension` against a mock
+ * ExtensionAPI (session_start/tool_call handlers) live in
+ * bash-tool-guard.integration.test.ts instead.
+ */
 import { describe, expect, it } from "vitest"
-import bashToolGuardExtension, {
+import {
 	applyDescriptionOverride,
 	BASH_TOOL_DESCRIPTION,
 	type BashCategory,
@@ -745,6 +753,11 @@ describe("BASH_TOOL_DESCRIPTION", () => {
 		// change runtime semantics. Verify the truncation info survives.
 		expect(BASH_TOOL_DESCRIPTION).toMatch(/truncat/i)
 	})
+
+	it("documents that cd does not persist between bash tool calls", () => {
+		expect(BASH_TOOL_DESCRIPTION).toContain("does NOT persist")
+		expect(BASH_TOOL_DESCRIPTION).toContain("cd <dir> && <command>")
+	})
 })
 
 describe("toolDescriptionOverride", () => {
@@ -779,112 +792,5 @@ describe("applyDescriptionOverride", () => {
 		const tool = { name: "read", description: "Read file contents" }
 		const result = applyDescriptionOverride(tool)
 		expect(result.description).toBe("Read file contents")
-	})
-})
-
-describe("bashToolGuardExtension — preference integration", () => {
-	interface MockTool {
-		name: string
-		description: string
-	}
-
-	interface MockPI {
-		handlers: Record<string, Array<(event: unknown) => unknown>>
-		on(event: string, handler: (event: unknown) => unknown): void
-		setTools(tools: MockTool[]): void
-		getAllTools(): MockTool[]
-	}
-
-	function createMockPI(): MockPI {
-		const handlers: MockPI["handlers"] = {}
-		let tools: MockTool[] = []
-		return {
-			handlers,
-			setTools(t) {
-				tools = t
-			},
-			getAllTools() {
-				return tools
-			},
-			on(event, handler) {
-				if (!handlers[event]) handlers[event] = []
-				handlers[event].push(handler)
-			},
-		}
-	}
-
-	function fireSessionStart(pi: MockPI): void {
-		const handlers = pi.handlers.session_start ?? []
-		for (const handler of handlers) handler({})
-	}
-
-	it("mutates the bash tool description on session_start", () => {
-		const pi = createMockPI()
-		// The extension requires more API surface than the mock
-		// provides — cast through `unknown` so the test stays focused
-		// on the session_start hook behavior.
-		bashToolGuardExtension(pi as unknown as Parameters<typeof bashToolGuardExtension>[0])
-
-		const tools = [
-			{ name: "read", description: "Read file contents" },
-			{ name: "bash", description: "Execute bash commands (ls, grep, find, etc.)" },
-			{ name: "edit", description: "Edit a file" },
-		]
-		pi.setTools(tools)
-
-		fireSessionStart(pi)
-
-		expect(tools[1].description).toBe(BASH_TOOL_DESCRIPTION)
-	})
-
-	it("does not mutate non-bash tools", () => {
-		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as Parameters<typeof bashToolGuardExtension>[0])
-
-		const tools = [
-			{ name: "read", description: "Read file contents" },
-			{ name: "edit", description: "Edit a file" },
-			{ name: "grep", description: "Search file contents" },
-		]
-		pi.setTools(tools)
-
-		fireSessionStart(pi)
-
-		// All non-bash tools should be byte-for-byte unchanged.
-		expect(tools[0].description).toBe("Read file contents")
-		expect(tools[1].description).toBe("Edit a file")
-		expect(tools[2].description).toBe("Search file contents")
-	})
-
-	it("is safe when no bash tool is registered", () => {
-		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as Parameters<typeof bashToolGuardExtension>[0])
-
-		pi.setTools([{ name: "read", description: "Read file contents" }])
-
-		expect(() => fireSessionStart(pi)).not.toThrow()
-	})
-
-	it("is safe when the tool list is empty", () => {
-		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as Parameters<typeof bashToolGuardExtension>[0])
-		pi.setTools([])
-		expect(() => fireSessionStart(pi)).not.toThrow()
-	})
-
-	it("mutates the actual tool object so downstream reads see the change", () => {
-		// The kimchi prompt-enrichment handler reads pi.getAllTools() and
-		// passes the same object references to buildSystemPrompt. If the
-		// extension returns a new object, the mutation never reaches the
-		// prompt. Guard against accidental reassignment.
-		const pi = createMockPI()
-		bashToolGuardExtension(pi as unknown as Parameters<typeof bashToolGuardExtension>[0])
-		const bashTool = { name: "bash", description: "old" }
-		pi.setTools([bashTool])
-
-		fireSessionStart(pi)
-
-		expect(pi.getAllTools()[0]).toBe(bashTool)
-		expect(bashTool.description).toBe(BASH_TOOL_DESCRIPTION)
 	})
 })

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -17,6 +17,15 @@
  *      the substitution rules explicit. Goal: the model picks the
  *      dedicated tool the first time, not after being told.
  *
+ *      The description override is delivered via `pi.registerTool()` on
+ *      `session_start`, re-registering the bash tool with an overridden
+ *      `description` but the same `execute`/`renderCall`/`renderResult`.
+ *      This writes into the real tool-definition registry, which every
+ *      later `pi.getAllTools()` call reads from — unlike mutating a
+ *      `pi.getAllTools()` result in place, which returns a fresh,
+ *      disposable array of fresh objects on every call and never reaches
+ *      the prompt builder's own later call.
+ *
  *   2. **Guard (downstream).** Inspects each bash call. If the command
  *      is a file-reading / in-place-edit / file-writing pattern that
  *      has a dedicated tool, emits a steer message pointing at the
@@ -55,6 +64,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext, InputEvent } from "@earendil-works/pi-coding-agent"
+import { createBashToolDefinition } from "@earendil-works/pi-coding-agent"
 import { isResourceEnabled } from "../resources/store.js"
 import {
 	BASH_TOOL_GUARD_EVENTS,
@@ -168,9 +178,10 @@ Use bash only for: build commands, test runners, git, package managers, shell sc
 /**
  * Replacement description for the bash tool. Keeps the original output
  * truncation behaviour from upstream but explicitly excludes the
- * file-operation substitutions and lists what bash IS for. Mutated
- * onto the upstream tool object on `session_start` so the kimchi prompt
- * builder picks up the new description when it renders the tool list.
+ * file-operation substitutions and lists what bash IS for. Delivered via
+ * `pi.registerTool()` on `session_start` (see `bashToolGuardExtension`)
+ * rather than by mutating a `pi.getAllTools()` result — the registry
+ * write is what actually reaches the rendered system prompt.
  */
 export const BASH_TOOL_DESCRIPTION = `
 Execute a bash command for operations without a dedicated tool: build commands, test runners, git, package managers, system administration, shell scripting.
@@ -178,6 +189,8 @@ Execute a bash command for operations without a dedicated tool: build commands, 
 DO NOT use bash for: reading files (use \`read\`), editing files (use \`edit\`), writing files (use \`write\`), searching file contents (use \`grep\`), finding files by pattern (use \`find\`), or listing directories (use \`ls\`) — dedicated tools are faster and unlock LSP context.
 
 Returns stdout and stderr. Output is truncated to last 2000 lines or 50KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.
+
+Each command runs in a fresh shell rooted at the session working directory; \`cd\` does NOT persist between bash tool calls. Use absolute paths, or chain \`cd <dir> && <command>\` within a single call.
 `.trim()
 
 /**
@@ -551,20 +564,20 @@ export default function bashToolGuardExtension(pi: ExtensionAPI, options?: BashG
 		render: () => TOOL_PREFERENCES_BLOCK,
 	})
 
-	pi.on("session_start", (_event, _ctx) => {
-		ctx = _ctx
+	pi.on("session_start", (_event, sessionCtx) => {
+		ctx = sessionCtx
 		guard.reset()
 
-		// Override the bash tool's description in place. The kimchi
-		// prompt-enrichment handler reads pi.getAllTools() and passes
-		// the same object references to buildSystemPrompt, so the
-		// mutation propagates to the rendered prompt. If the tool
-		// objects are cloned elsewhere (e.g. tool discovery UI), the
-		// worst case is they show a more accurate description there too.
-		const bashTool = pi.getAllTools().find((t) => t.name === "bash")
-		if (bashTool) {
-			bashTool.description = BASH_TOOL_DESCRIPTION
-		}
+		// Re-register the bash tool with the overridden description.
+		// `registerTool()` writes into the real tool-definition registry
+		// (upstream's documented way to override a built-in tool), so it
+		// is visible to every later `pi.getAllTools()` call — including
+		// the one the kimchi prompt-enrichment handler makes to build the
+		// system prompt. Re-created on every `session_start` (not once at
+		// factory-load time) so `cwd` tracks the actual resolved session
+		// cwd across resumes/forks, and so a fresh bash tool object is
+		// registered even if a previous session already registered one.
+		pi.registerTool(applyDescriptionOverride(createBashToolDefinition(sessionCtx.cwd)))
 	})
 
 	pi.on("input", (event: InputEvent) => {

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -66,7 +66,7 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		kind: "extensions",
 		label: "Bash-tool guard",
 		description:
-			"Steer the LLM away from using `bash` (cat/sed/echo) for tasks that have a dedicated read/edit/write tool. Catches read/edit/write anti-patterns and suggests the right tool.",
+			"Steer the LLM away from using `bash` (cat/sed/echo) for tasks that have a dedicated read/edit/write tool, and remind it that `cd` does not persist between bash calls. Catches read/edit/write anti-patterns and suggests the right tool.",
 		defaultEnabled: true,
 	},
 	{


### PR DESCRIPTION
The upstream bash tool spawns a fresh shell for every call, so `cd` never persists between tool calls. Models that run `cd subdir` lose track of their working directory and fail on relative paths in subsequent calls.

Added description override (via registerTool on session_start) now includes a paragraph stating cd does NOT persist between bash calls and the model should use absolute paths or `cd <dir> && <command>` chains.

Confirmed in tests the description change is sufficient to almost eliminate the unwanted behavour. Recorded 1 toll call error across 60 trials of my local repro. The baseline is 43 errors in 10 trials.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
