### PR TITLE
fix(benchmarks): Add a parameter to enable/disable autocompaction in benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,11 @@ kimchi-session-*.html
 .memory
 bin
 
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
 # LLM tools
 .codegraph/

--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -190,6 +190,19 @@ MODEL=multi-model ./scripts/run-local.sh -n 8 -k 3
 
 With no custom role config in the task container, the tested Kimchi revision supplies its default role configuration. The adapter writes `{"multiModel":true}` to the in-container harness settings before launching kimchi so orchestration is enabled even in a fresh benchmark image.
 
+### Compaction
+
+Compaction follows kimchi's default (on). Pass `disable-compaction=true` to turn it off for a run: the adapter then writes `{"compaction":{"enabled":false}}` to the in-container harness settings (`~/.config/kimchi/harness/settings.json`) before launching kimchi, which turns off upstream threshold auto-compaction, ferment stage-boundary and mid-turn compaction, and the model-guard mid-turn stopgap.
+
+To A/B compaction on vs. off, hold model + dataset constant and toggle the kwarg:
+
+```bash
+# one-shot ferment, compaction on (default)
+./scripts/run-local.sh -i terminal-bench/fix-git --agent-kwarg ferment-oneshot=true
+# one-shot ferment, compaction off
+./scripts/run-local.sh -i terminal-bench/fix-git --agent-kwarg ferment-oneshot=true --agent-kwarg disable-compaction=true
+```
+
 ### One-shot ferment per task
 
 Pass `ferment-oneshot=true` to wrap each trial in a one-shot exec-mode ferment. The agent boots into kimchi's progressive-refinement project mode and runs `scope_ferment` → `activate_ferment_phase` → `start_ferment_step` → `complete_ferment_step` → `complete_ferment` autonomously, delegating each step's implementation to a subagent worker. One-shot uses a static planner tool profile for the whole run, so current-ferment lifecycle tools are present from the first model call.

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -150,6 +151,10 @@ class Kimchi(BaseInstalledAgent):
         disable_multi_model = _coerce_bool_kwarg(
             kwargs.pop("disable-multi-model", False), "disable-multi-model"
         )
+        # Compaction follows kimchi's default (on) unless explicitly disabled.
+        disable_compaction = _coerce_bool_kwarg(
+            kwargs.pop("disable-compaction", False), "disable-compaction"
+        )
 
         super().__init__(*args, **kwargs)
         selected_multi_model = self.model_name == MULTI_MODEL
@@ -165,6 +170,7 @@ class Kimchi(BaseInstalledAgent):
                 "multi-model selection conflicts with legacy 'disable-multi-model=true'"
             )
         self._multi_model_enabled = selected_multi_model
+        self._disable_compaction = disable_compaction
         config_kwargs = {}
         api_key = self._get_env(KIMCHI_API_KEY_ENV)
         if api_key is not None:
@@ -331,9 +337,9 @@ class Kimchi(BaseInstalledAgent):
             # mounted logs directory.
             f"rm -f {shlex.quote(CONTAINER_AGENT_PGID_FILE)}",
         ]
-        multi_model_settings = self._multi_model_settings_command()
-        if multi_model_settings:
-            parts.append(multi_model_settings)
+        harness_settings = self._harness_settings_command()
+        if harness_settings:
+            parts.append(harness_settings)
         skills_registration = self._skills_registration_command()
         if skills_registration:
             parts.append(skills_registration)
@@ -366,11 +372,22 @@ class Kimchi(BaseInstalledAgent):
         )
         return " && ".join(parts)
 
-    def _multi_model_settings_command(self) -> str:
-        if not self._multi_model_enabled:
+    def _harness_settings_command(self) -> str:
+        # Compose the global harness settings (~/.config/kimchi/harness/
+        # settings.json) as one JSON object — the file is written wholesale, so
+        # every key must land in a single write or the last writer clobbers the
+        # rest.
+        settings: dict[str, Any] = {}
+        if self._multi_model_enabled:
+            settings["multiModel"] = True
+        if self._disable_compaction:
+            # Read by kimchi through pi's SettingsManager: disables upstream
+            # threshold auto-compaction and both ferment compaction paths.
+            settings["compaction"] = {"enabled": False}
+        if not settings:
             return ""
 
-        settings_json = '{"multiModel":true}'
+        settings_json = json.dumps(settings, separators=(",", ":"))
         return (
             f"mkdir -p {CONTAINER_HARNESS_SETTINGS_DIR} && "
             f"printf '%s\\n' {shlex.quote(settings_json)} > {CONTAINER_HARNESS_SETTINGS}"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -83,7 +83,23 @@ async def test_single_model_run_passes_model_without_multi_model_cli_flag(tmp_pa
     command = agent.agent_commands[0]
     assert "--model kimchi-dev/kimi-k2.6" in command
     assert "--multi-model" not in command
+    # Compaction defaults on (kimchi's default): no settings write at all.
     assert ".config/kimchi/harness/settings.json" not in command
+
+
+async def test_disable_compaction_writes_harness_setting(tmp_path: Path) -> None:
+    agent = RecordingKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="kimchi-dev/kimi-k2.6",
+        **{"disable-compaction": "true"},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert "~/.config/kimchi/harness/settings.json" in command
+    assert '{"compaction":{"enabled":false}}' in command
 
 
 async def test_multi_model_run_omits_model_and_enables_harness_setting(tmp_path: Path) -> None:
@@ -100,10 +116,26 @@ async def test_multi_model_run_omits_model_and_enables_harness_setting(tmp_path:
     assert "--multi-model" not in command
     assert "~/.config/kimchi/harness/settings.json" in command
     assert '{"multiModel":true}' in command
-    assert not agent._multi_model_settings_command().endswith("&& ")
-    assert f"{agent._multi_model_settings_command()} && set -m" in command
+    assert "compaction" not in command
+    assert not agent._harness_settings_command().endswith("&& ")
+    assert f"{agent._harness_settings_command()} && set -m" in command
     assert agent.to_agent_info().model_info.provider == "kimchi"
     assert agent.to_agent_info().model_info.name == "multi-model"
+
+
+async def test_multi_model_with_disable_compaction_writes_both_settings_in_one_json(tmp_path: Path) -> None:
+    agent = RecordingKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="multi-model",
+        **{"disable-compaction": "true"},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    # Both keys must land in one write — the file is written wholesale.
+    assert '{"multiModel":true,"compaction":{"enabled":false}}' in command
 
 
 def test_legacy_multi_model_kwarg_cannot_enable_mode(tmp_path: Path) -> None:

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -2,6 +2,7 @@ import type { ImageContent, TextContent, ToolResultMessage, UserMessage } from "
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../ferment/types.js"
+import { getCompactionEnabled } from "../settings-watcher.js"
 import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { clearActiveFermentId, setActive as setActiveFerment } from "./ferment/state.js"
 import modelGuardExtension, {
@@ -14,6 +15,12 @@ import modelGuardExtension, {
 	stripImages,
 	truncateMessages,
 } from "./model-guard.js"
+
+// Mock the settings-watcher so the /settings Auto-compact toggle can be
+// controlled per test without touching the real settings files.
+vi.mock("../settings-watcher.js", () => ({
+	getCompactionEnabled: vi.fn(() => true),
+}))
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -580,6 +587,10 @@ describe("turn_end compaction guard", () => {
 	const CONTEXT_WINDOW = 262_144
 	const THRESHOLD = CONTEXT_WINDOW - COMPACTION_RESERVE_TOKENS // 245,760
 
+	beforeEach(() => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
 	it("does not compact when totalTokens is below the compaction threshold", async () => {
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
@@ -652,6 +663,19 @@ describe("turn_end compaction guard", () => {
 			compact,
 		})
 		await trigger("turn_end", makeTurnEndEvent(THRESHOLD, "toolUse"), ctx)
+		expect(compact).not.toHaveBeenCalled()
+	})
+
+	it("does NOT compact when the /settings Auto-compact toggle is disabled", async () => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(false)
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
 		expect(compact).not.toHaveBeenCalled()
 	})
 

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -666,6 +666,28 @@ describe("turn_end compaction guard", () => {
 		expect(compact).not.toHaveBeenCalled()
 	})
 
+	it("still compacts (and warns) when the project-trust accessor throws unexpectedly", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+			const compact = vi.fn()
+			const ctx = makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+				compact,
+			})
+			ctx.isProjectTrusted = vi.fn(() => {
+				throw new Error("trust state unavailable")
+			})
+			await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+			// Trust falls back to the reader's last-synced value; the guard still runs.
+			expect(compact).toHaveBeenCalledOnce()
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining("failed to read project trust"), expect.any(Error))
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
 	it("does NOT compact when the /settings Auto-compact toggle is disabled", async () => {
 		vi.mocked(getCompactionEnabled).mockReturnValue(false)
 		const { pi, trigger } = makeMockPI()

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { getCompactionEnabled } from "../settings-watcher.js"
 import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { hasActiveFerment } from "./ferment/state.js"
 
@@ -355,6 +356,19 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 
 		// Use the same threshold as upstream auto-compaction: contextWindow - reserveTokens.
 		if (usage.totalTokens <= model.contextWindow - COMPACTION_RESERVE_TOKENS) return
+
+		// /settings Auto-compact toggle (settings.json compaction.enabled).
+		// ctx.compact() is upstream's manual path and does not check the toggle
+		// itself, so this stopgap must gate on it explicitly — otherwise it
+		// compacts even when the user (or a benchmark harness) disabled
+		// auto-compaction.
+		let projectTrusted: boolean | undefined
+		try {
+			projectTrusted = ctx.isProjectTrusted?.()
+		} catch {
+			projectTrusted = undefined
+		}
+		if (!getCompactionEnabled(projectTrusted)) return
 
 		// Threshold exceeded mid-turn. Compact now.
 		//

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -3,6 +3,7 @@ import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-wor
 import { getCompactionEnabled } from "../settings-watcher.js"
 import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { hasActiveFerment } from "./ferment/state.js"
+import { isStaleCtxError } from "./stale-ctx.js"
 
 /** Messages that have a content array we can inspect for images. */
 type ContentMessage = UserMessage | AssistantMessage | ToolResultMessage
@@ -361,12 +362,17 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		// ctx.compact() is upstream's manual path and does not check the toggle
 		// itself, so this stopgap must gate on it explicitly — otherwise it
 		// compacts even when the user (or a benchmark harness) disabled
-		// auto-compaction.
+		// auto-compaction. Undefined trust leaves the settings reader's
+		// last-synced trust untouched; stale-ctx errors are routine
+		// (post-shutdown/reload) and stay silent, anything else is warned so a
+		// broken trust accessor doesn't fail invisibly.
 		let projectTrusted: boolean | undefined
 		try {
 			projectTrusted = ctx.isProjectTrusted?.()
-		} catch {
-			projectTrusted = undefined
+		} catch (err) {
+			if (!isStaleCtxError(err)) {
+				console.warn("[model-guard] failed to read project trust:", err)
+			}
 		}
 		if (!getCompactionEnabled(projectTrusted)) return
 


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Adds a `disable-compaction=true` kwarg to the terminal-bench-2 agent that writes `{"compaction":{"enabled":false}}` to the in-container harness settings, enabling A/B compaction on/off runs.

Fix the /settings auto-compact toggle was not respected by the model-guard mid-turn compaction stopgap - the turn_end handler called ctx.compact() regardless of the setting. This meant compaction still fired mid-turn even when a user or benchmark harness explicitly disabled it.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
