### PR TITLE
fix(todos): todo session scope leak

### DIFF
--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -130,9 +130,6 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 	const unregisterFermentTips = registerTipProvider(createFermentTipProvider(runtime))
 	let unregisterFermentTodoSync: (() => void) | undefined
-	if (!isAgentWorker()) {
-		unregisterFermentTodoSync = registerFermentTodoSync(pi)
-	}
 	let planReviewTimer: ReturnType<typeof setTimeout> | undefined
 	let planReviewRunning = false
 	let finalCompletionNudgedThisRun = false
@@ -238,6 +235,16 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	pi.on("session_start", (_event, _ctx) => {
 		ctx = _ctx
 		runtime.clearMidTurnOneshotWarnings()
+
+		// (Re)wire the ferment todo bridge to the current session id. The
+		// session-scoped todo store requires every store call to target a
+		// specific session; the bridge captures the id at subscribe time so its
+		// internal handlers stay pure.
+		unregisterFermentTodoSync?.()
+		unregisterFermentTodoSync = undefined
+		if (!isAgentWorker()) {
+			unregisterFermentTodoSync = registerFermentTodoSync(pi, ctx.sessionManager.getSessionId())
+		}
 	})
 
 	pi.on("session_shutdown", () => {
@@ -245,6 +252,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		runtime.clearAllPendingPlanReviews()
 		unregisterFermentTips()
 		unregisterFermentTodoSync?.()
+		unregisterFermentTodoSync = undefined
 	})
 
 	pi.on("agent_end", async (_event, ctx) => {

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -429,12 +429,12 @@ describe("stall detection via step todo write tracking", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			expect(getTurnsSinceStepTodoWrite()).toBe(0)
-			bumpStallCounter()
-			expect(getTurnsSinceStepTodoWrite()).toBe(1)
-			bumpStallCounter()
-			bumpStallCounter()
-			expect(getTurnsSinceStepTodoWrite()).toBe(3)
+			expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(0)
+			bumpStallCounter(TEST_SESSION_ID)
+			expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(1)
+			bumpStallCounter(TEST_SESSION_ID)
+			bumpStallCounter(TEST_SESSION_ID)
+			expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(3)
 		} finally {
 			unsubscribe()
 		}
@@ -460,10 +460,10 @@ describe("stall detection via step todo write tracking", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			bumpStallCounter()
-			bumpStallCounter()
-			bumpStallCounter()
-			expect(getTurnsSinceStepTodoWrite()).toBe(3)
+			bumpStallCounter(TEST_SESSION_ID)
+			bumpStallCounter(TEST_SESSION_ID)
+			bumpStallCounter(TEST_SESSION_ID)
+			expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(3)
 
 			// Writing to the step scope resets the counter
 			applyWriteTodos(
@@ -473,7 +473,7 @@ describe("stall detection via step todo write tracking", () => {
 				},
 				TEST_SESSION_ID,
 			)
-			expect(getTurnsSinceStepTodoWrite()).toBe(0)
+			expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(0)
 		} finally {
 			unsubscribe()
 		}
@@ -509,7 +509,7 @@ describe("stall detection via step todo write tracking", () => {
 			)
 
 			// Bump past threshold (5 turns)
-			for (let i = 0; i < 6; i++) bumpStallCounter()
+			for (let i = 0; i < 6; i++) bumpStallCounter(TEST_SESSION_ID)
 
 			const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 			expect(md).toContain("\u26a0 Step todos have not been updated for 6 turns")
@@ -548,7 +548,7 @@ describe("stall detection via step todo write tracking", () => {
 			)
 
 			// Only 3 turns — below threshold
-			for (let i = 0; i < 3; i++) bumpStallCounter()
+			for (let i = 0; i < 3; i++) bumpStallCounter(TEST_SESSION_ID)
 
 			const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 			expect(md).not.toContain("\u26a0 Step todos have not been updated")
@@ -559,9 +559,9 @@ describe("stall detection via step todo write tracking", () => {
 
 	it("stall counter returns 0 when no step is running", () => {
 		// No step started — bumping should have no effect
-		bumpStallCounter()
-		bumpStallCounter()
-		expect(getTurnsSinceStepTodoWrite()).toBe(0)
+		bumpStallCounter(TEST_SESSION_ID)
+		bumpStallCounter(TEST_SESSION_ID)
+		expect(getTurnsSinceStepTodoWrite(TEST_SESSION_ID)).toBe(0)
 	})
 })
 
@@ -613,7 +613,7 @@ describe("parallel step tracking", () => {
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-b" }, ferment)
 
-			const running = __getRunningSteps()
+			const running = __getRunningSteps(TEST_SESSION_ID)
 			expect(running.size).toBe(2)
 			expect(running.has("phase-1/step-a")).toBe(true)
 			expect(running.has("phase-1/step-b")).toBe(true)
@@ -635,7 +635,7 @@ describe("parallel step tracking", () => {
 			// Complete step-a only
 			emitFermentDomainEvent(pi.events, { type: "complete_step", phaseId: "phase-1", stepId: "step-a" }, ferment)
 
-			const running = __getRunningSteps()
+			const running = __getRunningSteps(TEST_SESSION_ID)
 			expect(running.size).toBe(1)
 			expect(running.has("phase-1/step-a")).toBe(false)
 			expect(running.has("phase-1/step-b")).toBe(true)

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -18,12 +18,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { createEventBus } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
-import {
-	__test_renderTodoStateMarkdown,
-	currentSessionHasUI,
-	renderTodoStateBlock,
-	setCurrentSessionHasUI,
-} from "../todos/prompt-block.js"
+import { createContext } from "../__mocks__/context.js"
+import { __test_renderTodoStateMarkdown, renderTodoStateBlock } from "../todos/prompt-block.js"
 import { __resetTodoStore, applyWriteTodos, getTodosForScope, resolveTodoScope } from "../todos/store.js"
 import { emitFermentDomainEvent } from "./domain-events-emitter.js"
 import { setActive } from "./state.js"
@@ -33,6 +29,8 @@ import {
 	getTurnsSinceStepTodoWrite,
 	registerFermentTodoSync,
 } from "./todo-sync.js"
+
+const TEST_SESSION_ID = "test-session"
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -68,7 +66,7 @@ function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
 function makePiWithRealEventBus(): { pi: ExtensionAPI; unsubscribe: () => void } {
 	const bus = createEventBus()
 	const pi = { events: bus } as unknown as ExtensionAPI
-	const unsubscribe = registerFermentTodoSync(pi)
+	const unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 	return { pi, unsubscribe }
 }
 
@@ -78,22 +76,27 @@ describe("ferment → todo → headless prompt wiring", () => {
 	beforeEach(() => {
 		__resetTodoStore()
 		setActive(undefined)
-		setCurrentSessionHasUI(false) // simulate headless / one-shot mode
 	})
 
 	afterEach(() => {
 		setActive(undefined)
 		__resetTodoStore()
-		setCurrentSessionHasUI(true) // reset to safe interactive default
 	})
 
-	it("currentSessionHasUI starts as false in headless mode (setCurrentSessionHasUI wires correctly)", () => {
-		expect(currentSessionHasUI).toBe(false)
+	it("renderTodoStateBlock returns undefined when ctx.hasUI is true (widget handles it)", () => {
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		expect(renderTodoStateBlock(ctx)).toBeUndefined()
+	})
+
+	it("renderTodoStateBlock renders when ctx.hasUI is false (headless mode)", () => {
+		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		expect(renderTodoStateBlock(ctx)).toBeUndefined() // store still empty
 	})
 
 	it("renderTodoStateBlock returns undefined when no todos exist yet", () => {
 		// Before any phase starts, store is empty → block should not inject anything.
-		expect(renderTodoStateBlock()).toBeUndefined()
+		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		expect(renderTodoStateBlock(ctx)).toBeUndefined()
 	})
 
 	it("activate_phase event populates the todo store via the bridge", () => {
@@ -106,7 +109,7 @@ describe("ferment → todo → headless prompt wiring", () => {
 			// applyAndPersist({ type: "activate_phase", phaseId: "phase-1" }).
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 
-			const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+			const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 			// Phase header + 2 steps
 			expect(todos).toHaveLength(3)
 			expect(todos[0].content).toBe("[Phase 1] Implementation")
@@ -128,7 +131,8 @@ describe("ferment → todo → headless prompt wiring", () => {
 		try {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 
-			const md = renderTodoStateBlock()
+			const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+			const md = renderTodoStateBlock(ctx)
 			expect(md).toBeDefined()
 			expect(md).toContain("## Current Todos")
 			expect(md).toContain("**[Phase 1] Implementation**")
@@ -148,11 +152,11 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 
 			// Store is populated.
-			expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+			expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 
-			// Switching to interactive mode: renderTodoStateBlock gates on currentSessionHasUI.
-			setCurrentSessionHasUI(true)
-			expect(renderTodoStateBlock()).toBeUndefined()
+			// Switching to interactive mode: renderTodoStateBlock gates on ctx.hasUI.
+			const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+			expect(renderTodoStateBlock(ctx)).toBeUndefined()
 		} finally {
 			unsubscribe()
 		}
@@ -186,9 +190,11 @@ describe("ferment → todo → headless prompt wiring", () => {
 			expect(resolved).toEqual({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })
 
 			// Writing without explicit scope should go to ferment-step
-			applyWriteTodos({ todos: [{ content: "do something", status: "pending" }] })
-			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
-			expect(getTodosForScope({ kind: "global" })).toHaveLength(0)
+			applyWriteTodos({ todos: [{ content: "do something", status: "pending" }] }, TEST_SESSION_ID)
+			expect(
+				getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" }, TEST_SESSION_ID),
+			).toHaveLength(1)
+			expect(getTodosForScope({ kind: "global" }, TEST_SESSION_ID)).toHaveLength(0)
 		} finally {
 			unsubscribe()
 		}
@@ -232,8 +238,10 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
 			// Simulate model writing todos (without scope — auto-scoped)
-			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] })
-			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] }, TEST_SESSION_ID)
+			expect(
+				getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" }, TEST_SESSION_ID),
+			).toHaveLength(1)
 
 			// Complete the step
 			const completedFerment: Ferment = {
@@ -251,7 +259,9 @@ describe("ferment → todo → headless prompt wiring", () => {
 			)
 
 			// Step-level todos should be cleared
-			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+			expect(
+				getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" }, TEST_SESSION_ID),
+			).toHaveLength(0)
 			// Scope should revert to global
 			expect(resolveTodoScope(undefined)).toEqual({ kind: "global" })
 		} finally {
@@ -282,8 +292,10 @@ describe("ferment → todo → headless prompt wiring", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] })
-			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
+			applyWriteTodos({ todos: [{ content: "plan item", status: "in_progress" }] }, TEST_SESSION_ID)
+			expect(
+				getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" }, TEST_SESSION_ID),
+			).toHaveLength(1)
 
 			const failedFerment: Ferment = {
 				...ferment,
@@ -299,7 +311,9 @@ describe("ferment → todo → headless prompt wiring", () => {
 				failedFerment,
 			)
 
-			expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+			expect(
+				getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" }, TEST_SESSION_ID),
+			).toHaveLength(0)
 			expect(resolveTodoScope(undefined)).toEqual({ kind: "global" })
 		} finally {
 			unsubscribe()
@@ -329,7 +343,8 @@ describe("ferment → todo → headless prompt wiring", () => {
 				completedFerment,
 			)
 
-			const md = renderTodoStateBlock()
+			const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+			const md = renderTodoStateBlock(ctx)
 			expect(md).toContain("- [x] ↳ Write the code")
 			expect(md).toContain("- [ ] ↳ Run the tests")
 		} finally {
@@ -344,14 +359,15 @@ describe("ferment → todo → headless prompt wiring", () => {
 
 		try {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
-			expect(renderTodoStateBlock()).toContain("## Current Todos")
+			const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+			expect(renderTodoStateBlock(ctx)).toContain("## Current Todos")
 
 			const completedFerment: Ferment = { ...ferment, status: "complete" }
 			setActive(completedFerment)
 			emitFermentDomainEvent(pi.events, { type: "complete_ferment" }, completedFerment)
 
 			// All ferment-scoped todos cleared → block returns undefined.
-			expect(renderTodoStateBlock()).toBeUndefined()
+			expect(renderTodoStateBlock(ctx)).toBeUndefined()
 		} finally {
 			unsubscribe()
 		}
@@ -364,15 +380,16 @@ describe("ferment → todo → headless prompt wiring", () => {
 
 		try {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
-			expect(renderTodoStateBlock()).toContain("## Current Todos")
+			const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+			expect(renderTodoStateBlock(ctx)).toContain("## Current Todos")
 
 			// Pause clears todos from the store (but snapshots internally).
 			emitFermentDomainEvent(pi.events, { type: "pause" }, ferment)
-			expect(renderTodoStateBlock()).toBeUndefined()
+			expect(renderTodoStateBlock(ctx)).toBeUndefined()
 
 			// Resume restores the snapshot.
 			emitFermentDomainEvent(pi.events, { type: "resume" }, ferment)
-			const md = renderTodoStateBlock()
+			const md = renderTodoStateBlock(ctx)
 			expect(md).toContain("## Current Todos")
 			expect(md).toContain("**[Phase 1] Implementation**")
 		} finally {
@@ -385,13 +402,11 @@ describe("stall detection via step todo write tracking", () => {
 	beforeEach(() => {
 		__resetTodoStore()
 		setActive(undefined)
-		setCurrentSessionHasUI(false)
 	})
 
 	afterEach(() => {
 		setActive(undefined)
 		__resetTodoStore()
-		setCurrentSessionHasUI(true)
 	})
 
 	it("stall counter starts at 0 and increments with bumpStallCounter", () => {
@@ -451,10 +466,13 @@ describe("stall detection via step todo write tracking", () => {
 			expect(getTurnsSinceStepTodoWrite()).toBe(3)
 
 			// Writing to the step scope resets the counter
-			applyWriteTodos({
-				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-				todos: [{ content: "plan item", status: "pending" }],
-			})
+			applyWriteTodos(
+				{
+					scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+					todos: [{ content: "plan item", status: "pending" }],
+				},
+				TEST_SESSION_ID,
+			)
 			expect(getTurnsSinceStepTodoWrite()).toBe(0)
 		} finally {
 			unsubscribe()
@@ -482,15 +500,18 @@ describe("stall detection via step todo write tracking", () => {
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
 			// Populate step todos so markdown renders
-			applyWriteTodos({
-				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-				todos: [{ content: "plan item", status: "in_progress" }],
-			})
+			applyWriteTodos(
+				{
+					scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+					todos: [{ content: "plan item", status: "in_progress" }],
+				},
+				TEST_SESSION_ID,
+			)
 
 			// Bump past threshold (5 turns)
 			for (let i = 0; i < 6; i++) bumpStallCounter()
 
-			const md = __test_renderTodoStateMarkdown()
+			const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 			expect(md).toContain("\u26a0 Step todos have not been updated for 6 turns")
 			expect(md).toContain("reassess your approach")
 		} finally {
@@ -518,15 +539,18 @@ describe("stall detection via step todo write tracking", () => {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
 			emitFermentDomainEvent(pi.events, { type: "start_step", phaseId: "phase-1", stepId: "step-1" }, ferment)
 
-			applyWriteTodos({
-				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-				todos: [{ content: "plan item", status: "in_progress" }],
-			})
+			applyWriteTodos(
+				{
+					scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+					todos: [{ content: "plan item", status: "in_progress" }],
+				},
+				TEST_SESSION_ID,
+			)
 
 			// Only 3 turns — below threshold
 			for (let i = 0; i < 3; i++) bumpStallCounter()
 
-			const md = __test_renderTodoStateMarkdown()
+			const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 			expect(md).not.toContain("\u26a0 Step todos have not been updated")
 		} finally {
 			unsubscribe()
@@ -545,13 +569,11 @@ describe("parallel step tracking", () => {
 	beforeEach(() => {
 		__resetTodoStore()
 		setActive(undefined)
-		setCurrentSessionHasUI(false)
 	})
 
 	afterEach(() => {
 		setActive(undefined)
 		__resetTodoStore()
-		setCurrentSessionHasUI(true)
 	})
 
 	function makeParallelFerment(): Ferment {

--- a/src/extensions/ferment/todo-sync.test.ts
+++ b/src/extensions/ferment/todo-sync.test.ts
@@ -13,6 +13,8 @@ import { FERMENT_EVENTS } from "./domain-events.js"
 import { setActive } from "./state.js"
 import { registerFermentTodoSync } from "./todo-sync.js"
 
+const TEST_SESSION_ID = "test-session"
+
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
 /** Minimal fake ExtensionAPI with pi.events support */
@@ -113,7 +115,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 3)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED for phase-1
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -124,7 +126,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Assert: scope should have 1 header + 3 step todos
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(todos).toHaveLength(4)
 
 		// Header: should show phase name and be in_progress
@@ -151,7 +153,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 3)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -171,7 +173,7 @@ describe("todo-sync bridge", () => {
 			success: true,
 		})
 
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 
 		// Phase header should still be in_progress
 		expect(todos[0].status).toBe("in_progress")
@@ -190,7 +192,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 3)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -209,7 +211,7 @@ describe("todo-sync bridge", () => {
 			reason: "Test failure",
 		})
 
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 
 		// Phase header should still be in_progress
 		expect(todos[0].status).toBe("in_progress")
@@ -231,15 +233,18 @@ describe("todo-sync bridge", () => {
 		setActive(ferment)
 
 		// Add a manual global todo before registering the sync
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [
-				{ content: "Manual global todo", status: "pending" },
-				{ content: "Another manual todo", status: "in_progress" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [
+					{ content: "Manual global todo", status: "pending" },
+					{ content: "Another manual todo", status: "in_progress" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED for phase-1
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -250,7 +255,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Assert: global scope should still have the manual todos
-		const globalTodos = getTodosForScope({ kind: "global" })
+		const globalTodos = getTodosForScope({ kind: "global" }, TEST_SESSION_ID)
 		expect(globalTodos).toHaveLength(2)
 		expect(globalTodos[0].content).toBe("Manual global todo")
 		expect(globalTodos[0].status).toBe("pending")
@@ -258,7 +263,7 @@ describe("todo-sync bridge", () => {
 		expect(globalTodos[1].status).toBe("in_progress")
 
 		// Assert: ferment scope should have its own separate todos
-		const fermentTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const fermentTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(fermentTodos).toHaveLength(3) // 1 header + 2 steps
 		expect(fermentTodos[0].content).toBe("[Phase 1] Test Phase")
 		expect(fermentTodos[1].content).toBe("↳ Step 1")
@@ -270,7 +275,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 3)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -311,7 +316,7 @@ describe("todo-sync bridge", () => {
 			blockRetries: 0,
 		})
 
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 
 		// Phase header should be completed
 		expect(todos[0].status).toBe("completed")
@@ -331,7 +336,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -342,7 +347,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Verify todos were created
-		let todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		let todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(todos).toHaveLength(3)
 
 		// Unsubscribe
@@ -360,7 +365,7 @@ describe("todo-sync bridge", () => {
 			phaseName: "Test Phase",
 		})
 
-		todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(todos).toHaveLength(0)
 	})
 
@@ -369,7 +374,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 4)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -408,7 +413,7 @@ describe("todo-sync bridge", () => {
 			reason: "Test failure",
 		})
 
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 
 		// Phase header should still be in_progress
 		expect(todos[0].status).toBe("in_progress")
@@ -429,7 +434,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED for a different ferment
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -440,7 +445,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Assert: no todos should be created
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(todos).toHaveLength(0)
 	})
 
@@ -449,7 +454,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Emit PHASE_STARTED to populate initial todos
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -460,7 +465,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Capture initial IDs
-		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		const headerIdBefore = initialTodos[0].id
 		const step1IdBefore = initialTodos[1].id
 		const step2IdBefore = initialTodos[2].id
@@ -485,7 +490,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Assert: IDs should remain stable
-		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(updatedTodos[0].id).toBe(headerIdBefore)
 		expect(updatedTodos[1].id).toBe(step1IdBefore)
 		expect(updatedTodos[2].id).toBe(step2IdBefore)
@@ -496,7 +501,7 @@ describe("todo-sync bridge", () => {
 		const activeFerment = createTestFerment("phase-1", 2)
 		setActive(activeFerment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Set up todos for the active ferment
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
@@ -506,7 +511,7 @@ describe("todo-sync bridge", () => {
 			phaseName: "Active Phase",
 		})
 
-		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(initialTodos).toHaveLength(3) // header + 2 steps
 		expect(initialTodos[0].status).toBe("in_progress")
 		expect(initialTodos[1].status).toBe("pending")
@@ -526,7 +531,7 @@ describe("todo-sync bridge", () => {
 		})
 
 		// Assert: todos for the active ferment are untouched
-		const afterStaleEvent = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const afterStaleEvent = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(afterStaleEvent).toHaveLength(3)
 		expect(afterStaleEvent[0].status).toBe("in_progress")
 		expect(afterStaleEvent[1].status).toBe("pending")
@@ -537,7 +542,7 @@ describe("todo-sync bridge", () => {
 		const { pi, emit } = createFakePI()
 		setActive(undefined)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		// Should not throw even though there's no active ferment and no todos.
 		expect(() =>
@@ -559,7 +564,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 3)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -568,7 +573,7 @@ describe("todo-sync bridge", () => {
 			phaseName: "Test Phase",
 		})
 
-		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const initialTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		const headerIdBefore = initialTodos[0].id
 		const step1IdBefore = initialTodos[1].id
 		const step3IdBefore = initialTodos[3].id
@@ -584,7 +589,7 @@ describe("todo-sync bridge", () => {
 			success: true,
 		})
 
-		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const updatedTodos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(updatedTodos[0].id).toBe(headerIdBefore)
 		expect(updatedTodos[1].id).toBe(step1IdBefore)
 		expect(updatedTodos[3].id).toBe(step3IdBefore)
@@ -599,12 +604,15 @@ describe("todo-sync bridge", () => {
 		setActive(ferment)
 
 		// Mix global and ferment todos before suspension
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "User todo", status: "pending" }],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "User todo", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -613,24 +621,28 @@ describe("todo-sync bridge", () => {
 			phaseName: "Test Phase",
 		})
 		// Add a ferment-step scoped todo (agent-written plan bullet)
-		applyWriteTodos({
-			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-			todos: [{ content: "plan bullet", status: "in_progress" }],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+				todos: [{ content: "plan bullet", status: "in_progress" }],
+			},
+			TEST_SESSION_ID,
+		)
 
 		// Sanity: ferment scope has 3 todos, ferment-step scope has 1, global has 1
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
-		expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(1)
-		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
+		const stepScope = { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" } as const
+		expect(getTodosForScope(stepScope, TEST_SESSION_ID)).toHaveLength(1)
+		expect(getTodosForScope({ kind: "global" }, TEST_SESSION_ID)).toHaveLength(1)
 
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
 
 		// Ferment-scoped todos are cleared
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
-		expect(getTodosForScope({ kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(0)
+		expect(getTodosForScope(stepScope, TEST_SESSION_ID)).toHaveLength(0)
 		// Global scope is untouched
-		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
-		expect(getTodosForScope({ kind: "global" })[0].content).toBe("User todo")
+		expect(getTodosForScope({ kind: "global" }, TEST_SESSION_ID)).toHaveLength(1)
+		expect(getTodosForScope({ kind: "global" }, TEST_SESSION_ID)[0].content).toBe("User todo")
 	})
 
 	it("FERMENT_RESUMED restores the snapshot taken at suspension time", () => {
@@ -638,7 +650,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -655,18 +667,18 @@ describe("todo-sync bridge", () => {
 			success: true,
 		})
 
-		const beforeSuspend = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const beforeSuspend = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(beforeSuspend).toHaveLength(3)
 		const phaseHeaderContent = beforeSuspend[0].content
 		const step1Content = beforeSuspend[1].content
 		const step1Status = beforeSuspend[1].status
 
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(0)
 
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
 
-		const afterResume = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const afterResume = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(afterResume).toHaveLength(3)
 		expect(afterResume[0].content).toBe(phaseHeaderContent)
 		expect(afterResume[1].content).toBe(step1Content)
@@ -678,7 +690,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -690,7 +702,7 @@ describe("todo-sync bridge", () => {
 		expect(() => emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })).not.toThrow()
 
 		// Phase scope is still populated from PHASE_STARTED — RESUMED did nothing
-		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" })
+		const todos = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)
 		expect(todos).toHaveLength(3)
 	})
 
@@ -699,12 +711,15 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "User todo", status: "pending" }],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "User todo", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -713,7 +728,7 @@ describe("todo-sync bridge", () => {
 			phaseName: "Test Phase",
 		})
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(0)
 
 		emit(FERMENT_EVENTS.COMPLETED, {
 			fermentId: ferment.id,
@@ -726,13 +741,13 @@ describe("todo-sync bridge", () => {
 			blockRetries: 0,
 		})
 
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
-		expect(getTodosForScope({ kind: "global" })).toHaveLength(1)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(0)
+		expect(getTodosForScope({ kind: "global" }, TEST_SESSION_ID)).toHaveLength(1)
 
 		// Subsequent RESUMED for the same ferment should be a no-op (snapshot
 		// was discarded by COMPLETED).
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(0)
 	})
 
 	it("suspend/resume cycle preserves stable behavior across multiple cycles", () => {
@@ -740,7 +755,7 @@ describe("todo-sync bridge", () => {
 		const ferment = createTestFerment("phase-1", 2)
 		setActive(ferment)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: ferment.id,
@@ -748,19 +763,20 @@ describe("todo-sync bridge", () => {
 			phaseIndex: 1,
 			phaseName: "Test Phase",
 		})
-		const initialContent = getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)
+		const phaseScope = { kind: "ferment", phaseId: "phase-1" } as const
+		const initialContent = getTodosForScope(phaseScope, TEST_SESSION_ID).map((t) => t.content)
 
 		// First suspend/resume cycle
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope(phaseScope, TEST_SESSION_ID)).toHaveLength(0)
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)).toEqual(initialContent)
+		expect(getTodosForScope(phaseScope, TEST_SESSION_ID).map((t) => t.content)).toEqual(initialContent)
 
 		// Second suspend/resume cycle
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(0)
+		expect(getTodosForScope(phaseScope, TEST_SESSION_ID)).toHaveLength(0)
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }).map((t) => t.content)).toEqual(initialContent)
+		expect(getTodosForScope(phaseScope, TEST_SESSION_ID).map((t) => t.content)).toEqual(initialContent)
 	})
 
 	it("ignores FERMENT_SUSPENDED / RESUMED / COMPLETED events for a different ferment", () => {
@@ -768,12 +784,15 @@ describe("todo-sync bridge", () => {
 		const activeFerment = createTestFerment("phase-1", 2)
 		setActive(activeFerment)
 
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "User todo", status: "pending" }],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "User todo", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
 
-		unsubscribe = registerFermentTodoSync(pi)
+		unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
 
 		emit(FERMENT_EVENTS.PHASE_STARTED, {
 			fermentId: activeFerment.id,
@@ -781,11 +800,11 @@ describe("todo-sync bridge", () => {
 			phaseIndex: 1,
 			phaseName: "Active Phase",
 		})
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 
 		// Stale events from another ferment must not affect the active one
 		emit(FERMENT_EVENTS.SUSPENDED, { fermentId: "different-ferment" })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 
 		emit(FERMENT_EVENTS.COMPLETED, {
 			fermentId: "different-ferment",
@@ -797,9 +816,9 @@ describe("todo-sync bridge", () => {
 			steeringCount: 0,
 			blockRetries: 0,
 		})
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: "different-ferment" })
-		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" })).toHaveLength(3)
+		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 	})
 })

--- a/src/extensions/ferment/todo-sync.test.ts
+++ b/src/extensions/ferment/todo-sync.test.ts
@@ -11,7 +11,12 @@ import type { Ferment, Phase } from "../../ferment/types.js"
 import { __resetTodoStore, applyWriteTodos, getTodosForScope } from "../todos/store.js"
 import { FERMENT_EVENTS } from "./domain-events.js"
 import { setActive } from "./state.js"
-import { registerFermentTodoSync } from "./todo-sync.js"
+import {
+	__getRunningSteps,
+	bumpStallCounter,
+	getTurnsSinceStepTodoWrite,
+	registerFermentTodoSync,
+} from "./todo-sync.js"
 
 const TEST_SESSION_ID = "test-session"
 
@@ -820,5 +825,244 @@ describe("todo-sync bridge", () => {
 
 		emit(FERMENT_EVENTS.RESUMED, { fermentId: "different-ferment" })
 		expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
+	})
+
+	describe("cross-session isolation", () => {
+		it("isolates running steps and stall counters between sessions", () => {
+			const { pi: piA, emit: emitA } = createFakePI()
+			const { pi: piB, emit: emitB } = createFakePI()
+			const ferment = createTestFerment("phase-1", 2)
+			setActive(ferment)
+
+			const unsubA = registerFermentTodoSync(piA, "session-a")
+			const unsubB = registerFermentTodoSync(piB, "session-b")
+
+			emitA(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitA(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+			emitB(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitB(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+
+			expect(__getRunningSteps("session-a").size).toBe(1)
+			expect(__getRunningSteps("session-b").size).toBe(1)
+
+			bumpStallCounter("session-a")
+			bumpStallCounter("session-a")
+			expect(getTurnsSinceStepTodoWrite("session-a")).toBe(2)
+			expect(getTurnsSinceStepTodoWrite("session-b")).toBe(0)
+
+			// A ferment-step todo written for session-a should reset A's counter only.
+			applyWriteTodos(
+				{
+					scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+					todos: [{ content: "agent bullet", status: "in_progress" }],
+				},
+				"session-a",
+			)
+			expect(getTurnsSinceStepTodoWrite("session-a")).toBe(0)
+			expect(getTurnsSinceStepTodoWrite("session-b")).toBe(0)
+
+			unsubA()
+			unsubB()
+		})
+
+		it("isolates suspend/resume snapshots between sessions", () => {
+			const { pi: piA, emit: emitA } = createFakePI()
+			const { pi: piB, emit: emitB } = createFakePI()
+			const ferment = createTestFerment("phase-1", 2)
+			setActive(ferment)
+
+			const unsubA = registerFermentTodoSync(piA, "session-a")
+			const unsubB = registerFermentTodoSync(piB, "session-b")
+
+			emitA(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitA(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+			emitB(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitB(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+
+			// Complete step 1 only in session A.
+			emitA(FERMENT_EVENTS.STEP_COMPLETED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+				durationMs: 1000,
+				success: true,
+			})
+
+			const scope = { kind: "ferment", phaseId: "phase-1" } as const
+			expect(getTodosForScope(scope, "session-a")[1]?.status).toBe("completed")
+			expect(getTodosForScope(scope, "session-b")[1]?.status).toBe("pending")
+
+			// Suspend both sessions.
+			emitA(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+			emitB(FERMENT_EVENTS.SUSPENDED, { fermentId: ferment.id })
+			expect(getTodosForScope(scope, "session-a")).toHaveLength(0)
+			expect(getTodosForScope(scope, "session-b")).toHaveLength(0)
+
+			// Resume session A: it restores its own completed snapshot.
+			emitA(FERMENT_EVENTS.RESUMED, { fermentId: ferment.id })
+			expect(getTodosForScope(scope, "session-a")[1]?.status).toBe("completed")
+			expect(getTodosForScope(scope, "session-b")).toHaveLength(0)
+
+			unsubA()
+			unsubB()
+		})
+
+		it("unsubscribe only clears the bridge's own session state", () => {
+			const { pi: piA, emit: emitA } = createFakePI()
+			const { pi: piB, emit: emitB } = createFakePI()
+			const ferment = createTestFerment("phase-1", 1)
+			setActive(ferment)
+
+			const unsubA = registerFermentTodoSync(piA, "session-a")
+			const unsubB = registerFermentTodoSync(piB, "session-b")
+
+			emitA(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitB(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitB(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+
+			unsubA()
+
+			// Session B should still have a running step and respond to events.
+			emitB(FERMENT_EVENTS.STEP_COMPLETED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+				durationMs: 1000,
+				success: true,
+			})
+			expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, "session-b")[1]?.status).toBe("completed")
+
+			unsubB()
+		})
+
+		it("handles interleaved concurrent events without cross-session contamination", () => {
+			const { pi: piA, emit: emitA } = createFakePI()
+			const { pi: piB, emit: emitB } = createFakePI()
+			const ferment = createTestFerment("phase-1", 2)
+			setActive(ferment)
+
+			const unsubA = registerFermentTodoSync(piA, "session-a")
+			const unsubB = registerFermentTodoSync(piB, "session-b")
+
+			// Interleave phase and step-start events across the two sessions.
+			emitA(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitB(FERMENT_EVENTS.PHASE_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				phaseIndex: 1,
+				phaseName: "Test Phase",
+			})
+			emitA(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+			})
+			emitB(FERMENT_EVENTS.STEP_STARTED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-2",
+				stepIndex: 2,
+			})
+
+			// Complete opposite steps in each session.
+			emitA(FERMENT_EVENTS.STEP_COMPLETED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-1",
+				stepIndex: 1,
+				durationMs: 1000,
+				success: true,
+			})
+			emitB(FERMENT_EVENTS.STEP_COMPLETED, {
+				fermentId: ferment.id,
+				phaseId: "phase-1",
+				stepId: "step-2",
+				stepIndex: 2,
+				durationMs: 1000,
+				success: true,
+			})
+
+			const scope = { kind: "ferment", phaseId: "phase-1" } as const
+			const todosA = getTodosForScope(scope, "session-a")
+			const todosB = getTodosForScope(scope, "session-b")
+
+			// Session A completed step-1 only.
+			expect(todosA[1]?.content).toBe("↳ Step 1")
+			expect(todosA[1]?.status).toBe("completed")
+			expect(todosA[2]?.content).toBe("↳ Step 2")
+			expect(todosA[2]?.status).toBe("pending")
+
+			// Session B completed step-2 only.
+			expect(todosB[1]?.content).toBe("↳ Step 1")
+			expect(todosB[1]?.status).toBe("pending")
+			expect(todosB[2]?.content).toBe("↳ Step 2")
+			expect(todosB[2]?.status).toBe("completed")
+
+			unsubA()
+			unsubB()
+		})
 	})
 })

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -18,7 +18,10 @@
  *
  * Every todo-store call is scoped to the session id passed to
  * `registerFermentTodoSync` so that concurrent sessions sharing the same
- * process do not see each other's ferment todos.
+ * process do not see each other's ferment todos. The bridge's internal
+ * state (id maps, suspended snapshots, running steps, stall counter) is
+ * also keyed by session id, so each session owns its own bucket and
+ * unsubscribe only tears down that session's state.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
@@ -46,24 +49,35 @@ import {
 import { getActive } from "./state.js"
 
 // ─── Stable ID tracking ──────────────────────────────────────────────────────
-// Map structure: `${fermentId}:${phaseId}` → Map<stepId | "header", todoId>
-// The phase header gets a synthetic key "header" to distinguish it from steps.
+// All four top-level Maps are keyed by session id so concurrent sessions
+// never see each other's bridge state. The second-level key keeps each
+// phase / ferment / running-step bucket independent.
+//
+//   todoIdMaps: sessionId → (fermentId:phaseId → stepKey → todoId)
+//   suspendedSnapshots: sessionId → fermentId → ScopeSnapshot[]
+//   runningSteps: sessionId → phaseId/stepId → RunningStep
+//   turnsSinceStepTodoWrite: sessionId → count
 
-const todoIdMaps = new Map<string, Map<string, number>>()
+const todoIdMaps = new Map<string, Map<string, Map<string, number>>>()
 
-function getOrCreateIdMap(fermentId: string, phaseId: string): Map<string, number> {
+function getOrCreateIdMap(fermentId: string, phaseId: string, sessionId: string): Map<string, number> {
+	let sessionBuckets = todoIdMaps.get(sessionId)
+	if (!sessionBuckets) {
+		sessionBuckets = new Map()
+		todoIdMaps.set(sessionId, sessionBuckets)
+	}
 	const key = `${fermentId}:${phaseId}`
-	let map = todoIdMaps.get(key)
+	let map = sessionBuckets.get(key)
 	if (!map) {
 		map = new Map()
-		todoIdMaps.set(key, map)
+		sessionBuckets.set(key, map)
 	}
 	return map
 }
 
-function clearIdMap(fermentId: string, phaseId: string): void {
+function clearIdMap(fermentId: string, phaseId: string, sessionId: string): void {
 	const key = `${fermentId}:${phaseId}`
-	todoIdMaps.delete(key)
+	todoIdMaps.get(sessionId)?.delete(key)
 }
 
 // ─── Suspend / resume snapshot ──────────────────────────────────────────────
@@ -76,10 +90,10 @@ interface ScopeSnapshot {
 	todos: TodoItem[]
 }
 
-const suspendedSnapshots = new Map<string, ScopeSnapshot[]>()
+const suspendedSnapshots = new Map<string, Map<string, ScopeSnapshot[]>>()
 
-function clearSnapshot(fermentId: string): void {
-	suspendedSnapshots.delete(fermentId)
+function clearSnapshot(sessionId: string, fermentId: string): void {
+	suspendedSnapshots.get(sessionId)?.delete(fermentId)
 }
 
 /** Find every todo scope (in the current store) whose phaseId matches one of
@@ -155,10 +169,11 @@ function stepStatusToTodoStatus(stepStatus: StepStatus): TodoStatus {
 function buildPhaseTodos(
 	phase: Phase,
 	fermentId: string,
+	sessionId: string,
 ): {
 	todos: TodoDraft[]
 } {
-	const idMap = getOrCreateIdMap(fermentId, phase.id)
+	const idMap = getOrCreateIdMap(fermentId, phase.id, sessionId)
 	const todos: TodoDraft[] = []
 
 	// Phase header — use phase.name as the content, status is always in_progress
@@ -186,8 +201,8 @@ function buildPhaseTodos(
 	return { todos }
 }
 
-function syncTodoIds(fermentId: string, phaseId: string, writtenTodos: TodoItem[]): void {
-	const idMap = getOrCreateIdMap(fermentId, phaseId)
+function syncTodoIds(fermentId: string, phaseId: string, sessionId: string, writtenTodos: TodoItem[]): void {
+	const idMap = getOrCreateIdMap(fermentId, phaseId, sessionId)
 	// Match written todos back to ferment entities via the internal _syncKey.
 	// This is deterministic regardless of how the store reorders, filters,
 	// or reassigns IDs, and avoids the fragility of correlating on user-
@@ -219,11 +234,11 @@ function handlePhaseStarted(raw: unknown, sessionId: string): void {
 		return
 	}
 
-	const { todos } = buildPhaseTodos(phase, ferment.id)
+	const { todos } = buildPhaseTodos(phase, ferment.id, sessionId)
 	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos }, sessionId)
 
 	// Capture the assigned IDs for future updates
-	syncTodoIds(ferment.id, payload.phaseId, details.todos)
+	syncTodoIds(ferment.id, payload.phaseId, sessionId, details.todos)
 }
 
 // ─── Active step tracking for scope provider ────────────────────────────────
@@ -237,38 +252,53 @@ function handlePhaseStarted(raw: unknown, sessionId: string): void {
 
 type RunningStep = { phaseId: string; stepId: string }
 
-const runningSteps = new Map<string, RunningStep>()
+const runningSteps = new Map<string, Map<string, RunningStep>>()
 
 function stepKey(phaseId: string, stepId: string): string {
 	return `${phaseId}/${stepId}`
 }
 
-/** Exported for tests only. */
-export function __getRunningSteps(): ReadonlyMap<string, RunningStep> {
-	return runningSteps
+function getRunningStepsBucket(sessionId: string): Map<string, RunningStep> {
+	let bucket = runningSteps.get(sessionId)
+	if (!bucket) {
+		bucket = new Map()
+		runningSteps.set(sessionId, bucket)
+	}
+	return bucket
+}
+
+/** Exported for tests only. Returns the running-step bucket for a specific
+ *  session id so tests can assert without leaking across other sessions. */
+export function __getRunningSteps(sessionId: string): ReadonlyMap<string, RunningStep> {
+	return runningSteps.get(sessionId) ?? new Map<string, RunningStep>()
 }
 
 /**
  * Number of orchestrator turns since any step-scope todos were last written.
- * Increments only while at least one step is running; resets when any
- * active step's scope is written to.
+ * Per-session so concurrent sessions do not share a counter. Increments only
+ * while at least one step is running for the session; resets when any active
+ * step's scope is written to.
  */
-let turnsSinceStepTodoWrite = 0
+const turnsSinceStepTodoWrite = new Map<string, number>()
 
 /** Call once per orchestrator turn_end to track how long the step scope
- *  has been untouched. Only increments when a step is actually running. */
-export function bumpStallCounter(): void {
-	if (runningSteps.size > 0) turnsSinceStepTodoWrite++
+ *  has been untouched. Only increments when a step is actually running
+ *  for the given session. */
+export function bumpStallCounter(sessionId: string): void {
+	const bucket = runningSteps.get(sessionId)
+	if (!bucket?.size) return
+	turnsSinceStepTodoWrite.set(sessionId, (turnsSinceStepTodoWrite.get(sessionId) ?? 0) + 1)
 }
 
 /** Returns the number of turns since any step-scope todos were last written,
- *  or 0 when no step is running. */
-export function getTurnsSinceStepTodoWrite(): number {
-	if (runningSteps.size === 0) return 0
-	return turnsSinceStepTodoWrite
+ *  or 0 when no step is running for the given session. */
+export function getTurnsSinceStepTodoWrite(sessionId: string): number {
+	const bucket = runningSteps.get(sessionId)
+	if (!bucket?.size) return 0
+	return turnsSinceStepTodoWrite.get(sessionId) ?? 0
 }
 
-function handleStepStarted(raw: unknown): void {
+function handleStepStarted(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentStepStartedPayload
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
@@ -276,11 +306,11 @@ function handleStepStarted(raw: unknown): void {
 	// Track the running step so the scope provider can auto-scope todo calls.
 	// Multiple parallel siblings coexist in the map; the scope provider handles
 	// the ambiguity when more than one is active.
-	runningSteps.set(stepKey(payload.phaseId, payload.stepId), {
+	getRunningStepsBucket(sessionId).set(stepKey(payload.phaseId, payload.stepId), {
 		phaseId: payload.phaseId,
 		stepId: payload.stepId,
 	})
-	turnsSinceStepTodoWrite = 0
+	turnsSinceStepTodoWrite.set(sessionId, 0)
 }
 
 function clearStepTodos(phaseId: string, stepId: string, sessionId: string): void {
@@ -309,9 +339,10 @@ function handleStepCompleted(raw: unknown, sessionId: string): void {
 	// Clear the step-level implementation todos and stop tracking this step
 	// (parallel siblings remain tracked in runningSteps).
 	clearStepTodos(payload.phaseId, payload.stepId, sessionId)
-	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
+	const bucket = runningSteps.get(sessionId)
+	bucket?.delete(stepKey(payload.phaseId, payload.stepId))
 
-	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
+	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId, sessionId)
 	const stepTodoId = idMap.get(payload.stepId)
 	if (stepTodoId === undefined) {
 		console.warn(`[todo-sync] STEP_COMPLETED for step ${payload.stepId} but no todo ID recorded. Skipping update.`)
@@ -351,9 +382,9 @@ function handleStepFailed(raw: unknown, sessionId: string): void {
 	// Clear the step-level implementation todos and stop tracking this step
 	// (parallel siblings remain tracked in runningSteps).
 	clearStepTodos(payload.phaseId, payload.stepId, sessionId)
-	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
+	runningSteps.get(sessionId)?.delete(stepKey(payload.phaseId, payload.stepId))
 
-	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
+	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId, sessionId)
 	const stepTodoId = idMap.get(payload.stepId)
 	if (stepTodoId === undefined) {
 		console.warn(`[todo-sync] STEP_FAILED for step ${payload.stepId} but no todo ID recorded. Skipping update.`)
@@ -384,7 +415,7 @@ function handlePhaseCompleted(raw: unknown, sessionId: string): void {
 	if (currentTodos.length === 0) {
 		// No todos written for this phase (edge case: phase with zero steps that
 		// completed before PHASE_STARTED fired). Nothing to update.
-		clearIdMap(payload.fermentId, payload.phaseId)
+		clearIdMap(payload.fermentId, payload.phaseId, sessionId)
 		return
 	}
 
@@ -400,7 +431,7 @@ function handlePhaseCompleted(raw: unknown, sessionId: string): void {
 	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated }, sessionId)
 
 	// Cleanup: drop the ID map for this phase since the phase is now complete
-	clearIdMap(payload.fermentId, payload.phaseId)
+	clearIdMap(payload.fermentId, payload.phaseId, sessionId)
 }
 
 function handleFermentSuspended(raw: unknown, sessionId: string): void {
@@ -416,11 +447,16 @@ function handleFermentSuspended(raw: unknown, sessionId: string): void {
 	if (snapshots.length === 0) {
 		// Nothing to snapshot — make sure no stale snapshot from a prior cycle
 		// leaks into a future resume.
-		clearSnapshot(ferment.id)
+		clearSnapshot(sessionId, ferment.id)
 		return
 	}
 
-	suspendedSnapshots.set(ferment.id, snapshots)
+	let sessionBuckets = suspendedSnapshots.get(sessionId)
+	if (!sessionBuckets) {
+		sessionBuckets = new Map()
+		suspendedSnapshots.set(sessionId, sessionBuckets)
+	}
+	sessionBuckets.set(ferment.id, snapshots)
 	clearScopeTodos(snapshots, sessionId)
 }
 
@@ -432,9 +468,10 @@ function handleFermentResumed(raw: unknown, sessionId: string): void {
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
 
-	const snapshots = suspendedSnapshots.get(ferment.id)
+	const sessionBuckets = suspendedSnapshots.get(sessionId)
+	const snapshots = sessionBuckets?.get(ferment.id)
 	if (!snapshots) return // RESUMED without prior SUSPENDED — no-op
-	suspendedSnapshots.delete(ferment.id)
+	sessionBuckets?.delete(ferment.id)
 
 	// Only restore scopes that still belong to this ferment. If phases were
 	// added/removed between suspend and resume, stale scopes are skipped.
@@ -460,7 +497,7 @@ function handleFermentCompleted(raw: unknown, sessionId: string): void {
 	}
 	// Drop any snapshot left behind by a prior SUSPENDED that was never
 	// resumed (e.g. ferment was abandoned mid-suspend). Nothing to restore.
-	clearSnapshot(ferment.id)
+	clearSnapshot(sessionId, ferment.id)
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────
@@ -470,7 +507,9 @@ function handleFermentCompleted(raw: unknown, sessionId: string): void {
  * specific session id. Every store call inside the bridge targets that
  * session's bucket; concurrent sessions do not see each other's ferment todos.
  *
- * Returns an unsubscribe function that removes all listeners and cleans up state.
+ * Returns an unsubscribe function that removes all listeners and cleans up
+ * only this session's bridge state (id maps, suspended snapshots, running
+ * steps, and stall counter for that session id).
  */
 export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): () => void {
 	const unsubscribes: Array<() => void> = []
@@ -480,8 +519,9 @@ export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): ()
 	// steps are active, return undefined to force the caller to pass an
 	// explicit scope — avoids silently writing to the wrong step.
 	const unregisterScope = registerActiveTodoScopeProvider(() => {
-		if (runningSteps.size !== 1) return undefined
-		const [, step] = [...runningSteps.entries()][0]
+		const bucket = runningSteps.get(sessionId)
+		if (bucket?.size !== 1) return undefined
+		const [, step] = [...bucket.entries()][0]
 		return {
 			kind: "ferment-step" as const,
 			phaseId: step.phaseId,
@@ -489,18 +529,21 @@ export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): ()
 		}
 	})
 
-	// Reset the stall counter whenever ANY running step's todo scope is written to.
-	const unsubscribeTodoListener = subscribeTodoStore((details) => {
-		if (runningSteps.size === 0) return
+	// Reset the stall counter whenever ANY running step's todo scope is written
+	// to within this bridge's session.
+	const unsubscribeTodoListener = subscribeTodoStore((details, emitterSessionId) => {
+		if (emitterSessionId !== sessionId) return
+		const bucket = runningSteps.get(sessionId)
+		if (!bucket?.size) return
 		if (details.scope.kind !== "ferment-step") return
 		const scope = details.scope as { phaseId: string; stepId: string }
-		if (runningSteps.has(stepKey(scope.phaseId, scope.stepId))) {
-			turnsSinceStepTodoWrite = 0
+		if (bucket.has(stepKey(scope.phaseId, scope.stepId))) {
+			turnsSinceStepTodoWrite.set(sessionId, 0)
 		}
 	})
 
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, (raw) => handlePhaseStarted(raw, sessionId)))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, handleStepStarted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, (raw) => handleStepStarted(raw, sessionId)))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, (raw) => handleStepCompleted(raw, sessionId)))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, (raw) => handleStepFailed(raw, sessionId)))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, (raw) => handlePhaseCompleted(raw, sessionId)))
@@ -514,10 +557,16 @@ export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): ()
 		}
 		unregisterScope()
 		unsubscribeTodoListener()
-		runningSteps.clear()
-		turnsSinceStepTodoWrite = 0
-		// Clear all in-memory state on unsubscribe to avoid memory leaks.
-		todoIdMaps.clear()
-		suspendedSnapshots.clear()
+
+		// Tear down only this session's bridge state. Other sessions sharing
+		// the process keep their buckets intact.
+		runningSteps.delete(sessionId)
+		turnsSinceStepTodoWrite.delete(sessionId)
+
+		todoIdMaps.get(sessionId)?.clear()
+		todoIdMaps.delete(sessionId)
+
+		suspendedSnapshots.get(sessionId)?.clear()
+		suspendedSnapshots.delete(sessionId)
 	}
 }

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -15,6 +15,10 @@
  *   - FERMENT_SUSPENDED → snapshot all ferment-scoped todos, then clear them
  *   - FERMENT_RESUMED → restore the snapshot taken at suspension time
  *   - FERMENT_COMPLETED → clear all ferment-scoped todos (no restore)
+ *
+ * Every todo-store call is scoped to the session id passed to
+ * `registerFermentTodoSync` so that concurrent sessions sharing the same
+ * process do not see each other's ferment todos.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
@@ -81,9 +85,9 @@ function clearSnapshot(fermentId: string): void {
 /** Find every todo scope (in the current store) whose phaseId matches one of
  *  the given phase IDs and whose kind is ferment-scoped. Global scope is
  *  excluded — it belongs to the user, not the ferment. */
-function findFermentScopes(phaseIds: ReadonlySet<string>): ScopeSnapshot[] {
+function findFermentScopes(phaseIds: ReadonlySet<string>, sessionId: string): ScopeSnapshot[] {
 	if (phaseIds.size === 0) return []
-	const state = getTodoState()
+	const state = getTodoState(sessionId)
 	const found: ScopeSnapshot[] = []
 	for (const scopeKey of Object.keys(state.byScope)) {
 		let scope: TodoScope
@@ -102,13 +106,13 @@ function findFermentScopes(phaseIds: ReadonlySet<string>): ScopeSnapshot[] {
 	return found
 }
 
-function clearScopeTodos(snapshots: ScopeSnapshot[]): void {
+function clearScopeTodos(snapshots: ScopeSnapshot[], sessionId: string): void {
 	for (const { scope } of snapshots) {
-		applyWriteTodos({ scope, todos: [] })
+		applyWriteTodos({ scope, todos: [] }, sessionId)
 	}
 }
 
-function restoreScopeTodos(snapshots: ScopeSnapshot[]): void {
+function restoreScopeTodos(snapshots: ScopeSnapshot[], sessionId: string): void {
 	for (const { scope, todos } of snapshots) {
 		// Re-emit as drafts so the store assigns fresh IDs in the new lifecycle.
 		const drafts: TodoDraft[] = todos.map((todo) => ({
@@ -117,7 +121,7 @@ function restoreScopeTodos(snapshots: ScopeSnapshot[]): void {
 			activeForm: todo.activeForm,
 			note: todo.note,
 		}))
-		applyWriteTodos({ scope, todos: drafts })
+		applyWriteTodos({ scope, todos: drafts }, sessionId)
 	}
 }
 
@@ -198,7 +202,7 @@ function syncTodoIds(fermentId: string, phaseId: string, writtenTodos: TodoItem[
 
 // ─── Event handlers ──────────────────────────────────────────────────────────
 
-function handlePhaseStarted(raw: unknown): void {
+function handlePhaseStarted(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentPhaseStartedPayload
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) {
@@ -216,7 +220,7 @@ function handlePhaseStarted(raw: unknown): void {
 	}
 
 	const { todos } = buildPhaseTodos(phase, ferment.id)
-	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos })
+	const details = applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos }, sessionId)
 
 	// Capture the assigned IDs for future updates
 	syncTodoIds(ferment.id, payload.phaseId, details.todos)
@@ -279,14 +283,11 @@ function handleStepStarted(raw: unknown): void {
 	turnsSinceStepTodoWrite = 0
 }
 
-function clearStepTodos(phaseId: string, stepId: string): void {
-	applyWriteTodos({
-		scope: { kind: "ferment-step", phaseId, stepId },
-		todos: [],
-	})
+function clearStepTodos(phaseId: string, stepId: string, sessionId: string): void {
+	applyWriteTodos({ scope: { kind: "ferment-step", phaseId, stepId }, todos: [] }, sessionId)
 }
 
-function handleStepCompleted(raw: unknown): void {
+function handleStepCompleted(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentStepCompletedPayload
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
@@ -307,7 +308,7 @@ function handleStepCompleted(raw: unknown): void {
 
 	// Clear the step-level implementation todos and stop tracking this step
 	// (parallel siblings remain tracked in runningSteps).
-	clearStepTodos(payload.phaseId, payload.stepId)
+	clearStepTodos(payload.phaseId, payload.stepId, sessionId)
 	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
@@ -317,7 +318,7 @@ function handleStepCompleted(raw: unknown): void {
 		return
 	}
 
-	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId }, sessionId)
 	const updated = currentTodos.map((todo) => {
 		if (todo.id === stepTodoId) {
 			return { ...todo, status: "completed" as TodoStatus }
@@ -325,10 +326,10 @@ function handleStepCompleted(raw: unknown): void {
 		return todo
 	})
 
-	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated }, sessionId)
 }
 
-function handleStepFailed(raw: unknown): void {
+function handleStepFailed(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentStepFailedPayload
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
@@ -349,7 +350,7 @@ function handleStepFailed(raw: unknown): void {
 
 	// Clear the step-level implementation todos and stop tracking this step
 	// (parallel siblings remain tracked in runningSteps).
-	clearStepTodos(payload.phaseId, payload.stepId)
+	clearStepTodos(payload.phaseId, payload.stepId, sessionId)
 	runningSteps.delete(stepKey(payload.phaseId, payload.stepId))
 
 	const idMap = getOrCreateIdMap(ferment.id, payload.phaseId)
@@ -359,7 +360,7 @@ function handleStepFailed(raw: unknown): void {
 		return
 	}
 
-	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId }, sessionId)
 	const updated = currentTodos.map((todo) => {
 		if (todo.id === stepTodoId) {
 			return { ...todo, status: "blocked" as TodoStatus }
@@ -367,10 +368,10 @@ function handleStepFailed(raw: unknown): void {
 		return todo
 	})
 
-	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated }, sessionId)
 }
 
-function handlePhaseCompleted(raw: unknown): void {
+function handlePhaseCompleted(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentPhaseCompletedPayload
 
 	// Guard: ignore stale PHASE_COMPLETED events from ferments other than the
@@ -379,7 +380,7 @@ function handlePhaseCompleted(raw: unknown): void {
 	const ferment = getActive()
 	if (!ferment || ferment.id !== payload.fermentId) return
 
-	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId })
+	const currentTodos = getTodosForScope({ kind: "ferment", phaseId: payload.phaseId }, sessionId)
 	if (currentTodos.length === 0) {
 		// No todos written for this phase (edge case: phase with zero steps that
 		// completed before PHASE_STARTED fired). Nothing to update.
@@ -396,13 +397,13 @@ function handlePhaseCompleted(raw: unknown): void {
 		return todo
 	})
 
-	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated })
+	applyWriteTodos({ scope: { kind: "ferment", phaseId: payload.phaseId }, todos: updated }, sessionId)
 
 	// Cleanup: drop the ID map for this phase since the phase is now complete
 	clearIdMap(payload.fermentId, payload.phaseId)
 }
 
-function handleFermentSuspended(raw: unknown): void {
+function handleFermentSuspended(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentSuspendedPayload
 
 	// Active-ferment guard: stale or cross-ferment pause events must not touch
@@ -411,7 +412,7 @@ function handleFermentSuspended(raw: unknown): void {
 	if (!ferment || ferment.id !== payload.fermentId) return
 
 	const phaseIds = new Set(ferment.phases.map((p) => p.id))
-	const snapshots = findFermentScopes(phaseIds)
+	const snapshots = findFermentScopes(phaseIds, sessionId)
 	if (snapshots.length === 0) {
 		// Nothing to snapshot — make sure no stale snapshot from a prior cycle
 		// leaks into a future resume.
@@ -420,10 +421,10 @@ function handleFermentSuspended(raw: unknown): void {
 	}
 
 	suspendedSnapshots.set(ferment.id, snapshots)
-	clearScopeTodos(snapshots)
+	clearScopeTodos(snapshots, sessionId)
 }
 
-function handleFermentResumed(raw: unknown): void {
+function handleFermentResumed(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentResumedPayload
 
 	// Active-ferment guard: stale resume events for a different ferment must
@@ -442,10 +443,10 @@ function handleFermentResumed(raw: unknown): void {
 		const scopePhaseId = (snapshot.scope as { phaseId?: string }).phaseId
 		return scopePhaseId !== undefined && phaseIds.has(scopePhaseId)
 	})
-	restoreScopeTodos(liveSnapshots)
+	restoreScopeTodos(liveSnapshots, sessionId)
 }
 
-function handleFermentCompleted(raw: unknown): void {
+function handleFermentCompleted(raw: unknown, sessionId: string): void {
 	const payload = raw as FermentCompletedPayload
 
 	// Active-ferment guard.
@@ -453,9 +454,9 @@ function handleFermentCompleted(raw: unknown): void {
 	if (!ferment || ferment.id !== payload.fermentId) return
 
 	const phaseIds = new Set(ferment.phases.map((p) => p.id))
-	const snapshots = findFermentScopes(phaseIds)
+	const snapshots = findFermentScopes(phaseIds, sessionId)
 	if (snapshots.length > 0) {
-		clearScopeTodos(snapshots)
+		clearScopeTodos(snapshots, sessionId)
 	}
 	// Drop any snapshot left behind by a prior SUSPENDED that was never
 	// resumed (e.g. ferment was abandoned mid-suspend). Nothing to restore.
@@ -465,11 +466,13 @@ function handleFermentCompleted(raw: unknown): void {
 // ─── Public API ──────────────────────────────────────────────────────────────
 
 /**
- * Register ferment → todo sync listeners on the given ExtensionAPI.
+ * Register ferment → todo sync listeners on the given ExtensionAPI for a
+ * specific session id. Every store call inside the bridge targets that
+ * session's bucket; concurrent sessions do not see each other's ferment todos.
  *
  * Returns an unsubscribe function that removes all listeners and cleans up state.
  */
-export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
+export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): () => void {
 	const unsubscribes: Array<() => void> = []
 
 	// Auto-scope: when exactly one ferment step is running, scope-less todo
@@ -496,14 +499,14 @@ export function registerFermentTodoSync(pi: ExtensionAPI): () => void {
 		}
 	})
 
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, handlePhaseStarted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_STARTED, (raw) => handlePhaseStarted(raw, sessionId)))
 	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_STARTED, handleStepStarted))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, handleStepCompleted))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, handleStepFailed))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, handlePhaseCompleted))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.SUSPENDED, handleFermentSuspended))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.RESUMED, handleFermentResumed))
-	unsubscribes.push(pi.events.on(FERMENT_EVENTS.COMPLETED, handleFermentCompleted))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_COMPLETED, (raw) => handleStepCompleted(raw, sessionId)))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.STEP_FAILED, (raw) => handleStepFailed(raw, sessionId)))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.PHASE_COMPLETED, (raw) => handlePhaseCompleted(raw, sessionId)))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.SUSPENDED, (raw) => handleFermentSuspended(raw, sessionId)))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.RESUMED, (raw) => handleFermentResumed(raw, sessionId)))
+	unsubscribes.push(pi.events.on(FERMENT_EVENTS.COMPLETED, (raw) => handleFermentCompleted(raw, sessionId)))
 
 	return () => {
 		for (const unsub of unsubscribes) {

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -111,7 +111,13 @@ export interface StepHandlerServices {
 		exitCode: number,
 	): Promise<JudgeVerdict>
 	onStepCompleted(runtime: FermentRuntime): void
-	buildWorkerContext: typeof buildWorkerContext
+	buildWorkerContext: (
+		ferment: Ferment,
+		phase: Phase,
+		step: Step,
+		sessionId: string,
+		opts?: { includeDecisions?: boolean; includeMemories?: boolean },
+	) => string
 	runVerification(args: VerificationExecution): Promise<VerificationResult>
 }
 
@@ -351,7 +357,9 @@ Do NOT call start_ferment_step again without user input.`,
 			: ""
 
 	const workerContext =
-		freshPhase && freshStep ? services.buildWorkerContext(outcome.ferment, freshPhase, freshStep) : ""
+		freshPhase && freshStep
+			? services.buildWorkerContext(outcome.ferment, freshPhase, freshStep, ctx.sessionManager.getSessionId())
+			: ""
 	const contextBlock = workerContext ? `\n\nWorker context (pass to subagent verbatim):\n${workerContext}` : ""
 	const taskRef = {
 		kind: "ferment_step" as const,

--- a/src/extensions/ferment/worker-prompt.test.ts
+++ b/src/extensions/ferment/worker-prompt.test.ts
@@ -3,6 +3,8 @@ import type { Decision, Ferment, Memory, Phase, Step } from "../../ferment/types
 import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
 import { buildWorkerContext } from "./worker-prompt.js"
 
+const TEST_SESSION_ID = "test-session"
+
 function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
 	return {
 		id: "ferment-1",
@@ -46,7 +48,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ name: "Auth rewrite", phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).toContain("Auth rewrite")
 		expect(ctx).toContain("Build it")
 		expect(ctx).toContain("Ship a working thing")
@@ -58,7 +60,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [step] })
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, step)
+		const ctx = buildWorkerContext(f, phase, step, TEST_SESSION_ID)
 		expect(ctx).toContain("verify:")
 		expect(ctx).toContain("pnpm test")
 	})
@@ -67,7 +69,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ id: "ferment-docs-1", phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 
 		expect(ctx).toContain("Ferment docs directory:")
 		expect(ctx).toContain(".kimchi/ferments/ferment-docs-1/docs/")
@@ -79,7 +81,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep({ description: "Explore the prompt assembly path" })] })
 		const f = makeFerment({ id: "ferment-docs-2", phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 
 		expect(ctx).toContain("Explore/read-only workers must return decision-ready findings directly")
 		expect(ctx).toContain("write no reports, docs, notes, or scratch files")
@@ -102,7 +104,7 @@ describe("buildWorkerContext", () => {
 			},
 		})
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).toContain("Goal:")
 		expect(ctx).toContain("Write /app/jump_analyzer.py")
 		expect(ctx).toContain("/app/output.toml")
@@ -114,7 +116,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).not.toContain("Goal:")
 		expect(ctx).not.toContain("Criteria:")
 	})
@@ -129,7 +131,7 @@ describe("buildWorkerContext", () => {
 		})
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[2])
+		const ctx = buildWorkerContext(f, phase, phase.steps[2], TEST_SESSION_ID)
 		expect(ctx).toContain("Prior:")
 		expect(ctx).toContain("✓1")
 		expect(ctx).toContain("Created the User type")
@@ -148,7 +150,7 @@ describe("buildWorkerContext", () => {
 		})
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[1])
+		const ctx = buildWorkerContext(f, phase, phase.steps[1], TEST_SESSION_ID)
 		expect(ctx).toContain("⊘1")
 		expect(ctx).not.toContain("✓1")
 	})
@@ -163,7 +165,7 @@ describe("buildWorkerContext", () => {
 		})
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[2])
+		const ctx = buildWorkerContext(f, phase, phase.steps[2], TEST_SESSION_ID)
 		expect(ctx).not.toContain("Prior:")
 	})
 
@@ -177,7 +179,7 @@ describe("buildWorkerContext", () => {
 		})
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[1])
+		const ctx = buildWorkerContext(f, phase, phase.steps[1], TEST_SESSION_ID)
 		expect(ctx).toContain("…")
 		// The full 500 'x's should not appear verbatim
 		expect(ctx).not.toContain(longSummary)
@@ -195,7 +197,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase], decisions })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).toContain("Decisions:")
 		expect(ctx).toContain("Use Zod for validation")
 	})
@@ -212,7 +214,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase], memories })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).toContain("Memories:")
 		expect(ctx).toContain("[gotcha]")
 		expect(ctx).toContain("Date.parse")
@@ -228,7 +230,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase], decisions })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		// Most recent 5 are decisions 3..7
 		expect(ctx).toContain("Decision 3")
 		expect(ctx).toContain("Decision 7")
@@ -241,7 +243,7 @@ describe("buildWorkerContext", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase], decisions })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0], { includeDecisions: false })
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID, { includeDecisions: false })
 		expect(ctx).not.toContain("Decisions:")
 	})
 })
@@ -259,16 +261,19 @@ describe("step todo forwarding", () => {
 		const phase = makePhase({ id: "phase-1", steps: [makeStep({ id: "step-1" })] })
 		const f = makeFerment({ phases: [phase] })
 
-		applyWriteTodos({
-			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
-			todos: [
-				{ content: "Install dependencies", status: "completed" },
-				{ content: "Write main module", status: "in_progress" },
-				{ content: "Run tests", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-1" },
+				todos: [
+					{ content: "Install dependencies", status: "completed" },
+					{ content: "Write main module", status: "in_progress" },
+					{ content: "Run tests", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).toContain("Plan:")
 		expect(ctx).toContain("\u2713 Install dependencies")
 		expect(ctx).toContain("\u25b6 Write main module")
@@ -279,7 +284,7 @@ describe("step todo forwarding", () => {
 		const phase = makePhase({ steps: [makeStep()] })
 		const f = makeFerment({ phases: [phase] })
 
-		const ctx = buildWorkerContext(f, phase, phase.steps[0])
+		const ctx = buildWorkerContext(f, phase, phase.steps[0], TEST_SESSION_ID)
 		expect(ctx).not.toContain("Plan:")
 	})
 })

--- a/src/extensions/ferment/worker-prompt.ts
+++ b/src/extensions/ferment/worker-prompt.ts
@@ -22,7 +22,13 @@ export interface WorkerContextOpts {
 	includeMemories?: boolean
 }
 
-export function buildWorkerContext(ferment: Ferment, phase: Phase, step: Step, opts: WorkerContextOpts = {}): string {
+export function buildWorkerContext(
+	ferment: Ferment,
+	phase: Phase,
+	step: Step,
+	sessionId: string,
+	opts: WorkerContextOpts = {},
+): string {
 	const lines: string[] = []
 	lines.push("## Worker Context")
 	lines.push(`Ferment: ${ferment.name}`)
@@ -72,7 +78,7 @@ export function buildWorkerContext(ferment: Ferment, phase: Phase, step: Step, o
 
 	// Include the orchestrator's step-level implementation plan so the worker
 	// knows what sub-tasks were planned and can track progress against them.
-	const stepTodos = getTodosForScope({ kind: "ferment-step", phaseId: phase.id, stepId: step.id })
+	const stepTodos = getTodosForScope({ kind: "ferment-step", phaseId: phase.id, stepId: step.id }, sessionId)
 	if (stepTodos.length > 0) {
 		const planItems = stepTodos.map((t) => {
 			const glyph = t.status === "completed" ? "\u2713" : t.status === "in_progress" ? "\u25b6" : "\u25cb"

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -904,7 +904,8 @@ describe("continuation nudge turn_end handler", () => {
 
 		const fire = async (event: string, payload: unknown) => {
 			const handlers = handlerMap.get(event) ?? []
-			for (const h of handlers) await h(payload)
+			const ctx = createContext({ model: { provider: "test", id: "test-model" } })
+			for (const h of handlers) await h(payload, ctx)
 		}
 
 		return { fire, sendMessageCalls }

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -27,7 +27,7 @@ import { randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
 import { join } from "node:path"
-import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
 import {
 	type ExtensionAPI,
 	type ExtensionContext,
@@ -137,25 +137,18 @@ function isDelegationToolCallName(name: string | undefined): boolean {
 	return name != null && DELEGATION_TOOL_NAMES.has(name)
 }
 
-/**
- * Shape of a tool-call content block as emitted in assistant messages.
- * Defined narrowly here because the upstream `OrchestratorMessages` type does
- * not export the per-block discriminated-union members we need to narrow on.
- */
-type ToolCallBlock = { type: "toolCall"; name: string; id?: string }
-
-function isToolCallBlock(block: unknown): block is ToolCallBlock {
+function isToolCallBlock(block: AssistantMessage["content"][number]): block is ToolCall {
 	return (
 		typeof block === "object" &&
 		block !== null &&
 		"type" in block &&
-		(block as { type: unknown }).type === "toolCall" &&
+		block.type === "toolCall" &&
 		"name" in block &&
-		typeof (block as { name: unknown }).name === "string"
+		typeof block.name === "string"
 	)
 }
 
-function isEmptyToolCallBlock(block: unknown): block is ToolCallBlock {
+function isEmptyToolCallBlock(block: AssistantMessage["content"][number]): block is ToolCall {
 	return isToolCallBlock(block) && block.name.trim() === ""
 }
 
@@ -257,12 +250,8 @@ export default function (skillPaths: string[]) {
 					)
 				}
 			}
-			function notifyIfDeprecated(ctx: {
-				sessionManager?: { getSessionId: () => string | undefined }
-				model?: { id: string }
-				ui?: { notify: (msg: string, kind?: "warning" | "error" | "info") => void }
-			}) {
-				const sessionId = ctx.sessionManager?.getSessionId() ?? "unknown"
+			function notifyIfDeprecated(ctx: ExtensionContext) {
+				const sessionId = ctx.sessionManager.getSessionId() ?? "unknown"
 				if (ctx.model && deprecatedWarnings.has(ctx.model.id) && !deprecatedNotificationFired.has(sessionId)) {
 					deprecatedNotificationFired.add(sessionId)
 					const replacement = deprecatedWarnings.get(ctx.model.id)
@@ -276,8 +265,8 @@ export default function (skillPaths: string[]) {
 			}
 
 			pi.on("session_shutdown", async (_event, ctx) => {
-				const sessionId = ctx.sessionManager?.getSessionId()
-				if (sessionId) deprecatedNotificationFired.delete(sessionId)
+				const sessionId = ctx.sessionManager.getSessionId()
+				deprecatedNotificationFired.delete(sessionId)
 			})
 
 			pi.on("session_start", async (_event, ctx) => {
@@ -316,12 +305,38 @@ export default function (skillPaths: string[]) {
 			// The reset handler is registered BEFORE the enrichment handler below because
 			// that one returns `{action: "handled"}` in interactive mode, which short-
 			// circuits the input-handler chain.
-			const continuationNudge = new ContinuationNudge()
-			const emptyTurnNudge = new EmptyTurnNudge()
-			pi.on("agent_start", async () => {
+			const continuationNudgeMap = new Map<string, ContinuationNudge>()
+			const emptyTurnNudgeMap = new Map<string, EmptyTurnNudge>()
+
+			function getContinuationNudge(sessionId: string): ContinuationNudge {
+				let nudge = continuationNudgeMap.get(sessionId)
+				if (!nudge) {
+					nudge = new ContinuationNudge()
+					continuationNudgeMap.set(sessionId, nudge)
+				}
+				return nudge
+			}
+
+			function getEmptyTurnNudge(sessionId: string): EmptyTurnNudge {
+				let nudge = emptyTurnNudgeMap.get(sessionId)
+				if (!nudge) {
+					nudge = new EmptyTurnNudge()
+					emptyTurnNudgeMap.set(sessionId, nudge)
+				}
+				return nudge
+			}
+
+			pi.on("agent_start", async (_event, ctx) => {
+				const sessionId = ctx.sessionManager.getSessionId()
+				const continuationNudge = getContinuationNudge(sessionId)
 				continuationNudge.resetForNewAgentRun()
 			})
-			pi.on("input", async (event) => {
+
+			pi.on("input", async (event, ctx) => {
+				const sessionId = ctx.sessionManager.getSessionId()
+				const continuationNudge = getContinuationNudge(sessionId)
+				const emptyTurnNudge = getEmptyTurnNudge(sessionId)
+
 				if (event.source === "extension") {
 					// Agent result arriving. Clear the delegation-pending flag so the
 					// continuation nudge can fire normally once the model has processed
@@ -333,11 +348,16 @@ export default function (skillPaths: string[]) {
 				emptyTurnNudge.resetForNewUserInput()
 			})
 
-			pi.on("tool_execution_start", async () => {
+			pi.on("tool_execution_start", async (_event, ctx) => {
+				const sessionId = ctx.sessionManager.getSessionId()
+				const continuationNudge = getContinuationNudge(sessionId)
 				continuationNudge.recordToolCall()
 			})
 
-			pi.on("message_update", (event) => {
+			pi.on("message_update", (event, ctx) => {
+				const sessionId = ctx.sessionManager.getSessionId()
+				const continuationNudge = getContinuationNudge(sessionId)
+
 				if (!continuationNudge.isNudgeResponsePending()) return
 				const ame = event.assistantMessageEvent
 				if (ame.type !== "text_delta") return
@@ -349,14 +369,19 @@ export default function (skillPaths: string[]) {
 				}
 			})
 
-			pi.on("turn_end", async (event) => {
+			pi.on("turn_end", async (event, ctx) => {
 				if (event.message.role !== "assistant") return
 				// Safe after the role guard: AgentMessage with role "assistant" is AssistantMessage.
 				const assistantMsg = event.message as AssistantMessage
 
+				const sessionId = ctx.sessionManager.getSessionId()
+				const continuationNudge = getContinuationNudge(sessionId)
+				const emptyTurnNudge = getEmptyTurnNudge(sessionId)
+
 				// Track stall: increment counter each turn so the headless prompt
 				// block can detect when the orchestrator hasn't updated step todos.
-				bumpStallCounter()
+				// Scoped to this session so concurrent sessions do not share a counter.
+				bumpStallCounter(sessionId)
 
 				// Mark each delegation tool call so the continuation nudge stays
 				// suppressed until all delegated-agent results have been received.
@@ -515,7 +540,7 @@ export default function (skillPaths: string[]) {
 				mode,
 				roles,
 				customConfigs,
-				sessionId: ctx.sessionManager?.getSessionId(),
+				sessionId: ctx.sessionManager.getSessionId(),
 			})
 
 			// The rebuilt prompt replaces pi's base prompt entirely, which would

--- a/src/extensions/prompt-construction/system-prompt-blocks.ts
+++ b/src/extensions/prompt-construction/system-prompt-blocks.ts
@@ -84,8 +84,8 @@ export function createSystemPromptBlocks(pi: ExtensionAPI, owner: string): Syste
 		handles = new Set()
 		handlesByPi.set(pi, handles)
 		pi.on("session_start", (_event, ctx) => {
-			const sessionId = ctx?.sessionManager?.getSessionId()
-			if (sessionId) sessionIdByPi.set(pi, sessionId)
+			const sessionId = ctx.sessionManager.getSessionId()
+			sessionIdByPi.set(pi, sessionId)
 		})
 		pi.on("session_shutdown", () => {
 			handlesByPi.delete(pi)

--- a/src/extensions/todos/command.test.ts
+++ b/src/extensions/todos/command.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { __test_applyTodoAction, __test_parseTodoArgs, registerTodosCommand } from "./command.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
-import { __resetTodoStore, applyWriteTodos, getTodosForScope } from "./store.js"
+import { __resetTodoStore, applyWriteTodos, GLOBAL_TODO_SCOPE, getTodosForScope } from "./store.js"
+
+const TEST_SESSION_ID = "test-session"
 
 describe("/todos command helpers", () => {
 	beforeEach(() => {
@@ -21,35 +23,44 @@ describe("/todos command helpers", () => {
 	})
 
 	it("adds and updates todos through store writes", () => {
-		expect(__test_applyTodoAction({ action: "add", text: " first task ", index: null })).toEqual({
+		const addResult = __test_applyTodoAction(
+			{ action: "add", text: " first task ", index: null },
+			{ sessionId: TEST_SESSION_ID },
+		)
+		expect(addResult).toEqual({
 			message: "Added todo: first task",
 			level: "info",
 		})
-		expect(getTodosForScope()).toEqual([{ id: 1, content: "first task", status: "pending" }])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)).toEqual([
+			{ id: 1, content: "first task", status: "pending" },
+		])
 
-		__test_applyTodoAction({ action: "start", text: "", index: 0 })
-		expect(getTodosForScope()[0]).toMatchObject({ status: "in_progress" })
+		__test_applyTodoAction({ action: "start", text: "", index: 0 }, { sessionId: TEST_SESSION_ID })
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)[0]).toMatchObject({ status: "in_progress" })
 
-		__test_applyTodoAction({ action: "block", text: "", index: 0 })
-		expect(getTodosForScope()[0]).toMatchObject({ status: "blocked" })
+		__test_applyTodoAction({ action: "block", text: "", index: 0 }, { sessionId: TEST_SESSION_ID })
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)[0]).toMatchObject({ status: "blocked" })
 
-		__test_applyTodoAction({ action: "done", text: "", index: 0 })
-		expect(getTodosForScope()[0]).toMatchObject({ status: "completed" })
+		__test_applyTodoAction({ action: "done", text: "", index: 0 }, { sessionId: TEST_SESSION_ID })
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)[0]).toMatchObject({ status: "completed" })
 	})
 
 	it("removes and clears todos", () => {
-		applyWriteTodos({
-			todos: [
-				{ content: "one", status: "pending" },
-				{ content: "two", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "one", status: "pending" },
+					{ content: "two", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		__test_applyTodoAction({ action: "delete", text: "", index: 0 })
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["two"])
+		__test_applyTodoAction({ action: "delete", text: "", index: 0 }, { sessionId: TEST_SESSION_ID })
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID).map((todo) => todo.content)).toEqual(["two"])
 
-		__test_applyTodoAction({ action: "clear", text: "", index: null })
-		expect(getTodosForScope()).toEqual([])
+		__test_applyTodoAction({ action: "clear", text: "", index: null }, { sessionId: TEST_SESSION_ID })
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)).toEqual([])
 	})
 
 	it("persists slash-command edits as custom session entries", async () => {
@@ -64,7 +75,10 @@ describe("/todos command helpers", () => {
 		} as never)
 
 		try {
-			await registered.get("todos")?.handler("add persisted task", { hasUI: false } as never)
+			await registered.get("todos")?.handler("add persisted task", {
+				hasUI: false,
+				sessionManager: { getSessionId: () => TEST_SESSION_ID, getBranch: () => [] },
+			} as never)
 		} finally {
 			log.mockRestore()
 		}

--- a/src/extensions/todos/command.ts
+++ b/src/extensions/todos/command.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
-import { applyWriteTodos, getTodosForScope } from "./store.js"
+import { applyWriteTodos, GLOBAL_TODO_SCOPE, getTodosForScope } from "./store.js"
 import type { TodoStatus, WriteTodosDetails, WriteTodosParams } from "./types.js"
 import {
 	buildTodoLines,
@@ -136,19 +136,20 @@ function targetStatus(action: TodoAction, currentStatus: TodoStatus): TodoStatus
 
 interface ApplyTodoActionOptions {
 	onWrite?: (details: WriteTodosDetails) => void
+	sessionId: string
 }
 
 function writeTodos(params: WriteTodosParams, options: ApplyTodoActionOptions): WriteTodosDetails {
-	const details = applyWriteTodos(params)
+	const details = applyWriteTodos(params, options.sessionId)
 	options.onWrite?.(details)
 	return details
 }
 
 function applyTodoAction(
 	parsed: TodoUiLine,
-	options: ApplyTodoActionOptions = {},
+	options: ApplyTodoActionOptions,
 ): { message: string; level: "info" | "error" } | null {
-	const todos = getTodosForScope()
+	const todos = getTodosForScope(GLOBAL_TODO_SCOPE, options.sessionId)
 
 	if (parsed.action === "add") {
 		const content = parsed.text.trim().replace(/\s+/g, " ")
@@ -219,26 +220,40 @@ async function handleTodosCommand(args: string, ctx: ExtensionCommandContext, pi
 		return
 	}
 	if (parsed.action === "list") {
-		const lines = ctx.hasUI
-			? buildTodoLines(ctx.ui.theme)
-			: getTodosForScope().map((todo, index) => `${index + 1}. [${todo.status}] ${todo.content}`)
-		if (ctx.hasUI) ctx.ui.notify(lines.join("\n"), "info")
-		else console.log(lines.join("\n"))
+		const sessionId = ctx.sessionManager.getSessionId()
+		if (ctx.hasUI) {
+			const lines = buildTodoLines(ctx.ui.theme, sessionId)
+			ctx.ui.notify(lines.join("\n"), "info")
+		} else {
+			const lines = getTodosForScope(GLOBAL_TODO_SCOPE, sessionId).map(
+				(todo, index) => `${index + 1}. [${todo.status}] ${todo.content}`,
+			)
+			console.log(lines.join("\n"))
+		}
 		return
 	}
 	if (parsed.action === "help") {
-		const lines = notifyUsage(ctx.hasUI ? ctx.ui.theme : plainTheme())
-		if (ctx.hasUI) ctx.ui.notify(lines.join("\n"), "info")
-		else console.log(lines.join("\n"))
+		if (ctx.hasUI) {
+			const lines = notifyUsage(ctx.ui.theme)
+			ctx.ui.notify(lines.join("\n"), "info")
+		} else {
+			const lines = notifyUsage(plainTheme())
+			console.log(lines.join("\n"))
+		}
 		return
 	}
 
+	const sessionId = ctx.sessionManager.getSessionId()
 	const outcome = applyTodoAction(parsed, {
+		sessionId,
 		onWrite: (details) => pi.appendEntry(TODO_CUSTOM_ENTRY_TYPE, details),
 	})
 	if (outcome) {
-		if (ctx.hasUI) ctx.ui.notify(outcome.message, outcome.level)
-		else console.log(outcome.message)
+		if (ctx.hasUI) {
+			ctx.ui.notify(outcome.message, outcome.level)
+		} else {
+			console.log(outcome.message)
+		}
 	}
 	syncTodoWidget(ctx)
 }

--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -271,6 +271,32 @@ describe("todos extension session state", () => {
 		expect(await harness.fire("context", { messages: [] }, ctx)).toBeUndefined()
 	})
 
+	it("only resets checkpoint pressure for the session that wrote todos", async () => {
+		const harness = createTodosHarness()
+		const ctxA = createContext("session-a", [])
+		const ctxB = createContext("session-b", [])
+
+		// Start both sessions. The second start registers the active subscriber;
+		// the fix ensures the subscriber uses the writing session id rather than
+		// closing over session-b's context.
+		await harness.fire("session_start", { reason: "new" }, ctxA)
+		await harness.fire("session_start", { reason: "new" }, ctxB)
+
+		applyWriteTodos({ todos: [{ content: "A work", status: "in_progress" }] }, "session-a")
+		applyWriteTodos({ todos: [{ content: "B work", status: "in_progress" }] }, "session-b")
+
+		// Both sessions do non-todo work, creating checkpoint pressure.
+		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctxA)
+		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctxB)
+		expect(await harness.fire("context", { messages: [] }, ctxA)).toBeDefined()
+		expect(await harness.fire("context", { messages: [] }, ctxB)).toBeDefined()
+
+		// Session A writes todos. Only A's pressure should clear.
+		applyWriteTodos({ todos: [{ id: 1, content: "A work", status: "completed" }] }, "session-a")
+		expect(await harness.fire("context", { messages: [] }, ctxA)).toBeUndefined()
+		expect(await harness.fire("context", { messages: [] }, ctxB)).toBeDefined()
+	})
+
 	it("queues reconciliation follow-ups after visible terminal stops", async () => {
 		const harness = createTodosHarness()
 		const ctx = createContext("session", [])

--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext, SessionEntry, Theme } from "@earen
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
 import todosExtension, { TODO_CHECKPOINT_MESSAGE, TODO_RECONCILE_MESSAGE } from "./index.js"
-import { __resetTodoStore, applyWriteTodos, getTodosForScope } from "./store.js"
+import { __resetTodoStore, applyWriteTodos, GLOBAL_TODO_SCOPE, getTodosForScope } from "./store.js"
 import { TODO_TOOL_NAMES, UPDATE_TODOS_TOOL_NAME } from "./tool.js"
 import { TODO_TOOL_RESULT_SCHEMA_VERSION, type TodoStatus } from "./types.js"
 
@@ -128,7 +128,7 @@ describe("todos extension session state", () => {
 
 	it("restores todos from the active session branch instead of the previous store", async () => {
 		const harness = createTodosHarness()
-		applyWriteTodos({ todos: [{ content: "stale previous session", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "stale previous session", status: "pending" }] }, "previous-session")
 
 		await harness.fire(
 			"session_start",
@@ -139,16 +139,18 @@ describe("todos extension session state", () => {
 			]),
 		)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["current resumed todo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "resumed-session").map((todo) => todo.content)).toEqual([
+			"current resumed todo",
+		])
 	})
 
 	it("clears stale todos when the replacement session has no todo history", async () => {
 		const harness = createTodosHarness()
-		applyWriteTodos({ todos: [{ content: "stale previous session", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "stale previous session", status: "pending" }] }, "previous-session")
 
 		await harness.fire("session_start", { reason: "fork" }, createContext("forked-session", []))
 
-		expect(getTodosForScope()).toEqual([])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "forked-session")).toEqual([])
 	})
 
 	it("replays todos when the active session tree branch changes", async () => {
@@ -159,7 +161,7 @@ describe("todos extension session state", () => {
 			createContext("session", [writeTodosEntry("a", "root todo")]),
 		)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["root todo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["root todo"])
 
 		await harness.fire(
 			"session_tree",
@@ -167,7 +169,7 @@ describe("todos extension session state", () => {
 			createContext("session", [writeTodosEntry("b", "branch todo", "in_progress")]),
 		)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["branch todo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["branch todo"])
 	})
 
 	it("restores slash-command todo edits from custom entries", async () => {
@@ -179,7 +181,7 @@ describe("todos extension session state", () => {
 			createContext("session", [customTodosEntry("c", "command todo")]),
 		)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["command todo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["command todo"])
 	})
 
 	it("restores todos from every todo tool result", async () => {
@@ -193,8 +195,8 @@ describe("todos extension session state", () => {
 				createContext("session", [writeTodosEntry("u", `${toolName} todo`, "completed", toolName)]),
 			)
 
-			expect(getTodosForScope().map((todo) => todo.content)).toEqual([`${toolName} todo`])
-			expect(getTodosForScope()[0]?.status).toBe("completed")
+			expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual([`${toolName} todo`])
+			expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session")[0]?.status).toBe("completed")
 		}
 	})
 
@@ -207,8 +209,8 @@ describe("todos extension session state", () => {
 			createContext("session", [writeTodosEntry("legacy", "legacy todo", "in_progress", "write_todos")]),
 		)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["legacy todo"])
-		expect(getTodosForScope()[0]?.status).toBe("in_progress")
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["legacy todo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session")[0]?.status).toBe("in_progress")
 	})
 
 	it("adds todo guidance to a system prompt that missed extension prompt blocks", async () => {
@@ -236,7 +238,7 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "check work", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "check work", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 
 		const result = (await harness.fire("context", { messages: [] }, ctx)) as {
@@ -262,9 +264,9 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "check work", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "check work", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
-		applyWriteTodos({ todos: [{ id: 1, content: "check work", status: "completed" }] })
+		applyWriteTodos({ todos: [{ id: 1, content: "check work", status: "completed" }] }, "session")
 
 		expect(await harness.fire("context", { messages: [] }, ctx)).toBeUndefined()
 	})
@@ -274,7 +276,7 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 		await harness.fire("turn_end", terminalTurnWithText(), ctx)
 		await harness.fire("input", { type: "input", text: "", source: "extension", streamingBehavior: "followUp" }, ctx)
@@ -306,7 +308,7 @@ describe("todos extension session state", () => {
 		expect(checkpoint.messages[0].details).toEqual({ reason: "todo_checkpoint" })
 		expect(checkpoint.messages[0].content[0].text).toContain("still active")
 
-		applyWriteTodos({ todos: [{ id: 1, content: "still active", status: "completed" }] })
+		applyWriteTodos({ todos: [{ id: 1, content: "still active", status: "completed" }] }, "session")
 		await harness.fire("turn_end", terminalTurn(), ctx)
 		expect(harness.sendMessage).toHaveBeenCalledTimes(2)
 	})
@@ -316,7 +318,7 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 		await harness.fire("turn_end", terminalTurn("stop"), ctx)
 
@@ -333,7 +335,7 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "new plan", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "new plan", status: "pending" }] }, "session")
 		await harness.fire("turn_end", terminalTurn(), ctx)
 
 		expect(harness.sendMessage).not.toHaveBeenCalled()
@@ -348,7 +350,7 @@ describe("todos extension session state", () => {
 		})
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "visible active todo", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "visible active todo", status: "in_progress" }] }, "session")
 		const component = setWidget.mock.calls[0][1]
 		const instance = component({ requestRender: vi.fn() }, theme)
 		instance.dispose()
@@ -363,7 +365,7 @@ describe("todos extension session state", () => {
 		const harness = createTodosHarness()
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
-		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 
 		await harness.fire("turn_end", { message: { role: "assistant", stopReason: "aborted" }, toolResults: [] }, ctx)
@@ -381,7 +383,7 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 		await harness.fire("turn_end", terminalTurnWithText(), ctx)
 
@@ -396,10 +398,27 @@ describe("todos extension session state", () => {
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
 
-		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] })
+		applyWriteTodos({ todos: [{ content: "still active", status: "in_progress" }] }, "session")
 		await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 
 		const result = await harness.fire("context", { messages: [] }, ctx)
 		expect(result).toBeUndefined()
+	})
+
+	it("isolates todos between concurrent sessions", async () => {
+		const harness = createTodosHarness()
+		const ctxA = createContext("session-a", [writeTodosEntry("a1", "alpha for A", "in_progress")])
+		const ctxB = createContext("session-b", [])
+
+		await harness.fire("session_start", { reason: "new" }, ctxA)
+		await harness.fire("session_start", { reason: "new" }, ctxB)
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["alpha for A"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b")).toEqual([])
+
+		// Writes targeted at session-b must not bleed into session-a.
+		applyWriteTodos({ todos: [{ content: "beta for B", status: "pending" }] }, "session-b")
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["alpha for A"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b").map((todo) => todo.content)).toEqual(["beta for B"])
 	})
 })

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -142,15 +142,28 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	registerTodosCommand(pi)
 	registerTodoShortcut(pi)
 
-	let unsubscribeTodoStore: (() => void) | undefined
 	const _workSinceTodoWrite = new Map<string, boolean>()
+	const _activeSessionContexts = new Map<string, ExtensionContext>()
+	let unsubscribeTodoStore: (() => void) | undefined
 
-	const setWorkSinceTodoWrite = (sessionId: string, value: boolean) => {
+	function setWorkSinceTodoWrite(sessionId: string, value: boolean): void {
 		_workSinceTodoWrite.set(sessionId, value)
 	}
 
-	const getWorkSinceTodoWrite = (sessionId: string): boolean => {
+	function getWorkSinceTodoWrite(sessionId: string): boolean {
 		return _workSinceTodoWrite.get(sessionId) ?? false
+	}
+
+	function setSessionContext(sessionId: string, ctx: ExtensionContext): void {
+		_activeSessionContexts.set(sessionId, ctx)
+	}
+
+	function getSessionContext(sessionId: string): ExtensionContext | undefined {
+		return _activeSessionContexts.get(sessionId)
+	}
+
+	function deleteSessionContext(sessionId: string): void {
+		_activeSessionContexts.delete(sessionId)
 	}
 
 	const maybeSteerTodoReconciliation = (message: unknown, ctx: ExtensionContext) => {
@@ -184,6 +197,9 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	}
 
 	pi.on("session_start", (_event, ctx) => {
+		const sessionId = ctx.sessionManager.getSessionId()
+		setSessionContext(sessionId, ctx)
+
 		// Headless (one-shot) runs have no widget; the todo-state prompt block
 		// renders the same content as markdown so the orchestrator agent can see
 		// it. It receives the session context and self-gates on ctx.hasUI.
@@ -193,10 +209,10 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		ensureTodoWidget(ctx)
 
 		unsubscribeTodoStore?.()
-		unsubscribeTodoStore = subscribeTodoStore(() => {
-			const sessionId = ctx.sessionManager.getSessionId()
-			setWorkSinceTodoWrite(sessionId, false)
-			syncTodoWidget(ctx)
+		unsubscribeTodoStore = subscribeTodoStore((_, emitterSessionId) => {
+			setWorkSinceTodoWrite(emitterSessionId, false)
+			const sessionCtx = getSessionContext(emitterSessionId)
+			if (sessionCtx) syncTodoWidget(sessionCtx)
 		})
 
 		replayAndSync(ctx)
@@ -245,5 +261,8 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = undefined
 		disposeTodoWidget(ctx)
+
+		const sessionId = ctx.sessionManager.getSessionId()
+		deleteSessionContext(sessionId)
 	})
 }

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -1,13 +1,8 @@
-import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, SessionEntry, SessionManager } from "@earendil-works/pi-coding-agent"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { registerTodosCommand } from "./command.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
-import {
-	appendTodoPromptBlockIfMissing,
-	registerTodoPromptBlock,
-	registerTodoStateBlock,
-	setCurrentSessionHasUI,
-} from "./prompt-block.js"
+import { appendTodoPromptBlockIfMissing, registerTodoPromptBlock, registerTodoStateBlock } from "./prompt-block.js"
 import { getTodosForScope, resolveTodoScope, restoreTodoStoreFromDetails, subscribeTodoStore } from "./store.js"
 import { registerTodosTool, TODO_TOOL_NAMES } from "./tool.js"
 import { TODO_TOOL_RESULT_SCHEMA_VERSION, type WriteTodosDetails } from "./types.js"
@@ -78,20 +73,25 @@ function getWriteTodosDetails(entry: SessionEntry): WriteTodosDetails | undefine
 	return undefined
 }
 
-export function restoreTodoStoreFromSessionEntries(entries: readonly SessionEntry[]): void {
-	restoreTodoStoreFromDetails(entries.map(getWriteTodosDetails).filter((details) => details !== undefined))
+function restoreTodoStoreFromSessionEntries(sessionManager: Pick<SessionManager, "getBranch" | "getSessionId">): void {
+	const sessionId = sessionManager.getSessionId()
+	const entries = sessionManager.getBranch()
+	restoreTodoStoreFromDetails(
+		entries.map(getWriteTodosDetails).filter((details) => details !== undefined),
+		sessionId,
+	)
 }
 
-function currentTodoStateKey(): string | undefined {
+function currentTodoStateKey(sessionId: string): string | undefined {
 	const scope = resolveTodoScope()
-	const todos = getTodosForScope(scope)
+	const todos = getTodosForScope(scope, sessionId)
 	if (todos.length === 0) return undefined
 	return JSON.stringify({ scope, todos: todos.map((todo) => [todo.id, todo.status, todo.content]) })
 }
 
-function currentTodoStateText(): string | undefined {
+function currentTodoStateText(sessionId: string): string | undefined {
 	const scope = resolveTodoScope()
-	const todos = getTodosForScope(scope)
+	const todos = getTodosForScope(scope, sessionId)
 	if (todos.length === 0) return undefined
 	const scopeText = scope.kind === "global" ? "global" : JSON.stringify(scope)
 	return [
@@ -131,6 +131,7 @@ function isTerminalAssistantTurn(
 export default function todosExtension(pi: ExtensionAPI): void {
 	registerTodosTool(pi)
 	registerTodoPromptBlock(pi)
+
 	pi.on("before_agent_start", (event) => {
 		const systemPrompt = appendTodoPromptBlockIfMissing(event.systemPrompt)
 		return systemPrompt ? { systemPrompt } : undefined
@@ -138,59 +139,66 @@ export default function todosExtension(pi: ExtensionAPI): void {
 
 	if (isAgentWorker()) return
 
-	let latestCtx: ExtensionContext | undefined
-	let unsubscribeTodoStore: (() => void) | undefined
-	let workSinceTodoWrite = false
+	registerTodosCommand(pi)
+	registerTodoShortcut(pi)
 
-	const resetTodoProcessState = () => {
-		workSinceTodoWrite = false
+	let unsubscribeTodoStore: (() => void) | undefined
+	const _workSinceTodoWrite = new Map<string, boolean>()
+
+	const setWorkSinceTodoWrite = (sessionId: string, value: boolean) => {
+		_workSinceTodoWrite.set(sessionId, value)
 	}
 
-	const maybeSteerTodoReconciliation = (message: unknown) => {
-		if (!workSinceTodoWrite) return
+	const getWorkSinceTodoWrite = (sessionId: string): boolean => {
+		return _workSinceTodoWrite.get(sessionId) ?? false
+	}
+
+	const maybeSteerTodoReconciliation = (message: unknown, ctx: ExtensionContext) => {
+		const sessionId = ctx.sessionManager.getSessionId()
+
+		if (!getWorkSinceTodoWrite(sessionId)) return
 		if (!hasVisibleText(message)) return
 		// If the model has no todo tools available (e.g. during a ferment plan
 		// review where all tools are suppressed), it cannot reconcile todos.
 		// Sending a follow-up would trap it in a text-only loop. Reset the flag
 		// and defer reconciliation until tools are restored.
 		if (!anyTodoToolsAvailable(pi)) {
-			resetTodoProcessState()
+			setWorkSinceTodoWrite(sessionId, false)
 			return
 		}
-		if (!currentTodoStateKey()) {
-			resetTodoProcessState()
+		if (!currentTodoStateKey(sessionId)) {
+			setWorkSinceTodoWrite(sessionId, false)
 			return
 		}
-		const stateText = currentTodoStateText()
+		const stateText = currentTodoStateText(sessionId)
 		const promptText = stateText ? `${TODO_RECONCILE_MESSAGE}\n\n${stateText}` : TODO_RECONCILE_MESSAGE
 		pi.sendMessage(hiddenTodoMessage("reconcile_todos", promptText), { deliverAs: "followUp" })
 	}
 
-	registerTodosCommand(pi)
-	registerTodoShortcut(pi)
-	// Headless (one-shot) runs have no widget; the todo-state prompt block
-	// renders the same content as markdown so the orchestrator agent can see
-	// it. Self-gates on currentSessionHasUI inside the block's render fn.
-	registerTodoStateBlock(pi)
-
 	const replayAndSync = (ctx: ExtensionContext) => {
-		latestCtx = ctx
-		restoreTodoStoreFromSessionEntries(ctx.sessionManager.getBranch())
-		resetTodoProcessState()
+		const sessionId = ctx.sessionManager.getSessionId()
+
+		restoreTodoStoreFromSessionEntries(ctx.sessionManager)
+		setWorkSinceTodoWrite(sessionId, false)
 		syncTodoWidget(ctx)
 	}
 
 	pi.on("session_start", (_event, ctx) => {
-		resetTodoProcessState()
-		resetTodoWidgetState()
+		// Headless (one-shot) runs have no widget; the todo-state prompt block
+		// renders the same content as markdown so the orchestrator agent can see
+		// it. Self-gates on currentSessionHasUI inside the block's render fn.
+		registerTodoStateBlock(pi, ctx)
+
+		resetTodoWidgetState(ctx)
 		ensureTodoWidget(ctx)
-		setCurrentSessionHasUI(ctx.hasUI)
+
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = subscribeTodoStore(() => {
-			workSinceTodoWrite = false
-			if (!latestCtx?.hasUI) return
-			syncTodoWidget(latestCtx)
+			const sessionId = ctx.sessionManager.getSessionId()
+			setWorkSinceTodoWrite(sessionId, false)
+			syncTodoWidget(ctx)
 		})
+
 		replayAndSync(ctx)
 	})
 
@@ -198,18 +206,23 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		replayAndSync(ctx)
 	})
 
-	pi.on("tool_execution_end", (event) => {
+	pi.on("tool_execution_end", (event, ctx) => {
 		if (event.isError || TODO_REPLAY_TOOL_NAME_SET.has(event.toolName)) return
-		if (currentTodoStateKey()) workSinceTodoWrite = true
+		const sessionId = ctx.sessionManager.getSessionId()
+		if (currentTodoStateKey(sessionId)) {
+			setWorkSinceTodoWrite(sessionId, true)
+		}
 	})
 
-	pi.on("context", (event) => {
-		if (!workSinceTodoWrite) return undefined
+	pi.on("context", (event, ctx) => {
+		const sessionId = ctx.sessionManager.getSessionId()
+
+		if (!getWorkSinceTodoWrite(sessionId)) return undefined
 		// Same guard as maybeSteerTodoReconciliation: if todo tools are not
 		// available (e.g. ferment plan review), skip checkpoint injection.
 		if (!anyTodoToolsAvailable(pi)) return undefined
-		const stateText = currentTodoStateText()
-		if (!stateText) return resetTodoProcessState()
+		const stateText = currentTodoStateText(sessionId)
+		if (!stateText) return setWorkSinceTodoWrite(sessionId, false)
 		return {
 			messages: [
 				...event.messages,
@@ -225,14 +238,12 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	pi.on("turn_end", (event, ctx) => {
 		if (!isTerminalAssistantTurn(event, ctx)) return
 		syncTodoWidget(ctx)
-		maybeSteerTodoReconciliation(event.message)
+		maybeSteerTodoReconciliation(event.message, ctx)
 	})
 
 	pi.on("session_shutdown", (_event, ctx) => {
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = undefined
-		latestCtx = undefined
-		setCurrentSessionHasUI(true)
 		disposeTodoWidget(ctx)
 	})
 }

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -186,7 +186,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
 		// Headless (one-shot) runs have no widget; the todo-state prompt block
 		// renders the same content as markdown so the orchestrator agent can see
-		// it. Self-gates on currentSessionHasUI inside the block's render fn.
+		// it. It receives the session context and self-gates on ctx.hasUI.
 		registerTodoStateBlock(pi, ctx)
 
 		resetTodoWidgetState(ctx)

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -1,7 +1,10 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import type { Ferment } from "../../ferment/types.js"
+import type { Ferment, Phase } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
+import { FERMENT_EVENTS } from "../ferment/domain-events.js"
 import { setActive } from "../ferment/state.js"
+import { bumpStallCounter, registerFermentTodoSync } from "../ferment/todo-sync.js"
 import {
 	__test_renderTodoPromptBlock,
 	__test_renderTodoStateMarkdown,
@@ -11,6 +14,81 @@ import {
 import { __resetTodoStore, applyWriteTodos } from "./store.js"
 
 const TEST_SESSION_ID = "test-session"
+
+// ─── Cross-session stall-counter helpers ────────────────────────────────────
+
+function createFakePI(): {
+	pi: ExtensionAPI
+	emit: (channel: string, payload: unknown) => void
+} {
+	const listeners = new Map<string, Array<(payload: unknown) => void>>()
+
+	const events = {
+		on: (channel: string, handler: (payload: unknown) => void) => {
+			if (!listeners.has(channel)) {
+				listeners.set(channel, [])
+			}
+			const list = listeners.get(channel)
+			if (list) {
+				list.push(handler)
+			}
+			return () => {
+				const list = listeners.get(channel)
+				if (list) {
+					const idx = list.indexOf(handler)
+					if (idx !== -1) list.splice(idx, 1)
+				}
+			}
+		},
+		emit: (channel: string, payload: unknown) => {
+			const list = listeners.get(channel)
+			if (list) {
+				for (const fn of list) {
+					fn(payload)
+				}
+			}
+		},
+	}
+
+	const pi = {
+		events,
+	} as unknown as ExtensionAPI
+
+	return { pi, emit: events.emit }
+}
+
+function createTestFerment(phaseId: string, stepCount: number): Ferment {
+	const steps = Array.from({ length: stepCount }, (_, i) => ({
+		id: `step-${i + 1}`,
+		index: i + 1,
+		description: `Step ${i + 1}`,
+		status: "pending" as const,
+	}))
+
+	const phase: Phase = {
+		id: phaseId,
+		index: 1,
+		name: "Test Phase",
+		goal: "Test phase goal",
+		status: "active",
+		steps,
+	}
+
+	return {
+		id: "ferment-prompt-block-test",
+		name: "Test Ferment",
+		status: "running",
+		worktree: { path: "/tmp" },
+		scoping: {},
+		phases: [phase],
+		decisions: [],
+		memories: [],
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	}
+}
+
+// ─── Test suites ────────────────────────────────────────────────────────────
 
 describe("todo prompt block", () => {
 	beforeEach(() => {
@@ -242,5 +320,47 @@ describe("ferment-conditional todo guidance", () => {
 		setActive(undefined)
 		const block = __test_renderTodoPromptBlock()
 		expect(block).not.toContain("When working inside a ferment step")
+	})
+})
+
+describe("cross-session stall counter isolation", () => {
+	afterEach(() => {
+		setActive(undefined)
+	})
+
+	it("only warns about stalls for the session whose step is running", () => {
+		const { pi, emit } = createFakePI()
+		const ferment = createTestFerment("phase-1", 1)
+		setActive(ferment)
+
+		const unsubA = registerFermentTodoSync(pi, "session-a")
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		emit(FERMENT_EVENTS.STEP_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-1",
+			stepId: "step-1",
+			stepIndex: 1,
+		})
+
+		// Bump session A's stall counter enough times to trigger the warning.
+		for (let i = 0; i < 5; i++) {
+			bumpStallCounter("session-a")
+		}
+
+		// Session A should see the stall warning.
+		const mdA = __test_renderTodoStateMarkdown("session-a")
+		expect(mdA).toContain("Step todos have not been updated for 5 turns")
+
+		// Session B has no running step and no stall counter; no warning.
+		const mdB = __test_renderTodoStateMarkdown("session-b")
+		expect(mdB).toBeUndefined()
+
+		unsubA()
 	})
 })

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -1,19 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
+import { createContext } from "../__mocks__/context.js"
 import { setActive } from "../ferment/state.js"
 import {
 	__test_renderTodoPromptBlock,
 	__test_renderTodoStateMarkdown,
 	appendTodoPromptBlockIfMissing,
-	currentSessionHasUI,
-	setCurrentSessionHasUI,
+	renderTodoStateBlock,
 } from "./prompt-block.js"
 import { __resetTodoStore, applyWriteTodos } from "./store.js"
+
+const TEST_SESSION_ID = "test-session"
 
 describe("todo prompt block", () => {
 	beforeEach(() => {
 		__resetTodoStore()
-		setCurrentSessionHasUI(true)
 	})
 
 	it("renders guidance without a current list", () => {
@@ -32,12 +33,15 @@ describe("todo prompt block", () => {
 	})
 
 	it("keeps guidance stable when todos exist", () => {
-		applyWriteTodos({
-			todos: [
-				{ content: "alpha", status: "in_progress" },
-				{ content: "bravo", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "alpha", status: "in_progress" },
+					{ content: "bravo", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
 		expect(__test_renderTodoPromptBlock()).not.toContain("Current global todos:")
 		expect(__test_renderTodoPromptBlock()).not.toContain("alpha")
@@ -56,30 +60,32 @@ describe("todo prompt block", () => {
 describe("todo state prompt block (headless)", () => {
 	beforeEach(() => {
 		__resetTodoStore()
-		setCurrentSessionHasUI(false) // simulate headless session
 	})
 
 	it("returns undefined when the store is empty", () => {
-		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toBeUndefined()
 	})
 
 	it("returns undefined when only the global scope is empty", () => {
-		applyWriteTodos({ scope: { kind: "global" }, todos: [] })
-		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+		applyWriteTodos({ scope: { kind: "global" }, todos: [] }, TEST_SESSION_ID)
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toBeUndefined()
 	})
 
 	it("renders global todos with the correct status glyphs", () => {
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [
-				{ content: "pending one", status: "pending" },
-				{ content: "working one", status: "in_progress" },
-				{ content: "blocked one", status: "blocked" },
-				{ content: "done one", status: "completed" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [
+					{ content: "pending one", status: "pending" },
+					{ content: "working one", status: "in_progress" },
+					{ content: "blocked one", status: "blocked" },
+					{ content: "done one", status: "completed" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const md = __test_renderTodoStateMarkdown()
+		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 		expect(md).toBeDefined()
 		expect(md).toContain("## Current Todos")
 		expect(md).toContain("**Global**")
@@ -90,17 +96,20 @@ describe("todo state prompt block (headless)", () => {
 	})
 
 	it("renders a ferment phase with header and indented steps", () => {
-		applyWriteTodos({
-			scope: { kind: "ferment", phaseId: "phase-1" },
-			todos: [
-				{ content: "[Phase 1] Test Phase", status: "in_progress", activeForm: "Test Phase" },
-				{ content: "↳ Step 1", status: "completed" },
-				{ content: "↳ Step 2", status: "in_progress" },
-				{ content: "↳ Step 3", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment", phaseId: "phase-1" },
+				todos: [
+					{ content: "[Phase 1] Test Phase", status: "in_progress", activeForm: "Test Phase" },
+					{ content: "↳ Step 1", status: "completed" },
+					{ content: "↳ Step 2", status: "in_progress" },
+					{ content: "↳ Step 3", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const md = __test_renderTodoStateMarkdown()
+		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 		expect(md).toContain("**[Phase 1] Test Phase**")
 		expect(md).toContain("- [x] ↳ Step 1")
 		expect(md).toContain("- [~] ↳ Step 2")
@@ -108,37 +117,49 @@ describe("todo state prompt block (headless)", () => {
 	})
 
 	it("renders ferment-step scopes with a header line per step", () => {
-		applyWriteTodos({
-			scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-2" },
-			todos: [{ content: "agent-written plan bullet", status: "in_progress" }],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment-step", phaseId: "phase-1", stepId: "step-2" },
+				todos: [{ content: "agent-written plan bullet", status: "in_progress" }],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const md = __test_renderTodoStateMarkdown()
+		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 		expect(md).toContain("**Step phase-1/step-2**")
 		expect(md).toContain("- [~] agent-written plan bullet")
 	})
 
 	it("groups global + multiple ferment phases together", () => {
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "global thing", status: "pending" }],
-		})
-		applyWriteTodos({
-			scope: { kind: "ferment", phaseId: "phase-1" },
-			todos: [
-				{ content: "[Phase 1] First", status: "in_progress", activeForm: "First" },
-				{ content: "↳ step", status: "pending" },
-			],
-		})
-		applyWriteTodos({
-			scope: { kind: "ferment", phaseId: "phase-2" },
-			todos: [
-				{ content: "[Phase 2] Second", status: "in_progress", activeForm: "Second" },
-				{ content: "↳ other step", status: "completed" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "global thing", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment", phaseId: "phase-1" },
+				todos: [
+					{ content: "[Phase 1] First", status: "in_progress", activeForm: "First" },
+					{ content: "↳ step", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment", phaseId: "phase-2" },
+				todos: [
+					{ content: "[Phase 2] Second", status: "in_progress", activeForm: "Second" },
+					{ content: "↳ other step", status: "completed" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const md = __test_renderTodoStateMarkdown()
+		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 		// Sections in order: Global, Phase 1, Phase 2
 		const globalIdx = md?.indexOf("**Global**") ?? -1
 		const phase1Idx = md?.indexOf("**[Phase 1] First**") ?? -1
@@ -149,38 +170,44 @@ describe("todo state prompt block (headless)", () => {
 	})
 
 	it("reflects subsequent writes (renders fresh state each call)", () => {
-		expect(__test_renderTodoStateMarkdown()).toBeUndefined()
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toBeUndefined()
 
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "first", status: "pending" }],
-		})
-		expect(__test_renderTodoStateMarkdown()).toContain("- [ ] first")
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "first", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toContain("- [ ] first")
 
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [{ content: "first", status: "completed" }],
-		})
-		expect(__test_renderTodoStateMarkdown()).toContain("- [x] first")
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "first", status: "completed" }],
+			},
+			TEST_SESSION_ID,
+		)
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toContain("- [x] first")
 	})
 })
 
 describe("todo state block gating", () => {
-	beforeEach(() => {
-		setCurrentSessionHasUI(true)
+	it("returns undefined when the session has a UI", () => {
+		const ctx = createContext({ hasUI: true })
+		expect(renderTodoStateBlock(ctx)).toBeUndefined()
 	})
 
-	it("reflects explicit setCurrentSessionHasUI calls", () => {
-		setCurrentSessionHasUI(false)
-		expect(currentSessionHasUI).toBe(false)
-		setCurrentSessionHasUI(true)
-		expect(currentSessionHasUI).toBe(true)
-	})
-
-	it("setCurrentSessionHasUI persists across reads until the next set", () => {
-		setCurrentSessionHasUI(false)
-		expect(currentSessionHasUI).toBe(false)
-		expect(currentSessionHasUI).toBe(false) // repeated reads are stable
+	it("renders markdown when the session is headless", () => {
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "headline", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
+		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		expect(renderTodoStateBlock(ctx)).toContain("- [ ] headline")
 	})
 })
 

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getActive } from "../ferment/state.js"
 import { getTurnsSinceStepTodoWrite } from "../ferment/todo-sync.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
@@ -30,23 +30,6 @@ export function registerTodoPromptBlock(pi: ExtensionAPI): void {
 	})
 }
 
-// ─── Live todo state for headless / one-shot runs ─────────────────────────────
-// In interactive sessions the todo widget renders the current state. In
-// headless runs there is no widget, so we surface the same state as a markdown
-// block injected into the system prompt. The block self-gates: when the UI is
-// present it returns undefined (no duplication), and when the store is empty
-// it also returns undefined (no prompt pollution).
-
-/** Module-level mirror of `ctx.hasUI` for the active session. Set by
- *  `todosExtension` from `session_start`, cleared on `session_shutdown`.
- *  Defaults to `true` so that pre-session renders (e.g. in tests) safely skip
- *  rather than injecting headless-only content into an interactive prompt. */
-export let currentSessionHasUI = true
-
-export function setCurrentSessionHasUI(value: boolean): void {
-	currentSessionHasUI = value
-}
-
 function statusGlyph(status: TodoStatus): string {
 	switch (status) {
 		case "completed":
@@ -69,8 +52,8 @@ function formatTodoLine(todo: TodoItem): string {
 /** Render the current todo store as a markdown section suitable for injection
  *  into the system prompt. Returns `undefined` when there is nothing to show
  *  (no scopes at all) so the block pipeline skips it. */
-export function renderTodoStateMarkdown(): string | undefined {
-	const state = getTodoState()
+export function renderTodoStateMarkdown(sessionId: string): string | undefined {
+	const state = getTodoState(sessionId)
 	const scopeKeys = Object.keys(state.byScope)
 	if (scopeKeys.length === 0) return undefined
 
@@ -152,12 +135,13 @@ export function renderTodoStateMarkdown(): string | undefined {
  *  - returns `undefined` when the active session has a UI (widget handles it)
  *  - returns `undefined` when the store is empty
  *  Both cases let the existing prompt-block pipeline skip cleanly. */
-export function registerTodoStateBlock(pi: ExtensionAPI): void {
+export function registerTodoStateBlock(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	createSystemPromptBlocks(pi, "todos").register({
 		id: "todo-state",
 		render: () => {
-			if (currentSessionHasUI) return undefined
-			return renderTodoStateMarkdown()
+			if (ctx.hasUI) return undefined
+			const sessionId = ctx.sessionManager.getSessionId()
+			return renderTodoStateMarkdown(sessionId)
 		},
 	})
 }
@@ -165,9 +149,10 @@ export function registerTodoStateBlock(pi: ExtensionAPI): void {
 /** Applies the full gate (currentSessionHasUI check) exactly as the registered
  *  system-prompt block does. Use this in tests to validate the complete path
  *  rather than calling the raw renderer directly. */
-export function renderTodoStateBlock(): string | undefined {
-	if (currentSessionHasUI) return undefined
-	return renderTodoStateMarkdown()
+export function renderTodoStateBlock(ctx: ExtensionContext): string | undefined {
+	if (ctx.hasUI) return undefined
+	const sessionId = ctx.sessionManager.getSessionId()
+	return renderTodoStateMarkdown(sessionId)
 }
 
 export {

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -118,7 +118,7 @@ export function renderTodoStateMarkdown(sessionId: string): string | undefined {
 
 	// Stall detection: if a ferment step is running and the step-scope
 	// todos haven't been updated in several turns, nudge the model.
-	const staleTurns = getTurnsSinceStepTodoWrite()
+	const staleTurns = getTurnsSinceStepTodoWrite(sessionId)
 	if (staleTurns >= 5) {
 		lines.push("")
 		lines.push(
@@ -146,7 +146,7 @@ export function registerTodoStateBlock(pi: ExtensionAPI, ctx: ExtensionContext):
 	})
 }
 
-/** Applies the full gate (currentSessionHasUI check) exactly as the registered
+/** Applies the full gate (ctx.hasUI check) exactly as the registered
  *  system-prompt block does. Use this in tests to validate the complete path
  *  rather than calling the raw renderer directly. */
 export function renderTodoStateBlock(ctx: ExtensionContext): string | undefined {

--- a/src/extensions/todos/store.test.ts
+++ b/src/extensions/todos/store.test.ts
@@ -138,10 +138,24 @@ describe("todo store", () => {
 		const unsubscribe = subscribeTodoStore(listener)
 
 		const details = applyWriteTodos({ todos: [{ content: "alpha", status: "pending" }] }, TEST_SESSION_ID)
-		expect(listener).toHaveBeenCalledWith(details)
+		expect(listener).toHaveBeenCalledWith(details, TEST_SESSION_ID)
 
 		unsubscribe()
 		applyWriteTodos({ todos: [{ content: "bravo", status: "pending" }] }, TEST_SESSION_ID)
 		expect(listener).toHaveBeenCalledTimes(1)
+	})
+
+	it("notifies subscribers with the writing session id, not the subscriber's session", () => {
+		const listener = vi.fn()
+		const unsubscribe = subscribeTodoStore(listener)
+
+		applyWriteTodos({ todos: [{ content: "from A", status: "pending" }] }, "session-a")
+		applyWriteTodos({ todos: [{ content: "from B", status: "pending" }] }, "session-b")
+
+		expect(listener).toHaveBeenCalledTimes(2)
+		expect(listener.mock.calls[0]?.[1]).toBe("session-a")
+		expect(listener.mock.calls[1]?.[1]).toBe("session-b")
+
+		unsubscribe()
 	})
 })

--- a/src/extensions/todos/store.test.ts
+++ b/src/extensions/todos/store.test.ts
@@ -8,8 +8,12 @@ import {
 	getTodoState,
 	getTodosForScope,
 	registerActiveTodoScopeProvider,
+	restoreTodoStoreFromDetails,
 	subscribeTodoStore,
 } from "./store.js"
+import type { WriteTodosDetails } from "./types.js"
+
+const TEST_SESSION_ID = "test-session"
 
 describe("todo store", () => {
 	beforeEach(() => {
@@ -17,16 +21,23 @@ describe("todo store", () => {
 	})
 
 	it("replaces, reads, counts, and clears global todos", () => {
-		applyWriteTodos({
-			todos: [
-				{ content: "alpha", status: "in_progress" },
-				{ content: "bravo", status: "blocked" },
-				{ content: "charlie", status: "completed" },
-			],
-		})
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "alpha", status: "in_progress" },
+					{ content: "bravo", status: "blocked" },
+					{ content: "charlie", status: "completed" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		expect(getTodosForScope(GLOBAL_TODO_SCOPE).map((todo) => todo.content)).toEqual(["alpha", "bravo", "charlie"])
-		expect(getTodoCountsForScope(GLOBAL_TODO_SCOPE)).toEqual({
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID).map((todo) => todo.content)).toEqual([
+			"alpha",
+			"bravo",
+			"charlie",
+		])
+		expect(getTodoCountsForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)).toEqual({
 			total: 3,
 			completed: 1,
 			pending: 0,
@@ -34,8 +45,66 @@ describe("todo store", () => {
 			inProgress: 1,
 		})
 
-		clearTodoStore()
-		expect(getTodoState()).toEqual({ byScope: {} })
+		clearTodoStore(TEST_SESSION_ID)
+		expect(getTodoState(TEST_SESSION_ID)).toEqual({ byScope: {} })
+	})
+
+	it("isolates todos between different session ids", () => {
+		applyWriteTodos({ todos: [{ content: "for session A", status: "in_progress" }] }, "session-a")
+		applyWriteTodos({ todos: [{ content: "for session B", status: "pending" }] }, "session-b")
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["for session A"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b").map((todo) => todo.content)).toEqual(["for session B"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)).toEqual([])
+	})
+
+	it("restoreTodoStoreFromDetails targets the given session id only", () => {
+		const detailsA: WriteTodosDetails = {
+			schemaVersion: 1,
+			scope: { kind: "global" },
+			todos: [{ id: 1, content: "restored A", status: "in_progress" }],
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		}
+		const detailsB: WriteTodosDetails = {
+			schemaVersion: 1,
+			scope: { kind: "global" },
+			todos: [{ id: 1, content: "restored B", status: "completed" }],
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		}
+
+		restoreTodoStoreFromDetails([detailsA], "session-a")
+		restoreTodoStoreFromDetails([detailsB], "session-b")
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["restored A"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b").map((todo) => todo.content)).toEqual(["restored B"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID)).toEqual([])
+	})
+
+	it("clearTodoStore(sessionId) clears only that session", () => {
+		applyWriteTodos({ todos: [{ content: "keep", status: "pending" }] }, "session-a")
+		applyWriteTodos({ todos: [{ content: "drop", status: "pending" }] }, "session-b")
+
+		clearTodoStore("session-b")
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["keep"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b")).toEqual([])
+	})
+
+	it("__resetTodoStore clears every session bucket", () => {
+		applyWriteTodos({ todos: [{ content: "a", status: "pending" }] }, "session-a")
+		applyWriteTodos({ todos: [{ content: "b", status: "pending" }] }, "session-b")
+
+		__resetTodoStore()
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a")).toEqual([])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b")).toEqual([])
+	})
+
+	it("routes scope-less writes to the supplied session", () => {
+		applyWriteTodos({ todos: [{ content: "explicit session", status: "pending" }] }, TEST_SESSION_ID)
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, TEST_SESSION_ID).map((todo) => todo.content)).toEqual([
+			"explicit session",
+		])
 	})
 
 	it("uses providers only when scope is omitted", () => {
@@ -44,13 +113,13 @@ describe("todo store", () => {
 		registerActiveTodoScopeProvider(first)
 		registerActiveTodoScopeProvider(second)
 
-		applyWriteTodos({ todos: [{ content: "from provider", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "from provider", status: "pending" }] }, TEST_SESSION_ID)
 		expect(first).toHaveBeenCalledTimes(1)
 		expect(second).toHaveBeenCalledTimes(1)
 
 		first.mockClear()
 		second.mockClear()
-		applyWriteTodos({ scope: { kind: "global" }, todos: [{ content: "explicit", status: "pending" }] })
+		applyWriteTodos({ scope: { kind: "global" }, todos: [{ content: "explicit", status: "pending" }] }, TEST_SESSION_ID)
 		expect(first).not.toHaveBeenCalled()
 		expect(second).not.toHaveBeenCalled()
 	})
@@ -60,7 +129,7 @@ describe("todo store", () => {
 		const unregister = registerActiveTodoScopeProvider(provider)
 		unregister()
 
-		applyWriteTodos({ todos: [{ content: "global", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "global", status: "pending" }] }, TEST_SESSION_ID)
 		expect(provider).not.toHaveBeenCalled()
 	})
 
@@ -68,11 +137,11 @@ describe("todo store", () => {
 		const listener = vi.fn()
 		const unsubscribe = subscribeTodoStore(listener)
 
-		const details = applyWriteTodos({ todos: [{ content: "alpha", status: "pending" }] })
+		const details = applyWriteTodos({ todos: [{ content: "alpha", status: "pending" }] }, TEST_SESSION_ID)
 		expect(listener).toHaveBeenCalledWith(details)
 
 		unsubscribe()
-		applyWriteTodos({ todos: [{ content: "bravo", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "bravo", status: "pending" }] }, TEST_SESSION_ID)
 		expect(listener).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/todos/store.ts
+++ b/src/extensions/todos/store.ts
@@ -9,7 +9,7 @@ export type TodoScopeProvider = () => TodoScope | undefined
 /** Per-session todo state. Keyed by session id so that two concurrent keyed
  * sessions in the same process do not see each other's todos. */
 const stateMap = new Map<string, TodosSliceState>()
-const todoStoreListeners = new Set<(details: WriteTodosDetails) => void>()
+const todoStoreListeners = new Set<(details: WriteTodosDetails, sessionId: string) => void>()
 const activeScopeProviders: TodoScopeProvider[] = []
 
 function getSessionState(sessionId: string): TodosSliceState {
@@ -45,9 +45,9 @@ function resolveWriteTodoScope(params: WriteTodosParams): TodoScope {
 	return resolveTodoScope(params.scope)
 }
 
-function notifyTodoStoreListeners(details: WriteTodosDetails): void {
+function notifyTodoStoreListeners(details: WriteTodosDetails, sessionId: string): void {
 	for (const listener of [...todoStoreListeners]) {
-		listener(details)
+		listener(details, sessionId)
 	}
 }
 
@@ -56,7 +56,7 @@ export function applyWriteTodos(params: WriteTodosParams, sessionId: string): Wr
 	const current = getSessionState(sessionId)
 	const result = reduceReplaceList(current, { ...params, scope })
 	setSessionState(sessionId, result.state)
-	notifyTodoStoreListeners(result.details)
+	notifyTodoStoreListeners(result.details, sessionId)
 	return result.details
 }
 
@@ -75,7 +75,7 @@ export function getTodoCountsForScope(scope: TodoScope, sessionId: string): Todo
 	}
 }
 
-export function subscribeTodoStore(listener: (details: WriteTodosDetails) => void): () => void {
+export function subscribeTodoStore(listener: (details: WriteTodosDetails, sessionId: string) => void): () => void {
 	todoStoreListeners.add(listener)
 	return () => {
 		todoStoreListeners.delete(listener)

--- a/src/extensions/todos/store.ts
+++ b/src/extensions/todos/store.ts
@@ -6,12 +6,28 @@ export const GLOBAL_TODO_SCOPE: TodoScope = { kind: "global" }
 
 export type TodoScopeProvider = () => TodoScope | undefined
 
-let state = createEmptyTodosSliceState()
+/** Per-session todo state. Keyed by session id so that two concurrent keyed
+ * sessions in the same process do not see each other's todos. */
+const stateMap = new Map<string, TodosSliceState>()
 const todoStoreListeners = new Set<(details: WriteTodosDetails) => void>()
 const activeScopeProviders: TodoScopeProvider[] = []
 
-export function getTodoState(): TodosSliceState {
-	return state
+function getSessionState(sessionId: string): TodosSliceState {
+	const existing = stateMap.get(sessionId)
+	if (existing) {
+		return existing
+	}
+	const created = createEmptyTodosSliceState()
+	stateMap.set(sessionId, created)
+	return created
+}
+
+function setSessionState(sessionId: string, next: TodosSliceState): void {
+	stateMap.set(sessionId, next)
+}
+
+export function getTodoState(sessionId: string): TodosSliceState {
+	return getSessionState(sessionId)
 }
 
 export function resolveTodoScope(scopeInput?: unknown): TodoScope {
@@ -35,20 +51,21 @@ function notifyTodoStoreListeners(details: WriteTodosDetails): void {
 	}
 }
 
-export function applyWriteTodos(params: WriteTodosParams): WriteTodosDetails {
+export function applyWriteTodos(params: WriteTodosParams, sessionId: string): WriteTodosDetails {
 	const scope = resolveWriteTodoScope(params)
-	const result = reduceReplaceList(state, { ...params, scope })
-	state = result.state
+	const current = getSessionState(sessionId)
+	const result = reduceReplaceList(current, { ...params, scope })
+	setSessionState(sessionId, result.state)
 	notifyTodoStoreListeners(result.details)
 	return result.details
 }
 
-export function getTodosForScope(scope: TodoScope = GLOBAL_TODO_SCOPE): TodoItem[] {
-	return state.byScope[getTodoScopeKey(scope)]?.todos ?? []
+export function getTodosForScope(scope: TodoScope, sessionId: string): TodoItem[] {
+	return getSessionState(sessionId).byScope[getTodoScopeKey(scope)]?.todos ?? []
 }
 
-export function getTodoCountsForScope(scope: TodoScope = GLOBAL_TODO_SCOPE): TodoCounts {
-	const todos = getTodosForScope(scope)
+export function getTodoCountsForScope(scope: TodoScope, sessionId: string): TodoCounts {
+	const todos = getTodosForScope(scope, sessionId)
 	return {
 		total: todos.length,
 		completed: todos.filter((todo) => todo.status === "completed").length,
@@ -73,20 +90,20 @@ export function registerActiveTodoScopeProvider(provider: TodoScopeProvider): ()
 	}
 }
 
-export function clearTodoStore(): void {
-	state = createEmptyTodosSliceState()
+export function clearTodoStore(sessionId: string): void {
+	stateMap.delete(sessionId)
 }
 
-export function restoreTodoStoreFromDetails(details: readonly WriteTodosDetails[]): void {
+export function restoreTodoStoreFromDetails(details: readonly WriteTodosDetails[], sessionId: string): void {
 	let restored = createEmptyTodosSliceState()
 	for (const detail of details) {
 		restored = reduceReplaceList(restored, { scope: detail.scope, todos: detail.todos }).state
 	}
-	state = restored
+	setSessionState(sessionId, restored)
 }
 
 export function __resetTodoStore(): void {
-	clearTodoStore()
+	stateMap.clear()
 	activeScopeProviders.length = 0
 	todoStoreListeners.clear()
 }

--- a/src/extensions/todos/tool.test.ts
+++ b/src/extensions/todos/tool.test.ts
@@ -1,6 +1,18 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { __resetTodoStore, getTodosForScope } from "./store.js"
+import { __resetTodoStore, GLOBAL_TODO_SCOPE, getTodosForScope } from "./store.js"
 import { CREATE_TODOS_TOOL_NAME, registerTodosTool, TODO_TOOL_NAMES, UPDATE_TODOS_TOOL_NAME } from "./tool.js"
+
+function fakeCtx(sessionId: string): ExtensionContext {
+	return {
+		hasUI: false,
+		cwd: "/test",
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getBranch: () => [],
+		},
+	} as unknown as ExtensionContext
+}
 
 function registeredTools() {
 	const registerTool = vi.fn()
@@ -29,12 +41,18 @@ describe("todo tools", () => {
 
 	it("returns a structured error when reducer validation fails", async () => {
 		const tool = registeredTools()[UPDATE_TODOS_TOOL_NAME]
-		const result = await tool.execute("call-1", {
-			todos: [
-				{ id: 1, content: "one", status: "pending" },
-				{ id: 1, content: "two", status: "pending" },
-			],
-		})
+		const result = await tool.execute(
+			"call-1",
+			{
+				todos: [
+					{ id: 1, content: "one", status: "pending" },
+					{ id: 1, content: "two", status: "pending" },
+				],
+			},
+			undefined,
+			undefined,
+			fakeCtx("session"),
+		)
 
 		expect(result).toEqual({
 			content: [{ type: "text", text: "Failed to write todos: Duplicate todo id '1'" }],
@@ -58,27 +76,56 @@ describe("todo tools", () => {
 		expect(tool.description).toContain("before starting multi-step tasks")
 		expect(tool.promptSnippet).toBe("Create the initial todo list before multi-step work")
 
-		const result = await tool.execute("create-1", {
-			todos: [{ content: "inspect trace", status: "in_progress" }],
-		})
+		const result = await tool.execute(
+			"create-1",
+			{ todos: [{ content: "inspect trace", status: "in_progress" }] },
+			undefined,
+			undefined,
+			fakeCtx("session"),
+		)
 
 		expect(result.content).toEqual([{ type: "text", text: "Updated 1 todos." }])
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["inspect trace"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["inspect trace"])
 	})
 
 	it("adds, marks, and clears todos", async () => {
 		const tools = registeredTools()
+		const ctx = fakeCtx("session")
 
-		await tools.add_todo.execute("add-1", { content: "alpha" })
-		await tools.add_todo.execute("add-2", { content: "bravo" })
+		await tools.add_todo.execute("add-1", { content: "alpha" }, undefined, undefined, ctx)
+		await tools.add_todo.execute("add-2", { content: "bravo" }, undefined, undefined, ctx)
 
-		expect(getTodosForScope().map((todo) => todo.content)).toEqual(["alpha", "bravo"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["alpha", "bravo"])
 
-		await tools.mark_todo.execute("mark-1", { id: 1, status: "completed" })
-		expect(getTodosForScope().find((todo) => todo.id === 1)?.status).toBe("completed")
+		await tools.mark_todo.execute("mark-1", { id: 1, status: "completed" }, undefined, undefined, ctx)
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").find((todo) => todo.id === 1)?.status).toBe("completed")
 
-		const clearResult = await tools.clear_todos.execute("clear-1", {})
+		const clearResult = await tools.clear_todos.execute("clear-1", {}, undefined, undefined, ctx)
 		expect(clearResult.details.todos).toEqual([])
-		expect(getTodosForScope()).toEqual([])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session")).toEqual([])
+	})
+
+	it("writes through to the session id reported by ctx.sessionManager", async () => {
+		const tools = registeredTools()
+		const ctxA = fakeCtx("session-a")
+		const ctxB = fakeCtx("session-b")
+
+		await tools.update_todos.execute(
+			"u-a",
+			{ todos: [{ content: "alpha", status: "in_progress" }] },
+			undefined,
+			undefined,
+			ctxA,
+		)
+		await tools.update_todos.execute(
+			"u-b",
+			{ todos: [{ content: "beta", status: "pending" }] },
+			undefined,
+			undefined,
+			ctxB,
+		)
+
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-a").map((todo) => todo.content)).toEqual(["alpha"])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session-b").map((todo) => todo.content)).toEqual(["beta"])
 	})
 })

--- a/src/extensions/todos/tool.ts
+++ b/src/extensions/todos/tool.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import { applyWriteTodos, getTodosForScope, resolveTodoScope } from "./store.js"
 import { TODO_STATUSES, type TodoDraft, type TodoItem, type TodoStatus, type WriteTodosParams } from "./types.js"
@@ -94,9 +94,12 @@ function normalizeTodoStatus(value: unknown, fallback: TodoStatus = "pending"): 
 	throw new Error(`Invalid todo status '${String(value)}'`)
 }
 
-function scopedTodos(scopeInput: unknown): { scope: ReturnType<typeof resolveTodoScope>; todos: TodoItem[] } {
+function scopedTodos(
+	scopeInput: unknown,
+	sessionId: string,
+): { scope: ReturnType<typeof resolveTodoScope>; todos: TodoItem[] } {
 	const scope = resolveTodoScope(scopeInput)
-	return { scope, todos: getTodosForScope(scope) }
+	return { scope, todos: getTodosForScope(scope, sessionId) }
 }
 
 function todoDraftWithOptionalFields(params: AddTodoParams): TodoDraft {
@@ -110,9 +113,16 @@ function todoDraftWithOptionalFields(params: AddTodoParams): TodoDraft {
 	}
 }
 
-async function executeWriteTodos(_toolCallId: string, params: WriteTodosParams) {
+async function executeWriteTodos(
+	_toolCallId: string,
+	params: WriteTodosParams,
+	_signal: AbortSignal | undefined,
+	_onUpdate: unknown,
+	ctx: ExtensionContext,
+) {
+	const sessionId = ctx.sessionManager.getSessionId()
 	try {
-		const details = applyWriteTodos(params)
+		const details = applyWriteTodos(params, sessionId)
 		return {
 			content: [{ type: "text" as const, text: `Updated ${details.todos.length} todos.` }],
 			details,
@@ -125,11 +135,18 @@ async function executeWriteTodos(_toolCallId: string, params: WriteTodosParams) 
 	}
 }
 
-async function executeAddTodo(_toolCallId: string, params: AddTodoParams) {
+async function executeAddTodo(
+	_toolCallId: string,
+	params: AddTodoParams,
+	_signal: AbortSignal | undefined,
+	_onUpdate: unknown,
+	ctx: ExtensionContext,
+) {
+	const sessionId = ctx.sessionManager.getSessionId()
 	try {
-		const { scope, todos } = scopedTodos(params.scope)
+		const { scope, todos } = scopedTodos(params.scope, sessionId)
 		const knownIds = new Set(todos.map((todo) => todo.id))
-		const details = applyWriteTodos({ scope, todos: [...todos, todoDraftWithOptionalFields(params)] })
+		const details = applyWriteTodos({ scope, todos: [...todos, todoDraftWithOptionalFields(params)] }, sessionId)
 		// Storage order is id-based; identify the new item by id rather than position.
 		const added = details.todos.find((todo) => !knownIds.has(todo.id))
 		return {
@@ -144,11 +161,18 @@ async function executeAddTodo(_toolCallId: string, params: AddTodoParams) {
 	}
 }
 
-async function executeMarkTodo(_toolCallId: string, params: MarkTodoParams) {
+async function executeMarkTodo(
+	_toolCallId: string,
+	params: MarkTodoParams,
+	_signal: AbortSignal | undefined,
+	_onUpdate: unknown,
+	ctx: ExtensionContext,
+) {
+	const sessionId = ctx.sessionManager.getSessionId()
 	try {
 		const id = normalizeTodoId(params.id)
 		const status = normalizeTodoStatus(params.status)
-		const { scope, todos } = scopedTodos(params.scope)
+		const { scope, todos } = scopedTodos(params.scope, sessionId)
 		let found = false
 		const nextTodos = todos.map((todo) => {
 			if (todo.id !== id) return todo
@@ -162,7 +186,7 @@ async function executeMarkTodo(_toolCallId: string, params: MarkTodoParams) {
 		})
 		if (!found) throw new Error(`Todo #${id} not found`)
 
-		const details = applyWriteTodos({ scope, todos: nextTodos })
+		const details = applyWriteTodos({ scope, todos: nextTodos }, sessionId)
 		return {
 			content: [{ type: "text" as const, text: `Marked todo #${id} ${status}.` }],
 			details,
@@ -175,10 +199,17 @@ async function executeMarkTodo(_toolCallId: string, params: MarkTodoParams) {
 	}
 }
 
-async function executeClearTodos(_toolCallId: string, params: ClearTodosParams) {
+async function executeClearTodos(
+	_toolCallId: string,
+	params: ClearTodosParams,
+	_signal: AbortSignal | undefined,
+	_onUpdate: unknown,
+	ctx: ExtensionContext,
+) {
+	const sessionId = ctx.sessionManager.getSessionId()
 	try {
 		const scope = resolveTodoScope(params.scope)
-		const details = applyWriteTodos({ scope, todos: [] })
+		const details = applyWriteTodos({ scope, todos: [] }, sessionId)
 		return {
 			content: [{ type: "text" as const, text: "Cleared todos." }],
 			details,

--- a/src/extensions/todos/widget.test.ts
+++ b/src/extensions/todos/widget.test.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
 import { __resetTodoStore, applyWriteTodos, registerActiveTodoScopeProvider } from "./store.js"
 import type { TodoScope } from "./types.js"
 import {
@@ -23,28 +24,33 @@ const theme = {
 	bold: (text: string) => text,
 } as Theme
 
+const TEST_SESSION_ID = "test-session"
+
 describe("todo widget helpers", () => {
 	beforeEach(() => {
 		__resetTodoStore()
-		resetTodoWidgetState()
+		resetTodoWidgetState(createContext({ sessionManager: { getSessionId: () => TEST_SESSION_ID } }))
 	})
 
 	it("renders empty state", () => {
-		expect(__test_buildTodoLines(theme)).toContain("No todos yet. Add one with `/todos add <text>`.")
+		expect(__test_buildTodoLines(theme, TEST_SESSION_ID)).toContain("No todos yet. Add one with `/todos add <text>`.")
 	})
 
 	it("summarizes and renders mixed statuses", () => {
-		applyWriteTodos({
-			todos: [
-				{ content: "active", status: "in_progress" },
-				{ content: "blocked", status: "blocked" },
-				{ content: "pending", status: "pending" },
-				{ content: "done", status: "completed" },
-			],
-		})
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "active", status: "in_progress" },
+					{ content: "blocked", status: "blocked" },
+					{ content: "pending", status: "pending" },
+					{ content: "done", status: "completed" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		expect(__test_summarizeTodos()).toBe("1/4 done · 3 active · 1 blocked")
-		expect(__test_buildTodoLines(theme)).toEqual([
+		expect(__test_summarizeTodos(TEST_SESSION_ID)).toBe("1/4 done · 3 active · 1 blocked")
+		expect(__test_buildTodoLines(theme, TEST_SESSION_ID)).toEqual([
 			"Todos · Global",
 			"",
 			"1/4 done · 3 active · 1 blocked",
@@ -57,14 +63,17 @@ describe("todo widget helpers", () => {
 	})
 
 	it("renders command positions instead of stored todo ids", () => {
-		applyWriteTodos({
-			todos: [
-				{ id: 6, content: "trace-visible id", status: "in_progress" },
-				{ id: 10, content: "later id", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				todos: [
+					{ id: 6, content: "trace-visible id", status: "in_progress" },
+					{ id: 10, content: "later id", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const lines = __test_buildTodoLines(theme)
+		const lines = __test_buildTodoLines(theme, TEST_SESSION_ID)
 		expect(lines).toContain("  1.  ▶ trace-visible id")
 		expect(lines).toContain("  2.  ○ later id")
 		expect(lines).not.toContain("  6.  ▶ trace-visible id")
@@ -72,8 +81,8 @@ describe("todo widget helpers", () => {
 
 	it("auto-opens while active todos exist", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({ todos: [{ content: "pending", status: "pending" }] })
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos({ todos: [{ content: "pending", status: "pending" }] }, TEST_SESSION_ID)
 
 		syncTodoWidget(ctx)
 
@@ -85,14 +94,14 @@ describe("todo widget helpers", () => {
 
 	it("auto-hides when all todos are completed", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
 		const tui = { requestRender: vi.fn() }
-		applyWriteTodos({ todos: [{ content: "finish", status: "pending" }] })
+		applyWriteTodos({ todos: [{ content: "finish", status: "pending" }] }, TEST_SESSION_ID)
 		syncTodoWidget(ctx)
 		const component = setWidget.mock.calls[0][1]
 		const instance = component(tui, theme)
 
-		applyWriteTodos({ todos: [{ id: 1, content: "finish", status: "completed" }] })
+		applyWriteTodos({ todos: [{ id: 1, content: "finish", status: "completed" }] }, TEST_SESSION_ID)
 		syncTodoWidget(ctx)
 
 		expect(instance.render(80)).toEqual([])
@@ -102,8 +111,8 @@ describe("todo widget helpers", () => {
 
 	it("manual open still renders completed todos", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({ todos: [{ content: "done", status: "completed" }] })
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos({ todos: [{ content: "done", status: "completed" }] }, TEST_SESSION_ID)
 
 		openTodoWidget(ctx)
 
@@ -116,13 +125,16 @@ describe("todo widget helpers", () => {
 
 	it("rolls the capped widget forward when leading todos are completed", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({
-			todos: Array.from({ length: 11 }, (_, index) => ({
-				content: `task ${index + 1}`,
-				status: index < 9 ? "completed" : index === 9 ? "in_progress" : "pending",
-			})),
-		})
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos(
+			{
+				todos: Array.from({ length: 11 }, (_, index) => ({
+					content: `task ${index + 1}`,
+					status: index < 9 ? "completed" : index === 9 ? "in_progress" : "pending",
+				})),
+			},
+			TEST_SESSION_ID,
+		)
 
 		openTodoWidget(ctx)
 
@@ -140,13 +152,16 @@ describe("todo widget helpers", () => {
 
 	it("can expand the widget to show all todo rows", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({
-			todos: Array.from({ length: 11 }, (_, index) => ({
-				content: `task ${index + 1}`,
-				status: index < 9 ? "completed" : index === 9 ? "in_progress" : "pending",
-			})),
-		})
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos(
+			{
+				todos: Array.from({ length: 11 }, (_, index) => ({
+					content: `task ${index + 1}`,
+					status: index < 9 ? "completed" : index === 9 ? "in_progress" : "pending",
+				})),
+			},
+			TEST_SESSION_ID,
+		)
 
 		expandTodoWidget(ctx)
 
@@ -161,13 +176,16 @@ describe("todo widget helpers", () => {
 
 	it("indicates hidden todos before and after the visible window", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({
-			todos: Array.from({ length: 19 }, (_, index) => ({
-				content: `task ${index + 1}`,
-				status: index < 9 ? "completed" : "pending",
-			})),
-		})
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos(
+			{
+				todos: Array.from({ length: 19 }, (_, index) => ({
+					content: `task ${index + 1}`,
+					status: index < 9 ? "completed" : "pending",
+				})),
+			},
+			TEST_SESSION_ID,
+		)
 
 		openTodoWidget(ctx)
 
@@ -186,13 +204,16 @@ describe("todo widget helpers", () => {
 
 	it("keeps pending overflow within the capped widget height", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({
-			todos: Array.from({ length: 19 }, (_, index) => ({
-				content: `task ${index + 1}`,
-				status: "pending",
-			})),
-		})
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos(
+			{
+				todos: Array.from({ length: 19 }, (_, index) => ({
+					content: `task ${index + 1}`,
+					status: "pending",
+				})),
+			},
+			TEST_SESSION_ID,
+		)
 
 		openTodoWidget(ctx)
 
@@ -207,13 +228,16 @@ describe("todo widget helpers", () => {
 
 	it("anchors completed overflow at the end", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
-		applyWriteTodos({
-			todos: Array.from({ length: 19 }, (_, index) => ({
-				content: `task ${index + 1}`,
-				status: "completed",
-			})),
-		})
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
+		applyWriteTodos(
+			{
+				todos: Array.from({ length: 19 }, (_, index) => ({
+					content: `task ${index + 1}`,
+					status: "completed",
+				})),
+			},
+			TEST_SESSION_ID,
+		)
 
 		openTodoWidget(ctx)
 
@@ -231,8 +255,8 @@ describe("todo widget helpers", () => {
 	it("re-registers the widget for a new context and ignores stale invalidations", () => {
 		const firstSetWidget = vi.fn()
 		const secondSetWidget = vi.fn()
-		const firstCtx = createUiContext("session", firstSetWidget)
-		const secondCtx = createUiContext("session", secondSetWidget)
+		const firstCtx = createUiContext(TEST_SESSION_ID, firstSetWidget)
+		const secondCtx = createUiContext(TEST_SESSION_ID, secondSetWidget)
 
 		openTodoWidget(firstCtx)
 		const firstComponent = firstSetWidget.mock.calls[0][1]
@@ -252,7 +276,7 @@ describe("todo widget helpers", () => {
 
 	it("re-registers after the TUI disposes extension widgets", () => {
 		const setWidget = vi.fn()
-		const ctx = createUiContext("session", setWidget)
+		const ctx = createUiContext(TEST_SESSION_ID, setWidget)
 
 		openTodoWidget(ctx)
 		const component = setWidget.mock.calls[0][1]
@@ -266,15 +290,18 @@ describe("todo widget helpers", () => {
 
 	it("visually distinguishes ferment todos from global todos", () => {
 		// Global scope todos - default behavior
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [
-				{ content: "global task", status: "pending" },
-				{ content: "global done", status: "completed" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [
+					{ content: "global task", status: "pending" },
+					{ content: "global done", status: "completed" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const globalLines = __test_buildTodoLines(theme)
+		const globalLines = __test_buildTodoLines(theme, TEST_SESSION_ID)
 		expect(globalLines[0]).toBe("Todos · Global")
 		expect(globalLines).toContain("  1.  ○ global task")
 		expect(globalLines).toContain("  2.  ✓ global done")
@@ -287,18 +314,21 @@ describe("todo widget helpers", () => {
 		const unregister = registerActiveTodoScopeProvider(() => fermentScope)
 
 		try {
-			applyWriteTodos({
-				scope: fermentScope,
-				todos: [
-					{ content: "[Phase 1] Setup", status: "in_progress", activeForm: "Setup" },
-					{ content: "↳ Install dependencies", status: "completed" },
-					{ content: "↳ Configure build", status: "in_progress" },
-					{ content: "↳ Run tests", status: "blocked" },
-					{ content: "↳ Deploy", status: "pending" },
-				],
-			})
+			applyWriteTodos(
+				{
+					scope: fermentScope,
+					todos: [
+						{ content: "[Phase 1] Setup", status: "in_progress", activeForm: "Setup" },
+						{ content: "↳ Install dependencies", status: "completed" },
+						{ content: "↳ Configure build", status: "in_progress" },
+						{ content: "↳ Run tests", status: "blocked" },
+						{ content: "↳ Deploy", status: "pending" },
+					],
+				},
+				TEST_SESSION_ID,
+			)
 
-			const lines = __test_buildTodoLines(theme)
+			const lines = __test_buildTodoLines(theme, TEST_SESSION_ID)
 
 			// Scope header shows ferment
 			expect(lines[0]).toBe("Todos · Ferment (phase-1)")
@@ -318,15 +348,18 @@ describe("todo widget helpers", () => {
 
 	it("detects ferment todos by content prefix even in global scope", () => {
 		// Edge case: ferment-formatted todos accidentally written to global scope
-		applyWriteTodos({
-			scope: { kind: "global" },
-			todos: [
-				{ content: "[Phase 1] Test", status: "in_progress", activeForm: "Test" },
-				{ content: "↳ Step 1", status: "pending" },
-			],
-		})
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [
+					{ content: "[Phase 1] Test", status: "in_progress", activeForm: "Test" },
+					{ content: "↳ Step 1", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
 
-		const lines = __test_buildTodoLines(theme)
+		const lines = __test_buildTodoLines(theme, TEST_SESSION_ID)
 
 		// Even in global scope, ferment-formatted content gets detected
 		expect(lines[0]).toBe("Todos · Global")

--- a/src/extensions/todos/widget.ts
+++ b/src/extensions/todos/widget.ts
@@ -33,24 +33,18 @@ interface TodoWidgetState {
 }
 
 const todoWidgetStates = new Map<string, TodoWidgetState>()
-let activeTodoWidgetSessionId: string | undefined
 
 function createTodoWidgetState(): TodoWidgetState {
 	return { visible: false, expanded: false, collapsed: false, registered: false, registrationId: 0 }
 }
 
-function todoWidgetSessionId(ctx: ExtensionContext): string {
-	return ctx.sessionManager.getSessionId()
-}
-
 function getTodoWidgetState(ctx: ExtensionContext): TodoWidgetState {
-	const sessionId = todoWidgetSessionId(ctx)
+	const sessionId = ctx.sessionManager.getSessionId()
 	let state = todoWidgetStates.get(sessionId)
 	if (!state) {
 		state = createTodoWidgetState()
 		todoWidgetStates.set(sessionId, state)
 	}
-	activeTodoWidgetSessionId = sessionId
 	return state
 }
 
@@ -65,8 +59,8 @@ function hasActiveTodos(counts: TodoCounts): boolean {
 	return counts.pending + counts.inProgress + counts.blocked > 0
 }
 
-export function summarizeTodos(): string {
-	return summarizeTodoCounts(getTodoCountsForScope(GLOBAL_TODO_SCOPE))
+export function summarizeTodos(sessionId: string): string {
+	return summarizeTodoCounts(getTodoCountsForScope(GLOBAL_TODO_SCOPE, sessionId))
 }
 
 function isFermentTodo(todo: TodoItem): boolean {
@@ -119,8 +113,8 @@ function formatScopeHeader(scope: TodoScope): string {
 	return "Todos · Global"
 }
 
-function summarizeTodosForScope(scope: TodoScope): string {
-	return summarizeTodoCounts(getTodoCountsForScope(scope))
+function summarizeTodosForScope(scope: TodoScope, sessionId: string): string {
+	return summarizeTodoCounts(getTodoCountsForScope(scope, sessionId))
 }
 
 function selectTodoWindow(todos: TodoItem[]): {
@@ -157,9 +151,9 @@ function todoWindowAfterText(hiddenAfter: number): string | undefined {
 	return hiddenAfter > 0 ? `… ${hiddenAfter} more` : undefined
 }
 
-export function buildTodoLines(theme: Theme): string[] {
+export function buildTodoLines(theme: Theme, sessionId: string): string[] {
 	const scope = resolveTodoScope()
-	const todos = getTodosForScope(scope)
+	const todos = getTodosForScope(scope, sessionId)
 
 	if (todos.length === 0) {
 		return [
@@ -169,19 +163,24 @@ export function buildTodoLines(theme: Theme): string[] {
 		]
 	}
 
-	const lines = buildTodoListHeaderLines(theme, scope)
+	const lines = buildTodoListHeaderLines(theme, scope, sessionId)
 	lines.push(...todos.map((todo, index) => todoLine(todo, index, theme, scope)))
 	return lines
 }
 
-function buildTodoListHeaderLines(theme: Theme, scope: TodoScope): string[] {
-	return [theme.fg("accent", formatScopeHeader(scope)), "", theme.fg("dim", summarizeTodosForScope(scope)), ""]
+function buildTodoListHeaderLines(theme: Theme, scope: TodoScope, sessionId: string): string[] {
+	return [
+		theme.fg("accent", formatScopeHeader(scope)),
+		"",
+		theme.fg("dim", summarizeTodosForScope(scope, sessionId)),
+		"",
+	]
 }
 
-function buildTodoWidgetLines(theme: Theme, expanded: boolean): string[] {
+function buildTodoWidgetLines(theme: Theme, expanded: boolean, sessionId: string): string[] {
 	const scope = resolveTodoScope()
-	const todos = getTodosForScope(scope)
-	const lines = buildTodoLines(theme)
+	const todos = getTodosForScope(scope, sessionId)
+	const lines = buildTodoLines(theme, sessionId)
 	const withHint = [...lines, "", theme.fg("dim", TODO_LIST_HINT_TEXT)]
 	if (expanded) return withHint
 	if (withHint.length <= MAX_TODO_WIDGET_LINES) return withHint
@@ -191,35 +190,37 @@ function buildTodoWidgetLines(theme: Theme, expanded: boolean): string[] {
 	const beforeText = todoWindowBeforeText(window.hiddenBefore)
 	const afterText = todoWindowAfterText(window.hiddenAfter)
 	return [
-		...buildTodoListHeaderLines(theme, scope),
+		...buildTodoListHeaderLines(theme, scope, sessionId),
 		...(beforeText ? [theme.fg("dim", beforeText)] : []),
 		...window.todos.map((todo, index) => todoLine(todo, window.startIndex + index, theme, scope)),
 		...(afterText ? [theme.fg("dim", afterText)] : []),
 	]
 }
 
-export function resetTodoWidgetState(): void {
-	todoWidgetStates.clear()
-	activeTodoWidgetSessionId = undefined
+export function resetTodoWidgetState(ctx: ExtensionContext): void {
+	const sessionId = ctx.sessionManager.getSessionId()
+	todoWidgetStates.delete(sessionId)
 }
 
 function requestTodoRender(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
-	const state = todoWidgetStates.get(todoWidgetSessionId(ctx))
+	const sessionId = ctx.sessionManager.getSessionId()
+	const state = todoWidgetStates.get(sessionId)
 	if (!state?.registered) return
 	state.tui?.requestRender?.(true)
 }
 
 export function setTodosStatus(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
+	const sessionId = ctx.sessionManager.getSessionId()
 	const scope = resolveTodoScope()
-	const counts = getTodoCountsForScope(scope)
+	const counts = getTodoCountsForScope(scope, sessionId)
 	ctx.ui.setStatus(TODO_STATUS_KEY, hasActiveTodos(counts) ? `${summarizeTodoCounts(counts)} -> F7` : undefined)
 }
 
 export function ensureTodoWidget(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
-	const sessionId = todoWidgetSessionId(ctx)
+	const sessionId = ctx.sessionManager.getSessionId()
 	const state = getTodoWidgetState(ctx)
 	if (state.registered && state.ctx === ctx) return
 
@@ -230,14 +231,15 @@ export function ensureTodoWidget(ctx: ExtensionContext): void {
 		state.registered = false
 		state.tui = undefined
 		state.ctx = undefined
-		if (activeTodoWidgetSessionId === sessionId) activeTodoWidgetSessionId = undefined
 	}
 	const component = (tui: unknown, theme: Theme) => {
 		state.tui = tui as { requestRender?: (force?: boolean) => void }
 		return {
 			render(width: number): string[] {
 				if (!state.visible) return []
-				return buildTodoWidgetLines(theme, state.expanded).map((line) => truncateToWidth(line, Math.max(20, width - 4)))
+				return buildTodoWidgetLines(theme, state.expanded, sessionId).map((line) =>
+					truncateToWidth(line, Math.max(20, width - 4)),
+				)
 			},
 			invalidate: unregister,
 			dispose: unregister,
@@ -254,7 +256,6 @@ export function ensureTodoWidget(ctx: ExtensionContext): void {
 	ctx.ui.setWidget(TODO_WIDGET_KEY, component, TODO_WIDGET_OPTIONS)
 	state.registered = true
 	state.ctx = ctx
-	activeTodoWidgetSessionId = sessionId
 }
 
 export function openTodoWidget(ctx: ExtensionContext): void {
@@ -295,8 +296,9 @@ export function toggleTodoWidget(ctx: ExtensionContext): void {
 
 export function syncTodoWidget(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
+	const sessionId = ctx.sessionManager.getSessionId()
 	const scope = resolveTodoScope()
-	const counts = getTodoCountsForScope(scope)
+	const counts = getTodoCountsForScope(scope, sessionId)
 	const state = getTodoWidgetState(ctx)
 	if (!state.collapsed && hasActiveTodos(counts)) openTodoWidget(ctx)
 	else clearTodoWidget(ctx)
@@ -305,7 +307,7 @@ export function syncTodoWidget(ctx: ExtensionContext): void {
 
 export function disposeTodoWidget(ctx: ExtensionContext): void {
 	if (!ctx.hasUI) return
-	const sessionId = todoWidgetSessionId(ctx)
+	const sessionId = ctx.sessionManager.getSessionId()
 	const state = todoWidgetStates.get(sessionId)
 	ctx.ui.setWidget(TODO_WIDGET_KEY, undefined, TODO_WIDGET_OPTIONS)
 	if (state) {
@@ -315,7 +317,6 @@ export function disposeTodoWidget(ctx: ExtensionContext): void {
 		state.ctx = undefined
 	}
 	todoWidgetStates.delete(sessionId)
-	if (activeTodoWidgetSessionId === sessionId) activeTodoWidgetSessionId = undefined
 }
 
 export function registerTodoShortcut(pi: ExtensionAPI): void {

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -64,7 +64,6 @@ function resetMocks(): void {
 
 beforeEach(() => {
 	resetMocks()
-	// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
 	delete process.env.KIMCHI_NO_UPDATE_CHECK
 	// Default platform: linux (CI). Individual tests can override.
 	Object.defineProperty(process, "platform", { value: "linux", configurable: true })
@@ -98,7 +97,6 @@ beforeEach(() => {
 
 afterEach(() => {
 	if (originalEnvNoCheck === undefined) {
-		// biome-ignore lint/performance/noDelete: setting to undefined produces the literal string "undefined", which is truthy and would pollute subsequent tests
 		delete process.env.KIMCHI_NO_UPDATE_CHECK
 	} else process.env.KIMCHI_NO_UPDATE_CHECK = originalEnvNoCheck
 	Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })

--- a/tests/e2e/acp/todo-session-isolation.test.ts
+++ b/tests/e2e/acp/todo-session-isolation.test.ts
@@ -1,0 +1,133 @@
+// ACP integration: todo state is isolated between concurrent keyed sessions.
+//
+// The store was previously a single global object, so two sessions running in
+// the same process could see (and overwrite) each other's todos. This test
+// creates two sessions, writes distinct todo lists in each, mutates one, and
+// asserts that the other is unchanged.
+
+import type { ClientCapabilities } from "@agentclientprotocol/sdk"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { ADVERTISED_CAPABILITIES } from "../../../src/modes/acp/capabilities.js"
+import { type AcpFixture, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
+import { newSession, prompt } from "./support/scenarios.js"
+
+const FULL_CAPABILITIES: ClientCapabilities = {
+	fs: { readTextFile: false, writeTextFile: false },
+	elicitation: { form: {} },
+}
+
+const PI_META = { "kimchi.dev": { ...ADVERTISED_CAPABILITIES } } as const
+
+interface TodoLike {
+	content: string
+	status: string
+}
+
+function textResponse(text: string) {
+	return { stream: [text] }
+}
+
+function todoToolCall(name: "create_todos" | "update_todos", contents: TodoLike[]) {
+	return {
+		stream: ["Updating todos."],
+		toolCalls: [
+			{
+				function: {
+					name,
+					arguments: JSON.stringify({
+						todos: contents.map((todo, index) => ({
+							id: index + 1,
+							content: todo.content,
+							status: todo.status,
+						})),
+					}),
+				},
+			},
+		],
+	}
+}
+
+function todoContentsFromUpdate(update: unknown): TodoLike[] {
+	const rawOutput = (update as { rawOutput?: { details?: { todos?: Array<TodoLike & { id?: number }> } } }).rawOutput
+	return (rawOutput?.details?.todos ?? []).map(({ content, status }) => ({ content, status }))
+}
+
+function todoContents(fixture: AcpFixture, sessionId: string): TodoLike[] {
+	const updates = fixture.client.sessionUpdates.filter(
+		(u) =>
+			u.sessionId === sessionId &&
+			u.update.sessionUpdate === "tool_call_update" &&
+			Array.isArray((u.update as { content?: unknown[] }).content),
+	)
+	const latest = updates[updates.length - 1]
+	if (!latest) return []
+	return todoContentsFromUpdate(latest.update)
+}
+
+describe("ACP integration — todo session isolation", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		fixture = await startAcpFixture({
+			artifactName: "todo-session-isolation",
+			responses: [
+				// Session A turn 1: create two todos.
+				todoToolCall("create_todos", [
+					{ content: "alpha for A", status: "pending" },
+					{ content: "beta for A", status: "in_progress" },
+				]),
+				textResponse("Created todos for session A."),
+				// Session B turn 1: create two different todos.
+				todoToolCall("create_todos", [
+					{ content: "alpha for B", status: "pending" },
+					{ content: "beta for B", status: "pending" },
+				]),
+				textResponse("Created todos for session B."),
+				// Session A turn 2: mark alpha completed.
+				todoToolCall("update_todos", [
+					{ content: "alpha for A", status: "completed" },
+					{ content: "beta for A", status: "in_progress" },
+				]),
+				textResponse("Updated todos for session A."),
+			],
+			clientCapabilities: FULL_CAPABILITIES,
+			clientMeta: PI_META,
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("keeps each session's todos separate across concurrent sessions", async () => {
+		const sessionA = await newSession(fixture, fixture.workDir)
+		const turnA1 = await prompt(fixture, sessionA, "Create todos for session A")
+		expect(turnA1.stopReason).toBe("end_turn")
+
+		const aAfterCreate = todoContents(fixture, sessionA)
+		expect(aAfterCreate.map((t) => t.content)).toEqual(["alpha for A", "beta for A"])
+
+		const sessionB = await newSession(fixture, fixture.workDir)
+		const turnB1 = await prompt(fixture, sessionB, "Create todos for session B")
+		expect(turnB1.stopReason).toBe("end_turn")
+
+		const bAfterCreate = todoContents(fixture, sessionB)
+		expect(bAfterCreate.map((t) => t.content)).toEqual(["alpha for B", "beta for B"])
+
+		// Mutate session A and verify session B did not change.
+		const turnA2 = await prompt(fixture, sessionA, "Mark alpha completed")
+		expect(turnA2.stopReason).toBe("end_turn")
+
+		const aAfterUpdate = todoContents(fixture, sessionA)
+		expect(aAfterUpdate).toEqual([
+			{ content: "alpha for A", status: "completed" },
+			{ content: "beta for A", status: "in_progress" },
+		])
+
+		const bAfterAUpdate = todoContents(fixture, sessionB)
+		expect(bAfterAUpdate).toEqual([
+			{ content: "alpha for B", status: "pending" },
+			{ content: "beta for B", status: "pending" },
+		])
+	})
+})


### PR DESCRIPTION
## Linked issue

Closes #0
LLM-2572

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Fixes a critical bug in todo scoping where todos leaked between multiple sessions due to the assumption that Pi is working in a single session at any one time. This caused models in ACP clients running multiple sessions to get very confused about what they were working on and what they needed to do next.

Example confusion caused by leaking state during multiple streaming sessions:

<img width="1014" height="728" alt="image" src="https://github.com/user-attachments/assets/10ca9a43-8586-4107-acc2-aad9af474168" />


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
