### PR TITLE
feat(budget): Add support for displaying and managing budget information

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import bashDefaultTimeoutExtension from "./extensions/bash-default-timeout.js"
 import bashTimeoutGuidanceExtension from "./extensions/bash-timeout-guidance.js"
 import bashToolGuardExtension from "./extensions/bash-tool-guard.js"
 import behavioursExtension from "./extensions/behaviours/index.js"
+import budgetCommandExtension from "./extensions/billing/command.js"
 import { refreshBillingStatusFromConfig } from "./extensions/billing/status.js"
 import branchCommandExtension from "./extensions/branch-command.js"
 import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.js"
@@ -587,6 +588,7 @@ try {
 			sessionNameExtension(),
 			shutdownMarkerExtension,
 			statsExtension,
+			budgetCommandExtension,
 			branchCommandExtension,
 			...terminalUiExtensionFactories,
 			loginExtension,

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -489,24 +489,46 @@ describe("StatusLine segment coverage", () => {
 		expect(visible).not.toContain("team:")
 	})
 
-	it("billing segment shows compact credit status", () => {
-		withPinned(["billing"], () => {
-			setBillingStatusForTest({
-				serverless: true,
-				plan: "coder",
-				isPaidTier: true,
-				remainingCredits: 5,
-				creditStatus: "low",
-				updatedAt: "2026-07-07T00:00:00.000Z",
-			})
+	it("credits and budget can be pinned independently", () => {
+		setBillingStatusForTest({
+			serverless: true,
+			plan: "coder",
+			isPaidTier: true,
+			remainingCredits: 5,
+			creditStatus: "low",
+			budget: {
+				period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+				budgets: [
+					{
+						scope: "USER",
+						scopeId: "owner",
+						budgetLimitUsd: "2000.000000",
+						totalSpendUsd: "274.594050",
+						providerBudgets: [],
+					},
+				],
+			},
+			updatedAt: "2026-07-07T00:00:00.000Z",
+		})
+
+		withPinned(["credits"], () => {
 			const statusLine = new StatusLine(createMockContext(), theme, createMockStatusLineData())
 			const visible = renderVisible(statusLine, 200)
 
 			expect(visible).toContain("Credits: $5.00")
+			expect(visible).not.toContain("Budget:")
+		})
+
+		withPinned(["budget"], () => {
+			const statusLine = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+			const visible = renderVisible(statusLine, 200)
+
+			expect(visible).not.toContain("Credits:")
+			expect(visible).toContain("Budget: 13.73% ($274.59/$2k)")
 		})
 	})
 
-	it("billing segment is hidden when unpinned", () => {
+	it("credits segment is hidden when unpinned", () => {
 		setBillingStatusForTest({
 			serverless: true,
 			plan: "coder",

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -522,9 +522,12 @@ describe("StatusLine segment coverage", () => {
 		withPinned(["budget"], () => {
 			const statusLine = new StatusLine(createMockContext(), theme, createMockStatusLineData())
 			const visible = renderVisible(statusLine, 200)
+			const compact = renderVisible(statusLine, 42)
 
 			expect(visible).not.toContain("Credits:")
 			expect(visible).toContain("Budget: 13.73% ($274.59/$2k)")
+			expect(compact).toContain("Budget: 13.73%")
+			expect(compact).not.toContain("$274.59/$2k")
 		})
 	})
 

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -9,7 +9,7 @@ import { RST_FG, resolvedAccentFg, resolvedSemanticFg } from "../ansi.js"
 import { readStatusLineConfig } from "../config/status-line-config.js"
 import { getActiveAgentCount } from "../extensions/agents/index.js"
 import { getBillingStatusLine } from "../extensions/billing/status.js"
-import { formatBillingStatusLine } from "../extensions/billing/status-line-format.js"
+import { formatBudgetStatusLine, formatCreditsStatusLine } from "../extensions/billing/status-line-format.js"
 import { getActiveFerment, getFermentContinuationPolicy } from "../extensions/ferment/index.js"
 import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-line.js"
 import { formatCount } from "../extensions/format.js"
@@ -28,7 +28,8 @@ type SegmentId =
 	| "phase"
 	| "tags"
 	| "team"
-	| "billing"
+	| "credits"
+	| "budget"
 	| "lsp"
 
 /** Raw inputs preserved on segments that have compact forms, so compaction
@@ -497,12 +498,20 @@ export class StatusLine implements Component {
 		return { id: "lsp", text, width: visibleWidth(text) }
 	}
 
-	private billingSegment(pinned = false): Segment | null {
+	private creditsSegment(pinned = false): Segment | null {
 		if (!pinned) return null
-		const line = getBillingStatusLine()
-		if (!line) return null
-		const text = formatBillingStatusLine(line, this.theme)
-		return { id: "billing", text, width: visibleWidth(text) }
+		const amount = getBillingStatusLine()?.amount
+		if (!amount) return null
+		const text = formatCreditsStatusLine(amount, this.theme)
+		return { id: "credits", text, width: visibleWidth(text) }
+	}
+
+	private budgetSegment(pinned = false): Segment | null {
+		if (!pinned) return null
+		const budget = getBillingStatusLine()?.budget
+		if (!budget) return null
+		const text = formatBudgetStatusLine(budget, this.theme)
+		return { id: "budget", text, width: visibleWidth(text) }
 	}
 
 	private subagentSegment(pinned = false): Segment | null {
@@ -571,7 +580,8 @@ export class StatusLine implements Component {
 			this.fermentSegment(pinnedSet.has("ferment")),
 			this.permissionsSegment(pinnedSet.has("permissions")),
 			this.modelSegment(),
-			this.billingSegment(pinnedSet.has("billing")),
+			this.creditsSegment(pinnedSet.has("credits")),
+			this.budgetSegment(pinnedSet.has("budget")),
 			this.subagentSegment(pinnedSet.has("agents")),
 			this.contextSegment(pinnedSet.has("context")),
 			this.usageSegment(pinnedSet.has("usage")),

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -43,6 +43,7 @@ type SegmentRaw =
 	| { kind: "context"; percent: number; pctColor?: "error" | "warning" }
 	| { kind: "model"; multiModel: boolean; modelId: string }
 	| { kind: "phase"; phase: string }
+	| { kind: "budget"; percentage: string }
 	| { kind: "ferment"; prefix: string; prefixWidth: number }
 
 /** A single piece of the status line. */
@@ -510,8 +511,9 @@ export class StatusLine implements Component {
 		if (!pinned) return null
 		const budget = getBillingStatusLine()?.budget
 		if (!budget) return null
+		const [percentage = budget] = budget.split(" ", 1)
 		const text = formatBudgetStatusLine(budget, this.theme)
-		return { id: "budget", text, width: visibleWidth(text) }
+		return { id: "budget", text, width: visibleWidth(text), raw: { kind: "budget", percentage } }
 	}
 
 	private subagentSegment(pinned = false): Segment | null {
@@ -604,14 +606,7 @@ export class StatusLine implements Component {
 		// Reserve its space upfront so compaction uses the right budget.
 		const minHintGap = 2
 		const hintReserve = hintWidth + minHintGap
-
-		// Reserve space for pinned segments so the unpinned portion compacts correctly.
-		const pinnedTotalWidth =
-			pinnedSegments.length > 0
-				? pinnedSegments.reduce((sum, s) => sum + s.width, 0) + (pinnedSegments.length - 1) * sepWidth + sepWidth // one sep between unpinned and pinned
-				: 0
 		const contentBudget = Math.max(0, width - hintReserve)
-		const unpinnedBudget = Math.max(0, contentBudget - pinnedTotalWidth)
 
 		const ctx: CompactionContext = {
 			dim: (s) => this.dim(s),
@@ -620,6 +615,21 @@ export class StatusLine implements Component {
 				`${resolvedSemanticFg(this.theme, color as "success" | "warning" | "error")}${s}${RST_FG}`,
 			showCommandHint: false, // hint is appended manually after all content
 		}
+
+		// Reserve space for pinned segments so the unpinned portion compacts correctly.
+		const getPinnedTotalWidth = () =>
+			pinnedSegments.length > 0
+				? pinnedSegments.reduce((sum, s) => sum + s.width, 0) + (pinnedSegments.length - 1) * sepWidth + sepWidth // one sep between unpinned and pinned
+				: 0
+		let pinnedTotalWidth = getPinnedTotalWidth()
+		if (pinnedTotalWidth > contentBudget) {
+			recompactSegment(pinnedSegments, "budget", "budget", (raw) => {
+				const text = formatBudgetStatusLine(raw.percentage, this.theme)
+				return { id: "budget", text, width: visibleWidth(text), raw }
+			})
+			pinnedTotalWidth = getPinnedTotalWidth()
+		}
+		const unpinnedBudget = Math.max(0, contentBudget - pinnedTotalWidth)
 
 		const unpinnedLine = layoutStatusLine(unpinnedSegments, unpinnedBudget, ctx, sep, sepWidth, {
 			text: hintText,

--- a/src/config/status-line-config.test.ts
+++ b/src/config/status-line-config.test.ts
@@ -46,8 +46,8 @@ afterEach(() => {
 // ── STATUS_LINE_ELEMENTS metadata ────────────────────────────────────────────
 
 describe("STATUS_LINE_ELEMENTS", () => {
-	it("has 10 entries", () => {
-		expect(STATUS_LINE_ELEMENTS).toHaveLength(10)
+	it("has 11 entries", () => {
+		expect(STATUS_LINE_ELEMENTS).toHaveLength(11)
 	})
 
 	it("every entry has id, label, description", () => {
@@ -70,7 +70,8 @@ describe("STATUS_LINE_ELEMENTS", () => {
 			"phase",
 			"tags",
 			"team",
-			"billing",
+			"credits",
+			"budget",
 		].sort()
 		expect(ids).toEqual(expected)
 	})
@@ -112,9 +113,9 @@ describe("readStatusLineConfig", () => {
 		expect(readStatusLineConfig().pinned).toEqual(["context"])
 	})
 
-	it("keeps billing when pinned in config", () => {
+	it("migrates the legacy billing toggle to credits and budget", () => {
 		memfs.set(SETTINGS_PATH, JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, 2))
-		expect(readStatusLineConfig().pinned).toEqual(["billing"])
+		expect(readStatusLineConfig().pinned).toEqual(["credits", "budget"])
 	})
 
 	it("ignores non-string items in the pinned array", () => {

--- a/src/config/status-line-config.ts
+++ b/src/config/status-line-config.ts
@@ -12,7 +12,8 @@ export type StatusLineElementId =
 	| "phase"
 	| "tags"
 	| "team"
-	| "billing"
+	| "credits"
+	| "budget"
 
 export type StatusLineConfig = { pinned: StatusLineElementId[] }
 
@@ -76,9 +77,14 @@ export const STATUS_LINE_ELEMENTS: Array<{
 		description: "Team tag value",
 	},
 	{
-		id: "billing",
-		label: "Billing",
-		description: "Plan and credit balance",
+		id: "credits",
+		label: "Credits",
+		description: "Remaining credit balance",
+	},
+	{
+		id: "budget",
+		label: "Budget",
+		description: "Budget usage and limit",
 	},
 ]
 
@@ -105,10 +111,16 @@ export function readStatusLineConfig(): StatusLineConfig {
 		return _config
 	}
 	const raw = asRecord(settings[STATUS_LINE_KEY])
-	const pinned = Array.isArray(raw.pinned)
-		? raw.pinned.filter((v): v is StatusLineElementId => STATUS_LINE_ELEMENTS.some((e) => e.id === v))
-		: []
-	_config = { pinned }
+	const values = Array.isArray(raw.pinned) ? raw.pinned : []
+	const pinned: StatusLineElementId[] = []
+	for (const value of values) {
+		if (value === "billing") {
+			pinned.push("credits", "budget")
+		} else if (STATUS_LINE_ELEMENTS.some((element) => element.id === value)) {
+			pinned.push(value as StatusLineElementId)
+		}
+	}
+	_config = { pinned: [...new Set(pinned)] }
 	return _config
 }
 

--- a/src/extensions/billing/command.test.ts
+++ b/src/extensions/billing/command.test.ts
@@ -1,0 +1,143 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const refreshBillingStatusFromConfigMock = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock("./status.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./status.js")>()
+	return { ...actual, refreshBillingStatusFromConfig: refreshBillingStatusFromConfigMock }
+})
+
+import budgetCommandExtension, { formatBudgetBreakdown } from "./command.js"
+import { type BillingStatus, type BudgetSnapshot, setBillingStatusForTest } from "./status.js"
+
+type BudgetCommand = {
+	handler: (args: string, ctx: ExtensionCommandContext) => Promise<void>
+}
+
+function registeredBudgetCommand(): BudgetCommand {
+	let command: BudgetCommand | undefined
+	budgetCommandExtension({
+		registerCommand: (_name: string, config: BudgetCommand) => {
+			command = config
+		},
+	} as unknown as ExtensionAPI)
+	if (!command) throw new Error("budget command not registered")
+	return command
+}
+
+function commandContext(): { ctx: ExtensionCommandContext; notify: ReturnType<typeof vi.fn> } {
+	const notify = vi.fn()
+	return {
+		ctx: { hasUI: true, ui: { notify } } as unknown as ExtensionCommandContext,
+		notify,
+	}
+}
+
+function billingStatus(budget: BudgetSnapshot | undefined): BillingStatus {
+	return { updatedAt: "2026-07-01T00:00:00Z", ...(budget ? { budget } : {}) }
+}
+
+beforeEach(() => {
+	refreshBillingStatusFromConfigMock.mockClear()
+	setBillingStatusForTest(undefined)
+})
+
+describe("formatBudgetBreakdown", () => {
+	it("renders active budget, provider, and UTC period rows deterministically", () => {
+		const snapshot: BudgetSnapshot = {
+			period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+			budgets: [
+				{
+					scope: "USER",
+					scopeId: "owner",
+					budgetType: "BUDGET_TYPE_PER_USER",
+					budgetLimitUsd: "2000.000000",
+					totalSpendUsd: "274.594050",
+					providerBudgets: [
+						{
+							provider: "anthropic",
+							limitType: "PROVIDER_BUDGET_LIMIT_TYPE_CAPPED",
+							budgetLimitUsd: "400.000000",
+							usageUsd: "273.201503",
+						},
+					],
+				},
+				{
+					scope: "ORGANIZATION_HARD",
+					scopeId: "516442fe-054a-49e2-ac2d-9dc9b104c3d2",
+					budgetType: "BUDGET_TYPE_PER_USER",
+					budgetLimitUsd: "300000.000000",
+					totalSpendUsd: "274.594050",
+					providerBudgets: [],
+				},
+			],
+		}
+
+		const output = formatBudgetBreakdown(snapshot).join("\n")
+		expect(output).toContain("Budget — Jul 1–Aug 1 UTC")
+		expect(output).toContain("ACTIVE    Personal")
+		expect(output).toContain("anthropic")
+		expect(output).toContain("68.30%")
+		expect(output).toContain("ACTIVE    Organization per-user hard")
+	})
+
+	it("renders disabled and unlimited provider limits without inventing dollar caps", () => {
+		const snapshot: BudgetSnapshot = {
+			period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+			budgets: [
+				{
+					scope: "USER",
+					scopeId: "owner",
+					budgetLimitUsd: "2000.000000",
+					totalSpendUsd: "0.000000",
+					providerBudgets: [
+						{
+							provider: "disabled-provider",
+							limitType: "PROVIDER_BUDGET_LIMIT_TYPE_DISABLED",
+							budgetLimitUsd: "400.000000",
+							usageUsd: "0.000000",
+						},
+						{
+							provider: "unlimited-provider",
+							limitType: "PROVIDER_BUDGET_LIMIT_TYPE_UNLIMITED",
+							budgetLimitUsd: "400.000000",
+							usageUsd: "1.000000",
+						},
+					],
+				},
+			],
+		}
+
+		const output = formatBudgetBreakdown(snapshot).join("\n")
+		expect(output).toContain("disabled-provider   $0.00 / disabled")
+		expect(output).toContain("unlimited-provider  $1.00 / unlimited")
+		expect(output.split("\n").find((line) => line.includes("disabled-provider"))).not.toContain("%")
+		expect(output.split("\n").find((line) => line.includes("unlimited-provider"))).not.toContain("%")
+	})
+})
+
+describe("budget command", () => {
+	it("reports unavailable budget information after refresh fails", async () => {
+		const { ctx, notify } = commandContext()
+
+		await registeredBudgetCommand().handler("", ctx)
+
+		expect(refreshBillingStatusFromConfigMock).toHaveBeenCalledOnce()
+		expect(notify).toHaveBeenCalledWith("Budget information is currently unavailable.", "warning")
+	})
+
+	it("reports when the owner has no configured budget", async () => {
+		setBillingStatusForTest(
+			billingStatus({
+				period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+				budgets: [],
+			}),
+		)
+		const { ctx, notify } = commandContext()
+
+		await registeredBudgetCommand().handler("", ctx)
+
+		expect(notify).toHaveBeenCalledWith("No budget is configured for this API key owner.", "info")
+	})
+})

--- a/src/extensions/billing/command.test.ts
+++ b/src/extensions/billing/command.test.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { createContext } from "../__mocks__/context.js"
+
 const refreshBillingStatusFromConfigMock = vi.hoisted(() => vi.fn(async () => undefined))
 
 vi.mock("./status.js", async (importOriginal) => {
@@ -24,14 +26,6 @@ function registeredBudgetCommand(): BudgetCommand {
 	} as unknown as ExtensionAPI)
 	if (!command) throw new Error("budget command not registered")
 	return command
-}
-
-function commandContext(): { ctx: ExtensionCommandContext; notify: ReturnType<typeof vi.fn> } {
-	const notify = vi.fn()
-	return {
-		ctx: { hasUI: true, ui: { notify, theme: theme() } } as unknown as ExtensionCommandContext,
-		notify,
-	}
 }
 
 function theme(): Theme {
@@ -86,16 +80,11 @@ describe("formatBudgetBreakdown", () => {
 		}
 
 		const output = formatBudgetBreakdown(snapshot, theme()).join("\n")
+		expect(unstyled(output)).toBe(
+			"Budget  Jul 1–Aug 1 UTC\n\nBUDGET                                USED      LIMIT    USAGE\n──────────────────────────────────────────────────────────────\nPersonal                           $274.59        $2k   13.73%\n  └─ anthropic                     $273.20       $400   68.30%\n\nOrganization per-user hard         $274.59      $300k    0.09%",
+		)
 		expect(output).toContain("<accent>Budget</accent>")
-		expect(unstyled(output)).toContain("Budget  Jul 1–Aug 1 UTC")
-		expect(unstyled(output)).toContain("BUDGET")
-		expect(unstyled(output)).not.toContain("STATUS")
-		expect(unstyled(output)).not.toContain("● OK")
 		expect(output).toContain("<success>")
-		expect(unstyled(output)).toContain("Personal")
-		expect(output).toContain("anthropic")
-		expect(output).toContain("68.30%")
-		expect(unstyled(output)).toContain("Organization per-user hard")
 	})
 
 	it("renders disabled, unlimited, and zero-capped provider limits", () => {
@@ -146,7 +135,8 @@ describe("formatBudgetBreakdown", () => {
 
 describe("budget command", () => {
 	it("reports unavailable budget information after refresh fails", async () => {
-		const { ctx, notify } = commandContext()
+		const notify = vi.fn()
+		const ctx = createContext({ ui: { notify, theme: theme() } }) as ExtensionCommandContext
 
 		await registeredBudgetCommand().handler("", ctx)
 
@@ -161,7 +151,8 @@ describe("budget command", () => {
 				budgets: [],
 			}),
 		)
-		const { ctx, notify } = commandContext()
+		const notify = vi.fn()
+		const ctx = createContext({ ui: { notify, theme: theme() } }) as ExtensionCommandContext
 
 		await registeredBudgetCommand().handler("", ctx)
 

--- a/src/extensions/billing/command.test.ts
+++ b/src/extensions/billing/command.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const refreshBillingStatusFromConfigMock = vi.hoisted(() => vi.fn(async () => undefined))
@@ -29,9 +29,20 @@ function registeredBudgetCommand(): BudgetCommand {
 function commandContext(): { ctx: ExtensionCommandContext; notify: ReturnType<typeof vi.fn> } {
 	const notify = vi.fn()
 	return {
-		ctx: { hasUI: true, ui: { notify } } as unknown as ExtensionCommandContext,
+		ctx: { hasUI: true, ui: { notify, theme: theme() } } as unknown as ExtensionCommandContext,
 		notify,
 	}
+}
+
+function theme(): Theme {
+	return {
+		fg: vi.fn((color: string, text: string) => `<${color}>${text}</${color}>`),
+		bold: vi.fn((text: string) => `<bold>${text}</bold>`),
+	} as unknown as Theme
+}
+
+function unstyled(value: string): string {
+	return value.replace(/<[^>]+>/g, "")
 }
 
 function billingStatus(budget: BudgetSnapshot | undefined): BillingStatus {
@@ -74,12 +85,17 @@ describe("formatBudgetBreakdown", () => {
 			],
 		}
 
-		const output = formatBudgetBreakdown(snapshot).join("\n")
-		expect(output).toContain("Budget — Jul 1–Aug 1 UTC")
-		expect(output).toContain("ACTIVE    Personal")
+		const output = formatBudgetBreakdown(snapshot, theme()).join("\n")
+		expect(output).toContain("<accent>Budget</accent>")
+		expect(unstyled(output)).toContain("Budget  Jul 1–Aug 1 UTC")
+		expect(unstyled(output)).toContain("BUDGET")
+		expect(unstyled(output)).not.toContain("STATUS")
+		expect(unstyled(output)).not.toContain("● OK")
+		expect(output).toContain("<success>")
+		expect(unstyled(output)).toContain("Personal")
 		expect(output).toContain("anthropic")
 		expect(output).toContain("68.30%")
-		expect(output).toContain("ACTIVE    Organization per-user hard")
+		expect(unstyled(output)).toContain("Organization per-user hard")
 	})
 
 	it("renders disabled and unlimited provider limits without inventing dollar caps", () => {
@@ -109,9 +125,11 @@ describe("formatBudgetBreakdown", () => {
 			],
 		}
 
-		const output = formatBudgetBreakdown(snapshot).join("\n")
-		expect(output).toContain("disabled-provider   $0.00 / disabled")
-		expect(output).toContain("unlimited-provider  $1.00 / unlimited")
+		const output = formatBudgetBreakdown(snapshot, theme()).join("\n")
+		expect(unstyled(output)).toContain("disabled-provider")
+		expect(unstyled(output)).toContain("$0.00   disabled")
+		expect(unstyled(output)).toContain("unlimited-provider")
+		expect(unstyled(output)).toContain("$1.00  unlimited")
 		expect(output.split("\n").find((line) => line.includes("disabled-provider"))).not.toContain("%")
 		expect(output.split("\n").find((line) => line.includes("unlimited-provider"))).not.toContain("%")
 	})

--- a/src/extensions/billing/command.test.ts
+++ b/src/extensions/billing/command.test.ts
@@ -98,7 +98,7 @@ describe("formatBudgetBreakdown", () => {
 		expect(unstyled(output)).toContain("Organization per-user hard")
 	})
 
-	it("renders disabled and unlimited provider limits without inventing dollar caps", () => {
+	it("renders disabled, unlimited, and zero-capped provider limits", () => {
 		const snapshot: BudgetSnapshot = {
 			period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
 			budgets: [
@@ -120,6 +120,12 @@ describe("formatBudgetBreakdown", () => {
 							budgetLimitUsd: "400.000000",
 							usageUsd: "1.000000",
 						},
+						{
+							provider: "zero-capped-provider",
+							limitType: "PROVIDER_BUDGET_LIMIT_TYPE_CAPPED",
+							budgetLimitUsd: "0.000000",
+							usageUsd: "0.000000",
+						},
 					],
 				},
 			],
@@ -130,6 +136,9 @@ describe("formatBudgetBreakdown", () => {
 		expect(unstyled(output)).toContain("$0.00   disabled")
 		expect(unstyled(output)).toContain("unlimited-provider")
 		expect(unstyled(output)).toContain("$1.00  unlimited")
+		const zeroCappedRow = output.split("\n").find((line) => line.includes("zero-capped-provider"))
+		expect(zeroCappedRow).toContain("$0")
+		expect(zeroCappedRow).not.toContain("unlimited")
 		expect(output.split("\n").find((line) => line.includes("disabled-provider"))).not.toContain("%")
 		expect(output.split("\n").find((line) => line.includes("unlimited-provider"))).not.toContain("%")
 	})

--- a/src/extensions/billing/command.ts
+++ b/src/extensions/billing/command.ts
@@ -75,6 +75,7 @@ function usageColor(percentage: number): "success" | "warning" | "error" {
 function formatProviderLimit(limitType: string, budgetLimitUsd: string): string {
 	if (limitType.endsWith("_DISABLED") || limitType === "DISABLED") return "disabled"
 	if (limitType.endsWith("_UNLIMITED") || limitType === "UNLIMITED") return "unlimited"
+	if (isCappedProviderLimitType(limitType) && Number(budgetLimitUsd) === 0) return "$0"
 	return formatBudgetLimit(budgetLimitUsd)
 }
 

--- a/src/extensions/billing/command.ts
+++ b/src/extensions/billing/command.ts
@@ -1,0 +1,76 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import {
+	type BudgetEntry,
+	type BudgetSnapshot,
+	budgetLabel,
+	budgetUsagePercentage,
+	formatBudgetAmount,
+	formatBudgetLimit,
+	getBillingStatus,
+	isCappedProviderLimitType,
+	providerBudgetUsagePercentage,
+	refreshBillingStatusFromConfig,
+} from "./status.js"
+
+export function formatBudgetBreakdown(snapshot: BudgetSnapshot): string[] {
+	return [
+		`Budget — ${formatBudgetPeriod(snapshot)}`,
+		"",
+		...snapshot.budgets.flatMap((budget) => formatBudgetRow(budget)),
+	]
+}
+
+function formatBudgetPeriod(snapshot: BudgetSnapshot): string {
+	const formatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
+	const start = new Date(snapshot.period.startTime)
+	const end = new Date(snapshot.period.endTime)
+	if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return "current UTC month"
+	return `${formatter.format(start)}–${formatter.format(end)} UTC`
+}
+
+function formatBudgetRow(budget: BudgetEntry): string[] {
+	const label = budgetLabel(budget).padEnd(32)
+	const amount = `${formatBudgetAmount(budget.totalSpendUsd)} / ${formatBudgetLimit(budget.budgetLimitUsd)}`.padEnd(18)
+	const rows = [`${"ACTIVE".padEnd(10)}${label}${amount}${budgetUsagePercentage(budget).toFixed(2)}%`]
+	for (const provider of budget.providerBudgets) {
+		const providerAmount =
+			`${formatBudgetAmount(provider.usageUsd)} / ${formatProviderLimit(provider.limitType, provider.budgetLimitUsd)}`.padEnd(
+				18,
+			)
+		const percentage = isCappedProviderLimitType(provider.limitType)
+			? `${providerBudgetUsagePercentage(provider).toFixed(2)}%`
+			: ""
+		rows.push(`  ${provider.provider.padEnd(20)}${providerAmount}${percentage}`)
+	}
+	return rows
+}
+
+function formatProviderLimit(limitType: string, budgetLimitUsd: string): string {
+	if (limitType.endsWith("_DISABLED") || limitType === "DISABLED") return "disabled"
+	if (limitType.endsWith("_UNLIMITED") || limitType === "UNLIMITED") return "unlimited"
+	return formatBudgetLimit(budgetLimitUsd)
+}
+
+async function handleBudgetCommand(ctx: ExtensionCommandContext): Promise<void> {
+	if (!ctx.hasUI) return
+	await refreshBillingStatusFromConfig()
+	const budget = getBillingStatus()?.budget
+	if (!budget) {
+		ctx.ui.notify("Budget information is currently unavailable.", "warning")
+		return
+	}
+	if (budget.budgets.length === 0) {
+		ctx.ui.notify("No budget is configured for this API key owner.", "info")
+		return
+	}
+	ctx.ui.notify(formatBudgetBreakdown(budget).join("\n"), "info")
+}
+
+export default function budgetCommandExtension(pi: ExtensionAPI): void {
+	pi.registerCommand("budget", {
+		description: "Show the current API key budget and usage",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			await handleBudgetCommand(ctx)
+		},
+	})
+}

--- a/src/extensions/billing/command.ts
+++ b/src/extensions/billing/command.ts
@@ -95,7 +95,7 @@ async function handleBudgetCommand(ctx: ExtensionCommandContext): Promise<void> 
 
 export default function budgetCommandExtension(pi: ExtensionAPI): void {
 	pi.registerCommand("budget", {
-		description: "Show the current API key budget and usage",
+		description: "Show current budget and usage",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
 			await handleBudgetCommand(ctx)
 		},

--- a/src/extensions/billing/command.ts
+++ b/src/extensions/billing/command.ts
@@ -1,8 +1,9 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent"
 import {
 	type BudgetEntry,
 	type BudgetSnapshot,
 	budgetLabel,
+	budgetStatus,
 	budgetUsagePercentage,
 	formatBudgetAmount,
 	formatBudgetLimit,
@@ -12,11 +13,19 @@ import {
 	refreshBillingStatusFromConfig,
 } from "./status.js"
 
-export function formatBudgetBreakdown(snapshot: BudgetSnapshot): string[] {
+const BUDGET_WIDTH = 31
+const USED_WIDTH = 11
+const LIMIT_WIDTH = 11
+const USAGE_WIDTH = 9
+const TABLE_WIDTH = BUDGET_WIDTH + USED_WIDTH + LIMIT_WIDTH + USAGE_WIDTH
+
+export function formatBudgetBreakdown(snapshot: BudgetSnapshot, theme: Theme): string[] {
 	return [
-		`Budget — ${formatBudgetPeriod(snapshot)}`,
+		`${theme.bold(theme.fg("accent", "Budget"))}  ${theme.fg("dim", formatBudgetPeriod(snapshot))}`,
 		"",
-		...snapshot.budgets.flatMap((budget) => formatBudgetRow(budget)),
+		theme.bold(theme.fg("dim", tableRow("BUDGET", "USED", "LIMIT", "USAGE"))),
+		theme.fg("dim", "─".repeat(TABLE_WIDTH)),
+		...snapshot.budgets.flatMap((budget, index) => [...(index > 0 ? [""] : []), ...formatBudgetRow(budget, theme)]),
 	]
 }
 
@@ -28,21 +37,39 @@ function formatBudgetPeriod(snapshot: BudgetSnapshot): string {
 	return `${formatter.format(start)}–${formatter.format(end)} UTC`
 }
 
-function formatBudgetRow(budget: BudgetEntry): string[] {
-	const label = budgetLabel(budget).padEnd(32)
-	const amount = `${formatBudgetAmount(budget.totalSpendUsd)} / ${formatBudgetLimit(budget.budgetLimitUsd)}`.padEnd(18)
-	const rows = [`${"ACTIVE".padEnd(10)}${label}${amount}${budgetUsagePercentage(budget).toFixed(2)}%`]
-	for (const provider of budget.providerBudgets) {
-		const providerAmount =
-			`${formatBudgetAmount(provider.usageUsd)} / ${formatProviderLimit(provider.limitType, provider.budgetLimitUsd)}`.padEnd(
-				18,
-			)
-		const percentage = isCappedProviderLimitType(provider.limitType)
-			? `${providerBudgetUsagePercentage(provider).toFixed(2)}%`
-			: ""
-		rows.push(`  ${provider.provider.padEnd(20)}${providerAmount}${percentage}`)
+function formatBudgetRow(budget: BudgetEntry, theme: Theme): string[] {
+	const status = budgetStatus(budget)
+	const color = statusColor(status)
+	const percentage = budgetUsagePercentage(budget)
+	const rows = [
+		`${theme.bold(budgetLabel(budget).padEnd(BUDGET_WIDTH))}${theme.fg("accent", formatBudgetAmount(budget.totalSpendUsd).padStart(USED_WIDTH))}${theme.fg("dim", formatBudgetLimit(budget.budgetLimitUsd).padStart(LIMIT_WIDTH))}${theme.fg(color, `${percentage.toFixed(2)}%`.padStart(USAGE_WIDTH))}`,
+	]
+	for (const [index, provider] of budget.providerBudgets.entries()) {
+		const capped = isCappedProviderLimitType(provider.limitType)
+		const providerPercentage = providerBudgetUsagePercentage(provider)
+		const branch = index === budget.providerBudgets.length - 1 ? "└─" : "├─"
+		const usage = capped ? `${providerPercentage.toFixed(2)}%` : "—"
+		rows.push(
+			`${theme.fg("dim", `  ${branch} ${provider.provider}`.padEnd(BUDGET_WIDTH))}${theme.fg("accent", formatBudgetAmount(provider.usageUsd).padStart(USED_WIDTH))}${theme.fg("dim", formatProviderLimit(provider.limitType, provider.budgetLimitUsd).padStart(LIMIT_WIDTH))}${theme.fg(capped ? usageColor(providerPercentage) : "dim", usage.padStart(USAGE_WIDTH))}`,
+		)
 	}
 	return rows
+}
+
+function tableRow(budget: string, used: string, limit: string, usage: string): string {
+	return `${budget.padEnd(BUDGET_WIDTH)}${used.padStart(USED_WIDTH)}${limit.padStart(LIMIT_WIDTH)}${usage.padStart(USAGE_WIDTH)}`
+}
+
+function statusColor(status: ReturnType<typeof budgetStatus>): "success" | "warning" | "error" {
+	if (status === "WARNING") return "warning"
+	if (status === "EXHAUSTED") return "error"
+	return "success"
+}
+
+function usageColor(percentage: number): "success" | "warning" | "error" {
+	if (percentage >= 100) return "error"
+	if (percentage >= 90) return "warning"
+	return "success"
 }
 
 function formatProviderLimit(limitType: string, budgetLimitUsd: string): string {
@@ -63,7 +90,7 @@ async function handleBudgetCommand(ctx: ExtensionCommandContext): Promise<void> 
 		ctx.ui.notify("No budget is configured for this API key owner.", "info")
 		return
 	}
-	ctx.ui.notify(formatBudgetBreakdown(budget).join("\n"), "info")
+	ctx.ui.notify(formatBudgetBreakdown(budget, ctx.ui.theme).join("\n"), "info")
 }
 
 export default function budgetCommandExtension(pi: ExtensionAPI): void {

--- a/src/extensions/billing/status-line-format.test.ts
+++ b/src/extensions/billing/status-line-format.test.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import { RST_FG } from "../../ansi.js"
-import { formatBillingStatusLine } from "./status-line-format.js"
+import { formatBudgetStatusLine, formatCreditsStatusLine } from "./status-line-format.js"
 
 function theme(): Theme {
 	return {
@@ -18,18 +18,18 @@ function theme(): Theme {
 	} as unknown as Theme
 }
 
-describe("formatBillingStatusLine", () => {
+describe("billing status line format", () => {
 	it("dims the fixed label and accents the dollar balance", () => {
 		const t = theme()
 
-		expect(formatBillingStatusLine({ amount: "$10.00" }, t)).toBe(`<dim>Credits:</dim> <accent>$10.00${RST_FG}`)
+		expect(formatCreditsStatusLine("$10.00", t)).toBe(`<dim>Credits:</dim> <accent>$10.00${RST_FG}`)
 	})
 
-	it("shows credits and budget together", () => {
+	it("formats budget independently from credits", () => {
 		const t = theme()
 
-		expect(formatBillingStatusLine({ amount: "$18.40", budget: "$274.59/$2k" }, t)).toBe(
-			`<dim>Credits:</dim> <accent>$18.40${RST_FG}<dim> · </dim><dim>Budget:</dim> <accent>$274.59/$2k${RST_FG}`,
+		expect(formatBudgetStatusLine("13.73% ($274.59/$2k)", t)).toBe(
+			`<dim>Budget:</dim> <accent>13.73% ($274.59/$2k)${RST_FG}`,
 		)
 	})
 })

--- a/src/extensions/billing/status-line-format.test.ts
+++ b/src/extensions/billing/status-line-format.test.ts
@@ -24,4 +24,12 @@ describe("formatBillingStatusLine", () => {
 
 		expect(formatBillingStatusLine({ amount: "$10.00" }, t)).toBe(`<dim>Credits:</dim> <accent>$10.00${RST_FG}`)
 	})
+
+	it("shows credits and budget together", () => {
+		const t = theme()
+
+		expect(formatBillingStatusLine({ amount: "$18.40", budget: "$274.59/$2k" }, t)).toBe(
+			`<dim>Credits:</dim> <accent>$18.40${RST_FG}<dim> · </dim><dim>Budget:</dim> <accent>$274.59/$2k${RST_FG}`,
+		)
+	})
 })

--- a/src/extensions/billing/status-line-format.ts
+++ b/src/extensions/billing/status-line-format.ts
@@ -3,5 +3,8 @@ import { RST_FG, resolvedAccentFg } from "../../ansi.js"
 import type { BillingStatusLine } from "./status.js"
 
 export function formatBillingStatusLine(line: BillingStatusLine, theme: Theme): string {
-	return `${theme.fg("dim", "Credits:")} ${resolvedAccentFg(theme)}${line.amount}${RST_FG}`
+	const parts: string[] = []
+	if (line.amount) parts.push(`${theme.fg("dim", "Credits:")} ${resolvedAccentFg(theme)}${line.amount}${RST_FG}`)
+	if (line.budget) parts.push(`${theme.fg("dim", "Budget:")} ${resolvedAccentFg(theme)}${line.budget}${RST_FG}`)
+	return parts.join(theme.fg("dim", " · "))
 }

--- a/src/extensions/billing/status-line-format.ts
+++ b/src/extensions/billing/status-line-format.ts
@@ -1,10 +1,10 @@
 import type { Theme } from "@earendil-works/pi-coding-agent"
 import { RST_FG, resolvedAccentFg } from "../../ansi.js"
-import type { BillingStatusLine } from "./status.js"
 
-export function formatBillingStatusLine(line: BillingStatusLine, theme: Theme): string {
-	const parts: string[] = []
-	if (line.amount) parts.push(`${theme.fg("dim", "Credits:")} ${resolvedAccentFg(theme)}${line.amount}${RST_FG}`)
-	if (line.budget) parts.push(`${theme.fg("dim", "Budget:")} ${resolvedAccentFg(theme)}${line.budget}${RST_FG}`)
-	return parts.join(theme.fg("dim", " · "))
+export function formatCreditsStatusLine(amount: string, theme: Theme): string {
+	return `${theme.fg("dim", "Credits:")} ${resolvedAccentFg(theme)}${amount}${RST_FG}`
+}
+
+export function formatBudgetStatusLine(budget: string, theme: Theme): string {
+	return `${theme.fg("dim", "Budget:")} ${resolvedAccentFg(theme)}${budget}${RST_FG}`
 }

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -446,7 +446,16 @@ describe("billing status", () => {
 		const fetchImpl = ((input: RequestInfo | URL) => {
 			if (String(input).endsWith("/credits")) return Promise.resolve(new Response("nope", { status: 500 }))
 			return Promise.resolve(
-				new Response(JSON.stringify(budgetPayload({ budgetType: "BUDGET_TYPE_PER_USER" })), { status: 200 }),
+				new Response(
+					JSON.stringify(
+						budgetPayload({
+							budgetType: "BUDGET_TYPE_PER_USER",
+							budgetLimitUsd: "2000.000000",
+							totalSpendUsd: "1800.000000",
+						}),
+					),
+					{ status: 200 },
+				),
 			)
 		}) as typeof fetch
 
@@ -455,6 +464,26 @@ describe("billing status", () => {
 		expect(getBillingStatus()?.budget?.budgets[0]?.scope).toBe("USER")
 		expect(getBillingStatus()?.budget?.budgets[0]?.budgetType).toBe("BUDGET_TYPE_PER_USER")
 		expect(getBillingStatusLine()).toEqual({ budget: "90.00% ($1.8k/$2k)" })
+	})
+
+	it("does not notify listeners when equivalent budget object keys are reordered", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const payload = budgetPayload()
+		setBillingStatusForTest({
+			budget: { budgets: payload.budgets, period: payload.period },
+			updatedAt: "2026-07-01T00:00:00Z",
+		})
+		const updates: Array<unknown> = []
+		const unsubscribe = subscribeBillingStatus((status) => updates.push(status))
+
+		try {
+			await refreshBudgetStatus({
+				fetch: (() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))) as typeof fetch,
+			})
+			expect(updates).toEqual([])
+		} finally {
+			unsubscribe()
+		}
 	})
 
 	it("preserves credits and clears only budget state when an older proxy returns 404", async () => {

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -454,7 +454,7 @@ describe("billing status", () => {
 
 		expect(getBillingStatus()?.budget?.budgets[0]?.scope).toBe("USER")
 		expect(getBillingStatus()?.budget?.budgets[0]?.budgetType).toBe("BUDGET_TYPE_PER_USER")
-		expect(getBillingStatusLine()).toEqual({ budget: "$1.8k/$2k" })
+		expect(getBillingStatusLine()).toEqual({ budget: "90.00% ($1.8k/$2k)" })
 	})
 
 	it("preserves credits and clears only budget state when an older proxy returns 404", async () => {
@@ -667,7 +667,7 @@ describe("billing status", () => {
 			fetch: (() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))) as typeof fetch,
 		})
 
-		expect(getBillingStatusLine()).toEqual({ budget: "$100.00/$25" })
+		expect(getBillingStatusLine()).toEqual({ budget: "400.00% ($100.00/$25)" })
 		expect(getBillingWarnings()).toEqual([
 			{
 				kind: "exhausted",

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -3,15 +3,20 @@ import { beforeEach, describe, expect, it } from "vitest"
 const {
 	BILLING_EXHAUSTED_MESSAGE,
 	COMMUNITY_TIER_HEADER_NOTICE,
+	budgetEndpointFromLlmEndpoint,
 	configureBillingCreditsApi,
 	creditsEndpointFromLlmEndpoint,
+	formatBudgetAmount,
+	formatBudgetLimit,
 	getBillingStatus,
 	getBillingStatusLine,
-	getBillingWarning,
+	getBillingWarnings,
 	getCommunityTierHeaderNotice,
 	observeCreditsPayload,
 	refreshBillingStatus,
 	refreshBillingStatusFromConfig,
+	refreshBillingSnapshot,
+	refreshBudgetStatus,
 	setBillingStatusForTest,
 	subscribeBillingStatus,
 } = await import("./status.js")
@@ -28,6 +33,19 @@ describe("billing status", () => {
 		expect(creditsEndpointFromLlmEndpoint("https://llm.kimchi.dev/openai/v1/")).toBe(
 			"https://llm.kimchi.dev/v1/credits",
 		)
+	})
+
+	it("derives the budget endpoint alongside credits", () => {
+		expect(budgetEndpointFromLlmEndpoint("https://llm.kimchi.dev")).toBe("https://llm.kimchi.dev/v1/budget")
+		expect(budgetEndpointFromLlmEndpoint("https://llm.kimchi.dev/openai/v1/")).toBe("https://llm.kimchi.dev/v1/budget")
+	})
+
+	it("formats budget spending, limits, and compact thousands", () => {
+		expect(formatBudgetAmount("274.594050")).toBe("$274.59")
+		expect(formatBudgetAmount("1800")).toBe("$1.8k")
+		expect(formatBudgetLimit("500.000000")).toBe("$500")
+		expect(formatBudgetLimit("2000.000000")).toBe("$2k")
+		expect(formatBudgetLimit("0.000000")).toBe("unlimited")
 	})
 
 	it("maps the proxy Community tier to header upsell without paid warnings", () => {
@@ -50,7 +68,7 @@ describe("billing status", () => {
 		expect(getCommunityTierHeaderNotice()).toBe(
 			"You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing",
 		)
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$0.00" })
 	})
 
@@ -71,7 +89,7 @@ describe("billing status", () => {
 			remainingCredits: 2,
 		})
 		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_HEADER_NOTICE)
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$2.00" })
 	})
 
@@ -91,7 +109,7 @@ describe("billing status", () => {
 			remainingCredits: 4.5,
 		})
 		expect(getCommunityTierHeaderNotice()).toBeUndefined()
-		expect(getBillingWarning()?.message).toContain("$4.50 remaining")
+		expect(getBillingWarnings()[0]?.message).toContain("$4.50 remaining")
 		expect(getBillingStatusLine()).toEqual({ amount: "$4.50" })
 	})
 
@@ -105,7 +123,7 @@ describe("billing status", () => {
 			remaining: "5",
 		})
 
-		expect(getBillingWarning()).toEqual({
+		expect(getBillingWarnings()[0]).toEqual({
 			kind: "low",
 			message:
 				"Heads up: your credits are running low ($5.00 remaining). Top up now to avoid slowdowns and rate limits: https://app.kimchi.dev/billing",
@@ -120,7 +138,7 @@ describe("billing status", () => {
 			billing_status: "low_balance",
 		})
 
-		expect(getBillingWarning()).toEqual({
+		expect(getBillingWarnings()[0]).toEqual({
 			kind: "low",
 			message:
 				"Heads up: your credits are running low. Top up now to avoid slowdowns and rate limits: https://app.kimchi.dev/billing",
@@ -146,7 +164,7 @@ describe("billing status", () => {
 			restrictedMode: false,
 			remainingCredits: 4,
 		})
-		expect(getBillingWarning()?.message).toContain("$4.00 remaining")
+		expect(getBillingWarnings()[0]?.message).toContain("$4.00 remaining")
 		expect(getBillingStatusLine()).toEqual({ amount: "$4.00" })
 	})
 
@@ -160,7 +178,7 @@ describe("billing status", () => {
 		})
 
 		expect(getBillingStatus()).toMatchObject({ plan: "coder", isPaidTier: true, creditStatus: "ok" })
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$4.00" })
 	})
 
@@ -207,7 +225,7 @@ describe("billing status", () => {
 			remaining: "0",
 		})
 
-		expect(getBillingWarning()).toEqual({
+		expect(getBillingWarnings()[0]).toEqual({
 			kind: "exhausted",
 			message: BILLING_EXHAUSTED_MESSAGE,
 		})
@@ -231,7 +249,7 @@ describe("billing status", () => {
 		expect(getBillingStatus()?.plan).toBeUndefined()
 		expect(getBillingStatus()?.isPaidTier).toBeUndefined()
 		expect(getCommunityTierHeaderNotice()).toBeUndefined()
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$12.50" })
 	})
 
@@ -245,7 +263,7 @@ describe("billing status", () => {
 
 		expect(getBillingStatus()).toMatchObject({ isPaidTier: true, creditStatus: "low", remainingCredits: 5 })
 		expect(getCommunityTierHeaderNotice()).toBeUndefined()
-		expect(getBillingWarning()?.kind).toBe("low")
+		expect(getBillingWarnings()[0]?.kind).toBe("low")
 		expect(getBillingStatusLine()).toEqual({ amount: "$5.00" })
 	})
 
@@ -257,7 +275,7 @@ describe("billing status", () => {
 			remaining: "5",
 		})
 
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 
 		observeCreditsPayload({
 			serverless: true,
@@ -266,7 +284,7 @@ describe("billing status", () => {
 			remaining: "4.99",
 		})
 
-		expect(getBillingWarning()?.kind).toBe("low")
+		expect(getBillingWarnings()[0]?.kind).toBe("low")
 	})
 
 	it("clears billing UI state for BYO-only credits API payloads", () => {
@@ -277,13 +295,13 @@ describe("billing status", () => {
 			billing_status: "depleted",
 			remaining: "0",
 		})
-		expect(getBillingWarning()?.kind).toBe("exhausted")
+		expect(getBillingWarnings()[0]?.kind).toBe("exhausted")
 
 		observeCreditsPayload({ serverless: false })
 
 		expect(getBillingStatus()).toMatchObject({ serverless: false })
 		expect(getBillingStatus()?.plan).toBeUndefined()
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 	})
 
 	it("clears stale paid warning fields when a full API snapshot reports recovery", () => {
@@ -295,7 +313,7 @@ describe("billing status", () => {
 			has_credits: false,
 			remaining: "0",
 		})
-		expect(getBillingWarning()?.kind).toBe("exhausted")
+		expect(getBillingWarnings()[0]?.kind).toBe("exhausted")
 
 		observeCreditsPayload({
 			serverless: true,
@@ -313,7 +331,7 @@ describe("billing status", () => {
 			restrictedMode: false,
 			remainingCredits: 10,
 		})
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$10.00" })
 	})
 
@@ -326,12 +344,12 @@ describe("billing status", () => {
 			billing_status: "low_balance",
 			remaining: "5",
 		})
-		expect(getBillingWarning()?.kind).toBe("low")
+		expect(getBillingWarnings()[0]?.kind).toBe("low")
 
 		configureBillingCreditsApi({ apiKey: "new-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
 
 		expect(getBillingStatus()).toBeUndefined()
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 	})
 
 	it("discards stale in-flight refreshes after credentials change", async () => {
@@ -403,7 +421,7 @@ describe("billing status", () => {
 		)
 
 		await expect(newerRefresh).resolves.toMatchObject({ creditStatus: "low", remainingCredits: 5 })
-		expect(getBillingWarning()?.kind).toBe("low")
+		expect(getBillingWarnings()[0]?.kind).toBe("low")
 
 		resolveFirstResponse(
 			new Response(
@@ -421,6 +439,241 @@ describe("billing status", () => {
 
 		await expect(olderRefresh).resolves.toBeUndefined()
 		expect(getBillingStatus()).toMatchObject({ creditStatus: "low", remainingCredits: 5 })
+	})
+
+	it("keeps a successful budget snapshot when the credits request fails", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			if (String(input).endsWith("/credits")) return Promise.resolve(new Response("nope", { status: 500 }))
+			return Promise.resolve(
+				new Response(JSON.stringify(budgetPayload({ budgetType: "BUDGET_TYPE_PER_USER" })), { status: 200 }),
+			)
+		}) as typeof fetch
+
+		await refreshBillingSnapshot({ fetch: fetchImpl })
+
+		expect(getBillingStatus()?.budget?.budgets[0]?.scope).toBe("USER")
+		expect(getBillingStatus()?.budget?.budgets[0]?.budgetType).toBe("BUDGET_TYPE_PER_USER")
+		expect(getBillingStatusLine()).toEqual({ budget: "$1.8k/$2k" })
+	})
+
+	it("preserves credits and clears only budget state when an older proxy returns 404", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		observeCreditsPayload({
+			serverless: true,
+			tier: "coder",
+			is_paid_tier: true,
+			billing_status: "ok",
+			remaining: "18.4",
+		})
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(budgetPayload()), { status: 200 }))) as typeof fetch,
+		})
+
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response("not found", { status: 404 }))) as typeof fetch,
+		})
+
+		expect(getBillingStatus()).toMatchObject({ remainingCredits: 18.4 })
+		expect(getBillingStatus()?.budget).toBeUndefined()
+	})
+
+	it("discards a stale budget response after credentials change", async () => {
+		configureBillingCreditsApi({ apiKey: "old-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		let resolveResponse!: (response: Response) => void
+		const pendingResponse = new Promise<Response>((resolve) => {
+			resolveResponse = resolve
+		})
+
+		const refresh = refreshBudgetStatus({ fetch: (() => pendingResponse) as typeof fetch })
+		configureBillingCreditsApi({ apiKey: "new-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		resolveResponse(new Response(JSON.stringify(budgetPayload()), { status: 200 }))
+
+		await expect(refresh).resolves.toBeUndefined()
+		expect(getBillingStatus()).toBeUndefined()
+	})
+
+	it("derives warnings from total usage, not provider usage", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(budgetPayload()), { status: 200 }))) as typeof fetch,
+		})
+
+		expect(getBillingWarnings()).toEqual([
+			{
+				kind: "low",
+				message: "Budget warning: Personal budget is 90% used ($1.8k/$2k).",
+			},
+		])
+	})
+
+	it("accepts provider entries whose non-capped limit is omitted by proto JSON", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const payload = budgetPayload()
+		const provider = payload.budgets[0].providerBudgets[0] as {
+			budgetLimitUsd?: string
+			limitType: string
+			usageUsd: string
+		}
+		provider.limitType = "PROVIDER_BUDGET_LIMIT_TYPE_UNLIMITED"
+		provider.usageUsd = "12.000000"
+		provider.budgetLimitUsd = undefined
+
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))) as typeof fetch,
+		})
+
+		expect(getBillingStatus()?.budget?.budgets[0]?.providerBudgets[0]).toMatchObject({
+			budgetLimitUsd: "",
+			limitType: "PROVIDER_BUDGET_LIMIT_TYPE_UNLIMITED",
+		})
+	})
+
+	it("normalizes an omitted provider limit type to disabled", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const payload = budgetPayload()
+		const provider = payload.budgets[0].providerBudgets[0] as {
+			budgetLimitUsd?: string
+			limitType?: string
+		}
+		provider.limitType = undefined
+		provider.budgetLimitUsd = undefined
+
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))) as typeof fetch,
+		})
+
+		expect(getBillingStatus()?.budget?.budgets[0]?.providerBudgets[0]).toMatchObject({
+			budgetLimitUsd: "",
+			limitType: "DISABLED",
+		})
+	})
+
+	it("rejects a capped provider whose limit is omitted and preserves the previous snapshot", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(budgetPayload()), { status: 200 }))) as typeof fetch,
+		})
+		const invalid = budgetPayload({ totalSpendUsd: "1900.000000" })
+		;(invalid.budgets[0].providerBudgets[0] as { budgetLimitUsd?: string }).budgetLimitUsd = undefined
+
+		await expect(
+			refreshBudgetStatus({
+				fetch: (() => Promise.resolve(new Response(JSON.stringify(invalid), { status: 200 }))) as typeof fetch,
+			}),
+		).resolves.toBeUndefined()
+		expect(getBillingStatus()?.budget?.budgets[0]?.totalSpendUsd).toBe("1800.000000")
+	})
+
+	it("normalizes repeated budget fields omitted by proto JSON", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const noBudgets = budgetPayload()
+		;(noBudgets as { budgets?: unknown }).budgets = undefined
+
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(noBudgets), { status: 200 }))) as typeof fetch,
+		})
+		expect(getBillingStatus()?.budget?.budgets).toEqual([])
+
+		const noProviders = budgetPayload()
+		;(noProviders.budgets[0] as { providerBudgets?: unknown }).providerBudgets = undefined
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(noProviders), { status: 200 }))) as typeof fetch,
+		})
+		expect(getBillingStatus()?.budget?.budgets[0]?.providerBudgets).toEqual([])
+	})
+
+	it("does not select an unlimited total budget for the footer", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		await refreshBudgetStatus({
+			fetch: (() =>
+				Promise.resolve(
+					new Response(JSON.stringify(budgetPayload({ budgetLimitUsd: "0.000000" })), { status: 200 }),
+				)) as typeof fetch,
+		})
+
+		expect(getBillingStatus()?.budget?.budgets).toHaveLength(1)
+		expect(getBillingStatusLine()).toBeUndefined()
+	})
+
+	it("preserves the last budget snapshot on a temporary budget failure", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(budgetPayload()), { status: 200 }))) as typeof fetch,
+		})
+
+		await expect(
+			refreshBudgetStatus({
+				fetch: (() => Promise.resolve(new Response("unavailable", { status: 503 }))) as typeof fetch,
+			}),
+		).resolves.toBeUndefined()
+		expect(getBillingStatus()?.budget?.budgets[0]?.totalSpendUsd).toBe("1800.000000")
+	})
+
+	it("warns rather than exhausts when an organization soft limit exceeds 100 percent", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		await refreshBudgetStatus({
+			fetch: (() =>
+				Promise.resolve(
+					new Response(
+						JSON.stringify(
+							budgetPayload({
+								scope: "ORGANIZATION_SOFT",
+								budgetLimitUsd: "100.000000",
+								totalSpendUsd: "125.000000",
+							}),
+						),
+						{ status: 200 },
+					),
+				)) as typeof fetch,
+		})
+
+		expect(getBillingWarnings()).toEqual([
+			{
+				kind: "low",
+				message: "Budget warning: Organization soft budget is 125% used ($125.00/$100).",
+			},
+		])
+	})
+
+	it("uses highest usage for the footer and worst total status for warnings", async () => {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		const payload = budgetPayload({
+			scope: "API_KEY",
+			scopeId: "key",
+			budgetLimitUsd: "200.000000",
+			totalSpendUsd: "100.000000",
+		})
+		payload.budgets.push(
+			{
+				...payload.budgets[0],
+				scope: "ORGANIZATION_SOFT",
+				scopeId: "org",
+				budgetType: "BUDGET_TYPE_PER_USER",
+				budgetLimitUsd: "25.000000",
+				providerBudgets: [],
+			},
+			{
+				...payload.budgets[0],
+				scope: "ORGANIZATION_HARD",
+				scopeId: "org",
+				budgetType: "BUDGET_TYPE_PER_USER",
+				budgetLimitUsd: "100.000000",
+				providerBudgets: [],
+			},
+		)
+
+		await refreshBudgetStatus({
+			fetch: (() => Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }))) as typeof fetch,
+		})
+
+		expect(getBillingStatusLine()).toEqual({ budget: "$100.00/$25" })
+		expect(getBillingWarnings()).toEqual([
+			{
+				kind: "exhausted",
+				message: "Budget exhausted: Organization per-user hard budget is fully used ($100.00/$100).",
+			},
+		])
 	})
 
 	it("times out a credits response body that never finishes", async () => {
@@ -455,7 +708,7 @@ describe("billing status", () => {
 			has_credits: false,
 			remaining: "0",
 		})
-		expect(getBillingWarning()?.kind).toBe("exhausted")
+		expect(getBillingWarnings()[0]?.kind).toBe("exhausted")
 
 		observeCreditsPayload({
 			serverless: true,
@@ -467,7 +720,7 @@ describe("billing status", () => {
 		expect(getBillingStatus()).toMatchObject({ plan: "coder", remainingCredits: 10 })
 		expect(getBillingStatus()?.creditStatus).toBeUndefined()
 		expect(getBillingStatus()?.restrictedMode).toBeUndefined()
-		expect(getBillingWarning()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toBeUndefined()
 	})
 
 	it("clears a stale Community plan when a rollout snapshot omits tier", () => {
@@ -506,3 +759,34 @@ describe("billing status", () => {
 		}
 	})
 })
+
+function budgetPayload(
+	options: {
+		scope?: "API_KEY" | "USER" | "TEAM_PER_USER" | "TEAM_POOLED" | "ORGANIZATION_SOFT" | "ORGANIZATION_HARD"
+		scopeId?: string
+		budgetType?: string
+		budgetLimitUsd?: string
+		totalSpendUsd?: string
+	} = {},
+) {
+	return {
+		period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+		budgets: [
+			{
+				scope: options.scope ?? "USER",
+				scopeId: options.scopeId ?? "1",
+				...(options.budgetType ? { budgetType: options.budgetType } : {}),
+				budgetLimitUsd: options.budgetLimitUsd ?? "2000.000000",
+				totalSpendUsd: options.totalSpendUsd ?? "1800.000000",
+				providerBudgets: [
+					{
+						provider: "anthropic",
+						limitType: "PROVIDER_BUDGET_LIMIT_TYPE_CAPPED",
+						budgetLimitUsd: "400.000000",
+						usageUsd: "400.000000",
+					},
+				],
+			},
+		],
+	}
+}

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -10,6 +10,7 @@ export interface BillingStatus {
 	remainingCredits?: number
 	creditStatus?: BillingCreditStatus
 	restrictedMode?: boolean
+	budget?: BudgetSnapshot
 	updatedAt: string
 }
 
@@ -19,12 +20,42 @@ export interface BillingWarning {
 }
 
 export interface BillingStatusLine {
-	amount: string
+	amount?: string
+	budget?: string
 }
 
-interface BillingCreditsApiConfig {
+export interface BudgetSnapshot {
+	period: BudgetPeriod
+	budgets: BudgetEntry[]
+}
+
+export interface BudgetPeriod {
+	startTime: string
+	endTime: string
+}
+
+export interface BudgetEntry {
+	scope: "API_KEY" | "USER" | "TEAM_PER_USER" | "TEAM_POOLED" | "ORGANIZATION_SOFT" | "ORGANIZATION_HARD"
+	scopeId: string
+	budgetType?: string
+	budgetLimitUsd: string
+	totalSpendUsd: string
+	providerBudgets: BudgetProvider[]
+}
+
+export interface BudgetProvider {
+	provider: string
+	limitType: string
+	budgetLimitUsd: string
+	usageUsd: string
+}
+
+export type BudgetStatus = "OK" | "WARNING" | "EXHAUSTED"
+
+interface BillingApiConfig {
 	apiKey: string
 	creditsUrl: string
+	budgetUrl: string
 }
 
 interface RefreshBillingStatusOptions {
@@ -46,9 +77,10 @@ const BILLING_STATUS_FIELDS = ["billing_status", "billingStatus"] as const
 const HAS_CREDITS_FIELDS = ["has_credits", "hasCredits"] as const
 
 let currentBillingStatus: BillingStatus | undefined
-let creditsApiConfig: BillingCreditsApiConfig | undefined
+let creditsApiConfig: BillingApiConfig | undefined
 let creditsApiGeneration = 0
 let latestBillingRefreshId = 0
+let latestBudgetRefreshId = 0
 const listeners = new Set<(status: BillingStatus | undefined) => void>()
 
 export function getBillingStatus(): BillingStatus | undefined {
@@ -74,12 +106,23 @@ export function subscribeBillingStatus(listener: (status: BillingStatus | undefi
 export function configureBillingCreditsApi(options: { apiKey?: string; llmEndpoint?: string }): void {
 	const apiKey = options.apiKey?.trim()
 	const llmEndpoint = options.llmEndpoint?.trim()
-	const next = apiKey && llmEndpoint ? { apiKey, creditsUrl: creditsEndpointFromLlmEndpoint(llmEndpoint) } : undefined
-	const changed = creditsApiConfig?.apiKey !== next?.apiKey || creditsApiConfig?.creditsUrl !== next?.creditsUrl
+	const next =
+		apiKey && llmEndpoint
+			? {
+					apiKey,
+					creditsUrl: creditsEndpointFromLlmEndpoint(llmEndpoint),
+					budgetUrl: budgetEndpointFromLlmEndpoint(llmEndpoint),
+				}
+			: undefined
+	const changed =
+		creditsApiConfig?.apiKey !== next?.apiKey ||
+		creditsApiConfig?.creditsUrl !== next?.creditsUrl ||
+		creditsApiConfig?.budgetUrl !== next?.budgetUrl
 	creditsApiConfig = next
 	if (changed) {
 		creditsApiGeneration++
 		latestBillingRefreshId++
+		latestBudgetRefreshId++
 		clearBillingStatus()
 	}
 }
@@ -88,6 +131,12 @@ export function creditsEndpointFromLlmEndpoint(llmEndpoint: string): string {
 	const trimmed = llmEndpoint.trim().replace(/\/+$/, "")
 	const proxyRoot = trimmed.replace(/\/openai\/v1$/i, "")
 	return `${proxyRoot}/v1/credits`
+}
+
+export function budgetEndpointFromLlmEndpoint(llmEndpoint: string): string {
+	const trimmed = llmEndpoint.trim().replace(/\/+$/, "")
+	const proxyRoot = trimmed.replace(/\/openai\/v1$/i, "")
+	return `${proxyRoot}/v1/budget`
 }
 
 export async function refreshBillingStatus(
@@ -126,13 +175,57 @@ export async function refreshBillingStatus(
 	return observeCreditsPayload(payload)
 }
 
+export async function refreshBudgetStatus(
+	options: RefreshBillingStatusOptions = {},
+): Promise<BudgetSnapshot | undefined> {
+	const config = creditsApiConfig
+	const generation = creditsApiGeneration
+	if (!config) return undefined
+	const refreshId = ++latestBudgetRefreshId
+	const fetchImpl = options.fetch ?? fetch
+	let response: Response
+	try {
+		response = await fetchImpl(config.budgetUrl, {
+			headers: { Authorization: `Bearer ${config.apiKey}` },
+			signal: AbortSignal.timeout(options.requestTimeoutMs ?? BILLING_REFRESH_TIMEOUT_MS),
+		})
+	} catch {
+		return undefined
+	}
+	if (response.status === 404) {
+		if (isCurrentBudgetRefresh(refreshId, generation, config)) clearBudgetSnapshot()
+		return undefined
+	}
+	if (!response.ok) return undefined
+
+	let payload: unknown
+	try {
+		payload = await readResponseJson(response, options.jsonTimeoutMs ?? BILLING_REFRESH_TIMEOUT_MS)
+	} catch {
+		return undefined
+	}
+	if (!isCurrentBudgetRefresh(refreshId, generation, config)) return undefined
+
+	const budget = parseBudgetPayload(payload)
+	if (!budget) return undefined
+	applyBudgetSnapshot(budget)
+	return budget
+}
+
+export async function refreshBillingSnapshot(
+	options: RefreshBillingStatusOptions = {},
+): Promise<BillingStatus | undefined> {
+	await Promise.allSettled([refreshBillingStatus(options), refreshBudgetStatus(options)])
+	return currentBillingStatus
+}
+
 export async function refreshBillingStatusFromConfig(
 	options: RefreshBillingStatusOptions = {},
 ): Promise<BillingStatus | undefined> {
 	try {
 		const config = (options.loadConfig ?? loadConfig)()
 		configureBillingCreditsApi({ apiKey: config.apiKey, llmEndpoint: config.llmEndpoint })
-		return await refreshBillingStatus(options)
+		return await refreshBillingSnapshot(options)
 	} catch {
 		return undefined
 	}
@@ -142,7 +235,7 @@ export function observeCreditsPayload(payload: unknown): BillingStatus | undefin
 	const update = parseCreditsPayload(payload)
 	if (!update) return undefined
 	if (update.serverless === false) {
-		return replaceBillingStatus({ serverless: false })
+		return replaceBillingStatus({ serverless: false, budget: currentBillingStatus?.budget })
 	}
 	return applyBillingUpdate(update)
 }
@@ -153,9 +246,14 @@ export function getCommunityTierHeaderNotice(
 	return status?.plan === "community" ? COMMUNITY_TIER_HEADER_NOTICE : undefined
 }
 
-export function getBillingWarning(
-	status: BillingStatus | undefined = currentBillingStatus,
-): BillingWarning | undefined {
+export function getBillingWarnings(status: BillingStatus | undefined = currentBillingStatus): BillingWarning[] {
+	const warnings = [getCreditBillingWarning(status), getBudgetWarning(status)].filter(
+		(warning): warning is BillingWarning => warning !== undefined,
+	)
+	return warnings
+}
+
+function getCreditBillingWarning(status: BillingStatus | undefined): BillingWarning | undefined {
 	if (!status || !isPaidPlan(status)) return undefined
 
 	if (status.creditStatus === "ok") return undefined
@@ -189,10 +287,17 @@ export function getBillingWarning(
 export function getBillingStatusLine(
 	status: BillingStatus | undefined = currentBillingStatus,
 ): BillingStatusLine | undefined {
-	if (!status || status.serverless === false) return undefined
-	if (typeof status.remainingCredits !== "number") return undefined
-
-	return { amount: formatCreditsAmount(status.remainingCredits) }
+	if (!status) return undefined
+	const amount =
+		status.serverless === false || typeof status.remainingCredits !== "number"
+			? undefined
+			: formatCreditsAmount(status.remainingCredits)
+	const displayBudget = getDisplayBudget(status.budget)
+	const budget = displayBudget
+		? `${formatBudgetAmount(displayBudget.totalSpendUsd)}/${formatBudgetLimit(displayBudget.budgetLimitUsd)}`
+		: undefined
+	if (!amount && !budget) return undefined
+	return { ...(amount ? { amount } : {}), ...(budget ? { budget } : {}) }
 }
 
 function parseCreditsPayload(payload: unknown): Partial<BillingStatus> | undefined {
@@ -227,6 +332,113 @@ function parseCreditsPayload(payload: unknown): Partial<BillingStatus> | undefin
 	if (serverless === true || hasAny(body, HAS_CREDITS_FIELDS)) update.restrictedMode = restrictedMode
 
 	return Object.keys(update).length > 0 ? update : undefined
+}
+
+function parseBudgetPayload(payload: unknown): BudgetSnapshot | undefined {
+	const body = asRecord(payload)
+	const period = asRecord(body.period)
+	const budgetValues = body.budgets === undefined ? [] : body.budgets
+	if (typeof period.startTime !== "string" || typeof period.endTime !== "string" || !Array.isArray(budgetValues)) {
+		return undefined
+	}
+
+	const budgets: BudgetEntry[] = []
+	for (const value of budgetValues) {
+		const budget = parseBudgetEntry(value)
+		if (!budget) return undefined
+		budgets.push(budget)
+	}
+	return {
+		period: { startTime: period.startTime, endTime: period.endTime },
+		budgets,
+	}
+}
+
+function parseBudgetEntry(value: unknown): BudgetEntry | undefined {
+	const entry = asRecord(value)
+	const providerValues = entry.providerBudgets === undefined ? [] : entry.providerBudgets
+	if (
+		!isBudgetScope(entry.scope) ||
+		typeof entry.scopeId !== "string" ||
+		(entry.budgetType !== undefined && typeof entry.budgetType !== "string") ||
+		!isUsd(entry.budgetLimitUsd) ||
+		!isUsd(entry.totalSpendUsd) ||
+		!Array.isArray(providerValues)
+	) {
+		return undefined
+	}
+
+	const providers: BudgetProvider[] = []
+	for (const value of providerValues) {
+		const provider = parseBudgetProvider(value)
+		if (!provider) return undefined
+		providers.push(provider)
+	}
+	return {
+		scope: entry.scope,
+		scopeId: entry.scopeId,
+		...(typeof entry.budgetType === "string" ? { budgetType: entry.budgetType } : {}),
+		budgetLimitUsd: entry.budgetLimitUsd,
+		totalSpendUsd: entry.totalSpendUsd,
+		providerBudgets: providers,
+	}
+}
+
+function parseBudgetProvider(value: unknown): BudgetProvider | undefined {
+	const provider = asRecord(value)
+	const rawLimitType = provider.limitType === undefined ? "DISABLED" : provider.limitType
+	if (typeof rawLimitType !== "string") return undefined
+	const limitType = rawLimitType === "UNSPECIFIED" || rawLimitType.endsWith("_UNSPECIFIED") ? "DISABLED" : rawLimitType
+	if (!isSupportedProviderLimitType(limitType)) return undefined
+	const budgetLimitUsd =
+		provider.budgetLimitUsd === undefined && !isCappedProviderLimitType(limitType) ? "" : provider.budgetLimitUsd
+	if (
+		typeof provider.provider !== "string" ||
+		!isOptionalUsd(budgetLimitUsd) ||
+		(isCappedProviderLimitType(limitType) && budgetLimitUsd === "") ||
+		!isUsd(provider.usageUsd)
+	) {
+		return undefined
+	}
+	return {
+		provider: provider.provider,
+		limitType,
+		budgetLimitUsd,
+		usageUsd: provider.usageUsd,
+	}
+}
+
+export function isCappedProviderLimitType(limitType: string): boolean {
+	return limitType === "CAPPED" || limitType.endsWith("_CAPPED")
+}
+
+function isSupportedProviderLimitType(limitType: string): boolean {
+	return (
+		isCappedProviderLimitType(limitType) ||
+		limitType === "DISABLED" ||
+		limitType.endsWith("_DISABLED") ||
+		limitType === "UNLIMITED" ||
+		limitType.endsWith("_UNLIMITED")
+	)
+}
+
+function isBudgetScope(value: unknown): value is BudgetEntry["scope"] {
+	return (
+		value === "API_KEY" ||
+		value === "USER" ||
+		value === "TEAM_PER_USER" ||
+		value === "TEAM_POOLED" ||
+		value === "ORGANIZATION_SOFT" ||
+		value === "ORGANIZATION_HARD"
+	)
+}
+
+function isUsd(value: unknown): value is string {
+	return typeof value === "string" && value !== "" && Number.isFinite(Number(value)) && Number(value) >= 0
+}
+
+function isOptionalUsd(value: unknown): value is string {
+	return value === "" || isUsd(value)
 }
 
 async function readResponseJson(response: Response, timeoutMs: number): Promise<unknown> {
@@ -286,6 +498,118 @@ function parseCreditsAmount(value: unknown): number | undefined {
 	return normalized !== "" && Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
 }
 
+export function getDisplayBudget(
+	snapshot: BudgetSnapshot | undefined = currentBillingStatus?.budget,
+): BudgetEntry | undefined {
+	return snapshot?.budgets
+		.filter((budget) => Number(budget.budgetLimitUsd) > 0)
+		.reduce<BudgetEntry | undefined>(
+			(selected, budget) =>
+				!selected || budgetUsagePercentage(budget) > budgetUsagePercentage(selected) ? budget : selected,
+			undefined,
+		)
+}
+
+export function budgetLabel(budget: Pick<BudgetEntry, "scope" | "scopeId" | "budgetType">): string {
+	switch (budget.scope) {
+		case "API_KEY":
+			return "API key"
+		case "USER":
+			return "Personal"
+		case "TEAM_PER_USER":
+		case "TEAM_POOLED":
+			return `Team ${budget.scopeId.slice(0, 8)}`
+		case "ORGANIZATION_SOFT":
+			return isPerUserBudgetType(budget.budgetType) ? "Organization per-user soft" : "Organization soft"
+		case "ORGANIZATION_HARD":
+			return isPerUserBudgetType(budget.budgetType) ? "Organization per-user hard" : "Organization hard"
+	}
+}
+
+function isPerUserBudgetType(value: string | undefined): boolean {
+	return value === "PER_USER" || value?.endsWith("_PER_USER") === true
+}
+
+export function budgetUsagePercentage(budget: Pick<BudgetEntry, "budgetLimitUsd" | "totalSpendUsd">): number {
+	return usagePercentage(budget.totalSpendUsd, budget.budgetLimitUsd)
+}
+
+export function providerBudgetUsagePercentage(budget: Pick<BudgetProvider, "budgetLimitUsd" | "usageUsd">): number {
+	return usagePercentage(budget.usageUsd, budget.budgetLimitUsd)
+}
+
+export function budgetStatus(budget: BudgetEntry): BudgetStatus {
+	const percentage = budgetUsagePercentage(budget)
+	if (percentage >= 100) return budget.scope === "ORGANIZATION_SOFT" ? "WARNING" : "EXHAUSTED"
+	return percentage >= 90 ? "WARNING" : "OK"
+}
+
+function usagePercentage(usageUsd: string, budgetLimitUsd: string): number {
+	const usage = Number(usageUsd)
+	const limit = Number(budgetLimitUsd)
+	return Number.isFinite(usage) && Number.isFinite(limit) && limit > 0 ? (usage / limit) * 100 : 0
+}
+
+export function formatBudgetAmount(value: string): string {
+	const amount = Number(value)
+	if (!Number.isFinite(amount)) return "$0.00"
+	if (amount >= 1000) {
+		return formatCompactBudgetAmount(amount)
+	}
+	return `$${amount.toFixed(2)}`
+}
+
+export function formatBudgetLimit(value: string): string {
+	if (value === "") return "unlimited"
+	const amount = Number(value)
+	if (!Number.isFinite(amount)) return "$0"
+	if (amount === 0) return "unlimited"
+	if (amount >= 1000) return formatCompactBudgetAmount(amount)
+	return `$${amount.toFixed(Number.isInteger(amount) ? 0 : 2)}`
+}
+
+function formatCompactBudgetAmount(amount: number): string {
+	const compact = Math.round((amount / 1000) * 10) / 10
+	return `$${compact.toFixed(compact % 1 === 0 ? 0 : 1)}k`
+}
+
+function getBudgetWarning(status: BillingStatus | undefined): BillingWarning | undefined {
+	let selected: BudgetEntry | undefined
+	for (const budget of status?.budget?.budgets ?? []) {
+		if (!selected) {
+			selected = budget
+			continue
+		}
+		const candidateStatus = budgetStatus(budget)
+		const selectedStatus = budgetStatus(selected)
+		if (
+			budgetStatusRank(candidateStatus) > budgetStatusRank(selectedStatus) ||
+			(candidateStatus === selectedStatus && budgetUsagePercentage(budget) > budgetUsagePercentage(selected))
+		) {
+			selected = budget
+		}
+	}
+	if (!selected) return undefined
+	const selectedStatus = budgetStatus(selected)
+	if (selectedStatus === "WARNING") {
+		return {
+			kind: "low",
+			message: `Budget warning: ${budgetLabel(selected)} budget is ${Math.round(budgetUsagePercentage(selected))}% used (${formatBudgetAmount(selected.totalSpendUsd)}/${formatBudgetLimit(selected.budgetLimitUsd)}).`,
+		}
+	}
+	if (selectedStatus === "EXHAUSTED") {
+		return {
+			kind: "exhausted",
+			message: `Budget exhausted: ${budgetLabel(selected)} budget is fully used (${formatBudgetAmount(selected.totalSpendUsd)}/${formatBudgetLimit(selected.budgetLimitUsd)}).`,
+		}
+	}
+	return undefined
+}
+
+function budgetStatusRank(status: BudgetStatus): number {
+	return status === "EXHAUSTED" ? 2 : status === "WARNING" ? 1 : 0
+}
+
 function isPaidPlan(status: BillingStatus): boolean {
 	return status.isPaidTier === true
 }
@@ -326,8 +650,28 @@ function hasSignificantChange(previous: BillingStatus | undefined, next: Billing
 		previous?.isPaidTier !== next.isPaidTier ||
 		previous?.remainingCredits !== next.remainingCredits ||
 		previous?.creditStatus !== next.creditStatus ||
-		previous?.restrictedMode !== next.restrictedMode
+		previous?.restrictedMode !== next.restrictedMode ||
+		JSON.stringify(previous?.budget) !== JSON.stringify(next.budget)
 	)
+}
+
+function isCurrentBudgetRefresh(refreshId: number, generation: number, config: BillingApiConfig): boolean {
+	return (
+		refreshId === latestBudgetRefreshId &&
+		generation === creditsApiGeneration &&
+		creditsApiConfig?.apiKey === config.apiKey &&
+		creditsApiConfig?.budgetUrl === config.budgetUrl
+	)
+}
+
+function applyBudgetSnapshot(budget: BudgetSnapshot): BillingStatus | undefined {
+	return replaceBillingStatus({ ...(currentBillingStatus ?? {}), budget })
+}
+
+function clearBudgetSnapshot(): void {
+	if (!currentBillingStatus?.budget) return
+	const { budget: _budget, ...status } = currentBillingStatus
+	replaceBillingStatus(status)
 }
 
 function applyBillingUpdate(update: Partial<BillingStatus>): BillingStatus | undefined {

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -294,7 +294,7 @@ export function getBillingStatusLine(
 			: formatCreditsAmount(status.remainingCredits)
 	const displayBudget = getDisplayBudget(status.budget)
 	const budget = displayBudget
-		? `${formatBudgetAmount(displayBudget.totalSpendUsd)}/${formatBudgetLimit(displayBudget.budgetLimitUsd)}`
+		? `${budgetUsagePercentage(displayBudget).toFixed(2)}% (${formatBudgetAmount(displayBudget.totalSpendUsd)}/${formatBudgetLimit(displayBudget.budgetLimitUsd)})`
 		: undefined
 	if (!amount && !budget) return undefined
 	return { ...(amount ? { amount } : {}), ...(budget ? { budget } : {}) }

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util"
 import { loadConfig } from "../../config.js"
 
 export type BillingPlan = "community" | "coder" | "teams" | "enterprise"
@@ -296,7 +297,7 @@ export function getBillingStatusLine(
 			: formatCreditsAmount(status.remainingCredits)
 	const displayBudget = getDisplayBudget(status.budget)
 	const budget = displayBudget
-		? `${budgetUsagePercentage(displayBudget).toFixed(2)}% (${formatBudgetAmount(displayBudget.totalSpendUsd)}/${formatBudgetLimit(displayBudget.budgetLimitUsd)})`
+		? `${budgetUsagePercentage(displayBudget).toFixed(2)}% (${formatBudgetSpendAndLimit(displayBudget)})`
 		: undefined
 	if (!amount && !budget) return undefined
 	return { ...(amount ? { amount } : {}), ...(budget ? { budget } : {}) }
@@ -570,6 +571,10 @@ export function formatBudgetLimit(value: string): string {
 	return `$${amount.toFixed(Number.isInteger(amount) ? 0 : 2)}`
 }
 
+function formatBudgetSpendAndLimit(budget: Pick<BudgetEntry, "budgetLimitUsd" | "totalSpendUsd">): string {
+	return `${formatBudgetAmount(budget.totalSpendUsd)}/${formatBudgetLimit(budget.budgetLimitUsd)}`
+}
+
 function formatCompactBudgetAmount(amount: number): string {
 	const compact = Math.round((amount / 1000) * 10) / 10
 	return `$${compact.toFixed(compact % 1 === 0 ? 0 : 1)}k`
@@ -596,13 +601,13 @@ function getBudgetWarning(status: BillingStatus | undefined): BillingWarning | u
 	if (selectedStatus === "WARNING") {
 		return {
 			kind: "low",
-			message: `Budget warning: ${budgetLabel(selected)} budget is ${Math.round(budgetUsagePercentage(selected))}% used (${formatBudgetAmount(selected.totalSpendUsd)}/${formatBudgetLimit(selected.budgetLimitUsd)}).`,
+			message: `Budget warning: ${budgetLabel(selected)} budget is ${Math.round(budgetUsagePercentage(selected))}% used (${formatBudgetSpendAndLimit(selected)}).`,
 		}
 	}
 	if (selectedStatus === "EXHAUSTED") {
 		return {
 			kind: "exhausted",
-			message: `Budget exhausted: ${budgetLabel(selected)} budget is fully used (${formatBudgetAmount(selected.totalSpendUsd)}/${formatBudgetLimit(selected.budgetLimitUsd)}).`,
+			message: `Budget exhausted: ${budgetLabel(selected)} budget is fully used (${formatBudgetSpendAndLimit(selected)}).`,
 		}
 	}
 	return undefined
@@ -653,7 +658,7 @@ function hasSignificantChange(previous: BillingStatus | undefined, next: Billing
 		previous?.remainingCredits !== next.remainingCredits ||
 		previous?.creditStatus !== next.creditStatus ||
 		previous?.restrictedMode !== next.restrictedMode ||
-		JSON.stringify(previous?.budget) !== JSON.stringify(next.budget)
+		!isDeepStrictEqual(previous?.budget, next.budget)
 	)
 }
 

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -128,15 +128,17 @@ export function configureBillingCreditsApi(options: { apiKey?: string; llmEndpoi
 }
 
 export function creditsEndpointFromLlmEndpoint(llmEndpoint: string): string {
-	const trimmed = llmEndpoint.trim().replace(/\/+$/, "")
-	const proxyRoot = trimmed.replace(/\/openai\/v1$/i, "")
-	return `${proxyRoot}/v1/credits`
+	return billingEndpointFromLlmEndpoint(llmEndpoint, "credits")
 }
 
 export function budgetEndpointFromLlmEndpoint(llmEndpoint: string): string {
+	return billingEndpointFromLlmEndpoint(llmEndpoint, "budget")
+}
+
+function billingEndpointFromLlmEndpoint(llmEndpoint: string, resource: "credits" | "budget"): string {
 	const trimmed = llmEndpoint.trim().replace(/\/+$/, "")
 	const proxyRoot = trimmed.replace(/\/openai\/v1$/i, "")
-	return `${proxyRoot}/v1/budget`
+	return `${proxyRoot}/v1/${resource}`
 }
 
 export async function refreshBillingStatus(

--- a/src/extensions/billing/tips.test.ts
+++ b/src/extensions/billing/tips.test.ts
@@ -18,7 +18,7 @@ describe("billing tips", () => {
 
 		expect(createBillingTipProvider().getTips()).toEqual([
 			expect.objectContaining({
-				id: "billing-low",
+				id: "billing-low-0",
 				tone: "warning",
 				showPrefix: false,
 			}),
@@ -36,7 +36,7 @@ describe("billing tips", () => {
 
 		expect(createBillingTipProvider().getTips()).toEqual([
 			expect.objectContaining({
-				id: "billing-exhausted",
+				id: "billing-exhausted-0",
 				tone: "error",
 				showPrefix: false,
 			}),

--- a/src/extensions/billing/tips.ts
+++ b/src/extensions/billing/tips.ts
@@ -1,5 +1,5 @@
 import type { TipProvider } from "../tips/types.js"
-import { getBillingWarning } from "./status.js"
+import { getBillingWarnings } from "./status.js"
 
 export const BILLING_TIP_SOURCE = "kimchi.billing"
 const BILLING_TIP_PRIORITY = 10_000
@@ -8,18 +8,14 @@ export function createBillingTipProvider(): TipProvider {
 	return {
 		source: BILLING_TIP_SOURCE,
 		getTips: () => {
-			const warning = getBillingWarning()
-			if (!warning) return []
-			return [
-				{
-					id: `billing-${warning.kind}`,
-					scope: "contextual",
-					message: warning.message,
-					priority: BILLING_TIP_PRIORITY,
-					tone: warning.kind === "exhausted" ? "error" : "warning",
-					showPrefix: false,
-				},
-			]
+			return getBillingWarnings().map((warning, index) => ({
+				id: `billing-${warning.kind}-${index}`,
+				scope: "contextual",
+				message: warning.message,
+				priority: BILLING_TIP_PRIORITY,
+				tone: warning.kind === "exhausted" ? "error" : "warning",
+				showPrefix: false,
+			}))
 		},
 	}
 }

--- a/src/extensions/customize-status-line-command.ts
+++ b/src/extensions/customize-status-line-command.ts
@@ -90,7 +90,7 @@ export class CustomizeStatusLineComponent implements Component {
 		out.push(wrapRow(`  ${dimText("● ")}${dimText("ELEMENT".padEnd(maxLabelW))}  ${dimText("DESCRIPTION")}`))
 		out.push(b(`├${"─".repeat(innerW)}┤`))
 
-		// ── element rows — always exactly 9 (STATUS_LINE_ELEMENTS is a fixed constant) ──
+		// ── element rows ──────────────────────────────────────────────────────
 
 		for (let i = 0; i < STATUS_LINE_ELEMENTS.length; i++) {
 			const el = STATUS_LINE_ELEMENTS[i]

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -14,7 +14,7 @@ import { buildScriptPayload, readStatusLineCommand, StatusLine, StatusLineScript
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { refreshGitBranch } from "../utils.js"
 import { getBillingStatusLine, getCommunityTierHeaderNotice, subscribeBillingStatus } from "./billing/status.js"
-import { formatBillingStatusLine } from "./billing/status-line-format.js"
+import { formatBudgetStatusLine, formatCreditsStatusLine } from "./billing/status-line-format.js"
 import { isBareExitAlias } from "./exit-utils.js"
 import { getActiveFerment, getFermentContinuationPolicy } from "./ferment/index.js"
 import { formatFermentStatusLineDisplay } from "./ferment/status-line.js"
@@ -327,7 +327,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 				const perm = statusLineData.getExtensionStatuses().get("permissions-mode")
 				if (perm) parts.push(perm)
 				const billing = getBillingStatusLine()
-				if (billing) parts.push(formatBillingStatusLine(billing, theme))
+				if (billing?.amount) parts.push(formatCreditsStatusLine(billing.amount, theme))
+				if (billing?.budget) parts.push(formatBudgetStatusLine(billing.budget, theme))
 				const modelId = getMultiModelEnabled(ctx.sessionManager)
 					? `multi-model (${getOrchestratorModelId(sessionId)})`
 					: (ctx.model?.id ?? "n/a")

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -109,3 +109,118 @@ test("shows Community tier notice from the credits API in the startup header", a
 		},
 	)
 })
+
+test("shows caller budget in the footer and command, then refreshes a budget warning after a response", async ({
+	terminal,
+}) => {
+	const healthyBudget = budgetResponse("274.594050")
+	const warningBudget = budgetResponse("1800.000000")
+
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "caller-budget-breakdown-and-warning",
+			creditsResponses: [
+				{
+					serverless: true,
+					tier: "coder",
+					is_paid_tier: true,
+					billing_status: "ok",
+					has_credits: true,
+					remaining: "18.4",
+				},
+			],
+			budgetResponses: [healthyBudget, healthyBudget, warningBudget],
+			responses: [{ stream: ["Done."] }],
+			seedHome: (homeDir) => {
+				const agentDir = join(homeDir, ".config", "kimchi", "harness")
+				writeFileSync(
+					join(agentDir, "settings.json"),
+					JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, "\t"),
+					"utf-8",
+				)
+			},
+		},
+		async () => {
+			await waitForText(terminal, "Credits: $18.40", { full: true })
+			await waitForText(terminal, "Budget: $274.59/$2k", { full: true })
+
+			terminal.submit("/budget")
+			await waitForText(terminal, "Budget — Jul 1–Aug 1 UTC", { full: true })
+			await waitForText(terminal, "ACTIVE    Personal", { full: true })
+			await waitForText(terminal, "ACTIVE    Organization per-user hard", { full: true })
+			await waitForText(terminal, "anthropic", { full: true })
+
+			terminal.submit("Use a few credits")
+			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
+			await waitForText(terminal, "Budget warning: Personal budget is 90% used ($1.8k/$2k).", { full: true })
+			await waitForText(terminal, "Budget: $1.8k/$2k", { full: true })
+		},
+	)
+})
+
+test("shows an exhausted budget warning after a model response", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "caller-budget-exhausted-warning",
+			creditsResponses: [
+				{
+					serverless: true,
+					tier: "coder",
+					is_paid_tier: true,
+					billing_status: "ok",
+					has_credits: true,
+					remaining: "18.4",
+				},
+			],
+			budgetResponses: [budgetResponse("100.000000"), budgetResponse("2000.000000")],
+			responses: [{ stream: ["Done."] }],
+			seedHome: (homeDir) => {
+				const agentDir = join(homeDir, ".config", "kimchi", "harness")
+				writeFileSync(
+					join(agentDir, "settings.json"),
+					JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, "\t"),
+					"utf-8",
+				)
+			},
+		},
+		async () => {
+			terminal.submit("Use the remaining budget")
+			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
+			await waitForText(terminal, "Budget exhausted: Personal budget is fully used ($2k/$2k).", { full: true })
+			await waitForText(terminal, "Budget: $2k/$2k", { full: true })
+		},
+	)
+})
+
+function budgetResponse(totalSpendUsd: string) {
+	return {
+		period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+		budgets: [
+			{
+				scope: "USER",
+				scopeId: "owner",
+				budgetType: "BUDGET_TYPE_PER_USER",
+				budgetLimitUsd: "2000.000000",
+				totalSpendUsd,
+				providerBudgets: [
+					{
+						provider: "anthropic",
+						limitType: "PROVIDER_BUDGET_LIMIT_TYPE_CAPPED",
+						budgetLimitUsd: "400.000000",
+						usageUsd: "273.201503",
+					},
+				],
+			},
+			{
+				scope: "ORGANIZATION_HARD",
+				scopeId: "516442fe-054a-49e2-ac2d-9dc9b104c3d2",
+				budgetType: "BUDGET_TYPE_PER_USER",
+				budgetLimitUsd: "300000.000000",
+				totalSpendUsd,
+				providerBudgets: [],
+			},
+		],
+	}
+}

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -34,7 +34,7 @@ test("shows paid balance at startup and low-credit warning after a model respons
 				const agentDir = join(homeDir, ".config", "kimchi", "harness")
 				writeFileSync(
 					join(agentDir, "settings.json"),
-					JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, "\t"),
+					JSON.stringify({ statusLine: { pinned: ["credits", "budget"] } }, null, "\t"),
 					"utf-8",
 				)
 			},
@@ -136,25 +136,25 @@ test("shows caller budget in the footer and command, then refreshes a budget war
 				const agentDir = join(homeDir, ".config", "kimchi", "harness")
 				writeFileSync(
 					join(agentDir, "settings.json"),
-					JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, "\t"),
+					JSON.stringify({ statusLine: { pinned: ["credits", "budget"] } }, null, "\t"),
 					"utf-8",
 				)
 			},
 		},
 		async () => {
 			await waitForText(terminal, "Credits: $18.40", { full: true })
-			await waitForText(terminal, "Budget: $274.59/$2k", { full: true })
+			await waitForText(terminal, "Budget: 13.73% ($274.59/$2k)", { full: true })
 
 			terminal.submit("/budget")
-			await waitForText(terminal, "Budget — Jul 1–Aug 1 UTC", { full: true })
-			await waitForText(terminal, "ACTIVE    Personal", { full: true })
-			await waitForText(terminal, "ACTIVE    Organization per-user hard", { full: true })
+			await waitForText(terminal, "Budget  Jul 1–Aug 1 UTC", { full: true })
+			await waitForText(terminal, "Personal", { full: true })
+			await waitForText(terminal, "Organization per-user hard", { full: true })
 			await waitForText(terminal, "anthropic", { full: true })
 
 			terminal.submit("Use a few credits")
 			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
 			await waitForText(terminal, "Budget warning: Personal budget is 90% used ($1.8k/$2k).", { full: true })
-			await waitForText(terminal, "Budget: $1.8k/$2k", { full: true })
+			await waitForText(terminal, "Budget: 90.00% ($1.8k/$2k)", { full: true })
 		},
 	)
 })
@@ -180,7 +180,7 @@ test("shows an exhausted budget warning after a model response", async ({ termin
 				const agentDir = join(homeDir, ".config", "kimchi", "harness")
 				writeFileSync(
 					join(agentDir, "settings.json"),
-					JSON.stringify({ statusLine: { pinned: ["billing"] } }, null, "\t"),
+					JSON.stringify({ statusLine: { pinned: ["credits", "budget"] } }, null, "\t"),
 					"utf-8",
 				)
 			},
@@ -189,7 +189,7 @@ test("shows an exhausted budget warning after a model response", async ({ termin
 			terminal.submit("Use the remaining budget")
 			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
 			await waitForText(terminal, "Budget exhausted: Personal budget is fully used ($2k/$2k).", { full: true })
-			await waitForText(terminal, "Budget: $2k/$2k", { full: true })
+			await waitForText(terminal, "Budget: 100.00% ($2k/$2k)", { full: true })
 		},
 	)
 })

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -76,6 +76,7 @@ interface StartFakeOpenAiServerOptions {
 	models?: FakeModel[]
 	responses: FakeResponseScript[]
 	creditsResponses?: unknown[]
+	budgetResponses?: unknown[]
 }
 
 export const DEFAULT_MODEL: Required<FakeModel> = {
@@ -120,7 +121,9 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 		}
 	}
 	const creditsQueue = [...(options.creditsResponses ?? [])]
+	const budgetQueue = [...(options.budgetResponses ?? [])]
 	let lastCreditsResponse: unknown
+	let lastBudgetResponse: unknown
 
 	const server = createServer(async (req, res) => {
 		const body = await readJsonBody(req)
@@ -163,6 +166,17 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 				const credits = creditsQueue.shift() ?? lastCreditsResponse ?? { serverless: false }
 				lastCreditsResponse = credits
 				writeJson(res, 200, credits)
+				return
+			}
+
+			if (req.method === "GET" && req.url?.startsWith("/v1/budget")) {
+				if (budgetQueue.length === 0 && lastBudgetResponse === undefined) {
+					writeJson(res, 404, { error: "Budget endpoint is not supported by this fake proxy" })
+					return
+				}
+				const budget = budgetQueue.shift() ?? lastBudgetResponse
+				lastBudgetResponse = budget
+				writeJson(res, 200, budget)
 				return
 			}
 

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -73,6 +73,7 @@ interface CreateKimchiFixtureOptions {
 	models?: FakeModel[]
 	responses: FakeResponseScript[]
 	creditsResponses?: unknown[]
+	budgetResponses?: unknown[]
 	/** `git init` the work dir so repo-checking flows (e.g. ferment) don't prompt to init one. */
 	gitInit?: boolean
 	/**


### PR DESCRIPTION
<img width="878" height="200" alt="image" src="https://github.com/user-attachments/assets/1f834ffd-d7c4-4ea0-bc3f-1744b21f19d1" />

<img width="778" height="222" alt="Screenshot 2026-07-17 at 10 58 53" src="https://github.com/user-attachments/assets/56b8c3a2-6258-411a-8322-1a99f2bc8f85" />

<img width="1208" height="246" alt="image" src="https://github.com/user-attachments/assets/d9d06ddd-d938-405d-a561-259fc13fa6ff" />

<img width="365" height="150" alt="Screenshot 2026-07-17 at 11 24 44" src="https://github.com/user-attachments/assets/de20d2cf-c674-4f41-b027-645dca6fa53d" />


## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
