### PR TITLE
feat: add notification hook

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,6 +54,7 @@ import hideThinkingExtension from "./extensions/hide-thinking.js"
 import ideAdapterExtension from "./extensions/ide-adapter/index.js"
 import infrastructureBreakerExtension from "./extensions/infrastructure-breaker.js"
 import inputHistoryExtension from "./extensions/input-history.js"
+import kimchiHooksAdapter from "./extensions/kimchi-hooks/index.js"
 import kimchiMinimalTintsExtension from "./extensions/kimchi-minimal-tints.js"
 import llmResponseLogExtension from "./extensions/llm-response-log.js"
 import loginExtension from "./extensions/login/index.js"
@@ -620,6 +621,7 @@ try {
 			// SessionStart steering blocks into the system prompt. Gated per-package
 			// by each package's own resource toggle (see pluginPackageHookSources).
 			pluginPackageHooksAdapter,
+			kimchiHooksAdapter,
 			permissionsExtension,
 			resourcesExtension,
 			resourceToolBlockerExtension,

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -701,6 +701,40 @@ describe("hook adapter command execution", () => {
 		expect(mockSpawn).not.toHaveBeenCalled()
 	})
 
+	it("runs Notification hooks from notification bus events", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				Notification: [{ hooks: [{ type: "command", command: "notification-observer" }] }],
+			},
+		})
+		const child = mockBlockingHook()
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.handlers.turn_start[0]({ type: "turn_start", turnIndex: 1 }, fakeCtx())
+		await pi.eventHandlers.notification[0]({ notification_type: "permission_prompt" })
+
+		expect(mockSpawn).toHaveBeenCalledTimes(1)
+		expect(hookPayload(child)).toMatchObject({
+			hook_event_name: "Notification",
+			notification_type: "permission_prompt",
+		})
+	})
+
+	it("skips Notification hooks before any extension context is captured", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				Notification: [{ hooks: [{ type: "command", command: "notification-observer" }] }],
+			},
+		})
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		await pi.eventHandlers.notification[0]({ notification_type: "permission_prompt" })
+
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
 	it("runs observer hooks for TurnStart, MessageEnd, ModelSelect, and UserBash", async () => {
 		writeJson(join(dir, "home", ".claude", "settings.json"), {
 			hooks: {

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -57,7 +57,11 @@ type HookToolResultEventResult = {
 export function createCommandHookAdapter(definition: CommandHookAdapterDefinition): (pi: ExtensionAPI) => void {
 	return (pi) => {
 		let stopHookFollowUpPending = false
-		let batchedToolResults: Array<{ tool_name: string; tool_use_id: string; is_error: boolean }> = []
+		let batchedToolResults: Array<{
+			tool_name: string
+			tool_use_id: string
+			is_error: boolean
+		}> = []
 		const pendingSystemPrompt: { context?: string } = {}
 		// Custom bus events (pi.events.on) carry no ExtensionContext, so keep the
 		// most recent one from core events for the subagent lifecycle hooks.
@@ -89,7 +93,9 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		pi.on("turn_start", async (event, ctx) => {
 			latestCtx = ctx
 			batchedToolResults = []
-			await runObserver(definition, "TurnStart", ctx, { turn_id: String(event.turnIndex) })
+			await runObserver(definition, "TurnStart", ctx, {
+				turn_id: String(event.turnIndex),
+			})
 		})
 		pi.on("tool_execution_end", (event) => {
 			batchedToolResults.push({
@@ -158,7 +164,11 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 		})
 		pi.events.on("notification", async (data) => {
 			if (!latestCtx) return
-			await runObserver(definition, "Notification", latestCtx, data as Record<string, unknown>)
+			try {
+				await runObserver(definition, "Notification", latestCtx, notificationPayload(data))
+			} catch (err) {
+				console.error(`Notification hook failed: ${err instanceof Error ? err.message : String(err)}`)
+			}
 		})
 	}
 }
@@ -357,7 +367,12 @@ async function runPostToolUse(
 	if (result.additionalContext) sendAdditionalContext(definition, pi, result.additionalContext, "steer")
 	if (result.block) {
 		return {
-			content: [{ type: "text", text: result.reason ?? "Hook blocked normal tool result processing." }],
+			content: [
+				{
+					type: "text",
+					text: result.reason ?? "Hook blocked normal tool result processing.",
+				},
+			],
 			isError: true,
 		}
 	}
@@ -656,11 +671,17 @@ function lastAssistantTextFromMessages(messages: AgentEndEvent["messages"]): str
 	return null
 }
 
-function lastAssistantStop(messages: AgentEndEvent["messages"]): { stopReason?: string; errorMessage?: string } {
+function lastAssistantStop(messages: AgentEndEvent["messages"]): {
+	stopReason?: string
+	errorMessage?: string
+} {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i]
 		if (isRecord(message) && message.role === "assistant") {
-			return { stopReason: stringValue(message.stopReason), errorMessage: stringValue(message.errorMessage) }
+			return {
+				stopReason: stringValue(message.stopReason),
+				errorMessage: stringValue(message.errorMessage),
+			}
 		}
 	}
 	return {}
@@ -695,6 +716,15 @@ function messagePayload(message: TurnEndEvent["message"]): Record<string, unknow
 	return {
 		message_role: isRecord(message) ? (stringValue(message.role) ?? null) : null,
 		message_text: lastAssistantText(message),
+	}
+}
+
+function notificationPayload(data: unknown): Record<string, unknown> {
+	const event = asRecord(data) ?? {}
+	return {
+		notification_type: stringValue(event.notification_type) ?? null,
+		tool_name: stringValue(event.tool_name) ?? null,
+		tool_use_id: stringValue(event.tool_use_id) ?? null,
 	}
 }
 

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -156,6 +156,10 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 			if (!latestCtx) return
 			await runObserver(definition, "SubagentStop", latestCtx, subagentStopPayload(data, true))
 		})
+		pi.events.on("notification", async (data) => {
+			if (!latestCtx) return
+			await runObserver(definition, "Notification", latestCtx, data as Record<string, unknown>)
+		})
 	}
 }
 

--- a/src/extensions/hook-adapters/discovery.ts
+++ b/src/extensions/hook-adapters/discovery.ts
@@ -22,6 +22,7 @@ export type CommandHookEventName =
 	| "UserBash"
 	| "SubagentStart"
 	| "SubagentStop"
+	| "Notification"
 	| "SessionEnd"
 
 /** Every hook event the command-hook adapter machinery can drive. */
@@ -44,6 +45,7 @@ export const FULL_COMMAND_HOOK_EVENTS: readonly CommandHookEventName[] = [
 	"UserBash",
 	"SubagentStart",
 	"SubagentStop",
+	"Notification",
 	"SessionEnd",
 ]
 

--- a/src/extensions/kimchi-hooks/definition.test.ts
+++ b/src/extensions/kimchi-hooks/definition.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { KIMCHI_HOOKS_ADAPTER_DEFINITION, discoverKimchiHookResources } from "./definition.js"
+import { discoverKimchiHookResources, KIMCHI_HOOKS_ADAPTER_DEFINITION } from "./definition.js"
 
 let dir: string
 

--- a/src/extensions/kimchi-hooks/definition.test.ts
+++ b/src/extensions/kimchi-hooks/definition.test.ts
@@ -1,0 +1,103 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { KIMCHI_HOOKS_ADAPTER_DEFINITION, discoverKimchiHookResources } from "./definition.js"
+
+let dir: string
+
+describe("Kimchi hooks discovery", () => {
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "kimchi-hooks-def-"))
+	})
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("sources() returns empty when .kimchi/ dir does not exist", () => {
+		const sources = KIMCHI_HOOKS_ADAPTER_DEFINITION.sources(dir)
+
+		expect(sources).toEqual([])
+	})
+
+	it("sources() returns the project path when .kimchi/hooks.json exists", () => {
+		const projectHooks = join(dir, ".kimchi", "hooks.json")
+		writeJson(projectHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "project-stop" }] }],
+			},
+		})
+
+		const sources = KIMCHI_HOOKS_ADAPTER_DEFINITION.sources(dir)
+
+		expect(sources).toEqual([{ scope: "project", path: projectHooks }])
+	})
+
+	it("sources() returns the local path when .kimchi/hooks.local.json exists", () => {
+		const localHooks = join(dir, ".kimchi", "hooks.local.json")
+		writeJson(localHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "local-stop" }] }],
+			},
+		})
+
+		const sources = KIMCHI_HOOKS_ADAPTER_DEFINITION.sources(dir)
+
+		expect(sources).toEqual([{ scope: "local", path: localHooks }])
+	})
+
+	it("sources() returns both when both exist", () => {
+		const projectHooks = join(dir, ".kimchi", "hooks.json")
+		const localHooks = join(dir, ".kimchi", "hooks.local.json")
+		writeJson(projectHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "project-stop" }] }],
+			},
+		})
+		writeJson(localHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "local-stop" }] }],
+			},
+		})
+
+		const sources = KIMCHI_HOOKS_ADAPTER_DEFINITION.sources(dir)
+
+		expect(sources).toEqual([
+			{ scope: "project", path: projectHooks },
+			{ scope: "local", path: localHooks },
+		])
+	})
+
+	it("discoverKimchiHookResources returns empty when .kimchi/ is absent", () => {
+		const resources = discoverKimchiHookResources(dir)
+
+		expect(resources).toEqual([])
+	})
+
+	it("discoverKimchiHookResources discovers hooks from both files", () => {
+		const projectHooks = join(dir, ".kimchi", "hooks.json")
+		const localHooks = join(dir, ".kimchi", "hooks.local.json")
+		writeJson(projectHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "project-stop" }] }],
+			},
+		})
+		writeJson(localHooks, {
+			hooks: {
+				Stop: [{ hooks: [{ type: "command", command: "local-stop" }] }],
+			},
+		})
+
+		const resources = discoverKimchiHookResources(dir)
+		const commands = resources.map((r) => r.command).sort()
+
+		expect(commands).toEqual(["local-stop", "project-stop"])
+		expect(resources.every((r) => r.adapterId === "kimchi-hooks")).toBe(true)
+	})
+})
+
+function writeJson(path: string, data: unknown): void {
+	mkdirSync(join(path, ".."), { recursive: true })
+	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8")
+}

--- a/src/extensions/kimchi-hooks/definition.ts
+++ b/src/extensions/kimchi-hooks/definition.ts
@@ -1,0 +1,33 @@
+import { existsSync } from "node:fs"
+import { join, resolve } from "node:path"
+import {
+	type CommandHookAdapterDefinition,
+	type CommandHookSource,
+	FULL_COMMAND_HOOK_EVENTS,
+	discoverCommandHookResources,
+} from "../hook-adapters/discovery.js"
+
+export const KIMCHI_HOOKS_ADAPTER_DEFINITION: CommandHookAdapterDefinition = {
+	id: "kimchi-hooks",
+	label: "Kimchi hooks",
+	customType: "kimchi-native-hook-context",
+	supportedEvents: FULL_COMMAND_HOOK_EVENTS,
+	sources: kimchiHookSources,
+	defaultTimeoutMs: 60_000,
+	sessionStartDelivery: "systemPrompt",
+}
+
+export function discoverKimchiHookResources(cwd = process.cwd()) {
+	return discoverCommandHookResources(KIMCHI_HOOKS_ADAPTER_DEFINITION, cwd)
+}
+
+function kimchiHookSources(cwd = process.cwd()): CommandHookSource[] {
+	const projectDir = resolve(cwd)
+	if (!existsSync(join(projectDir, ".kimchi"))) return []
+	const sources: CommandHookSource[] = []
+	const projectHooks = join(projectDir, ".kimchi", "hooks.json")
+	const localHooks = join(projectDir, ".kimchi", "hooks.local.json")
+	if (existsSync(projectHooks)) sources.push({ scope: "project", path: projectHooks })
+	if (existsSync(localHooks)) sources.push({ scope: "local", path: localHooks })
+	return sources
+}

--- a/src/extensions/kimchi-hooks/definition.ts
+++ b/src/extensions/kimchi-hooks/definition.ts
@@ -3,8 +3,8 @@ import { join, resolve } from "node:path"
 import {
 	type CommandHookAdapterDefinition,
 	type CommandHookSource,
-	FULL_COMMAND_HOOK_EVENTS,
 	discoverCommandHookResources,
+	FULL_COMMAND_HOOK_EVENTS,
 } from "../hook-adapters/discovery.js"
 
 export const KIMCHI_HOOKS_ADAPTER_DEFINITION: CommandHookAdapterDefinition = {

--- a/src/extensions/kimchi-hooks/index.ts
+++ b/src/extensions/kimchi-hooks/index.ts
@@ -1,0 +1,6 @@
+import { createCommandHookAdapter } from "../hook-adapters/adapter.js"
+import { KIMCHI_HOOKS_ADAPTER_DEFINITION } from "./definition.js"
+
+export const kimchiHooksAdapter = createCommandHookAdapter(KIMCHI_HOOKS_ADAPTER_DEFINITION)
+
+export default kimchiHooksAdapter

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -163,6 +163,7 @@ function createPermissionsHarness(
 			activeTools = names.filter((name) => known.has(name))
 		}),
 		sendMessage: vi.fn(),
+		events: { emit: vi.fn() },
 	} as unknown as ExtensionAPI
 
 	permissionsExtension(pi)
@@ -1007,6 +1008,34 @@ describe("permissions ferment tool classification", () => {
 		expect(readResult).toBeUndefined()
 		expect(bashResult).toBeUndefined()
 		expect(classifyToolCall).not.toHaveBeenCalled()
+	})
+})
+
+describe("permissions notification emission", () => {
+	afterEach(() => {
+		unregisterSessionPermissionFlagController(TEST_SESSION_ID)
+	})
+
+	it("emits permission_prompt notification before showing dialog", async () => {
+		const harness = createPermissionsHarness(["write"])
+		const ctx = createMockContext([undefined]) // user denies
+		await harness.fire("session_start", {}, ctx)
+
+		const event = {
+			toolName: "write",
+			toolCallId: "tc-write-1",
+			input: { path: "foo.txt", content: "bar" },
+		}
+		await harness.fire("tool_call", event, ctx)
+
+		expect((harness.pi as unknown as { events: { emit: ReturnType<typeof vi.fn> } }).events.emit).toHaveBeenCalledWith(
+			"notification",
+			{
+				notification_type: "permission_prompt",
+				tool_name: "write",
+				tool_use_id: "tc-write-1",
+			},
+		)
 	})
 })
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -854,6 +854,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				}
 				const result = await handleConfirm(event, {
 					ctx,
+					pi,
 					subtitle: `Classifier: ${verdict.reason}`,
 					session,
 					activeAborts: activeAbortControllers,
@@ -871,6 +872,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					if (subcommands && subcommands.length > 0) {
 						const result = await handleCompoundConfirm(event, {
 							ctx,
+							pi,
 							session,
 							activeAborts: activeAbortControllers,
 							subcommands,
@@ -883,6 +885,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			}
 			const result = await handleConfirm(event, {
 				ctx,
+				pi,
 				session,
 				activeAborts: activeAbortControllers,
 				allRules,
@@ -921,6 +924,7 @@ interface ConfirmOptions {
 	subtitle?: string
 	activeAborts: Set<AbortController>
 	allRules?: () => Rule[]
+	pi?: ExtensionAPI
 }
 
 async function handleConfirm(
@@ -933,6 +937,14 @@ async function handleConfirm(
 	try {
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
+
+		if (opts.pi?.events) {
+			opts.pi.events.emit("notification", {
+				notification_type: "permission_prompt",
+				tool_name: event.toolName,
+				tool_use_id: event.toolCallId,
+			})
+		}
 
 		const input = event.input
 		const outcome = await prompter.request({
@@ -961,6 +973,14 @@ export async function handleCompoundConfirm(
 	try {
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
+
+		if (opts.pi?.events) {
+			opts.pi.events.emit("notification", {
+				notification_type: "permission_prompt",
+				tool_name: event.toolName,
+				tool_use_id: event.toolCallId,
+			})
+		}
 
 		if (opts.ctx.mode !== "tui") {
 			// Non-TUI transports (chiefly ACP) present compound commands as one

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -938,7 +938,7 @@ async function handleConfirm(
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
 
-		if (opts.pi?.events) {
+		if (opts.pi?.events?.emit) {
 			opts.pi.events.emit("notification", {
 				notification_type: "permission_prompt",
 				tool_name: event.toolName,
@@ -974,7 +974,7 @@ export async function handleCompoundConfirm(
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
 
-		if (opts.pi?.events) {
+		if (opts.pi?.events?.emit) {
 			opts.pi.events.emit("notification", {
 				notification_type: "permission_prompt",
 				tool_name: event.toolName,

--- a/src/extensions/questionnaire/questionnaire.test.ts
+++ b/src/extensions/questionnaire/questionnaire.test.ts
@@ -256,6 +256,7 @@ describe("questionnaire environment behavior", () => {
 		on: ReturnType<typeof vi.fn>
 		getActiveTools: ReturnType<typeof vi.fn>
 		setActiveTools: ReturnType<typeof vi.fn>
+		events: { emit: ReturnType<typeof vi.fn> }
 		// Captures the registered session_start handler so tests can fire it.
 		_sessionStart: ((event: unknown, ctx: { hasUI: boolean }) => void) | null
 	}
@@ -266,6 +267,7 @@ describe("questionnaire environment behavior", () => {
 			on: vi.fn(),
 			getActiveTools: vi.fn(() => activeTools),
 			setActiveTools: vi.fn(),
+			events: { emit: vi.fn() },
 			_sessionStart: null,
 		}
 		pi.on.mockImplementation((event: string, handler: (e: unknown, ctx: { hasUI: boolean }) => void) => {
@@ -343,6 +345,53 @@ describe("questionnaire environment behavior", () => {
 		const text = result.content[0]?.text ?? ""
 		expect(text).toContain("questionnaire is unavailable")
 		expect(text).toContain("Do NOT call questionnaire again")
+	})
+
+	// ─── Notification on prompt ─────────────────────────────────────────────────
+
+	it("emits an agent_needs_input notification before prompting the user", async () => {
+		const pi = makePi(["questionnaire"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+		const tool = pi.registerTool.mock.calls[0]?.[0] as {
+			execute: (
+				toolCallId: string,
+				params: unknown,
+				signal: AbortSignal | undefined,
+				onUpdate: unknown,
+				ctx: unknown,
+			) => Promise<{ content: { text: string }[]; details: { cancelled: boolean } }>
+		}
+
+		await tool.execute("call-1", { questions: [{ id: "ship", prompt: "Ship it?" }] }, undefined, undefined, {
+			hasUI: true,
+			ui: { custom: vi.fn(async () => ({ questions: [], answers: [], cancelled: false })) },
+			mode: "tui",
+		})
+
+		expect(pi.events.emit).toHaveBeenCalledWith("notification", {
+			notification_type: "agent_needs_input",
+		})
+	})
+
+	it("does not emit a notification when no UI is attached (early return)", async () => {
+		const pi = makePi(["questionnaire"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+		const tool = pi.registerTool.mock.calls[0]?.[0] as {
+			execute: (
+				toolCallId: string,
+				params: unknown,
+				signal: AbortSignal | undefined,
+				onUpdate: unknown,
+				ctx: unknown,
+			) => Promise<{ content: { text: string }[]; details: { cancelled: boolean } }>
+		}
+
+		await tool.execute("call-1", { questions: [{ id: "ship", prompt: "Ship it?" }] }, undefined, undefined, {
+			hasUI: false,
+			ui: { custom: vi.fn() },
+		})
+
+		expect(pi.events.emit).not.toHaveBeenCalled()
 	})
 
 	// ─── Execute-path routing (ctx.mode) ───────────────────────────────────────

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -215,7 +215,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 				)
 			}
 
-			if (pi.events) {
+			if (pi.events?.emit) {
 				pi.events.emit("notification", { notification_type: "agent_needs_input" })
 			}
 

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -215,6 +215,10 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 				)
 			}
 
+			if (pi.events) {
+				pi.events.emit("notification", { notification_type: "agent_needs_input" })
+			}
+
 			let result: QuestionnaireResult
 			if (ctx.mode !== "tui") {
 				result = await promptQuestionnaireFallback(ctx.ui, questions)


### PR DESCRIPTION
## Linked issue

Closes #420

## What does this PR do?

Adds a `Notification` hook event to the command-hook adapter system, enabling external tools (e.g. peon-ping, context-mode) to react to lifecycle notifications via JSON-configured hooks.

**Changes:**

- **`src/extensions/hook-adapters/adapter.ts`** — subscribe to pi's `notification` event bus and dispatch to `Notification` observer hooks (skipped before first `turn_start` captures context).
- **`src/extensions/hook-adapters/discovery.ts`** — add `Notification` to `CommandHookEventName` and `FULL_COMMAND_HOOK_EVENTS`.
- **`src/extensions/kimchi-hooks/`** — new adapter definition (`definition.ts`, `index.ts`) that discovers `.kimchi/hooks.json` and `.kimchi/hooks.local.json`, wired into `src/cli.ts` extension factories.
- **`src/extensions/permissions/index.ts`** — emit `permission_prompt` notification before showing permission dialog (both `handleConfirm` and `handleCompoundConfirm`).
- **`src/extensions/questionnaire/questionnaire.ts`** — emit `agent_needs_input` notification before prompting user.
- **`src/extensions/prompt-summary.ts`** — guard `ctx.isIdle()` against stale-context errors to prevent uncaught throws during shutdown.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above (#420)
- [x] Tests pass locally (`pnpm run test` — all 151 tests in changed files pass)
- [x] Lint passes (`pnpm run check` — clean)
- [ ] Documentation updated if behavior changed
