### PR TITLE
fix(update): post-merge follow-up — applyUpdate timeout, argv scan, auto-update hint

### DIFF
--- a/src/extensions/auto-update-settings.test.ts
+++ b/src/extensions/auto-update-settings.test.ts
@@ -254,6 +254,7 @@ describe("default export — extension factory", () => {
 			registerCommand: (name: string, options: { description: string; handler: (...args: unknown[]) => unknown }) => {
 				commands.push({ name, options })
 			},
+			on: () => {},
 		}
 		// biome-ignore lint/suspicious/noExplicitAny: fake pi satisfies the structural surface used by this extension
 		defaultExport(fakePi as any)

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -94,6 +94,11 @@ async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
 		if (choice === UPDATE_NOW_LABEL) {
 			const result = await runManualUpdate()
 			ctx.ui.notify(result.message, result.ok ? "info" : "error")
+			// If the update succeeded and auto-update is still off, suggest
+			// enabling it so the user doesn't have to update manually next time.
+			if (result.ok && !loadAutoUpdateSetting()) {
+				ctx.ui.notify("Tip: enable auto-update from /update so kimchi stays up to date automatically.", "info")
+			}
 			return
 		}
 

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -12,12 +12,12 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
-import { createAutoUpdateTipProvider } from "./auto-update/tips.js"
-import { registerTipProvider } from "./tips/registry.js"
 import { isHomebrewInstall } from "../update/paths.js"
 import { loadAutoUpdateSetting, saveAutoUpdateSetting } from "../update/settings.js"
 import { applyUpdate, checkForUpdate, parseCanarySha7 } from "../update/workflow.js"
 import { getVersion } from "../utils.js"
+import { createAutoUpdateTipProvider } from "./auto-update/tips.js"
+import { registerTipProvider } from "./tips/registry.js"
 
 const LOG_PREFIX = "[kimchi-auto-update]"
 

--- a/src/extensions/auto-update-settings.ts
+++ b/src/extensions/auto-update-settings.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import { createAutoUpdateTipProvider } from "./auto-update/tips.js"
+import { registerTipProvider } from "./tips/registry.js"
 import { isHomebrewInstall } from "../update/paths.js"
 import { loadAutoUpdateSetting, saveAutoUpdateSetting } from "../update/settings.js"
 import { applyUpdate, checkForUpdate, parseCanarySha7 } from "../update/workflow.js"
@@ -121,6 +123,12 @@ async function showUpdateMenu(ctx: ExtensionCommandContext): Promise<void> {
 }
 
 export default function autoUpdateSettingsExtension(pi: ExtensionAPI) {
+	const unregisterTips = registerTipProvider(createAutoUpdateTipProvider())
+
+	pi.on("session_shutdown", () => {
+		unregisterTips()
+	})
+
 	pi.registerCommand("update", {
 		description: "Manage kimchi auto-update",
 		handler: async (_args, ctx) => {

--- a/src/extensions/auto-update/tips.test.ts
+++ b/src/extensions/auto-update/tips.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest"
+
+const mockLoadAutoUpdateSetting = vi.fn(() => false)
+const mockIsHomebrewInstall = vi.fn(() => false)
+
+vi.mock("../../update/settings.js", () => ({ loadAutoUpdateSetting: mockLoadAutoUpdateSetting }))
+vi.mock("../../update/paths.js", () => ({ isHomebrewInstall: mockIsHomebrewInstall }))
+
+const { createAutoUpdateTipProvider } = await import("./tips.js")
+
+describe("auto-update tip provider", () => {
+	it("returns the enable-auto-update tip when auto-update is disabled", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		mockIsHomebrewInstall.mockReturnValue(false)
+		delete process.env.KIMCHI_NO_UPDATE_CHECK
+
+		const tips = createAutoUpdateTipProvider().getTips()
+		expect(tips).toHaveLength(1)
+		expect(tips[0].id).toBe("enable-auto-update")
+		expect(tips[0].scope).toBe("general")
+		expect(tips[0].message).toContain("/update")
+	})
+
+	it("returns no tip when auto-update is enabled", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(true)
+
+		const tips = createAutoUpdateTipProvider().getTips()
+		expect(tips).toHaveLength(0)
+	})
+
+	it("returns no tip when KIMCHI_NO_UPDATE_CHECK is set", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		process.env.KIMCHI_NO_UPDATE_CHECK = "1"
+		try {
+			const tips = createAutoUpdateTipProvider().getTips()
+			expect(tips).toHaveLength(0)
+		} finally {
+			delete process.env.KIMCHI_NO_UPDATE_CHECK
+		}
+	})
+
+	it("returns no tip when installed via Homebrew", () => {
+		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		mockIsHomebrewInstall.mockReturnValue(true)
+
+		const tips = createAutoUpdateTipProvider().getTips()
+		expect(tips).toHaveLength(0)
+	})
+})

--- a/src/extensions/auto-update/tips.ts
+++ b/src/extensions/auto-update/tips.ts
@@ -1,6 +1,6 @@
-import type { Tip, TipProvider } from "../tips/types.js"
 import { isHomebrewInstall } from "../../update/paths.js"
 import { loadAutoUpdateSetting } from "../../update/settings.js"
+import type { Tip, TipProvider } from "../tips/types.js"
 
 const AUTO_UPDATE_TIP: Tip = {
 	id: "enable-auto-update",

--- a/src/extensions/auto-update/tips.ts
+++ b/src/extensions/auto-update/tips.ts
@@ -1,0 +1,26 @@
+import type { Tip, TipProvider } from "../tips/types.js"
+import { isHomebrewInstall } from "../../update/paths.js"
+import { loadAutoUpdateSetting } from "../../update/settings.js"
+
+const AUTO_UPDATE_TIP: Tip = {
+	id: "enable-auto-update",
+	scope: "general",
+	message: "Run `/update` to enable auto-update so kimchi stays up to date automatically.",
+}
+
+/**
+ * Tip provider that surfaces an "enable auto-update" tip in the TUI tips
+ * rotation whenever auto-update is disabled (and the install is eligible —
+ * not Homebrew, not disabled by env var).
+ */
+export function createAutoUpdateTipProvider(): TipProvider {
+	return {
+		source: "kimchi.auto-update",
+		getTips: () => {
+			if (process.env.KIMCHI_NO_UPDATE_CHECK) return []
+			if (isHomebrewInstall()) return []
+			if (loadAutoUpdateSetting()) return []
+			return [AUTO_UPDATE_TIP]
+		},
+	}
+}

--- a/src/extensions/auto-update/tips.ts
+++ b/src/extensions/auto-update/tips.ts
@@ -2,7 +2,7 @@ import { isHomebrewInstall } from "../../update/paths.js"
 import { loadAutoUpdateSetting } from "../../update/settings.js"
 import type { Tip, TipProvider } from "../tips/types.js"
 
-const AUTO_UPDATE_TIP: Tip = {
+export const AUTO_UPDATE_TIP: Tip = {
 	id: "enable-auto-update",
 	scope: "general",
 	message: "Run `/update` to enable auto-update so kimchi stays up to date automatically.",

--- a/src/extensions/tips/index.ts
+++ b/src/extensions/tips/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext, ExtensionFactory, WidgetPlacement } from "@earendil-works/pi-coding-agent"
 import { readHideTips, writeHideTips } from "../../config.js"
+import { AUTO_UPDATE_TIP } from "../auto-update/tips.js"
 import { subscribeBillingStatus } from "../billing/status.js"
 import { createBillingTipProvider } from "../billing/tips.js"
 import { FERMENT_TIPS } from "../ferment/tips.js"
@@ -250,6 +251,12 @@ function collectAllTips(registry: TipRegistry): TipCandidate[] {
 		seen.add(tip.id)
 		all.push({ ...tip, source: "kimchi.ferment" })
 	}
+
+	// Static auto-update tip — always shown in the catalog regardless of
+	// whether auto-update is currently enabled. The dynamic provider
+	// (createAutoUpdateTipProvider) gates visibility in the tips widget.
+	seen.add(AUTO_UPDATE_TIP.id)
+	all.push({ ...AUTO_UPDATE_TIP, source: "kimchi.auto-update" })
 
 	// Any additional tips from third-party providers not already included
 	for (const candidate of registry.getEligibleTips()) {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -253,6 +253,14 @@ describe("argvHasSkipTrigger — pure function over an argv array", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag=update"])).toBe(false)
 	})
 
+	it("recognizes a subcommand after a flag (e.g. kimchi --some-flag update)", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag", "update"])).toBe(true)
+	})
+
+	it("does NOT treat a flag value as a subcommand (e.g. --tag=update)", () => {
+		expect(argvHasSkipTrigger(["node", "kimchi", "--tag=update"])).toBe(false)
+	})
+
 	it("returns false for a plain TUI launch with no skip trigger", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi"])).toBe(false)
 	})

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -454,6 +454,38 @@ describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
 		expect(execveSpy).toHaveBeenCalledOnce()
 	})
 
+	it("skips re-exec when applyUpdate times out", async () => {
+		vi.useFakeTimers()
+		const originalWrite = process.stderr.write.bind(process.stderr)
+		const writeSpy = vi.fn((_chunk: string | Uint8Array, _enc?: unknown, _cb?: unknown) => true)
+		;(process.stderr.write as unknown) = writeSpy
+		try {
+			mockCheckForUpdate.mockResolvedValue({
+				currentVersion: "1.0.0",
+				latestVersion: "1.1.0",
+				tag: "v1.1.0",
+				releaseUrl: "https://example/v1.1.0",
+				hasUpdate: true,
+				cached: false,
+			})
+			// Never resolves — simulates a hung download
+			mockApplyUpdate.mockReturnValue(new Promise(() => {}))
+
+			const pending = maybeAutoUpdateOnLaunch()
+			// Advance past both the 5s check timeout and the 30s apply timeout
+			await vi.advanceTimersByTimeAsync(31_000)
+			await expect(pending).resolves.toBeUndefined()
+
+			expect(mockApplyUpdate).toHaveBeenCalledOnce()
+			expect(execveSpy).not.toHaveBeenCalled()
+			const lines = writeSpy.mock.calls.map((c) => String(c[0])).join("")
+			expect(lines).toContain("timed out")
+		} finally {
+			vi.useRealTimers()
+			;(process.stderr.write as unknown) = originalWrite
+		}
+	})
+
 	it("logs an audit line with tag + releaseUrl before applying", async () => {
 		const stderr = makeStderrSpy()
 		try {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -249,16 +249,18 @@ describe("argvHasSkipTrigger — pure function over an argv array", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "UPDATE"])).toBe(true)
 	})
 
-	it("does NOT treat arbitrary --flag=value as a positional subcommand", () => {
+	it("does NOT treat --flag=value as a subcommand", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag=update"])).toBe(false)
-	})
-
-	it("recognizes a subcommand after a flag (e.g. kimchi --some-flag update)", () => {
-		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag", "update"])).toBe(true)
 	})
 
 	it("does NOT treat a flag value as a subcommand (e.g. --tag=update)", () => {
 		expect(argvHasSkipTrigger(["node", "kimchi", "--tag=update"])).toBe(false)
+	})
+
+	it("does NOT treat a positional after a flag as a subcommand (e.g. kimchi --some-flag update)", () => {
+		// Only argv[2] is checked — scanning later positionals would cause
+		// false positives like `kimchi --tag update`.
+		expect(argvHasSkipTrigger(["node", "kimchi", "--some-flag", "update"])).toBe(false)
 	})
 
 	it("returns false for a plain TUI launch with no skip trigger", () => {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -64,7 +64,6 @@ function resetMocks(): void {
 
 beforeEach(() => {
 	resetMocks()
-	// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
 	delete process.env.KIMCHI_NO_UPDATE_CHECK
 	// Default platform: linux (CI). Individual tests can override.
 	Object.defineProperty(process, "platform", { value: "linux", configurable: true })
@@ -98,7 +97,6 @@ beforeEach(() => {
 
 afterEach(() => {
 	if (originalEnvNoCheck === undefined) {
-		// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
 		delete process.env.KIMCHI_NO_UPDATE_CHECK
 	} else process.env.KIMCHI_NO_UPDATE_CHECK = originalEnvNoCheck
 	Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -25,9 +25,6 @@ const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 // Pure flags that suppress auto-update. Checked anywhere in argv.
 const SKIP_FLAGS = new Set(["--no-auto-update", "--version", "-v", "--help", "-h"])
 
-// Re-exports for test files that import from this module.
-export { type CliMode, getCliModeArg, hasExportFlag, hasPrintFlag, PROTOCOL_MODES } from "../cli-modes.js"
-
 /** Return true when argv selects a non-interactive mode (ACP/JSON/RPC/print/
  *  export). In those modes stdout/stderr belong to the caller and a re-exec
  *  mid-startup would corrupt the protocol stream or break scripts.

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -16,10 +16,11 @@ import { applyUpdate, checkForUpdate, parseCanarySha7 } from "./workflow.js"
 const LOG_PREFIX = "[kimchi-auto-update]"
 
 // Subcommands that suppress auto-update so we never recurse into
-// `kimchi update --force` etc. Compared case-insensitively against any
-// positional argument (not just argv[2]) so `kimchi --some-flag update`
-// is also recognized. Only bare positional tokens are checked —
-// `--flag=update` is a flag value, not a subcommand.
+// `kimchi update --force` etc. Compared case-insensitively against
+// argv[2] only — the first positional argument. We deliberately do NOT
+// scan later positionals: `kimchi --tag update` would be a false positive
+// if we treated any bare token as a subcommand, and pi's parseArgs doesn't
+// expose a resolved subcommand field we could use instead.
 const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 
 // Pure flags that suppress auto-update. Checked anywhere in argv.
@@ -53,6 +54,14 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 		timer = setTimeout(() => reject(new TimeoutError()), ms)
 		;(timer as { unref?: () => void }).unref?.()
 	})
+	// Suppress unhandled rejection from the original promise if the
+	// timeout wins the race. The promise is abandoned but may still
+	// reject later (network error, checksum failure, etc.) — without
+	// this handler Node/Bun would emit an unhandledRejection that can
+	// crash the process. If the promise rejects *before* the timeout,
+	// Promise.race propagates the rejection normally and this handler
+	// is a no-op.
+	promise.catch(() => {})
 	return Promise.race([promise, timeout]).finally(() => {
 		if (timer) clearTimeout(timer)
 	})
@@ -166,13 +175,12 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
 	for (const arg of argv) {
 		if (SKIP_FLAGS.has(arg)) return true
 	}
-	// Subcommand anywhere in argv (case-insensitive). Only bare positional
-	// tokens are checked — arguments starting with `--` are flag values, not
-	// subcommands.
-	for (let i = 2; i < argv.length; i += 1) {
-		const arg = argv[i]
-		if (!arg.startsWith("-") && SKIP_SUBCOMMANDS.has(arg.toLowerCase())) return true
-	}
+	// Subcommand at argv[2] only (case-insensitive). We intentionally
+	// don't scan later positionals — a flag value like `kimchi --tag update`
+	// would be a false positive, and parseArgs doesn't expose a resolved
+	// subcommand we could use instead.
+	const first = argv[2]
+	if (first !== undefined && SKIP_SUBCOMMANDS.has(first.toLowerCase())) return true
 	return false
 }
 

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -183,6 +183,12 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
  *  `applyUpdate` is still mutating files on disk. */
 const AUTO_UPDATE_DEFAULT_TIMEOUT_MS = 5_000
 
+/** Hard cap on the apply phase. We never abandon applyUpdate mid-swap, but
+ *  a hung network or filesystem during download/copy shouldn't stall TUI
+ *  startup indefinitely. If applyUpdate hasn't finished after 30 seconds
+ *  we log a warning and continue on the current version. */
+const AUTO_UPDATE_APPLY_TIMEOUT_MS = 30_000
+
 export interface MaybeAutoUpdateOnLaunchOptions {
 	/** Optional external signal (e.g. from entry.ts). Checked at
 	 *  checkpoints before applyUpdate starts; ignored once the install
@@ -263,12 +269,18 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 		if (!check.hasUpdate) return
 
 		// Commit point: from here on we await applyUpdate fully. No external
-		// Promise.race can abandon it — the install must complete before
-		// cli.js boots.
+		// Promise.race can abandon it mid-swap — the install must complete
+		// before cli.js boots. We do cap with a 30s hard timeout so a hung
+		// network or filesystem doesn't stall startup indefinitely; on
+		// timeout we log a warning and continue on the current version.
 		warn(`applying update ${check.tag} from ${check.releaseUrl || "<no url>"}`)
 		try {
-			await applyUpdate({ tag: check.tag })
+			await raceWithTimeout(applyUpdate({ tag: check.tag }), AUTO_UPDATE_APPLY_TIMEOUT_MS)
 		} catch (err) {
+			if (err instanceof TimeoutError) {
+				warn(`update apply timed out after ${AUTO_UPDATE_APPLY_TIMEOUT_MS / 1000}s; skipping this launch`)
+				return
+			}
 			warn(`update apply failed: ${(err as Error).message}`)
 			return
 		}

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -16,11 +16,10 @@ import { applyUpdate, checkForUpdate, parseCanarySha7 } from "./workflow.js"
 const LOG_PREFIX = "[kimchi-auto-update]"
 
 // Subcommands that suppress auto-update so we never recurse into
-// `kimchi update --force` etc. Compared case-insensitively only at the
-// positional argv[2] slot. Scanning arbitrary `--flag=value` arguments
-// would suppress auto-update for unrelated user flags that happen to
-// contain these strings (e.g. `--tag=update`); no real CLI flag takes a
-// skip-subcommand value today.
+// `kimchi update --force` etc. Compared case-insensitively against any
+// positional argument (not just argv[2]) so `kimchi --some-flag update`
+// is also recognized. Only bare positional tokens are checked —
+// `--flag=update` is a flag value, not a subcommand.
 const SKIP_SUBCOMMANDS = new Set(["update", "setup", "mcp", "login", "install"])
 
 // Pure flags that suppress auto-update. Checked anywhere in argv.
@@ -170,9 +169,13 @@ export function argvHasSkipTrigger(argv: readonly string[]): boolean {
 	for (const arg of argv) {
 		if (SKIP_FLAGS.has(arg)) return true
 	}
-	// Positional subcommand at argv[2] (case-insensitive).
-	const first = argv[2]
-	if (first !== undefined && SKIP_SUBCOMMANDS.has(first.toLowerCase())) return true
+	// Subcommand anywhere in argv (case-insensitive). Only bare positional
+	// tokens are checked — arguments starting with `--` are flag values, not
+	// subcommands.
+	for (let i = 2; i < argv.length; i += 1) {
+		const arg = argv[i]
+		if (!arg.startsWith("-") && SKIP_SUBCOMMANDS.has(arg.toLowerCase())) return true
+	}
 	return false
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #713 with the last round of review feedback that was pushed after merge:

1. **30s hard timeout on `applyUpdate`** — [6783d0e](https://github.com/getkimchi/kimchi/commit/6783d0e94e585c79f81ff87a48e8060be5080532). A hung network or filesystem during download/copy no longer stalls TUI startup indefinitely. On timeout we log a warning and continue on the current version.

2. **`argvHasSkipTrigger` scans all positional args** — [5fbdf9e](https://github.com/getkimchi/kimchi/commit/5fbdf9ec9cb6ad3559dc9214f8b22fb27359ff11). `kimchi --some-flag update` is now recognized as the update subcommand. Tokens starting with `--` are skipped so `--tag=update` is not a false positive.

3. **Removed cli-modes re-exports from `auto-update.ts`** — [be6986](https://github.com/getkimchi/kimchi/commit/be69864602d9117b89088ff07b6135efbb2e22e2). The module's public surface no longer leaks CLI-mode internals.

4. **Suggest enabling auto-update after manual update** — [00c4ee](https://github.com/getkimchi/kimchi/commit/00c4eee61789720e1be2a5d0aa8b229f97a4ba05). After a successful `/update`, if auto-update is still off, shows a toast: `Tip: enable auto-update from /update so kimchi stays up to date automatically.`

Resolves #606