### PR TITLE
fix: apply anthropic compat to all claude- models regardless of provider

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -165,8 +165,15 @@ export interface PiModelConfig {
 function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// TODO: our LiteLLM gateway does not support `thinking.type.enabled` for Anthropic >Opus 4.6 models
 	// Therefore, we disable it for now. Revisit, once we upgrade our LiteLLM version.
+	// Band-aid: the models metadata API returns the same Claude slug under both
+	// "anthropic" and "azure_ai" providers. Pi's mergeCustomModels silently picks
+	// the last entry by (providerName, id) — if the azure_ai entry wins, the compat
+	// block is lost and cache_control markers are never injected. All Claude models
+	// support Anthropic-style prompt caching regardless of the upstream provider, so
+	// match on slug prefix rather than provider. Remove once the API stops returning
+	// duplicate slugs or pi deduplicates by (provider, id).
 	const compat =
-		m.provider === "anthropic"
+		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic" } as const)
 			: undefined
 	return {


### PR DESCRIPTION
## Problem

The models metadata API returns the same Claude slug under both `anthropic` and `azure_ai` providers (e.g. `claude-sonnet-4-6` appears twice). Both entries are written into the same `kimchi-dev` block in `models.json`.

Pi's [`mergeCustomModels`](https://github.com/earendil-works/pi/blob/92ffae5/packages/coding-agent/src/core/model-registry.ts#L497) silently picks the last entry by `(providerName, id)`. When the `azure_ai` entry (no `compat` block) wins, `cacheControlFormat: "anthropic"` is lost. Without it, pi's [`resolveCacheControl()`](https://github.com/earendil-works/pi/blob/92ffae5/packages/ai/src/api/openai-completions.ts#L743) returns `undefined` and no `cache_control: { type: "ephemeral" }` markers are injected into requests.

Result: prompt caching is silently disabled — `cache_read_input_tokens: 0` on every request. No error, no warning.

## Fix

Match on slug prefix (`m.slug.startsWith("claude-")`) instead of only `m.provider === "anthropic"`. All Claude models support Anthropic-style prompt caching regardless of whether they're served by Anthropic directly or via Azure AI.

## Verification

Captured raw HTTP request-response pairs via mitmproxy with three configurations:

| Config | `cache_control` markers | `cache_read_input_tokens` |
|---|---|---|
| Before fix (azure_ai entry wins) | ❌ none | 0 |
| After fix (either entry has compat) | ✅ on system + last user msg | 23514 |

## Context

This is a band-aid. The root cause is that the API returns duplicate slugs and `buildModelsConfig` writes them all without dedup. Pi then silently last-wins. The proper fix is dedup in `buildModelsConfig`, but this unblocks caching immediately.

Co-Authored-By: Kimchi <noreply@kimchi.dev>