### PR TITLE
fix(settings): read settings through pi's SettingsManager instead of hand-parsing

### DIFF
--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -1578,6 +1578,77 @@ describe("maybeTriggerFermentCompaction — /settings Auto-compact toggle", () =
 	})
 })
 
+// Paired tests proving the Auto-compact toggle turns stage compaction on/off for a
+// *one-shot* ferment specifically (isOneShot=true with inline compaction available —
+// the only path a one-shot run actually compacts).
+describe("maybeTriggerFermentCompaction — one-shot Auto-compact toggle", () => {
+	let storageMap: Map<string, Ferment>
+	let mockStorage: ReturnType<typeof makeMockStorage>
+	let runtime: FermentRuntime
+	let pi: ExtensionAPI
+	let ctx: ExtensionContext
+
+	beforeEach(() => {
+		storageMap = new Map()
+		mockStorage = makeMockStorage(storageMap)
+		runtime = makeRuntime({
+			getStorage: () => mockStorage as unknown as import("../../ferment/event-store.js").FermentEventStore,
+		})
+		pi = makePi()
+		ctx = makeCtx()
+		// One-shot ferment with inline compaction available — the path that compacts.
+		pi.getFlag = vi.fn((name) => (name === "ferment-oneshot" ? true : undefined))
+		ctx.model = { contextWindow: 100_000 } as ExtensionContext["model"]
+		ctx.inlineCompact = vi.fn(async () => ({ tokensBefore: 1_000 }) as CompactionResult)
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	afterEach(() => {
+		runtime.clearCompactionInFlight("ferment-1")
+		clearPendingCompaction("ferment-1")
+		vi.restoreAllMocks()
+		// restoreAllMocks does not reliably reset module-mock implementations, so
+		// re-pin the enabled default to avoid leaking a `false` into other blocks.
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	function seedPendingOneShot(): Ferment {
+		const ferment = makeFermentWithPhase(
+			{ id: "phase-1", name: "Phase", goal: "Goal" },
+			{ id: "step-1", description: "Do it" },
+		)
+		storageMap.set(ferment.id, ferment)
+		runtime.setActive(ferment)
+		setPendingCompaction(ferment.id, makePendingStep(ferment.id, "phase-1", "step-1"))
+		return ferment
+	}
+
+	it("compacts a one-shot ferment when the Auto-compact toggle is ENABLED", async () => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+		const ferment = seedPendingOneShot()
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// Compaction ran via inline compaction, and the pending entry was drained.
+		expect(ctx.inlineCompact).toHaveBeenCalledWith(expect.objectContaining({ force: true }))
+		expect(runtime.getPendingCompaction(ferment.id)).toBeUndefined()
+	})
+
+	it("does NOT compact a one-shot ferment when the Auto-compact toggle is DISABLED", async () => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(false)
+		const ferment = seedPendingOneShot()
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		// The toggle gates the one-shot path before any compaction call fires.
+		expect(ctx.inlineCompact).not.toHaveBeenCalled()
+		expect(ctx.compact).not.toHaveBeenCalled()
+		// The pending entry is left untouched (not drained), so it can still run later
+		// if the toggle is turned back on.
+		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
+	})
+})
+
 describe("maybeTriggerMidTurnFermentCompaction — /settings Auto-compact toggle", () => {
 	beforeEach(() => {
 		vi.mocked(getCompactionEnabled).mockReturnValue(true)

--- a/src/extensions/ferment/auto-compaction.test.ts
+++ b/src/extensions/ferment/auto-compaction.test.ts
@@ -1576,6 +1576,39 @@ describe("maybeTriggerFermentCompaction — /settings Auto-compact toggle", () =
 		// The pending compaction must be left untouched (not drained).
 		expect(runtime.getPendingCompaction(ferment.id)).toBeDefined()
 	})
+
+	it("passes the session's project-trust decision to getCompactionEnabled", async () => {
+		ctx.isProjectTrusted = vi.fn(() => true)
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(vi.mocked(getCompactionEnabled)).toHaveBeenCalledWith(true)
+	})
+
+	it("warns when the trust accessor fails unexpectedly, and still evaluates the toggle", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		ctx.isProjectTrusted = vi.fn(() => {
+			throw new Error("boom")
+		})
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("project trust"), expect.any(Error))
+		// Trust stays unknown — the toggle is still consulted with undefined.
+		expect(vi.mocked(getCompactionEnabled)).toHaveBeenCalledWith(undefined)
+	})
+
+	it("stays silent when the trust accessor throws a stale-ctx error", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		ctx.isProjectTrusted = vi.fn(() => {
+			throw new Error(STALE_CTX_MESSAGE)
+		})
+
+		await maybeTriggerFermentCompaction(pi, ctx, runtime)
+
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(vi.mocked(getCompactionEnabled)).toHaveBeenCalledWith(undefined)
+	})
 })
 
 // Paired tests proving the Auto-compact toggle turns stage compaction on/off for a

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -129,6 +129,20 @@ function readFermentOneshotFlag(pi: ExtensionAPI): boolean | undefined {
 	return isOneShot
 }
 
+/**
+ * Best-effort read of the session's project-trust decision. Passed to
+ * getCompactionEnabled so project-scope settings apply exactly when pi's own
+ * session applies them. Undefined (stale ctx, sloppy mock) leaves the reader's
+ * last-synced trust untouched.
+ */
+function readProjectTrust(ctx: ExtensionContext): boolean | undefined {
+	try {
+		return ctx.isProjectTrusted?.()
+	} catch {
+		return undefined
+	}
+}
+
 // ─── In-flight tool-call guard ────────────────────────────────────────────────
 
 export { isToolCallInFlight } from "../../tool-call-in-flight.js"
@@ -444,7 +458,7 @@ export async function maybeTriggerFermentCompaction(
 	if (isOneShot && !hasInlineCompact) return false
 
 	// /settings Auto-compact toggle (settings.json compaction.enabled).
-	if (!getCompactionEnabled()) return false
+	if (!getCompactionEnabled(readProjectTrust(ctx))) return false
 
 	// Root-cause guard: defer compaction while a tool call is in flight (the
 	// trailing assistant toolCall has no matching toolResult yet). Compacting
@@ -678,7 +692,7 @@ export async function maybeTriggerMidTurnFermentCompaction(
 	}
 
 	// /settings Auto-compact toggle — see maybeTriggerFermentCompaction.
-	if (!getCompactionEnabled()) return
+	if (!getCompactionEnabled(readProjectTrust(ctx))) return
 
 	const model = ctx.model
 	if (!model) return

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -40,6 +40,7 @@ import { getCompactionEnabled } from "../../settings-watcher.js"
 import { isToolCallInFlight } from "../../tool-call-in-flight.js"
 import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
 import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
+import { isStaleCtxError } from "../stale-ctx.js"
 import type { FermentRuntime } from "./runtime.js"
 import { safeSendMessage, tryPiAction } from "./safe-send.js"
 import { scheduleNextFermentAction } from "./scheduler.js"
@@ -133,12 +134,17 @@ function readFermentOneshotFlag(pi: ExtensionAPI): boolean | undefined {
  * Best-effort read of the session's project-trust decision. Passed to
  * getCompactionEnabled so project-scope settings apply exactly when pi's own
  * session applies them. Undefined (stale ctx, sloppy mock) leaves the reader's
- * last-synced trust untouched.
+ * last-synced trust untouched. Matches the tryPiAction idiom: stale-ctx errors
+ * are routine (post-shutdown/reload) and stay silent; anything else is traced
+ * so a broken trust accessor doesn't fail invisibly.
  */
 function readProjectTrust(ctx: ExtensionContext): boolean | undefined {
 	try {
 		return ctx.isProjectTrusted?.()
-	} catch {
+	} catch (err) {
+		if (!isStaleCtxError(err)) {
+			console.warn("[ferment] failed to read project trust:", err)
+		}
 		return undefined
 	}
 }

--- a/src/settings-watcher.test.ts
+++ b/src/settings-watcher.test.ts
@@ -237,6 +237,67 @@ describe("getSettingsManager", () => {
 		expect(mockCreate).toHaveBeenCalledTimes(2)
 		expect(mockWatch).toHaveBeenCalledTimes(3)
 	})
+
+	it("drops the watcher and cache even when close() throws during error handling", () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {})
+		const watcher = createMockWatcher()
+		watcher.close.mockImplementation(() => {
+			throw new Error("already destroyed")
+		})
+		mockWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>)
+
+		getSettingsManager()
+		expect(mockCreate).toHaveBeenCalledTimes(1)
+
+		const errorHandler = watcher.on.mock.calls.find((c) => c[0] === "error")?.[1] as (err: Error) => void
+		expect(() => errorHandler(new Error("EPERM"))).not.toThrow()
+
+		// Cache was dropped despite close() throwing — the next read rebuilds.
+		getSettingsManager()
+		expect(mockCreate).toHaveBeenCalledTimes(2)
+	})
+
+	it("delivers a theme change that happened while a watcher was dead", () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {})
+		const watcher = createMockWatcher()
+		mockWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>)
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "light" })))
+		const listener = vi.fn()
+		onThemeChange(listener) // seeds lastSeenTheme = "light"
+
+		// The global watcher dies; the theme changes while nothing is watching.
+		const errorHandler = watcher.on.mock.calls.find((c) => c[0] === "error")?.[1] as (err: Error) => void
+		errorHandler(new Error("EPERM"))
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "dark" })))
+
+		// The next read re-arms the watcher and schedules a catch-up fire.
+		getSettingsManager()
+		vi.runAllTimers()
+
+		expect(listener).toHaveBeenCalledWith("dark", "light")
+	})
+
+	it("catches up on changes that happened while a settings file was unwatched", () => {
+		// Global settings.json doesn't exist yet — its watch throws until it appears.
+		const globalPath = "/fake/agent/dir/settings.json"
+		let globalFileMissing = true
+		mockWatch.mockImplementation(((path: unknown) => {
+			if (globalFileMissing && path === globalPath) throw new Error("ENOENT")
+			return createMockWatcher() as unknown as ReturnType<typeof watch>
+		}) as unknown as typeof watch)
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "light" })))
+		const listener = vi.fn()
+		onThemeChange(listener) // seeds "light"; the global watch fails to arm
+
+		// The file appears with a different theme; the next read arms the watch
+		// and the catch-up fire delivers the change that predates it.
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "dark" })))
+		globalFileMissing = false
+		getSettingsManager()
+		vi.runAllTimers()
+
+		expect(listener).toHaveBeenCalledWith("dark", "light")
+	})
 })
 
 describe("onThemeChange", () => {

--- a/src/settings-watcher.test.ts
+++ b/src/settings-watcher.test.ts
@@ -1,127 +1,253 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-// settings-watcher reads from process.env and fs — mock both.
+// settings-watcher watches settings.json via fs.watch and reads settings through
+// pi's SettingsManager — mock both so tests don't depend on real files (and so the
+// node:fs mock doesn't leak into pi internals).
 vi.mock("node:fs", () => ({
-	readFileSync: vi.fn(),
 	watch: vi.fn(),
 }))
 
-import { readFileSync, watch } from "node:fs"
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	CONFIG_DIR_NAME: ".pi",
+	getAgentDir: vi.fn(() => "/fake/agent/dir"),
+	SettingsManager: { create: vi.fn() },
+}))
+
+import { watch } from "node:fs"
+import { getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent"
 import {
-	__resetCompactionCacheForTest,
+	__resetSettingsWatcherForTest,
 	getActiveThemeName,
 	getCompactionEnabled,
+	getSettingsManager,
 	onThemeChange,
+	setSettingsProjectTrusted,
 } from "./settings-watcher.js"
 
-const mockReadFileSync = vi.mocked(readFileSync)
 const mockWatch = vi.mocked(watch)
+const mockCreate = vi.mocked(SettingsManager.create)
+const mockAgentDir = vi.mocked(getAgentDir)
 
 function createMockWatcher() {
 	return { close: vi.fn(), on: vi.fn(), unref: vi.fn() }
 }
 
-function getWatchCallback(): (() => void) | undefined {
-	return (mockWatch.mock.calls[0] as unknown[] | undefined)?.[2] as (() => void) | undefined
+/** A stand-in SettingsManager exposing pi's theme + compaction + trust accessors. */
+function fakeManager(opts: { theme?: string; compactionEnabled?: boolean } = {}) {
+	let trusted = false
+	return {
+		getThemeSetting: vi.fn(() => opts.theme),
+		getCompactionEnabled: vi.fn(() => opts.compactionEnabled ?? true),
+		isProjectTrusted: vi.fn(() => trusted),
+		setProjectTrusted: vi.fn((t: boolean) => {
+			trusted = t
+		}),
+	}
+}
+
+function asManager(m: ReturnType<typeof fakeManager>): SettingsManager {
+	return m as unknown as SettingsManager
+}
+
+/** The scheduleFire callback of the n-th fs.watch call (0 = global, 1 = project). */
+function getWatchCallback(index = 0): (() => void) | undefined {
+	return (mockWatch.mock.calls[index] as unknown[] | undefined)?.[2] as (() => void) | undefined
 }
 
 beforeEach(() => {
-	process.env.KIMCHI_CODING_AGENT_DIR = "/fake/agent/dir"
-	__resetCompactionCacheForTest()
-	mockReadFileSync.mockReset()
+	__resetSettingsWatcherForTest()
 	mockWatch.mockReset()
 	mockWatch.mockReturnValue(createMockWatcher() as unknown as ReturnType<typeof watch>)
+	mockCreate.mockReset()
+	mockCreate.mockReturnValue(asManager(fakeManager()))
+	mockAgentDir.mockReset()
+	mockAgentDir.mockReturnValue("/fake/agent/dir")
 	vi.useFakeTimers()
 })
 
 afterEach(() => {
 	vi.restoreAllMocks()
 	vi.useRealTimers()
-	delete process.env.KIMCHI_CODING_AGENT_DIR
 })
 
 describe("getActiveThemeName", () => {
-	it("returns the theme from settings.json", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
+	it("returns the theme from pi settings", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "dark" })))
 		expect(getActiveThemeName()).toBe("dark")
 	})
 
-	it("returns undefined when theme key is missing", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ quietStartup: true }))
+	it("returns undefined when no theme is set", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({})))
 		expect(getActiveThemeName()).toBeUndefined()
 	})
 
-	it("returns undefined when file is unreadable", () => {
-		mockReadFileSync.mockImplementation(() => {
-			throw new Error("ENOENT")
+	it("returns undefined when the SettingsManager cannot be constructed", () => {
+		mockCreate.mockImplementation(() => {
+			throw new Error("boom")
 		})
-		expect(getActiveThemeName()).toBeUndefined()
-	})
-
-	it("returns undefined when KIMCHI_CODING_AGENT_DIR is unset", () => {
-		delete process.env.KIMCHI_CODING_AGENT_DIR
 		expect(getActiveThemeName()).toBeUndefined()
 	})
 })
 
 describe("getCompactionEnabled", () => {
-	it("returns true when compaction.enabled is true", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: true } }))
+	it("returns true when compaction is enabled", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: true })))
 		expect(getCompactionEnabled()).toBe(true)
 	})
 
-	it("returns false when compaction.enabled is false", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: false } }))
+	it("returns false when compaction is disabled", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: false })))
 		expect(getCompactionEnabled()).toBe(false)
 	})
 
-	it("returns true (default) when compaction key is absent", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
-		expect(getCompactionEnabled()).toBe(true)
-	})
-
-	it("returns true when settings.json is malformed JSON", () => {
-		mockReadFileSync.mockReturnValue("{ not valid json")
-		expect(getCompactionEnabled()).toBe(true)
-	})
-
-	it("returns true when settings.json is missing", () => {
-		mockReadFileSync.mockImplementation(() => {
-			throw new Error("ENOENT")
+	it("returns true when the SettingsManager cannot be constructed", () => {
+		mockCreate.mockImplementation(() => {
+			throw new Error("boom")
 		})
 		expect(getCompactionEnabled()).toBe(true)
 	})
 
-	it("caches the value and re-reads after the watcher fires", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: false } }))
+	it("returns true when reading settings throws", () => {
+		mockCreate.mockReturnValue({
+			isProjectTrusted: () => false,
+			getCompactionEnabled: () => {
+				throw new Error("boom")
+			},
+		} as unknown as SettingsManager)
+		expect(getCompactionEnabled()).toBe(true)
+	})
+
+	it("caches the manager and rebuilds it after the global settings file changes", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: false })))
 		expect(getCompactionEnabled()).toBe(false)
+		expect(mockCreate).toHaveBeenCalledTimes(1)
 
-		// Second call should NOT hit disk (cache hit).
-		mockReadFileSync.mockClear()
+		// Second call reuses the cached manager (no rebuild).
 		getCompactionEnabled()
-		expect(mockReadFileSync).not.toHaveBeenCalled()
+		expect(mockCreate).toHaveBeenCalledTimes(1)
 
-		// Simulate settings.json change → watcher fires → cache invalidated.
-		mockReadFileSync.mockReturnValue(JSON.stringify({ compaction: { enabled: true } }))
-		const unsub = onThemeChange(vi.fn())
-		getWatchCallback()?.()
+		// Global settings.json changes → watcher fires → manager dropped & rebuilt.
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: true })))
+		getWatchCallback(0)?.()
 		vi.runAllTimers()
 
 		expect(getCompactionEnabled()).toBe(true)
-		unsub()
+		expect(mockCreate).toHaveBeenCalledTimes(2)
+	})
+
+	it("rebuilds the manager after the PROJECT settings file changes", () => {
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: true })))
+		expect(getCompactionEnabled()).toBe(true)
+		expect(mockCreate).toHaveBeenCalledTimes(1)
+
+		// Project .pi/settings.json changes → project watcher fires → rebuild.
+		mockCreate.mockReturnValue(asManager(fakeManager({ compactionEnabled: false })))
+		getWatchCallback(1)?.()
+		vi.runAllTimers()
+
+		expect(getCompactionEnabled()).toBe(false)
+		expect(mockCreate).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe("project trust", () => {
+	it("constructs untrusted by default (project settings ignored until trust is known)", () => {
+		getSettingsManager()
+		expect(mockCreate).toHaveBeenCalledWith(expect.any(String), "/fake/agent/dir", { projectTrusted: false })
+	})
+
+	it("syncs a caller-reported trust decision onto the live manager", () => {
+		const sm = fakeManager({ compactionEnabled: true })
+		mockCreate.mockReturnValue(asManager(sm))
+
+		getCompactionEnabled() // constructs untrusted
+		getCompactionEnabled(true) // syncs trust onto the live instance
+
+		expect(sm.setProjectTrusted).toHaveBeenCalledWith(true)
+		// The live instance was updated in place — no rebuild required.
+		expect(mockCreate).toHaveBeenCalledTimes(1)
+	})
+
+	it("constructs later rebuilds with the last-synced trust", () => {
+		setSettingsProjectTrusted(true)
+		getSettingsManager()
+		expect(mockCreate).toHaveBeenLastCalledWith(expect.any(String), "/fake/agent/dir", { projectTrusted: true })
+	})
+
+	it("does not touch trust when the caller cannot report it", () => {
+		const sm = fakeManager()
+		mockCreate.mockReturnValue(asManager(sm))
+
+		getCompactionEnabled(undefined)
+
+		expect(sm.setProjectTrusted).not.toHaveBeenCalled()
+	})
+})
+
+describe("getSettingsManager", () => {
+	it("constructs a manager over the pi-resolved agent dir (getAgentDir)", () => {
+		mockAgentDir.mockReturnValue("/resolved/agent/dir")
+		getSettingsManager()
+		expect(mockAgentDir).toHaveBeenCalled()
+		expect(mockCreate).toHaveBeenCalledWith(expect.any(String), "/resolved/agent/dir", { projectTrusted: false })
+	})
+
+	it("watches both the global and project settings files", () => {
+		getSettingsManager()
+		const paths = mockWatch.mock.calls.map((c) => c[0])
+		expect(paths).toContain("/fake/agent/dir/settings.json")
+		expect(paths.some((p) => typeof p === "string" && p.endsWith("/.pi/settings.json"))).toBe(true)
+	})
+
+	it("re-arms a watcher that failed to start on the next read", () => {
+		// Global settings.json doesn't exist yet — its watch throws until it appears.
+		const globalPath = "/fake/agent/dir/settings.json"
+		let globalFileMissing = true
+		mockWatch.mockImplementation(((path: unknown) => {
+			if (globalFileMissing && path === globalPath) throw new Error("ENOENT")
+			return createMockWatcher() as unknown as ReturnType<typeof watch>
+		}) as unknown as typeof watch)
+
+		getSettingsManager()
+		const attemptsWhileMissing = mockWatch.mock.calls.filter((c) => c[0] === globalPath).length
+		expect(attemptsWhileMissing).toBeGreaterThan(0)
+
+		// The file appears — the next read re-arms the global watch.
+		globalFileMissing = false
+		getSettingsManager()
+		const attempts = mockWatch.mock.calls.filter((c) => c[0] === globalPath).length
+		expect(attempts).toBeGreaterThan(attemptsWhileMissing)
+	})
+
+	it("recreates a watcher and drops the cache after a watch error", () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {})
+		const watcher = createMockWatcher()
+		mockWatch.mockReturnValue(watcher as unknown as ReturnType<typeof watch>)
+
+		getSettingsManager()
+		expect(mockWatch).toHaveBeenCalledTimes(2) // global + project
+		expect(mockCreate).toHaveBeenCalledTimes(1)
+
+		// Fire the global watcher's error handler (registered via watcher.on).
+		const errorHandler = watcher.on.mock.calls.find((c) => c[0] === "error")?.[1] as (err: Error) => void
+		errorHandler(new Error("EPERM"))
+
+		// Next read rebuilds the manager (cache dropped) and re-arms the dead watcher.
+		getSettingsManager()
+		expect(mockCreate).toHaveBeenCalledTimes(2)
+		expect(mockWatch).toHaveBeenCalledTimes(3)
 	})
 })
 
 describe("onThemeChange", () => {
 	it("does not fire listener when theme has not changed", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "kimchi-minimal" }))
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "kimchi-minimal" })))
 		const listener = vi.fn()
 
-		// Subscribe — watcher captures lastSeenTheme = "kimchi-minimal"
+		// Subscribe — ensureWatchers seeds lastSeenTheme = "kimchi-minimal"
 		const unsub = onThemeChange(listener)
 
-		// Trigger the fs.watch callback (same theme in file)
-		getWatchCallback()?.()
+		getWatchCallback(0)?.()
 		vi.runAllTimers() // flush debounce
 
 		expect(listener).not.toHaveBeenCalled()
@@ -129,40 +255,36 @@ describe("onThemeChange", () => {
 	})
 
 	it("fires listener when theme changes", () => {
-		mockReadFileSync
-			.mockReturnValueOnce(JSON.stringify({ theme: "kimchi-minimal" })) // ensureWatcher init read
-			.mockReturnValue(JSON.stringify({ theme: "dark" })) // subsequent read after change
-
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "kimchi-minimal" })))
 		const listener = vi.fn()
 		const unsub = onThemeChange(listener)
 
-		getWatchCallback()?.()
+		// settings change → the rebuilt manager reports a different theme
+		mockCreate.mockReturnValue(asManager(fakeManager({ theme: "dark" })))
+		getWatchCallback(0)?.()
 		vi.runAllTimers()
 
 		expect(listener).toHaveBeenCalledWith("dark", "kimchi-minimal")
 		unsub()
 	})
 
-	it("closes the watcher when last listener unsubscribes", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
-		const mockWatcherInstance = createMockWatcher()
-		mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>)
-
-		const unsub = onThemeChange(vi.fn())
-		unsub()
-
-		expect(mockWatcherInstance.close).toHaveBeenCalled()
-	})
-
 	it("does not keep the process alive by default", () => {
-		mockReadFileSync.mockReturnValue(JSON.stringify({ theme: "dark" }))
 		const mockWatcherInstance = createMockWatcher()
 		mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>)
 
-		const unsub = onThemeChange(vi.fn())
-		unsub()
+		onThemeChange(vi.fn())
 
 		expect(mockWatch).toHaveBeenCalledWith("/fake/agent/dir/settings.json", { persistent: false }, expect.any(Function))
 		expect(mockWatcherInstance.unref).toHaveBeenCalled()
+	})
+
+	it("closes both the global and project watchers on reset", () => {
+		const mockWatcherInstance = createMockWatcher()
+		mockWatch.mockReturnValue(mockWatcherInstance as unknown as ReturnType<typeof watch>)
+
+		onThemeChange(vi.fn())
+		__resetSettingsWatcherForTest()
+
+		expect(mockWatcherInstance.close).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/settings-watcher.ts
+++ b/src/settings-watcher.ts
@@ -142,11 +142,23 @@ function fire(): void {
 	}
 }
 
+// True while the corresponding settings file is unwatched (watch failed to arm or
+// died); a successful re-arm then schedules a catch-up fire so changes that
+// happened while unwatched are still observed.
+let globalWatchBroken = false
+let projectWatchBroken = false
+
 // Watch both settings files pi reads — global <agentDir>/settings.json and project
 // <cwd>/.pi/settings.json — so a change to either drops the cached manager and the
-// next read reflects it. Watchers are unref'd (they never keep the process alive).
-// Each watcher is re-armed independently whenever it is missing, so a watch that
-// failed (file absent) or died (error) recovers on the next settings read.
+// next read reflects it. Each watcher is re-armed independently whenever it is
+// missing, so a watch that failed (file absent) or died (error) recovers on the
+// next settings read, and the catch-up fire delivers anything missed meanwhile.
+//
+// The watchers are intentionally process-lifetime: there is no dispose. They are
+// unref'd (never keep the process alive), and two fs.watch handles are the
+// steady-state cost of keeping the settings cache and theme listeners live —
+// tying their lifetime to individual consumers is what previously broke sharing
+// between the two.
 function ensureWatchers(): void {
 	if (!themeSeeded) {
 		// Seed before the getActiveThemeName call below — it re-enters this
@@ -154,12 +166,30 @@ function ensureWatchers(): void {
 		themeSeeded = true
 		lastSeenTheme = getActiveThemeName()
 	}
-	globalWatcher ??= startWatch(resolve(getAgentDir(), "settings.json"), () => {
-		globalWatcher = undefined
-	})
-	projectWatcher ??= startWatch(resolve(process.cwd(), CONFIG_DIR_NAME, "settings.json"), () => {
-		projectWatcher = undefined
-	})
+	if (!globalWatcher) {
+		globalWatcher = startWatch(resolve(getAgentDir(), "settings.json"), () => {
+			globalWatcher = undefined
+			globalWatchBroken = true
+		})
+		if (globalWatcher) {
+			if (globalWatchBroken) scheduleFire()
+			globalWatchBroken = false
+		} else {
+			globalWatchBroken = true
+		}
+	}
+	if (!projectWatcher) {
+		projectWatcher = startWatch(resolve(process.cwd(), CONFIG_DIR_NAME, "settings.json"), () => {
+			projectWatcher = undefined
+			projectWatchBroken = true
+		})
+		if (projectWatcher) {
+			if (projectWatchBroken) scheduleFire()
+			projectWatchBroken = false
+		} else {
+			projectWatchBroken = true
+		}
+	}
 }
 
 function startWatch(path: string, onDead: () => void): FSWatcher | undefined {
@@ -168,11 +198,15 @@ function startWatch(path: string, onDead: () => void): FSWatcher | undefined {
 		w.unref?.()
 		w.on("error", (err) => {
 			console.warn("[settings-watcher] watch error:", err)
-			w.close()
+			// Cleanup first: even if close() throws, the watcher must be marked
+			// dead and the cache dropped (events may have been missed while dying).
 			onDead()
-			// Events may have been missed while the watcher was dying — force a
-			// fresh read (which also re-arms the watcher) on the next access.
 			settingsManager = undefined
+			try {
+				w.close()
+			} catch {
+				// Watcher already destroyed.
+			}
 		})
 		return w
 	} catch {
@@ -184,10 +218,20 @@ function startWatch(path: string, onDead: () => void): FSWatcher | undefined {
 }
 
 function closeWatchers(): void {
-	globalWatcher?.close()
+	try {
+		globalWatcher?.close()
+	} catch {
+		// Watcher already destroyed.
+	}
 	globalWatcher = undefined
-	projectWatcher?.close()
+	globalWatchBroken = false
+	try {
+		projectWatcher?.close()
+	} catch {
+		// Watcher already destroyed.
+	}
 	projectWatcher = undefined
+	projectWatchBroken = false
 }
 
 export function onThemeChange(listener: ThemeChangeListener): () => void {

--- a/src/settings-watcher.ts
+++ b/src/settings-watcher.ts
@@ -1,56 +1,108 @@
-import { type FSWatcher, readFileSync, watch } from "node:fs"
+import { type FSWatcher, watch } from "node:fs"
 import { resolve } from "node:path"
+import { CONFIG_DIR_NAME, getAgentDir, SettingsManager } from "@earendil-works/pi-coding-agent"
 
-// Pi-coding-agent doesn't expose a theme_change event for extensions, so we
-// watch settings.json ourselves. The /settings UI updates `theme` here after
-// it has already swapped the in-memory Theme — we use the file write as the
-// signal that an extension's theme-derived state needs to be re-applied.
+// Pi-coding-agent doesn't expose a settings/theme_change event for extensions, so
+// we read settings through pi's own SettingsManager and watch its settings files
+// ourselves. The /settings UI writes the file after it has already swapped the
+// in-memory state — we use the file write as the signal to drop our cached manager
+// and re-apply any settings-derived state (e.g. an extension's theme).
+
+// A process-global SettingsManager mirroring pi's own settings — global
+// (<agentDir>/settings.json) and project (<cwd>/.pi/settings.json), merged the way
+// pi merges them. Every read goes through this instead of hand-parsing the file.
+// Cached and dropped/rebuilt lazily whenever either watched file changes, so
+// callers always see current settings.
+//
+// Read-only by contract: never call set*/save on this instance. It is a second
+// manager over the same files as the session's own — a write here would race pi's
+// in-memory state (pi wouldn't see it until its own reload()). The one exception
+// is setProjectTrusted, which only mutates in-memory merge state and never
+// persists.
+//
+// process.cwd() is captured per construction; if the session's cwd ever diverges
+// from the process cwd (rare), the project scope read here may point elsewhere.
+let settingsManager: SettingsManager | undefined
+
+// Last project-trust decision reported by a caller with session context
+// (ctx.isProjectTrusted()). Defaults to untrusted — the same conservative
+// bootstrap default pi's resource loader uses before real trust is resolved — so
+// an untrusted repo's .pi/settings.json can never influence reads that happen
+// before trust is known.
+let projectTrusted = false
+
+/**
+ * Sync the session's project-trust decision onto the settings reader. Callers with
+ * an ExtensionContext should pass ctx.isProjectTrusted() so project-scope settings
+ * are honored exactly when pi's own session honors them. setProjectTrusted
+ * re-reads the project scope in-memory; it never writes settings files.
+ */
+export function setSettingsProjectTrusted(trusted: boolean): void {
+	projectTrusted = trusted
+	try {
+		settingsManager?.setProjectTrusted(trusted)
+	} catch {
+		// Rebuild with the right trust on the next read.
+		settingsManager = undefined
+	}
+}
+
+/**
+ * Lazily construct (and cache) a SettingsManager over pi's settings, resolving the
+ * agent dir the same way pi does (getAgentDir() → env or default). Returns
+ * undefined only when construction fails, so callers must supply a safe fallback.
+ * The instance is dropped and rebuilt on the next read after either settings file
+ * changes.
+ */
+export function getSettingsManager(): SettingsManager | undefined {
+	if (!settingsManager) {
+		try {
+			settingsManager = SettingsManager.create(process.cwd(), getAgentDir(), { projectTrusted })
+		} catch {
+			return undefined
+		}
+	}
+	// Re-arm on every access: a watcher that died (fs.watch error) or never armed
+	// (settings file didn't exist yet) is recreated on the next read instead of
+	// staying dead for the process lifetime. Steady-state cost is two truthy checks.
+	ensureWatchers()
+	return settingsManager
+}
 
 export function getActiveThemeName(): string | undefined {
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) return undefined
 	try {
-		const raw = readFileSync(resolve(agentDir, "settings.json"), "utf-8")
-		const parsed: unknown = JSON.parse(raw)
-		if (parsed && typeof parsed === "object" && "theme" in parsed) {
-			const v = (parsed as { theme: unknown }).theme
-			return typeof v === "string" ? v : undefined
-		}
-		return undefined
+		return getSettingsManager()?.getThemeSetting()
 	} catch {
 		return undefined
 	}
 }
 
-let cachedCompactionEnabled: boolean | undefined
-
-export function getCompactionEnabled(): boolean {
-	if (cachedCompactionEnabled !== undefined) return cachedCompactionEnabled
-	cachedCompactionEnabled = readCompactionEnabledFromDisk()
-	ensureWatcher()
-	return cachedCompactionEnabled
-}
-
-function readCompactionEnabledFromDisk(): boolean {
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) return true
+/**
+ * Whether the /settings Auto-compact toggle is enabled, read via pi's own
+ * accessor (missing key defaults to enabled). Pass the session's
+ * ctx.isProjectTrusted() when available so project-scope settings apply exactly
+ * when pi's own session applies them; omitted, the last-synced trust is used
+ * (untrusted until a caller reports otherwise).
+ */
+export function getCompactionEnabled(isProjectTrusted?: boolean): boolean {
+	if (isProjectTrusted !== undefined && isProjectTrusted !== projectTrusted) {
+		setSettingsProjectTrusted(isProjectTrusted)
+	}
 	try {
-		const parsed: unknown = JSON.parse(readFileSync(resolve(agentDir, "settings.json"), "utf-8"))
-		const enabled = (parsed as { compaction?: { enabled?: unknown } })?.compaction?.enabled
-		return enabled !== false
+		return getSettingsManager()?.getCompactionEnabled() ?? true
 	} catch {
 		return true
 	}
 }
 
-/** @internal Test-only: reset the compaction cache and close the watcher so tests get a clean state. */
-export function __resetCompactionCacheForTest(): void {
-	cachedCompactionEnabled = undefined
-	if (watcher) {
-		watcher.close()
-		watcher = undefined
-	}
+/** @internal Test-only: drop the cached manager, close watchers, and clear listeners so tests get a clean state. */
+export function __resetSettingsWatcherForTest(): void {
+	settingsManager = undefined
+	projectTrusted = false
+	closeWatchers()
+	themeSeeded = false
 	listeners.clear()
+	lastSeenTheme = undefined
 	if (debounceTimer) {
 		clearTimeout(debounceTimer)
 		debounceTimer = undefined
@@ -59,14 +111,24 @@ export function __resetCompactionCacheForTest(): void {
 
 type ThemeChangeListener = (newName: string | undefined, oldName: string | undefined) => void
 
-let watcher: FSWatcher | undefined
+let globalWatcher: FSWatcher | undefined
+let projectWatcher: FSWatcher | undefined
+let themeSeeded = false
 let lastSeenTheme: string | undefined
 const listeners = new Set<ThemeChangeListener>()
 let debounceTimer: NodeJS.Timeout | undefined
 
+function scheduleFire(): void {
+	// fs.watch fires multiple events per write on macOS; debounce to one.
+	if (debounceTimer) clearTimeout(debounceTimer)
+	debounceTimer = setTimeout(fire, 30)
+	// Never let the debounce window keep a finished process alive (one-shot runs).
+	debounceTimer.unref?.()
+}
+
 function fire(): void {
 	debounceTimer = undefined
-	cachedCompactionEnabled = undefined
+	settingsManager = undefined
 	const current = getActiveThemeName()
 	if (current === lastSeenTheme) return
 	const previous = lastSeenTheme
@@ -80,36 +142,58 @@ function fire(): void {
 	}
 }
 
-function ensureWatcher(): void {
-	if (watcher) return
-	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
-	if (!agentDir) return
-	lastSeenTheme = getActiveThemeName()
+// Watch both settings files pi reads — global <agentDir>/settings.json and project
+// <cwd>/.pi/settings.json — so a change to either drops the cached manager and the
+// next read reflects it. Watchers are unref'd (they never keep the process alive).
+// Each watcher is re-armed independently whenever it is missing, so a watch that
+// failed (file absent) or died (error) recovers on the next settings read.
+function ensureWatchers(): void {
+	if (!themeSeeded) {
+		// Seed before the getActiveThemeName call below — it re-enters this
+		// function via getSettingsManager, and the flag bounds that recursion.
+		themeSeeded = true
+		lastSeenTheme = getActiveThemeName()
+	}
+	globalWatcher ??= startWatch(resolve(getAgentDir(), "settings.json"), () => {
+		globalWatcher = undefined
+	})
+	projectWatcher ??= startWatch(resolve(process.cwd(), CONFIG_DIR_NAME, "settings.json"), () => {
+		projectWatcher = undefined
+	})
+}
+
+function startWatch(path: string, onDead: () => void): FSWatcher | undefined {
 	try {
-		watcher = watch(resolve(agentDir, "settings.json"), { persistent: false }, () => {
-			// fs.watch fires multiple events per write on macOS; debounce to one.
-			if (debounceTimer) clearTimeout(debounceTimer)
-			debounceTimer = setTimeout(fire, 30)
-		})
-		watcher.unref?.()
-		watcher.on("error", (err) => {
+		const w = watch(path, { persistent: false }, scheduleFire)
+		w.unref?.()
+		w.on("error", (err) => {
 			console.warn("[settings-watcher] watch error:", err)
-			watcher?.close()
-			watcher = undefined
+			w.close()
+			onDead()
+			// Events may have been missed while the watcher was dying — force a
+			// fresh read (which also re-arms the watcher) on the next access.
+			settingsManager = undefined
 		})
+		return w
 	} catch {
-		// settings.json may not exist yet — listeners just won't fire.
+		// The file may not exist yet — especially the project .pi/settings.json.
+		// ensureWatchers retries on the next settings read; until then live
+		// updates for this file just won't fire.
+		return undefined
 	}
 }
 
+function closeWatchers(): void {
+	globalWatcher?.close()
+	globalWatcher = undefined
+	projectWatcher?.close()
+	projectWatcher = undefined
+}
+
 export function onThemeChange(listener: ThemeChangeListener): () => void {
-	ensureWatcher()
+	ensureWatchers()
 	listeners.add(listener)
 	return () => {
 		listeners.delete(listener)
-		if (listeners.size === 0 && cachedCompactionEnabled === undefined && watcher) {
-			watcher.close()
-			watcher = undefined
-		}
 	}
 }


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

getCompactionEnabled and getActiveThemeName previously hand-parsed the global settings.json and ignored project settings entirely. Replace the manual readFileSync/JSON.parse with a cached SettingsManager singleton built the way pi builds its own (getAgentDir() env-or-default, global + project scopes, pi's merge and defaulting), so kimchi reads settings exactly as pi resolves them.

- Project trust: construct untrusted (pi's own bootstrap default) so an untrusted repo's .pi/settings.json can never influence reads; ferment passes ctx.isProjectTrusted() at both compaction gates and setSettingsProjectTrusted() syncs it onto the live instance in memory.
- Watch both settings files (global <agentDir>/settings.json and project <cwd>/.pi/settings.json); a change to either drops the cached manager and the next read rebuilds it.
- Self-heal watchers: re-arm per-watcher on every settings access, so a watch that failed (file absent at startup) or died (fs.watch error) recovers on the next read instead of staying dead for the process lifetime; errors also drop the cache in case events were missed.
- Unref the debounce timer so the 30ms window can't keep one-shot runs alive.

The reader stays read-only by contract: it never writes settings files (setProjectTrusted only mutates in-memory merge state), so it cannot race pi's own manager.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
