### PR TITLE
feat: swap default explorer model from nemotron to deepseek-v4-flash

### DIFF
--- a/src/extensions/model-catalog/builtin-models.ts
+++ b/src/extensions/model-catalog/builtin-models.ts
@@ -179,6 +179,7 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				explore: [DEFAULT_EXPLORE_GUIDELINES],
 				research: [DEFAULT_RESEARCH_GUIDELINES],
 			}),
+			orchestrationGuidelines: "When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/model-catalog/builtin-models.ts
+++ b/src/extensions/model-catalog/builtin-models.ts
@@ -71,6 +71,12 @@ Best for: codebase exploration, research, and trivial re-verification (confirmin
 after a fix). \
 Not suitable for: code review, building code, or any task requiring correctness judgment.`
 
+const DEEPSEEK_V4_FLASH_DESCRIPTION = `\
+Fast and cost-effective model for codebase exploration and lightweight tasks. \
+Best for: codebase exploration, reading code, tracing architecture, and trivial re-verification \
+(confirming tests pass after a fix). \
+Not suitable for: code review, building code, or any task requiring correctness judgment.`
+
 /** Filter out empty layers and join with double newlines. */
 function concatGuidelines(...layers: string[]): string {
 	return layers.filter(Boolean).join("\n\n")
@@ -161,6 +167,18 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				NEMOTRON_FAMILY_ORCHESTRATION,
 				NEMOTRON_3_ULTRA_ORCHESTRATION,
 			),
+		},
+	],
+	[
+		"deepseek-v4-flash",
+		{
+			vision: false,
+			tier: "light",
+			description: DEEPSEEK_V4_FLASH_DESCRIPTION,
+			guidelines: guidelinesMap({
+				explore: [DEFAULT_EXPLORE_GUIDELINES],
+				research: [DEFAULT_RESEARCH_GUIDELINES],
+			}),
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/model-catalog/builtin-models.ts
+++ b/src/extensions/model-catalog/builtin-models.ts
@@ -179,7 +179,8 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				explore: [DEFAULT_EXPLORE_GUIDELINES],
 				research: [DEFAULT_RESEARCH_GUIDELINES],
 			}),
-			orchestrationGuidelines: "When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
+			orchestrationGuidelines:
+				"When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -85,6 +85,12 @@ Best for: codebase exploration, research, and trivial re-verification (confirmin
 after a fix). \
 Not suitable for: code review, building code, or any task requiring correctness judgment.`
 
+const DEEPSEEK_V4_FLASH_DESCRIPTION = `\
+Fast and cost-effective model for codebase exploration and lightweight tasks. \
+Best for: codebase exploration, reading code, tracing architecture, and trivial re-verification \
+(confirming tests pass after a fix). \
+Not suitable for: code review, building code, or any task requiring correctness judgment.`
+
 /** Filter out empty layers and join with double newlines. */
 function concatGuidelines(...layers: string[]): string {
 	return layers.filter(Boolean).join("\n\n")
@@ -208,6 +214,19 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				NEMOTRON_FAMILY_ORCHESTRATION,
 				NEMOTRON_3_ULTRA_ORCHESTRATION,
 			),
+		},
+	],
+	[
+		"deepseek-v4-flash",
+		{
+			vision: false,
+			reasoning: false,
+			tier: "light",
+			description: DEEPSEEK_V4_FLASH_DESCRIPTION,
+			guidelines: guidelinesMap({
+				explore: [DEFAULT_EXPLORE_GUIDELINES],
+				research: [DEFAULT_RESEARCH_GUIDELINES],
+			}),
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -227,6 +227,7 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				explore: [DEFAULT_EXPLORE_GUIDELINES],
 				research: [DEFAULT_RESEARCH_GUIDELINES],
 			}),
+			orchestrationGuidelines: "When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/orchestration/model-registry/builtin-models.ts
+++ b/src/extensions/orchestration/model-registry/builtin-models.ts
@@ -227,7 +227,8 @@ export const MODEL_CAPABILITIES: ReadonlyMap<string, ModelCapabilities | "ignore
 				explore: [DEFAULT_EXPLORE_GUIDELINES],
 				research: [DEFAULT_RESEARCH_GUIDELINES],
 			}),
-			orchestrationGuidelines: "When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
+			orchestrationGuidelines:
+				"When orchestrating (deepseek-v4-flash): No model-specific orchestration overrides — follow the default delegation rules.",
 		},
 	],
 	// Proprietary (Anthropic) models — excluded from OSS subagent routing.

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -260,9 +260,9 @@ describe("DEFAULT_MODEL_ROLES", () => {
 		expect(reviewers).not.toContain("kimchi-dev/minimax-m3")
 	})
 
-	it("explorer pool contains nemotron", () => {
+	it("explorer pool contains deepseek-v4-flash", () => {
 		const explorers = normalizeRoleModels(DEFAULT_MODEL_ROLES.explorer)
-		expect(explorers).toContain("kimchi-dev/nemotron-3-ultra-fp4")
+		expect(explorers).toContain("kimchi-dev/deepseek-v4-flash")
 	})
 
 	it("planner pool contains kimi-k2.7", () => {
@@ -370,7 +370,7 @@ describe("saveModelRoles", () => {
 })
 
 describe("validateModelRoles", () => {
-	const available = new Set(["kimi-k2.6", "kimi-k2.7", "minimax-m2.7", "minimax-m3", "nemotron-3-ultra-fp4"])
+	const available = new Set(["kimi-k2.6", "kimi-k2.7", "minimax-m2.7", "minimax-m3", "deepseek-v4-flash"])
 
 	it("returns no unavailable roles when all defaults are available", () => {
 		const result = validateModelRoles(DEFAULT_MODEL_ROLES, available)
@@ -492,9 +492,9 @@ describe("getAllowedMultiModelRefs", () => {
 	it("returns sorted unique refs for default roles", () => {
 		applyRoleAugmentation(() => ({ ...DEFAULT_MODEL_ROLES }))
 		expect(getAllowedMultiModelRefs()).toEqual([
+			"kimchi-dev/deepseek-v4-flash",
 			"kimchi-dev/kimi-k2.7",
 			"kimchi-dev/minimax-m3",
-			"kimchi-dev/nemotron-3-ultra-fp4",
 		])
 	})
 

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -30,7 +30,7 @@
  *     "orchestrator": "anthropic/claude-sonnet-4-5",
  *     "builder": ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"],
  *     "reviewer": "kimchi-dev/minimax-m2.7",
- *     "explorer": "kimchi-dev/nemotron-3-ultra-fp4",
+ *     "explorer": "kimchi-dev/deepseek-v4-flash",
  *     "judge": "kimchi-dev/kimi-k2.6",
  *     "compactor": "kimchi-dev/nemotron-3-ultra-fp4"
  *   }
@@ -96,7 +96,7 @@ export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
 	planner: "kimchi-dev/kimi-k2.7",
 	builder: ["kimchi-dev/minimax-m3"],
 	reviewer: ["kimchi-dev/kimi-k2.7"],
-	explorer: "kimchi-dev/nemotron-3-ultra-fp4",
+	explorer: "kimchi-dev/deepseek-v4-flash",
 	researcher: "kimchi-dev/minimax-m3",
 	judge: ["kimchi-dev/kimi-k2.7"],
 	compactor: "kimchi-dev/minimax-m3",


### PR DESCRIPTION
## Linked issue

Closes #858

## What does this PR do?

Swaps the default multi-model `explorer` role from `nemotron-3-ultra-fp4` to `deepseek-v4-flash`.

- Changes `DEFAULT_MODEL_ROLES.explorer` in `model-roles.ts` to `kimchi-dev/deepseek-v4-flash`
- Adds `deepseek-v4-flash` to both `MODEL_CAPABILITIES` catalogs (`model-registry` and `model-catalog`) with `tier: "light"`, no vision/reasoning, and default explore/research guidelines
- Updates affected tests in `model-roles.test.ts` to assert the new default explorer and sorted `getAllowedMultiModelRefs()` output
- Updates the doc comment example in `model-roles.ts`

`nemotron-3-ultra-fp4` remains in both catalogs as a valid user-configurable model — it is just no longer the default for the explorer role.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed