### PR TITLE
fix(tui): make ESC[3J opt-in to prevent iTerm2 scroll-to-top

### DIFF
--- a/patches/@earendil-works__pi-tui@0.79.10.patch
+++ b/patches/@earendil-works__pi-tui@0.79.10.patch
@@ -1,3 +1,20 @@
+# Patch: kimchi-dev fixes for pi-tui
+#
+# NOTE for upgraders: `pnpm patch-commit` regenerates this file and STRIPS this
+# header — re-add it (and re-run `pnpm install` to refresh the lockfile hash)
+# after every regeneration.
+#
+# Changes included:
+#   1. dist/components/box.js       — stroke-width accounting for bordered boxes
+#   2. dist/components/markdown.js  — stroke-width accounting for bordered markdown
+#   3. dist/components/text.js      — stroke-width accounting for bordered text
+#   4. dist/utils.js                — applyStrokeToLine helper
+#   5. dist/tui.js                  — make ESC[3J (erase scrollback) opt-in via
+#                                    PI_TUI_NO_CLEAR_SCROLLBACK=1 to avoid iTerm2
+#                                    snapping the viewport to the session start
+#                                    in long sessions / large diffs.
+#                                    See: https://github.com/getkimchi/kimchi/issues/863
+
 diff --git a/dist/components/box.js b/dist/components/box.js
 index 5de0f24bfe4e9ccb7b9476dae9ea55f882acce75..e8bf2e8986ec53c8189a58764e47e16d50d8793a 100644
 --- a/dist/components/box.js
@@ -134,6 +151,22 @@ index 0d840239c41181e24dfc60237c3338081c6b48d5..7208d53add7d89955c799f73d9d5ce13
              emptyLines.push(line);
          }
          const result = [...emptyLines, ...contentLines, ...emptyLines];
+diff --git a/dist/tui.js b/dist/tui.js
+index 62574431ce65ff9e6d7e68407b2563dcef5c8f3e..60fa69fd09776448a88e67d4e0ce0e4fb9640871 100644
+--- a/dist/tui.js
++++ b/dist/tui.js
+@@ -1004,7 +1004,10 @@ export class TUI extends Container {
+             let buffer = "\x1b[?2026h"; // Begin synchronized output
+             if (clear) {
+                 buffer += this.deleteKittyImages(this.previousKittyImageIds);
+-                buffer += "\x1b[2J\x1b[H\x1b[3J"; // Clear screen, home, then clear scrollback
++                buffer += "\x1b[2J\x1b[H"; // Clear screen and home
++                if (process.env.PI_TUI_NO_CLEAR_SCROLLBACK !== "1") {
++                    buffer += "\x1b[3J"; // Clear scrollback (disabled by PI_TUI_NO_CLEAR_SCROLLBACK=1 to avoid iTerm2 viewport jump)
++                }
+             }
+             for (let i = 0; i < newLines.length; i++) {
+                 if (i > 0)
 diff --git a/dist/utils.js b/dist/utils.js
 index bc550a400f3ac921263a8f2fa1753335b4fded8c..a9314e7ed5f39c4f31a5d38b17f84c07ccce8020 100644
 --- a/dist/utils.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: e821592e009160d9501e7047340e284867de484433216a8f9c5a9a4c05fd4322
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
-    hash: 3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38
+    hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
     path: patches/@earendil-works__pi-tui@0.79.10.patch
   playwright-core@1.59.1:
     hash: 1f27acbc8250451c9eea2efa9b19956afcb881a2b7a69ad4550cf8e59f15e102
@@ -36,7 +36,7 @@ importers:
         version: 0.79.10(patch_hash=e821592e009160d9501e7047340e284867de484433216a8f9c5a9a4c05fd4322)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)
+        version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.1
         version: 1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
@@ -2831,7 +2831,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)
+      '@earendil-works/pi-tui': 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -2857,7 +2857,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.10(patch_hash=3651856bfe24d881276c225f7ae61b415aaea13347e8667a70d24a3e0e1b3a38)':
+  '@earendil-works/pi-tui@0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/tests/unit/pi-tui-scrollback-flag.test.ts
+++ b/tests/unit/pi-tui-scrollback-flag.test.ts
@@ -1,0 +1,102 @@
+import { TUI } from "@earendil-works/pi-tui"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+
+/**
+ * Regression test for the iTerm2 scroll-to-top bug.
+ *
+ * pi-tui's fullRender(true) emits ESC[2J (erase screen) + ESC[3J (erase
+ * scrollback) + ESC[H (home cursor). On iTerm2, ESC[3J while the viewport is
+ * scrolled up snaps the view to the start of the session. Our patch makes
+ * ESC[3J conditional on the PI_TUI_NO_CLEAR_SCROLLBACK environment variable.
+ *
+ * This test exercises the patched pi-tui directly and asserts the presence or
+ * absence of ESC[3J in the terminal output based on the flag.
+ */
+
+/**
+ * Minimal fake terminal that satisfies the pi-tui Terminal interface.
+ * We only need to capture everything written to stdout; input, resizing,
+ * and cursor visibility methods are no-ops for this assertion.
+ */
+function makeMockTerminal(): {
+	writes: string[]
+	terminal: import("@earendil-works/pi-tui").Terminal
+} {
+	const writes: string[] = []
+	return {
+		writes,
+		terminal: {
+			start: vi.fn(),
+			stop: vi.fn(),
+			drainInput: vi.fn().mockResolvedValue(undefined),
+			write: vi.fn((data: string) => writes.push(data)),
+			columns: 80,
+			rows: 24,
+			kittyProtocolActive: false,
+			moveBy: vi.fn(),
+			hideCursor: vi.fn(),
+			showCursor: vi.fn(),
+			clearLine: vi.fn(),
+			clearFromCursor: vi.fn(),
+			clearScreen: vi.fn(),
+			setTitle: vi.fn(),
+			setProgress: vi.fn(),
+		} as unknown as import("@earendil-works/pi-tui").Terminal,
+	}
+}
+
+/** Wait long enough for requestRender(true) -> process.nextTick -> doRender. */
+function flushRender(ms = 50): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+beforeEach(() => {
+	vi.stubEnv("PI_TUI_NO_CLEAR_SCROLLBACK", "1")
+})
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+it("does not emit ESC[3J when PI_TUI_NO_CLEAR_SCROLLBACK=1", async () => {
+	const { writes, terminal } = makeMockTerminal()
+	const tui = new TUI(terminal, false)
+
+	// Render enough lines to exceed the 24-row mock terminal so the render
+	// path exercises scrolling and full redraw logic.
+	tui.addChild({
+		render: () => Array.from({ length: 50 }, (_, i) => `line-${i}`),
+		invalidate: () => {},
+	})
+
+	// force=true clears previous state and triggers fullRender(true), the path
+	// that normally emits ESC[3J.
+	tui.requestRender(true)
+	await flushRender()
+
+	const output = writes.join("")
+	expect(output).toContain("\x1b[2J")
+	expect(output).toContain("\x1b[H")
+	expect(output).not.toContain("\x1b[3J")
+})
+
+it("emits ESC[3J by default", async () => {
+	// Unset the flag so the default (legacy) behavior is exercised.
+	vi.stubEnv("PI_TUI_NO_CLEAR_SCROLLBACK", undefined)
+
+	const { writes, terminal } = makeMockTerminal()
+	const tui = new TUI(terminal, false)
+
+	tui.addChild({
+		render: () => Array.from({ length: 50 }, (_, i) => `line-${i}`),
+		invalidate: () => {},
+	})
+
+	tui.requestRender(true)
+	await flushRender()
+
+	const output = writes.join("")
+	expect(output).toContain("\x1b[2J")
+	expect(output).toContain("\x1b[H")
+	expect(output).toContain("\x1b[3J")
+})


### PR DESCRIPTION
## Problem
In iTerm2 on macOS, the terminal viewport sometimes jumps to the very start of the session in long sessions or when rendering large diffs.

Closes #863

## Change
- Patches `@earendil-works/pi-tui` so `ESC[3J` (erase scrollback) is only emitted when `PI_TUI_NO_CLEAR_SCROLLBACK` is **not** set.
- The old behavior remains the default; users who hit the iTerm2 jump can opt into the fix.
- Adds a unit test verifying `ESC[3J` is absent when the flag is enabled and present when it is not.

## Feature flag
```bash
# Default: pi-tui still clears scrollback on full renders (old behavior).
# Set this to disable scrollback clearing and avoid the iTerm2 viewport jump:
PI_TUI_NO_CLEAR_SCROLLBACK=1 kimchi
```

## Verification
- `pnpm vitest run tests/unit/pi-tui-scrollback-flag.test.ts` passes.