### PR TITLE
fix: backfill quietStartup default for existing settings.json files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import "./paste-to-editor-patch.js"
 import {
 	DEFAULT_SKILL_PATHS,
 	ensureHideThinkingBlockDefault,
+	ensureQuietStartupDefault,
 	getActiveVendorSkillPaths,
 	loadConfig,
 	RETRY_DEFAULTS,
@@ -435,6 +436,7 @@ try {
 		try {
 			const existing = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>
 			let changed = ensureHideThinkingBlockDefault(existing)
+			if (ensureQuietStartupDefault(existing)) changed = true
 			const upgraded = upgradeLegacyRetrySettings(existing.retry)
 			if (upgraded) {
 				existing.retry = upgraded

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -7,6 +7,7 @@ import {
 	checkConfigFilePermissions,
 	clearApiKey,
 	ensureHideThinkingBlockDefault,
+	ensureQuietStartupDefault,
 	getActiveVendorSkillPaths,
 	loadConfig,
 	RETRY_DEFAULTS,
@@ -877,5 +878,23 @@ describe("ensureHideThinkingBlockDefault", () => {
 		const visible = { hideThinkingBlock: false }
 		expect(ensureHideThinkingBlockDefault(visible)).toBe(false)
 		expect(visible.hideThinkingBlock).toBe(false)
+	})
+})
+
+describe("ensureQuietStartupDefault", () => {
+	it("seeds quietStartup when the key is absent", () => {
+		const settings: Record<string, unknown> = { statusLine: { pinned: [] } }
+		expect(ensureQuietStartupDefault(settings)).toBe(true)
+		expect(settings.quietStartup).toBe(true)
+	})
+
+	it("leaves an explicit quietStartup value alone", () => {
+		const quiet = { quietStartup: true }
+		expect(ensureQuietStartupDefault(quiet)).toBe(false)
+		expect(quiet.quietStartup).toBe(true)
+
+		const verbose = { quietStartup: false }
+		expect(ensureQuietStartupDefault(verbose)).toBe(false)
+		expect(verbose.quietStartup).toBe(false)
 	})
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,6 +166,17 @@ export function ensureHideThinkingBlockDefault(settings: Record<string, unknown>
 	return true
 }
 
+/**
+ * Seed quietStartup when absent so settings.json files predating this default
+ * (or otherwise missing the key) don't fall back to pi's verbose startup
+ * listing (the `[Extensions]`/`[Themes]` resource dump).
+ */
+export function ensureQuietStartupDefault(settings: Record<string, unknown>): boolean {
+	if ("quietStartup" in settings) return false
+	settings.quietStartup = true
+	return true
+}
+
 export const THIRD_PARTY_MAX_RETRIES = 4
 
 export const SEARCH_STRATEGY_DEFAULTS: SearchStrategyConfig = {


### PR DESCRIPTION
Existing installs whose settings.json predates the quietStartup default (or otherwise lacks the key) fell back to pi-coding-agent's verbose startup listing, exposing the raw [Extensions]/[Themes] resource dump — including synthetic <inline:N> placeholder names for factory-registered extensions. Backfill quietStartup: true whenever the key is absent, same pattern as ensureHideThinkingBlockDefault, without touching an explicit user override.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
