### PR TITLE
fix: phase and tags session state leak

### DIFF
--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -550,10 +550,11 @@ describe("StatusLine segment coverage", () => {
 		withPinned(["phase", "tags"], () => {
 			const getCurrentPhaseSpy = vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
 			const getActiveTagsSpy = vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["env:prod"])
-			const sl = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+			const ctx = createMockContext()
+			const sl = new StatusLine(ctx, theme, createMockStatusLineData())
 			renderVisible(sl, 200)
 			expect(getCurrentPhaseSpy).toHaveBeenCalledWith("test-session")
-			expect(getActiveTagsSpy).toHaveBeenCalledWith("test-session")
+			expect(getActiveTagsSpy).toHaveBeenCalledWith(ctx.sessionManager)
 		})
 	})
 })

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -545,6 +545,17 @@ describe("StatusLine segment coverage", () => {
 
 		expect(visible).not.toContain("Credits: $5.00")
 	})
+
+	it("passes the active session id to phase and tag lookups", () => {
+		withPinned(["phase", "tags"], () => {
+			const getCurrentPhaseSpy = vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+			const getActiveTagsSpy = vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["env:prod"])
+			const sl = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+			renderVisible(sl, 200)
+			expect(getCurrentPhaseSpy).toHaveBeenCalledWith("test-session")
+			expect(getActiveTagsSpy).toHaveBeenCalledWith("test-session")
+		})
+	})
 })
 
 describe("StatusLine info line", () => {

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -574,7 +574,7 @@ export class StatusLine implements Component {
 		const config = readStatusLineConfig()
 		const pinnedSet = new Set<SegmentId>(config.pinned)
 
-		const tags = getActiveTags(this.ctx.sessionManager.getSessionId())
+		const tags = getActiveTags(this.ctx.sessionManager)
 			.map(parseTag)
 			.filter((t): t is { key: string; value: string } => t !== null)
 

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -157,7 +157,7 @@ export function buildScriptPayload(
 		multi_model: {
 			enabled: getMultiModelEnabled(ctx.sessionManager),
 		},
-		phase: getCurrentPhase(),
+		phase: getCurrentPhase(sessionId),
 	}
 }
 
@@ -441,7 +441,7 @@ export class StatusLine implements Component {
 
 	private phaseSegment(pinned = false): Segment | null {
 		if (!pinned) return null
-		const phase = getCurrentPhase()
+		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
 		if (!phase) {
 			const text = `${this.dim("phase:")}${this.dim("—")}`
 			return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase: "—" } }
@@ -574,7 +574,7 @@ export class StatusLine implements Component {
 		const config = readStatusLineConfig()
 		const pinnedSet = new Set<SegmentId>(config.pinned)
 
-		const tags = getActiveTags()
+		const tags = getActiveTags(this.ctx.sessionManager.getSessionId())
 			.map(parseTag)
 			.filter((t): t is { key: string; value: string } => t !== null)
 

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -85,7 +85,7 @@ afterEach(() => {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe("getConfigSetting", () => {
-	it("returns global config value", () => {
+	it("returns config value", () => {
 		const config = { theme: "dark" }
 		expect(getConfigSetting(config, "theme", isString)).toBe("dark")
 	})
@@ -98,6 +98,11 @@ describe("getConfigSetting", () => {
 		const config = { count: "not-a-number" }
 		expect(getConfigSetting(config, "count", isNumber)).toBeUndefined()
 	})
+
+	it("returns fallback when value fails the type guard", () => {
+		const config = { count: "not-a-number" }
+		expect(getConfigSetting(config, "count", isNumber, 50)).toEqual(50)
+	})
 })
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -105,19 +110,21 @@ describe("getConfigSetting", () => {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe("readConfigSetting", () => {
-	it("reads a global setting from the store", () => {
+	it("reads a setting from the store", () => {
 		seed({ multiModel: true })
 		expect(readConfigSetting("multiModel", isBoolean)).toBe(true)
 	})
 
-	it("returns undefined when key is absent", () => {
+	it("returns undefined or fallback when key is absent", () => {
 		seed({})
 		expect(readConfigSetting("missing", isString)).toBeUndefined()
+		expect(readConfigSetting("missing", isString, "something")).toEqual("something")
 	})
 
-	it("returns undefined when readJson throws (malformed file)", () => {
+	it("returns undefined or fallback when readJson throws (malformed file)", () => {
 		readJsonError = new SyntaxError("Unexpected token")
 		expect(readConfigSetting("anything", isString)).toBeUndefined()
+		expect(readConfigSetting("anything", isString, "something")).toEqual("something")
 	})
 
 	it("returns object values when type guard matches", () => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -11,27 +11,35 @@ export function getConfigSetting<T>(
 	config: Record<string, unknown>,
 	key: string,
 	satisfies: Satisfies<T>,
+	fallback?: T,
 ): T | undefined {
 	const value = config[key]
 	if (satisfies(value)) {
 		return value
 	}
-	return undefined
+	return fallback ?? undefined
 }
 
-/** If `sessionId` is null, retrieve global configuration setting. */
-export function readConfigSetting<T>(key: string, satisfies: Satisfies<T>): T | undefined {
+export function readConfigSetting<T>(key: string, satisfies: Satisfies<T>): T | undefined
+export function readConfigSetting<T>(key: string, satisfies: Satisfies<T>, fallback: T): T
+export function readConfigSetting<T>(key: string, satisfies: Satisfies<T>, fallback?: T): T | undefined {
 	try {
 		const parsed = readJson(HARNESS_SETTINGS_PATH)
-		return getConfigSetting(parsed, key, satisfies)
+		return getConfigSetting(parsed, key, satisfies, fallback)
 	} catch {
 		// thrown if the file is malformed: fall through
 	}
-	return undefined
+	return fallback ?? undefined
 }
 
-export async function readConfigSettingAsync<T>(key: string, satisfies: Satisfies<T>): Promise<T | undefined> {
-	return readConfigSetting(key, satisfies)
+export function readConfigSettingAsync<T>(key: string, satisfies: Satisfies<T>): Promise<T | undefined>
+export function readConfigSettingAsync<T>(key: string, satisfies: Satisfies<T>, fallback: T): Promise<T>
+export async function readConfigSettingAsync<T>(
+	key: string,
+	satisfies: Satisfies<T>,
+	fallback?: T,
+): Promise<T | undefined> {
+	return readConfigSetting(key, satisfies, fallback)
 }
 
 export function writeConfigSetting<T>(key: string, value: T): void {

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -117,6 +117,7 @@ import { DEFAULT_BASH_TIMEOUT_SECONDS } from "../../bash-default-timeout.js"
 import { FERMENT_TOOL_NAMES } from "../../ferment/tool-names.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
+import { getCurrentPhase, setCurrentPhase } from "../../tags.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { getAgentConfig, getConfig, getToolNamesForType } from "../personas/agent-types.js"
 import { buildAgentPrompt } from "../prompt/prompts.js"
@@ -133,6 +134,8 @@ const mockBuildPhaseGuidelinesSection = vi.mocked(buildPhaseGuidelinesSection)
 const mockDefaultResourceLoader = vi.mocked(DefaultResourceLoader)
 const mockTelemetryExtension = vi.mocked(telemetryExtension)
 const mockReadTelemetryConfig = vi.mocked(readTelemetryConfig)
+const mockGetCurrentPhase = vi.mocked(getCurrentPhase)
+const mockSetCurrentPhase = vi.mocked(setCurrentPhase)
 
 type SessionEvent = { type: string; [k: string]: unknown }
 type Subscriber = (event: SessionEvent) => void
@@ -1763,6 +1766,7 @@ describe("runAgent — includeContextFiles", () => {
 			makeAgentConfig({ name: "Builder", description: "Build agent", roles: ["build"] }),
 		)
 		mockBuildPhaseGuidelinesSection.mockReturnValue("## Model Guidelines\n\nBuilder guideline")
+		mockGetCurrentPhase.mockReturnValue("explore")
 
 		mockCreateAgentSession.mockResolvedValue({
 			session: makeFakeSession() as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
@@ -1778,6 +1782,9 @@ describe("runAgent — includeContextFiles", () => {
 		expect(mockBuildPhaseGuidelinesSection).toHaveBeenCalledWith(undefined, "build", expect.anything())
 		const extras = mockBuildAgentPrompt.mock.calls[0]?.[4]
 		expect(extras?.guidelinesBlock).toContain("Builder guideline")
+		expect(mockGetCurrentPhase).toHaveBeenCalledWith("session-1")
+		expect(mockSetCurrentPhase).toHaveBeenCalledWith("session-1", "build")
+		expect(mockSetCurrentPhase).toHaveBeenLastCalledWith("session-1", "explore")
 	})
 
 	it("omits guidelines when agent has no persona role", async () => {

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -709,10 +709,11 @@ async function runAgentInner(
 		process.env.KIMCHI_AGENT_PERSONA = agentConfig.name
 	}
 
-	const prevPhase = getCurrentPhase()
+	const sessionId = ctx.sessionManager.getSessionId()
+	const prevPhase = getCurrentPhase(sessionId)
 	const personaPhase = agentConfig?.roles?.[0]
 	if (personaPhase) {
-		setCurrentPhase(personaPhase)
+		setCurrentPhase(sessionId, personaPhase)
 	}
 
 	try {
@@ -735,7 +736,7 @@ async function runAgentInner(
 			}
 		}
 		if (personaPhase) {
-			setCurrentPhase(prevPhase)
+			setCurrentPhase(sessionId, prevPhase)
 		}
 	}
 

--- a/src/extensions/multi-model.ts
+++ b/src/extensions/multi-model.ts
@@ -16,7 +16,7 @@ export interface MultiModelResolution {
 // 3. Persisted session-log value (last custom entry in session entries)          → source: "persisted"
 // 4. Global config default (settings.json "multiModel" key, default true)        → source: "global"
 
-const _multiModelEntryType = "multi_model_enabled" as const
+const MULTI_MODEL_SESSION_ENTRY_TYPE = "multi_model_enabled"
 
 /** Whether --model was passed on the CLI. */
 export function hasExplicitModelFlag(): boolean {
@@ -37,7 +37,8 @@ export function getPersistedMultiModelEnabled(sessionManager: Pick<SessionManage
 	const lastEntry = sessionManager
 		.getEntries()
 		.findLast(
-			(item): item is CustomEntry<boolean> => item.type === "custom" && item.customType === _multiModelEntryType,
+			(item): item is CustomEntry<boolean> =>
+				item.type === "custom" && item.customType === MULTI_MODEL_SESSION_ENTRY_TYPE,
 		)
 	return lastEntry?.data
 }
@@ -113,7 +114,7 @@ export function setAndPersistMultiModelEnabled(
 	// we persist even if --model was also present (runtime outranks cli).
 	if (persisted !== resolution.value && resolution.source !== "cli") {
 		const append = "appendCustomEntry" in appendCtx ? appendCtx.appendCustomEntry : appendCtx.appendEntry
-		append(_multiModelEntryType, resolution.value)
+		append(MULTI_MODEL_SESSION_ENTRY_TYPE, resolution.value)
 	}
 
 	return resolution

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -12,6 +12,7 @@ import { createContext } from "../__mocks__/context.js"
 import * as agentWorkerContext from "../agent-worker-context.js"
 import { CLAUDE_CODE_SKILLS_RESOURCE_ID } from "../claude-code-skills/definition.js"
 import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
+import * as tags from "../tags.js"
 import promptEnrichmentExtension, {
 	_resetDeprecatedNotificationTracking,
 	stripEmptyToolCalls,
@@ -275,6 +276,18 @@ describe("prompt enrichment environment context", () => {
 				process.env.SHELL = oldShell
 			}
 		}
+	})
+
+	it("reads the current phase using the active session id", async () => {
+		const { beforeAgentStart } = buildPromptExtensionWithHandlers()
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const getCurrentPhaseSpy = vi.spyOn(tags, "getCurrentPhase").mockReturnValue("plan")
+		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => "enrichment-session" } })
+
+		await beforeAgentStart({}, ctx)
+
+		expect(getCurrentPhaseSpy).toHaveBeenCalledWith("enrichment-session")
 	})
 })
 

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -535,7 +535,7 @@ export default function (skillPaths: string[]) {
 				contextFiles: cachedContextFiles,
 				skills: cachedSkills,
 				currentModelId: mode === "orchestrator" ? getOrchestratorModelId(sessionId) : ctx.model?.id,
-				currentPhase: getCurrentPhase(),
+				currentPhase: getCurrentPhase(sessionId),
 				registry: registry,
 				mode,
 				roles,

--- a/src/extensions/review-write-guard.integration.test.ts
+++ b/src/extensions/review-write-guard.integration.test.ts
@@ -3,7 +3,9 @@
  * Tests the event handler registration (session_start, tool_call, tool_result)
  * using a mock ExtensionAPI.
  */
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
+import { createContext } from "./__mocks__/context.js"
 import reviewWriteGuardExtension, { STEER_MESSAGE_TYPE } from "./review-write-guard.js"
 
 let mockPhase: string | undefined = "review"
@@ -15,8 +17,11 @@ vi.mock("./tags.js", () => ({
 type BlockResult = { block: true; reason: string }
 
 interface MockExtensionAPI {
-	handlers: Record<string, Array<(event: { toolName?: string; result?: unknown }) => unknown>>
-	on: (event: string, handler: (event: { toolName?: string; result?: unknown }) => unknown) => void
+	handlers: Record<string, Array<(event: { toolName?: string; result?: unknown }, ctx: ExtensionContext) => unknown>>
+	on: (
+		event: string,
+		handler: (event: { toolName?: string; result?: unknown }, ctx: ExtensionContext) => unknown,
+	) => void
 	sendMessage: ReturnType<typeof vi.fn>
 	_blockResult?: BlockResult
 }
@@ -33,10 +38,15 @@ function createMockPI(): MockExtensionAPI {
 	}
 }
 
-function emit(pi: MockExtensionAPI, event: string, payload: { toolName?: string; result?: unknown } = {}) {
+function emit(
+	pi: MockExtensionAPI,
+	event: string,
+	payload: { toolName?: string; result?: unknown } = {},
+	ctx = createContext(),
+) {
 	const handlers = pi.handlers[event] ?? []
 	for (const h of handlers) {
-		const result = h(payload) as BlockResult | undefined
+		const result = h(payload, ctx) as BlockResult | undefined
 		if (result?.block) {
 			pi._blockResult = result
 		}
@@ -162,5 +172,33 @@ describe("reviewWriteGuardExtension wiring", () => {
 			}),
 			{ deliverAs: "steer" },
 		)
+	})
+
+	it("keeps build-phase state isolated between sessions", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		mockPhase = "build"
+
+		// Session A hits the steer threshold.
+		emit(
+			pi,
+			"tool_result",
+			{ toolName: "Agent" },
+			createContext({ sessionManager: { getSessionId: () => "session-a" } }),
+		)
+		emit(pi, "tool_call", { toolName: "edit" }, createContext({ sessionManager: { getSessionId: () => "session-a" } }))
+		emit(pi, "tool_call", { toolName: "edit" }, createContext({ sessionManager: { getSessionId: () => "session-a" } }))
+
+		// Session B records its own subagent return and makes only one edit.
+		emit(
+			pi,
+			"tool_result",
+			{ toolName: "Agent" },
+			createContext({ sessionManager: { getSessionId: () => "session-b" } }),
+		)
+		emit(pi, "tool_call", { toolName: "edit" }, createContext({ sessionManager: { getSessionId: () => "session-b" } }))
+
+		// Only session A should have triggered a steer.
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/review-write-guard.test.ts
+++ b/src/extensions/review-write-guard.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "./__mocks__/context.js"
 import { OrchestratorWriteGuard } from "./review-write-guard.js"
 
 let mockPhase: string | undefined = "review"
@@ -13,26 +14,26 @@ afterEach(() => {
 
 describe("OrchestratorWriteGuard — review phase", () => {
 	it("blocks edit during review phase", () => {
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		const result = guard.checkToolCall("edit")
 		expect(result).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
 	})
 
 	it("blocks write during review phase", () => {
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		const result = guard.checkToolCall("write")
 		expect(result).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
 	})
 
 	it("does not block read-only tools during review phase", () => {
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("read")).toBeUndefined()
 		expect(guard.checkToolCall("bash")).toBeUndefined()
 		expect(guard.checkToolCall("grep")).toBeUndefined()
 	})
 
 	it("resets when Agent is called", () => {
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		guard.checkToolCall("Agent")
 		mockPhase = "review"
 		const result = guard.checkToolCall("edit")
@@ -40,7 +41,7 @@ describe("OrchestratorWriteGuard — review phase", () => {
 	})
 
 	it("blocks every edit attempt, not just the first", () => {
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("edit")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
 		expect(guard.checkToolCall("edit")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
 		expect(guard.checkToolCall("write")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
@@ -50,14 +51,14 @@ describe("OrchestratorWriteGuard — review phase", () => {
 describe("OrchestratorWriteGuard — build phase", () => {
 	it("allows edits in build phase before any subagent returns", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 		expect(guard.checkToolCall("write")).toBeUndefined()
 	})
 
 	it("steers after threshold edits following a subagent return", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
 		guard.recordSubagentReturn()
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 		const result = guard.checkToolCall("edit")
@@ -66,7 +67,7 @@ describe("OrchestratorWriteGuard — build phase", () => {
 
 	it("steers only once then allows edits until block threshold", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
 		guard.recordSubagentReturn()
 		guard.checkToolCall("edit")
 		guard.checkToolCall("edit")
@@ -77,7 +78,7 @@ describe("OrchestratorWriteGuard — build phase", () => {
 
 	it("blocks after block threshold edits following a subagent return", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
 		guard.recordSubagentReturn()
 		for (let i = 0; i < 4; i++) guard.checkToolCall("edit")
 		const result = guard.checkToolCall("edit")
@@ -86,7 +87,7 @@ describe("OrchestratorWriteGuard — build phase", () => {
 
 	it("keeps blocking on every edit after block threshold", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })
 		guard.recordSubagentReturn()
 		for (let i = 0; i < 5; i++) guard.checkToolCall("edit")
 		expect(guard.checkToolCall("edit")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
@@ -95,7 +96,7 @@ describe("OrchestratorWriteGuard — build phase", () => {
 
 	it("resets when a new Agent is spawned", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
 		guard.recordSubagentReturn()
 		guard.checkToolCall("edit")
 		guard.checkToolCall("Agent")
@@ -105,14 +106,14 @@ describe("OrchestratorWriteGuard — build phase", () => {
 
 	it("does not track subagent returns outside build phase", () => {
 		mockPhase = "plan"
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		guard.recordSubagentReturn()
 		expect(guard.getState().subagentReturnedInBuild).toBe(false)
 	})
 
 	it("uses default threshold of 2", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		guard.recordSubagentReturn()
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
@@ -122,25 +123,25 @@ describe("OrchestratorWriteGuard — build phase", () => {
 describe("OrchestratorWriteGuard — other phases", () => {
 	it("does not block edits outside review phase", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 	})
 
 	it("does not block edits in plan phase", () => {
 		mockPhase = "plan"
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 	})
 
 	it("does nothing when phase is undefined", () => {
 		mockPhase = undefined
-		const guard = new OrchestratorWriteGuard()
+		const guard = new OrchestratorWriteGuard(createContext())
 		expect(guard.checkToolCall("edit")).toBeUndefined()
 	})
 
 	it("resets build tracking when phase changes to non-build/review", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard({ buildPhaseThreshold: 2 })
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
 		guard.recordSubagentReturn()
 		guard.checkToolCall("edit")
 		mockPhase = "plan"

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getCurrentPhase } from "./tags.js"
 
 const IMPLEMENTATION_TOOLS = new Set(["edit", "write"])
@@ -29,6 +29,8 @@ const BUILD_BLOCK_REASON =
 	"The orchestrator must not do a subagent's job. Spawn a fix Agent with the remaining work."
 
 export class OrchestratorWriteGuard {
+	private readonly ctx: ExtensionContext
+
 	private readonly implementationTools: Set<string>
 	private readonly delegationTools: Set<string>
 	private readonly buildPhaseThreshold: number
@@ -38,7 +40,9 @@ export class OrchestratorWriteGuard {
 	private buildWriteCount = 0
 	private buildSteered = false
 
-	constructor(options: OrchestratorWriteGuardOptions = {}) {
+	constructor(ctx: ExtensionContext, options: OrchestratorWriteGuardOptions = {}) {
+		this.ctx = ctx
+
 		this.implementationTools = options.implementationTools ?? new Set(IMPLEMENTATION_TOOLS)
 		this.delegationTools = new Set(DELEGATION_TOOLS)
 		this.buildPhaseThreshold = options.buildPhaseThreshold ?? 2
@@ -52,7 +56,7 @@ export class OrchestratorWriteGuard {
 	}
 
 	checkToolCall(toolName: string): { block: true; reason: string } | { steer: string } | undefined {
-		const phase = getCurrentPhase()
+		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
 
 		if (this.delegationTools.has(toolName)) {
 			this.subagentReturnedInBuild = false
@@ -86,7 +90,7 @@ export class OrchestratorWriteGuard {
 	}
 
 	recordSubagentReturn(): void {
-		const phase = getCurrentPhase()
+		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
 		if (phase === "build") {
 			this.subagentReturnedInBuild = true
 			this.buildWriteCount = 0
@@ -104,19 +108,31 @@ export class OrchestratorWriteGuard {
 }
 
 export default function reviewWriteGuardExtension(pi: ExtensionAPI, options?: OrchestratorWriteGuardOptions): void {
-	const guard = new OrchestratorWriteGuard(options)
+	const guardMap = new Map<string, OrchestratorWriteGuard>()
 
-	pi.on("session_start", () => {
+	function getOrchestratorWriteGuard(ctx: ExtensionContext): OrchestratorWriteGuard {
+		const sessionId = ctx.sessionManager.getSessionId()
+		let guard = guardMap.get(sessionId)
+		if (!guard) {
+			guard = new OrchestratorWriteGuard(ctx, options)
+			guardMap.set(sessionId, guard)
+		}
+		return guard
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		const guard = getOrchestratorWriteGuard(ctx)
 		guard.reset()
 	})
 
-	pi.on("tool_call", (event) => {
+	pi.on("tool_call", (event, ctx) => {
 		if (!event.toolName) return
 
 		if (event.toolName === "Agent") {
 			return { block: false }
 		}
 
+		const guard = getOrchestratorWriteGuard(ctx)
 		const result = guard.checkToolCall(event.toolName)
 		if (!result) return { block: false }
 
@@ -135,8 +151,9 @@ export default function reviewWriteGuardExtension(pi: ExtensionAPI, options?: Or
 		return { block: false }
 	})
 
-	pi.on("tool_result", (event) => {
+	pi.on("tool_result", (event, ctx) => {
 		if (event.toolName === "Agent") {
+			const guard = getOrchestratorWriteGuard(ctx)
 			guard.recordSubagentReturn()
 		}
 	})

--- a/src/extensions/tags.test.ts
+++ b/src/extensions/tags.test.ts
@@ -1,10 +1,30 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { dirname, join } from "node:path"
+import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "./__mocks__/context.js"
 import { buildSystemPrompt, type EnvironmentInfo } from "./prompt-construction/system-prompt.js"
-import tagsExtension, { isValidTag, parseTag, TagManager } from "./tags.js"
+
+vi.mock("node:os", async (importOriginal) => {
+	const { join } = await import("node:path")
+	const mod = await importOriginal<typeof import("node:os")>()
+	return {
+		...mod,
+		homedir: () => join(mod.tmpdir(), `kimchi-tags-mock-home-${process.pid}`),
+	}
+})
+
+import tagsExtension, {
+	getActiveTags,
+	getCurrentPhase,
+	isValidTag,
+	parseTag,
+	setCurrentPhase,
+	TagManager,
+} from "./tags.js"
+
+const MOCK_HOME = join(tmpdir(), `kimchi-tags-mock-home-${process.pid}`)
 
 const testEnv: EnvironmentInfo = {
 	os: "Linux",
@@ -29,20 +49,36 @@ type RegisteredTool = {
 	execute: (...args: unknown[]) => unknown
 }
 
+type RegisteredCommand = {
+	name: string
+	handler: (args: string, ctx: unknown) => unknown | Promise<unknown>
+}
+
 function makePi(): ExtensionAPI & {
 	fire: (event: string, payload?: unknown, ctx?: unknown) => Promise<unknown[]>
 	fireShutdown: () => void
 	getActiveTools: () => string[]
 	setActiveTools: (tools: string[]) => void
 	tools: Map<string, RegisteredTool>
+	commands: Map<string, RegisteredCommand>
+	runCommand: (name: string, args: string, ctx?: unknown) => Promise<unknown>
 } {
 	const shutdownHandlers: Array<() => void> = []
 	const handlers = new Map<string, Handler[]>()
-	const sessionStartCtx = { hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } }
+	const sessionStartCtx = createContext({
+		hasUI: false,
+		sessionManager: { getSessionId: () => TEST_SESSION_ID },
+	})
 	const tools = new Map<string, RegisteredTool>()
+	const commands = new Map<string, RegisteredCommand>()
 	let activeTools: string[] = []
 	const pi = {
-		registerCommand: () => {},
+		registerCommand: (
+			name: string,
+			command: { handler: (args: string, ctx: unknown) => unknown | Promise<unknown> },
+		) => {
+			commands.set(name, { name, handler: command.handler })
+		},
 		registerTool: (tool: RegisteredTool) => {
 			tools.set(tool.name, tool)
 			activeTools.push(tool.name)
@@ -70,6 +106,12 @@ function makePi(): ExtensionAPI & {
 			for (const handler of shutdownHandlers) handler()
 		},
 		tools,
+		commands,
+		runCommand: async (name: string, args: string, ctx = sessionStartCtx) => {
+			const command = commands.get(name)
+			if (!command) throw new Error(`Command "${name}" not registered`)
+			return command.handler(args, ctx)
+		},
 	}
 	return pi as unknown as ExtensionAPI & {
 		fire: (event: string, payload?: unknown, ctx?: unknown) => Promise<unknown[]>
@@ -77,6 +119,8 @@ function makePi(): ExtensionAPI & {
 		getActiveTools: () => string[]
 		setActiveTools: (tools: string[]) => void
 		tools: Map<string, RegisteredTool>
+		commands: Map<string, RegisteredCommand>
+		runCommand: (name: string, args: string, ctx?: unknown) => Promise<unknown>
 	}
 }
 
@@ -142,7 +186,7 @@ describe("tags system prompt block", () => {
 		return pi
 	}
 	const setPhase = (pi: ReturnType<typeof makeTagsPi>, phase = "explore") =>
-		pi.tools.get("set_phase")?.execute("call-1", { phase }, undefined, undefined, { hasUI: false })
+		pi.tools.get("set_phase")?.execute("call-1", { phase }, undefined, undefined, createContext({ hasUI: false }))
 
 	it("registers phase tagging instructions with the extension that owns set_phase", async () => {
 		const pi = makeTagsPi()
@@ -185,7 +229,7 @@ describe("tags system prompt block", () => {
 
 		const result = await pi.tools
 			.get("set_phase")
-			?.execute("call-1", { phase: "plan", thinking: "high" }, undefined, undefined, { hasUI: false })
+			?.execute("call-1", { phase: "plan", thinking: "high" }, undefined, undefined, createContext({ hasUI: false }))
 
 		expect(result).toMatchObject({
 			content: [{ type: "text", text: "Phase changed to: plan" }],
@@ -196,83 +240,81 @@ describe("tags system prompt block", () => {
 })
 
 describe("TagManager persistence", () => {
-	let tempDir: string
-	let configPath: string
-
 	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "kimchi-tags-test-"))
-		configPath = join(tempDir, "tags.json")
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		mkdirSync(MOCK_HOME, { recursive: true })
 		vi.stubEnv("KIMCHI_TAGS", "")
 	})
 
 	afterEach(() => {
-		rmSync(tempDir, { recursive: true, force: true })
+		rmSync(MOCK_HOME, { recursive: true, force: true })
 		vi.unstubAllEnvs()
 	})
 
 	it("persists added tags to config file", () => {
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		manager.add("project:test")
 
-		const loaded = new TagManager(configPath)
+		const loaded = new TagManager()
 		expect(loaded.getAllTags()).toContain("project:test")
 	})
 
 	it("loads tags from config file on initialization", () => {
+		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
+		mkdirSync(dirname(configPath), { recursive: true })
 		writeFileSync(configPath, JSON.stringify({ tags: ["env:prod", "team:backend"] }))
 
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		expect(manager.getAllTags()).toEqual(expect.arrayContaining(["env:prod", "team:backend"]))
 	})
 
 	it("removes tags from config file when deleted", () => {
+		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
+		mkdirSync(dirname(configPath), { recursive: true })
 		writeFileSync(configPath, JSON.stringify({ tags: ["tag1:value1", "tag2:value2"] }))
 
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		manager.remove("tag1:value1")
 
-		const loaded = new TagManager(configPath)
+		const loaded = new TagManager()
 		expect(loaded.getAllTags()).toEqual(["tag2:value2"])
 	})
 
 	it("clears all user tags from config file", () => {
+		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
+		mkdirSync(dirname(configPath), { recursive: true })
 		writeFileSync(configPath, JSON.stringify({ tags: ["tag1:value1", "tag2:value2", "tag3:value3"] }))
 
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		manager.clear()
 
-		const loaded = new TagManager(configPath)
+		const loaded = new TagManager()
 		expect(loaded.getAllTags()).toEqual([])
 	})
 
 	it("creates config directory if it does not exist", () => {
-		const nestedPath = join(tempDir, "nested", "config", "tags.json")
-
-		const manager = new TagManager(nestedPath)
+		const manager = new TagManager()
 		manager.add("test:value")
 
-		const loaded = new TagManager(nestedPath)
+		const loaded = new TagManager()
 		expect(loaded.getAllTags()).toEqual(["test:value"])
 	})
 })
 
 describe("TagManager.add", () => {
-	let tempDir: string
-	let configPath: string
-
 	beforeEach(() => {
-		tempDir = mkdtempSync(join(tmpdir(), "kimchi-tags-test-"))
-		configPath = join(tempDir, "tags.json")
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		mkdirSync(MOCK_HOME, { recursive: true })
 		vi.stubEnv("KIMCHI_TAGS", "")
 	})
 
 	afterEach(() => {
-		rmSync(tempDir, { recursive: true, force: true })
+		rmSync(MOCK_HOME, { recursive: true, force: true })
 		vi.unstubAllEnvs()
 	})
 
 	it("returns duplicate error before limit error when tag already exists at capacity", () => {
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		for (let i = 0; i < 10; i++) {
 			manager.add(`tag${i}:value`)
 		}
@@ -281,11 +323,115 @@ describe("TagManager.add", () => {
 	})
 
 	it("returns limit error when adding a new tag at capacity", () => {
-		const manager = new TagManager(configPath)
+		const manager = new TagManager()
 		for (let i = 0; i < 10; i++) {
 			manager.add(`tag${i}:value`)
 		}
 		const result = manager.add("new:tag")
 		expect(result).toEqual({ success: false, error: "Maximum 10 tags allowed (including static tags)." })
+	})
+})
+
+function commandContext(sessionId: string) {
+	return createContext({
+		hasUI: false,
+		sessionManager: { getSessionId: () => sessionId },
+		ui: {
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as unknown as ExtensionUIContext["theme"],
+		},
+	})
+}
+
+describe("getCurrentPhase", () => {
+	beforeEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		mkdirSync(MOCK_HOME, { recursive: true })
+		vi.stubEnv("KIMCHI_TAGS", "")
+	})
+
+	afterEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		vi.unstubAllEnvs()
+	})
+
+	it("returns undefined before a phase is set", () => {
+		expect(getCurrentPhase("fresh-session")).toBeUndefined()
+	})
+
+	it("returns the phase set for a specific session", () => {
+		setCurrentPhase("get-phase-session", "plan")
+		expect(getCurrentPhase("get-phase-session")).toBe("plan")
+	})
+
+	it("isolates phases between sessions", () => {
+		setCurrentPhase("get-phase-a", "plan")
+		setCurrentPhase("get-phase-b", "build")
+		expect(getCurrentPhase("get-phase-a")).toBe("plan")
+		expect(getCurrentPhase("get-phase-b")).toBe("build")
+	})
+})
+
+describe("setCurrentPhase", () => {
+	beforeEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		mkdirSync(MOCK_HOME, { recursive: true })
+		vi.stubEnv("KIMCHI_TAGS", "")
+	})
+
+	afterEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		vi.unstubAllEnvs()
+	})
+
+	it("sets a valid phase", () => {
+		setCurrentPhase("set-phase-session", "review")
+		expect(getCurrentPhase("set-phase-session")).toBe("review")
+	})
+
+	it("ignores invalid phases", () => {
+		setCurrentPhase("invalid-phase-session", "invalid")
+		expect(getCurrentPhase("invalid-phase-session")).toBeUndefined()
+	})
+
+	it("clears the phase when given undefined", () => {
+		setCurrentPhase("clear-phase-session", "build")
+		expect(getCurrentPhase("clear-phase-session")).toBe("build")
+		setCurrentPhase("clear-phase-session", undefined)
+		expect(getCurrentPhase("clear-phase-session")).toBeUndefined()
+	})
+})
+
+describe("getActiveTags", () => {
+	beforeEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		mkdirSync(MOCK_HOME, { recursive: true })
+		vi.stubEnv("KIMCHI_TAGS", "")
+	})
+
+	afterEach(() => {
+		rmSync(MOCK_HOME, { recursive: true, force: true })
+		vi.unstubAllEnvs()
+	})
+
+	it("returns an empty array before tags are added", () => {
+		expect(getActiveTags("fresh-tags-session")).toEqual([])
+	})
+
+	it("returns tags added through the extension command", async () => {
+		const pi = makePi()
+		tagsExtension(pi)
+		await pi.runCommand("tags", "add team:backend", commandContext("command-tags-session"))
+		expect(getActiveTags("command-tags-session")).toEqual(["team:backend"])
+	})
+
+	it("shares persisted tags across sessions", async () => {
+		const pi = makePi()
+		tagsExtension(pi)
+		await pi.runCommand("tags", "add team:backend", commandContext("tags-session-a"))
+		expect(getActiveTags("tags-session-a")).toEqual(["team:backend"])
+		expect(getActiveTags("tags-session-b")).toEqual(["team:backend"])
 	})
 })

--- a/src/extensions/tags.test.ts
+++ b/src/extensions/tags.test.ts
@@ -26,6 +26,56 @@ import tagsExtension, {
 
 const MOCK_HOME = join(tmpdir(), `kimchi-tags-mock-home-${process.pid}`)
 
+type FakeSessionEntry = {
+	type: "custom"
+	customType: string
+	data: unknown
+	id: string
+	parentId: null
+	timestamp: string
+}
+const sessionEntriesStore = new Map<string, FakeSessionEntry[]>()
+
+function clearSessionEntriesStore(): void {
+	sessionEntriesStore.clear()
+}
+
+function appendEntryForSession(sessionId: string, customType: string, data: unknown): void {
+	const entries = sessionEntriesStore.get(sessionId) ?? []
+	entries.push({
+		type: "custom",
+		customType,
+		data,
+		id: `entry-${entries.length}`,
+		parentId: null,
+		timestamp: new Date().toISOString(),
+	})
+	sessionEntriesStore.set(sessionId, entries)
+}
+
+function getSessionEntries(sessionId: string): FakeSessionEntry[] {
+	return sessionEntriesStore.get(sessionId) ?? []
+}
+
+function makeSessionManager(sessionId: string) {
+	return {
+		getSessionId: () => sessionId,
+		getEntries: () => getSessionEntries(sessionId),
+	}
+}
+
+function makeTagManager(sessionId = TEST_SESSION_ID) {
+	const appendEntry = vi.fn((customType: string, data: unknown) => {
+		appendEntryForSession(sessionId, customType, data)
+	})
+	const sessionManager = makeSessionManager(sessionId)
+	return {
+		manager: new TagManager(sessionManager, appendEntry),
+		sessionManager,
+		appendEntry,
+	}
+}
+
 const testEnv: EnvironmentInfo = {
 	os: "Linux",
 	rawPlatform: "linux",
@@ -59,6 +109,8 @@ function makePi(): ExtensionAPI & {
 	fireShutdown: () => void
 	getActiveTools: () => string[]
 	setActiveTools: (tools: string[]) => void
+	appendEntry: (customType: string, data?: unknown) => void
+	getEntries: (sessionId: string) => FakeSessionEntry[]
 	tools: Map<string, RegisteredTool>
 	commands: Map<string, RegisteredCommand>
 	runCommand: (name: string, args: string, ctx?: unknown) => Promise<unknown>
@@ -67,11 +119,12 @@ function makePi(): ExtensionAPI & {
 	const handlers = new Map<string, Handler[]>()
 	const sessionStartCtx = createContext({
 		hasUI: false,
-		sessionManager: { getSessionId: () => TEST_SESSION_ID },
+		sessionManager: makeSessionManager(TEST_SESSION_ID),
 	})
 	const tools = new Map<string, RegisteredTool>()
 	const commands = new Map<string, RegisteredCommand>()
 	let activeTools: string[] = []
+	let activeSessionId = TEST_SESSION_ID
 	const pi = {
 		registerCommand: (
 			name: string,
@@ -88,6 +141,10 @@ function makePi(): ExtensionAPI & {
 			activeTools = next
 		},
 		setThinkingLevel: vi.fn(),
+		appendEntry: (customType: string, data?: unknown) => {
+			appendEntryForSession(activeSessionId, customType, data)
+		},
+		getEntries: (sessionId: string) => getSessionEntries(sessionId),
 		on: (event: string, handler: Handler) => {
 			const existing = handlers.get(event) ?? []
 			existing.push(handler)
@@ -110,6 +167,7 @@ function makePi(): ExtensionAPI & {
 		runCommand: async (name: string, args: string, ctx = sessionStartCtx) => {
 			const command = commands.get(name)
 			if (!command) throw new Error(`Command "${name}" not registered`)
+			activeSessionId = (ctx as { sessionManager: { getSessionId: () => string } }).sessionManager.getSessionId()
 			return command.handler(args, ctx)
 		},
 	}
@@ -118,6 +176,8 @@ function makePi(): ExtensionAPI & {
 		fireShutdown: () => void
 		getActiveTools: () => string[]
 		setActiveTools: (tools: string[]) => void
+		appendEntry: (customType: string, data?: unknown) => void
+		getEntries: (sessionId: string) => FakeSessionEntry[]
 		tools: Map<string, RegisteredTool>
 		commands: Map<string, RegisteredCommand>
 		runCommand: (name: string, args: string, ctx?: unknown) => Promise<unknown>
@@ -244,6 +304,7 @@ describe("TagManager persistence", () => {
 		rmSync(MOCK_HOME, { recursive: true, force: true })
 		mkdirSync(MOCK_HOME, { recursive: true })
 		vi.stubEnv("KIMCHI_TAGS", "")
+		clearSessionEntriesStore()
 	})
 
 	afterEach(() => {
@@ -251,53 +312,65 @@ describe("TagManager persistence", () => {
 		vi.unstubAllEnvs()
 	})
 
-	it("persists added tags to config file", () => {
-		const manager = new TagManager()
+	it("persists added tags to session entries", () => {
+		const { manager, appendEntry } = makeTagManager()
 		manager.add("project:test")
 
-		const loaded = new TagManager()
+		expect(appendEntry).toHaveBeenCalledWith("kimchi_active_tags", ["project:test"])
+
+		const { manager: loaded } = makeTagManager()
 		expect(loaded.getAllTags()).toContain("project:test")
 	})
 
-	it("loads tags from config file on initialization", () => {
+	it("loads tags from session entries on initialization", () => {
+		appendEntryForSession(TEST_SESSION_ID, "kimchi_active_tags", ["env:prod", "team:backend"])
+
+		const { manager } = makeTagManager()
+		expect(manager.getAllTags()).toEqual(expect.arrayContaining(["env:prod", "team:backend"]))
+	})
+
+	it("falls back to config file for new sessions", () => {
 		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
 		mkdirSync(dirname(configPath), { recursive: true })
 		writeFileSync(configPath, JSON.stringify({ tags: ["env:prod", "team:backend"] }))
 
-		const manager = new TagManager()
+		const { manager } = makeTagManager()
 		expect(manager.getAllTags()).toEqual(expect.arrayContaining(["env:prod", "team:backend"]))
 	})
 
-	it("removes tags from config file when deleted", () => {
-		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
-		mkdirSync(dirname(configPath), { recursive: true })
-		writeFileSync(configPath, JSON.stringify({ tags: ["tag1:value1", "tag2:value2"] }))
+	it("falls back to env tags for new sessions", () => {
+		vi.stubEnv("KIMCHI_TAGS", "env:prod,team:backend")
 
-		const manager = new TagManager()
+		const { manager } = makeTagManager()
+		expect(manager.getAllTags()).toEqual(expect.arrayContaining(["env:prod", "team:backend"]))
+	})
+
+	it("session tags take priority over config/env for existing sessions", () => {
+		appendEntryForSession(TEST_SESSION_ID, "kimchi_active_tags", ["team:frontend"])
+		vi.stubEnv("KIMCHI_TAGS", "env:prod,team:backend")
+
+		const { manager } = makeTagManager()
+		expect(manager.getAllTags()).toEqual(["team:frontend"])
+	})
+
+	it("removes tags from session entries when deleted", () => {
+		appendEntryForSession(TEST_SESSION_ID, "kimchi_active_tags", ["tag1:value1", "tag2:value2"])
+
+		const { manager } = makeTagManager()
 		manager.remove("tag1:value1")
 
-		const loaded = new TagManager()
+		const { manager: loaded } = makeTagManager()
 		expect(loaded.getAllTags()).toEqual(["tag2:value2"])
 	})
 
-	it("clears all user tags from config file", () => {
-		const configPath = join(MOCK_HOME, ".config", "kimchi", "tags.json")
-		mkdirSync(dirname(configPath), { recursive: true })
-		writeFileSync(configPath, JSON.stringify({ tags: ["tag1:value1", "tag2:value2", "tag3:value3"] }))
+	it("clears all tags from session entries", () => {
+		appendEntryForSession(TEST_SESSION_ID, "kimchi_active_tags", ["tag1:value1", "tag2:value2", "tag3:value3"])
 
-		const manager = new TagManager()
+		const { manager } = makeTagManager()
 		manager.clear()
 
-		const loaded = new TagManager()
+		const { manager: loaded } = makeTagManager()
 		expect(loaded.getAllTags()).toEqual([])
-	})
-
-	it("creates config directory if it does not exist", () => {
-		const manager = new TagManager()
-		manager.add("test:value")
-
-		const loaded = new TagManager()
-		expect(loaded.getAllTags()).toEqual(["test:value"])
 	})
 })
 
@@ -306,6 +379,7 @@ describe("TagManager.add", () => {
 		rmSync(MOCK_HOME, { recursive: true, force: true })
 		mkdirSync(MOCK_HOME, { recursive: true })
 		vi.stubEnv("KIMCHI_TAGS", "")
+		clearSessionEntriesStore()
 	})
 
 	afterEach(() => {
@@ -314,7 +388,7 @@ describe("TagManager.add", () => {
 	})
 
 	it("returns duplicate error before limit error when tag already exists at capacity", () => {
-		const manager = new TagManager()
+		const { manager } = makeTagManager()
 		for (let i = 0; i < 10; i++) {
 			manager.add(`tag${i}:value`)
 		}
@@ -323,19 +397,19 @@ describe("TagManager.add", () => {
 	})
 
 	it("returns limit error when adding a new tag at capacity", () => {
-		const manager = new TagManager()
+		const { manager } = makeTagManager()
 		for (let i = 0; i < 10; i++) {
 			manager.add(`tag${i}:value`)
 		}
 		const result = manager.add("new:tag")
-		expect(result).toEqual({ success: false, error: "Maximum 10 tags allowed (including static tags)." })
+		expect(result).toEqual({ success: false, error: "Maximum 10 tags allowed (including default tags)." })
 	})
 })
 
 function commandContext(sessionId: string) {
 	return createContext({
 		hasUI: false,
-		sessionManager: { getSessionId: () => sessionId },
+		sessionManager: makeSessionManager(sessionId),
 		ui: {
 			theme: {
 				fg: (_color: string, text: string) => text,
@@ -409,6 +483,7 @@ describe("getActiveTags", () => {
 		rmSync(MOCK_HOME, { recursive: true, force: true })
 		mkdirSync(MOCK_HOME, { recursive: true })
 		vi.stubEnv("KIMCHI_TAGS", "")
+		clearSessionEntriesStore()
 	})
 
 	afterEach(() => {
@@ -417,21 +492,21 @@ describe("getActiveTags", () => {
 	})
 
 	it("returns an empty array before tags are added", () => {
-		expect(getActiveTags("fresh-tags-session")).toEqual([])
+		expect(getActiveTags(makeSessionManager("fresh-tags-session"))).toEqual([])
 	})
 
 	it("returns tags added through the extension command", async () => {
 		const pi = makePi()
 		tagsExtension(pi)
 		await pi.runCommand("tags", "add team:backend", commandContext("command-tags-session"))
-		expect(getActiveTags("command-tags-session")).toEqual(["team:backend"])
+		expect(getActiveTags(makeSessionManager("command-tags-session"))).toEqual(["team:backend"])
 	})
 
-	it("shares persisted tags across sessions", async () => {
+	it("isolates tags between sessions", async () => {
 		const pi = makePi()
 		tagsExtension(pi)
 		await pi.runCommand("tags", "add team:backend", commandContext("tags-session-a"))
-		expect(getActiveTags("tags-session-a")).toEqual(["team:backend"])
-		expect(getActiveTags("tags-session-b")).toEqual(["team:backend"])
+		expect(getActiveTags(makeSessionManager("tags-session-a"))).toEqual(["team:backend"])
+		expect(getActiveTags(makeSessionManager("tags-session-b"))).toEqual([])
 	})
 })

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -14,15 +14,17 @@ import { homedir } from "node:os"
 import { resolve } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type {
+	CustomEntry,
 	ExtensionAPI,
 	ExtensionCommandContext,
 	ExtensionContext,
+	SessionManager,
 	Theme,
 	ThemeColor,
 } from "@earendil-works/pi-coding-agent"
 import { Text } from "@earendil-works/pi-tui"
 import { Type } from "typebox"
-import { readJson, writeJson } from "../config/json.js"
+import { readJson } from "../config/json.js"
 import { readConfigSetting } from "../config/settings.js"
 import type { ThinkingLevel } from "./agents/personas/types.js"
 import { createSystemPromptBlocks } from "./prompt-construction/index.js"
@@ -32,6 +34,7 @@ import { isStaleCtxError } from "./stale-ctx.js"
 
 const STATUS_LINE_TAGS_KEY = "active-tags"
 const TAGS_CONFIG_FILE = resolve(homedir(), ".config", "kimchi", "tags.json")
+const TAGS_SESSION_ENTRY_TYPE = "kimchi_active_tags"
 
 export function readHidePhaseChanges(): boolean {
 	return readConfigSetting("hidePhaseChanges", (value) => typeof value === "boolean", false)
@@ -75,27 +78,51 @@ interface TagsConfig {
 	tags?: string[]
 }
 
+export type TagAppendEntry = (customType: string, data?: unknown) => void
+
 export class TagManager {
+	private readonly sessionManager: Pick<SessionManager, "getEntries" | "getSessionId">
+	private readonly appendEntry: TagAppendEntry
 	private readonly configFile = TAGS_CONFIG_FILE
 
 	private tags: Set<string> = new Set()
-	private staticTags: Set<string> = new Set()
-	private persistedTags: Set<string> = new Set() // Tags persisted in config file (non-static)
-	private currentPhase: Phase | undefined = undefined
+	private defaultTags: Set<string> = new Set()
+	private hasSessionTags = false
 
-	constructor() {
+	constructor(sessionManager: Pick<SessionManager, "getEntries" | "getSessionId">, appendEntry: TagAppendEntry) {
+		this.sessionManager = sessionManager
+		this.appendEntry = appendEntry
 		this.loadTags()
 	}
 
 	private loadTags(): void {
-		// Load from config file
+		this.loadDefaultTags()
+
+		const sessionTags = this.loadSessionTags()
+		if (sessionTags !== undefined) {
+			this.tags.clear()
+			for (const tag of sessionTags) {
+				if (isValidTag(tag)) {
+					this.tags.add(tag)
+				}
+			}
+			this.hasSessionTags = true
+			return
+		}
+
+		for (const tag of this.defaultTags) {
+			this.tags.add(tag)
+		}
+	}
+
+	private loadDefaultTags(): void {
+		// Load from config file (defaults for new sessions)
 		try {
 			const config = readJson(this.configFile) as TagsConfig
 			if (Array.isArray(config.tags)) {
 				for (const tag of config.tags) {
 					if (isValidTag(tag)) {
-						this.persistedTags.add(tag)
-						this.tags.add(tag)
+						this.defaultTags.add(tag)
 					}
 				}
 			}
@@ -103,39 +130,29 @@ export class TagManager {
 			// Config file doesn't exist or is invalid, ignore
 		}
 
-		// Load from environment variable (takes precedence for static tags)
+		// Load from environment variable (defaults for new sessions)
 		const envTags = process.env.KIMCHI_TAGS
 		if (envTags) {
-			// Environment tags become static and override config file tags
 			for (const tag of envTags.split(",")) {
 				const trimmed = tag.trim()
 				if (isValidTag(trimmed)) {
-					this.staticTags.add(trimmed)
-					// Remove from persisted if it was there (env takes precedence)
-					this.persistedTags.delete(trimmed)
+					this.defaultTags.add(trimmed)
 				}
-			}
-
-			// Rebuild tags: env tags (static) + persisted tags (non-static)
-			this.tags.clear()
-			for (const tag of this.staticTags) {
-				this.tags.add(tag)
-			}
-			for (const tag of this.persistedTags) {
-				this.tags.add(tag)
 			}
 		}
 	}
 
-	private saveTags(): void {
-		try {
-			// Only persist non-static tags
-			const tagsToPersist = Array.from(this.persistedTags).sort()
-			const config: TagsConfig = { tags: tagsToPersist }
-			writeJson(this.configFile, config)
-		} catch {
-			// Silent fail - don't break the app if we can't write config
-		}
+	private loadSessionTags(): string[] | undefined {
+		const entry = this.sessionManager
+			.getEntries()
+			.findLast(
+				(item): item is CustomEntry<string[]> => item.type === "custom" && item.customType === TAGS_SESSION_ENTRY_TYPE,
+			)
+		return entry?.data
+	}
+
+	private persistTags(): void {
+		this.appendEntry(TAGS_SESSION_ENTRY_TYPE, Array.from(this.tags).sort())
 	}
 
 	getAllTags(): string[] {
@@ -143,11 +160,13 @@ export class TagManager {
 	}
 
 	getUserTags(): string[] {
-		return Array.from(this.tags).filter((tag) => !this.staticTags.has(tag))
+		return this.hasSessionTags
+			? Array.from(this.tags)
+			: Array.from(this.tags).filter((tag) => !this.defaultTags.has(tag))
 	}
 
 	getStaticTags(): string[] {
-		return Array.from(this.staticTags)
+		return Array.from(this.defaultTags)
 	}
 
 	add(tag: string): { success: boolean; error?: string } {
@@ -158,62 +177,45 @@ export class TagManager {
 			}
 		}
 
-		if (this.staticTags.has(tag)) {
-			return { success: false, error: `Tag "${tag}" is a static tag and cannot be modified.` }
-		}
-
 		if (this.tags.has(tag)) {
 			return { success: false, error: `Tag "${tag}" already exists.` }
 		}
 
 		if (this.tags.size >= 10) {
-			return { success: false, error: "Maximum 10 tags allowed (including static tags)." }
+			return { success: false, error: "Maximum 10 tags allowed (including default tags)." }
 		}
 
 		this.tags.add(tag)
-		this.persistedTags.add(tag)
-		this.saveTags()
+		this.hasSessionTags = true
+		this.persistTags()
 		return { success: true }
 	}
 
 	remove(tag: string): { success: boolean; error?: string } {
-		if (this.staticTags.has(tag)) {
-			return { success: false, error: `Tag "${tag}" is a static tag and cannot be removed.` }
-		}
-
 		if (!this.tags.has(tag)) {
 			return { success: false, error: `Tag "${tag}" not found.` }
 		}
 
 		this.tags.delete(tag)
-		this.persistedTags.delete(tag)
-		this.saveTags()
+		this.hasSessionTags = true
+		this.persistTags()
 		return { success: true }
 	}
 
 	clear(): { removed: number } {
-		const userTags = this.getUserTags()
-		for (const tag of userTags) {
-			this.tags.delete(tag)
-			this.persistedTags.delete(tag)
-		}
-		this.saveTags()
-		return { removed: userTags.length }
+		const removed = this.tags.size
+		this.tags.clear()
+		this.hasSessionTags = true
+		this.persistTags()
+		return { removed }
 	}
+
 	isStatic(tag: string): boolean {
-		return this.staticTags.has(tag)
+		return this.defaultTags.has(tag)
 	}
 
-	setPhase(phase: Phase | undefined): void {
-		this.currentPhase = phase
-	}
-
-	getPhase(): Phase | undefined {
-		return this.currentPhase
-	}
-
-	getPhaseTag(): string | undefined {
-		return this.currentPhase ? `phase:${this.currentPhase}` : undefined
+	getPhaseTag(phase: Phase | undefined): string | undefined {
+		return phase ? `phase:${phase}` : undefined
 	}
 }
 
@@ -276,7 +278,7 @@ function updateStatusLineTags(tagManager: TagManager, ctx: ExtensionContext): vo
 	if (!ctx.hasUI) return
 
 	const allTags = tagManager.getAllTags()
-	const currentPhase = tagManager.getPhase()
+	const currentPhase = getCurrentPhase(ctx.sessionManager.getSessionId())
 	const statusText = formatTagsForStatusLine(allTags, ctx.ui.theme, currentPhase)
 	ctx.ui.setStatus(STATUS_LINE_TAGS_KEY, statusText)
 }
@@ -290,10 +292,11 @@ function subcommandArgs(args: string, subcommand: string): string {
 
 async function handlePhaseCommand(args: string, ctx: ExtensionCommandContext, tagManager: TagManager): Promise<void> {
 	const trimmed = args.trim().toLowerCase()
+	const sessionId = ctx.sessionManager.getSessionId()
 
 	// No arg → show current phase + offer interactive selector when there's a UI.
 	if (!trimmed) {
-		const current = tagManager.getPhase()
+		const current = getCurrentPhase(sessionId)
 		const currentLabel = current ? `current phase: ${current}` : "no phase set"
 
 		if (!ctx.hasUI) {
@@ -305,14 +308,14 @@ async function handlePhaseCommand(args: string, ctx: ExtensionCommandContext, ta
 		if (!choice) return
 
 		if (choice === "none (clear)") {
-			tagManager.setPhase(undefined)
+			setCurrentPhase(sessionId, undefined)
 			updateStatusLineTags(tagManager, ctx)
 			ctx.ui.notify("Phase cleared", "info")
 			return
 		}
 
 		const next = choice as Phase
-		tagManager.setPhase(next)
+		setCurrentPhase(sessionId, next)
 		updateStatusLineTags(tagManager, ctx)
 		ctx.ui.notify(`Phase changed to: ${next}`, "info")
 		return
@@ -320,7 +323,7 @@ async function handlePhaseCommand(args: string, ctx: ExtensionCommandContext, ta
 
 	// Explicit clear.
 	if (trimmed === "none" || trimmed === "clear" || trimmed === "off") {
-		tagManager.setPhase(undefined)
+		setCurrentPhase(sessionId, undefined)
 		if (ctx.hasUI) {
 			updateStatusLineTags(tagManager, ctx)
 			ctx.ui.notify("Phase cleared", "info")
@@ -338,7 +341,7 @@ async function handlePhaseCommand(args: string, ctx: ExtensionCommandContext, ta
 		return
 	}
 
-	tagManager.setPhase(trimmed)
+	setCurrentPhase(sessionId, trimmed)
 	if (ctx.hasUI) {
 		updateStatusLineTags(tagManager, ctx)
 		ctx.ui.notify(`Phase changed to: ${trimmed}`, "info")
@@ -365,8 +368,8 @@ function handleTagsCommand(args: string, ctx: ExtensionCommandContext, tagManage
 		lines.push("Active tags:")
 
 		for (const tag of allTags.sort()) {
-			const isStatic = staticTags.includes(tag)
-			const marker = isStatic ? "[static]" : "[user]"
+			const isDefault = staticTags.includes(tag)
+			const marker = isDefault ? "[default]" : "[user]"
 			const colorTag = ctx.ui.theme.fg("accent", tag)
 			const colorMarker = ctx.ui.theme.fg("dim", marker)
 			lines.push(`  ${colorMarker} ${colorTag}`)
@@ -479,8 +482,8 @@ function handleTagsCommand(args: string, ctx: ExtensionCommandContext, tagManage
 		"  /tags remove tag ...       Remove one or more user-defined tags",
 		"  /tags clear                Remove all user-defined tags",
 		"",
-		"Static tags (from config/env) cannot be modified.",
-		`Current static tags: ${tagManager.getStaticTags().length > 0 ? tagManager.getStaticTags().join(", ") : "none"}`,
+		"Default tags from config/env are applied to new sessions; session changes override them.",
+		`Current default tags: ${tagManager.getStaticTags().length > 0 ? tagManager.getStaticTags().join(", ") : "none"}`,
 	]
 	ctx.ui.notify(helpLines.join("\n"), "info")
 }
@@ -503,35 +506,42 @@ const SetPhaseParams = Type.Object({
 
 // ─── Extension entry point ─────────────────────────────────────────────────────
 
+const phaseMap = new Map<string, Phase | undefined>()
+
+export function getCurrentPhase(sessionId: string): Phase | undefined {
+	return phaseMap.get(sessionId)
+}
+
+export function setCurrentPhase(sessionId: string, phase: string | undefined): void {
+	if (phase !== undefined && !isValidPhase(phase)) return
+	phaseMap.set(sessionId, phase)
+}
+
 const tagManagerMap = new Map<string, TagManager>()
 
-function getTagManager(sessionId: string): TagManager {
+function getTagManager(
+	sessionManager: Pick<SessionManager, "getEntries" | "getSessionId">,
+	appendEntry: TagAppendEntry,
+): TagManager {
+	const sessionId = sessionManager.getSessionId()
 	let tagManager = tagManagerMap.get(sessionId)
 	if (!tagManager) {
-		tagManager = new TagManager()
+		tagManager = new TagManager(sessionManager, appendEntry)
 		tagManagerMap.set(sessionId, tagManager)
 	}
 	return tagManager
 }
 
-export function getCurrentPhase(sessionId: string): Phase | undefined {
-	return getTagManager(sessionId).getPhase()
-}
-
-export function setCurrentPhase(sessionId: string, phase: string | undefined): void {
-	const tagManager = getTagManager(sessionId)
-	if (phase !== undefined && !isValidPhase(phase)) return
-	tagManager.setPhase(phase)
-}
-
-export function getActiveTags(sessionId: string): string[] {
-	return getTagManager(sessionId).getAllTags()
+export function getActiveTags(sessionManager: Pick<SessionManager, "getEntries" | "getSessionId">): string[] {
+	// Read-only lookup: do not cache this instance, otherwise a later
+	// command/tool context that needs to mutate tags would get a no-op
+	// appendEntry from the cached instance.
+	return new TagManager(sessionManager, () => {}).getAllTags()
 }
 
 export default function tagsExtension(pi: ExtensionAPI) {
 	function getExtensionTagManager(ctx: ExtensionContext): TagManager {
-		const sessionId = ctx.sessionManager.getSessionId()
-		return getTagManager(sessionId)
+		return getTagManager(ctx.sessionManager, pi.appendEntry)
 	}
 
 	// Register the /tags command
@@ -570,8 +580,9 @@ export default function tagsExtension(pi: ExtensionAPI) {
 			const phase = params.phase as Phase
 			const thinking = params.thinking as ThinkingLevel | undefined
 			const tagManager = getExtensionTagManager(ctx)
+			const sessionId = ctx.sessionManager.getSessionId()
 
-			tagManager.setPhase(phase)
+			setCurrentPhase(sessionId, phase)
 			if (thinking) {
 				pi.setThinkingLevel(thinking)
 			}
@@ -613,8 +624,9 @@ export default function tagsExtension(pi: ExtensionAPI) {
 	// Initialize status line tags status and default phase on session start
 	pi.on("session_start", async (_event, ctx) => {
 		const tagManager = getExtensionTagManager(ctx)
+		const sessionId = ctx.sessionManager.getSessionId()
 
-		tagManager.setPhase("explore")
+		setCurrentPhase(sessionId, "explore")
 		updateStatusLineTags(tagManager, ctx)
 	})
 
@@ -635,6 +647,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		const payload = event.payload as Record<string, unknown> | null
 		if (!payload || typeof payload !== "object") return
 
+		const sessionId = ctx.sessionManager.getSessionId()
 		const tagManager = getExtensionTagManager(ctx)
 		const allTags = tagManager.getAllTags()
 
@@ -643,7 +656,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		if (model?.id) {
 			reservedTags.push(`model:${model.id}`)
 		}
-		const phaseTag = tagManager.getPhaseTag()
+		const phaseTag = tagManager.getPhaseTag(getCurrentPhase(sessionId))
 		if (phaseTag) {
 			reservedTags.push(phaseTag)
 		}

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -10,9 +10,9 @@
  * Tags are stored per-session and persisted via session entries.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, join, resolve } from "node:path"
+import { resolve } from "node:path"
+import type { Api, Model } from "@earendil-works/pi-ai"
 import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
@@ -22,6 +22,8 @@ import type {
 } from "@earendil-works/pi-coding-agent"
 import { Text } from "@earendil-works/pi-tui"
 import { Type } from "typebox"
+import { readJson, writeJson } from "../config/json.js"
+import { readConfigSetting } from "../config/settings.js"
 import type { ThinkingLevel } from "./agents/personas/types.js"
 import { createSystemPromptBlocks } from "./prompt-construction/index.js"
 import { isStaleCtxError } from "./stale-ctx.js"
@@ -30,21 +32,9 @@ import { isStaleCtxError } from "./stale-ctx.js"
 
 const STATUS_LINE_TAGS_KEY = "active-tags"
 const TAGS_CONFIG_FILE = resolve(homedir(), ".config", "kimchi", "tags.json")
-const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
-
-function readHarnessSetting<T>(key: string, fallback: T): T {
-	try {
-		const raw = readFileSync(HARNESS_SETTINGS_PATH, "utf-8")
-		const parsed = JSON.parse(raw)
-		if (key in parsed) return parsed[key] as T
-	} catch {
-		// settings.json absent or unreadable — use fallback
-	}
-	return fallback
-}
 
 export function readHidePhaseChanges(): boolean {
-	return readHarnessSetting<boolean>("hidePhaseChanges", false)
+	return readConfigSetting("hidePhaseChanges", (value) => typeof value === "boolean", false)
 }
 
 const TAG_COLORS: ThemeColor[] = ["accent", "mdLink", "success", "warning"]
@@ -86,29 +76,26 @@ interface TagsConfig {
 }
 
 export class TagManager {
+	private readonly configFile = TAGS_CONFIG_FILE
+
 	private tags: Set<string> = new Set()
 	private staticTags: Set<string> = new Set()
 	private persistedTags: Set<string> = new Set() // Tags persisted in config file (non-static)
 	private currentPhase: Phase | undefined = undefined
-	private readonly configFile: string
 
-	constructor(configFile: string = TAGS_CONFIG_FILE) {
-		this.configFile = configFile
+	constructor() {
 		this.loadTags()
 	}
 
 	private loadTags(): void {
 		// Load from config file
 		try {
-			if (existsSync(this.configFile)) {
-				const content = readFileSync(this.configFile, "utf-8")
-				const config = JSON.parse(content) as TagsConfig
-				if (Array.isArray(config.tags)) {
-					for (const tag of config.tags) {
-						if (isValidTag(tag)) {
-							this.persistedTags.add(tag)
-							this.tags.add(tag)
-						}
+			const config = readJson(this.configFile) as TagsConfig
+			if (Array.isArray(config.tags)) {
+				for (const tag of config.tags) {
+					if (isValidTag(tag)) {
+						this.persistedTags.add(tag)
+						this.tags.add(tag)
 					}
 				}
 			}
@@ -145,14 +132,7 @@ export class TagManager {
 			// Only persist non-static tags
 			const tagsToPersist = Array.from(this.persistedTags).sort()
 			const config: TagsConfig = { tags: tagsToPersist }
-
-			// Ensure directory exists
-			const configDir = dirname(this.configFile)
-			if (!existsSync(configDir)) {
-				mkdirSync(configDir, { recursive: true })
-			}
-
-			writeFileSync(this.configFile, JSON.stringify(config, null, 2))
+			writeJson(this.configFile, config)
 		} catch {
 			// Silent fail - don't break the app if we can't write config
 		}
@@ -523,35 +503,42 @@ const SetPhaseParams = Type.Object({
 
 // ─── Extension entry point ─────────────────────────────────────────────────────
 
-let tagManagerInstance: TagManager | undefined
+const tagManagerMap = new Map<string, TagManager>()
 
-export function getCurrentPhase(): Phase | undefined {
-	return tagManagerInstance?.getPhase()
-}
-
-export function setCurrentPhase(phase: string | undefined): void {
-	if (!tagManagerInstance) return
-	if (phase === undefined) {
-		tagManagerInstance.setPhase(undefined)
-		return
+function getTagManager(sessionId: string): TagManager {
+	let tagManager = tagManagerMap.get(sessionId)
+	if (!tagManager) {
+		tagManager = new TagManager()
+		tagManagerMap.set(sessionId, tagManager)
 	}
-	if (!isValidPhase(phase)) return
-	tagManagerInstance.setPhase(phase)
+	return tagManager
 }
 
-export function getActiveTags(): string[] {
-	return tagManagerInstance?.getAllTags() ?? []
+export function getCurrentPhase(sessionId: string): Phase | undefined {
+	return getTagManager(sessionId).getPhase()
+}
+
+export function setCurrentPhase(sessionId: string, phase: string | undefined): void {
+	const tagManager = getTagManager(sessionId)
+	if (phase !== undefined && !isValidPhase(phase)) return
+	tagManager.setPhase(phase)
+}
+
+export function getActiveTags(sessionId: string): string[] {
+	return getTagManager(sessionId).getAllTags()
 }
 
 export default function tagsExtension(pi: ExtensionAPI) {
-	const tagManager = new TagManager()
-	tagManagerInstance = tagManager
+	function getExtensionTagManager(ctx: ExtensionContext): TagManager {
+		const sessionId = ctx.sessionManager.getSessionId()
+		return getTagManager(sessionId)
+	}
 
 	// Register the /tags command
 	pi.registerCommand("tags", {
 		description: "Manage LLM request tags for usage tracking",
 		handler: async (args, ctx) => {
-			handleTagsCommand(args, ctx, tagManager)
+			handleTagsCommand(args, ctx, getExtensionTagManager(ctx))
 		},
 	})
 
@@ -567,7 +554,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 			}))
 		},
 		handler: async (args, ctx) => {
-			await handlePhaseCommand(args, ctx, tagManager)
+			await handlePhaseCommand(args, ctx, getExtensionTagManager(ctx))
 		},
 	})
 
@@ -582,6 +569,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const phase = params.phase as Phase
 			const thinking = params.thinking as ThinkingLevel | undefined
+			const tagManager = getExtensionTagManager(ctx)
 
 			tagManager.setPhase(phase)
 			if (thinking) {
@@ -624,6 +612,8 @@ export default function tagsExtension(pi: ExtensionAPI) {
 
 	// Initialize status line tags status and default phase on session start
 	pi.on("session_start", async (_event, ctx) => {
+		const tagManager = getExtensionTagManager(ctx)
+
 		tagManager.setPhase("explore")
 		updateStatusLineTags(tagManager, ctx)
 	})
@@ -633,7 +623,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		// Tags are a Cast AI-specific API field; skip for other providers.
 		// If a request from a torn-down session reaches us after `/new` (etc.),
 		// any ctx getter throws via assertActive — bail silently in that case.
-		let model: { provider?: string; id?: string } | undefined
+		let model: Model<Api> | undefined
 		try {
 			model = ctx.model ?? undefined
 		} catch (err) {
@@ -645,6 +635,7 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		const payload = event.payload as Record<string, unknown> | null
 		if (!payload || typeof payload !== "object") return
 
+		const tagManager = getExtensionTagManager(ctx)
 		const allTags = tagManager.getAllTags()
 
 		// Build reserved tags first (model + phase) so they are never dropped by the cap


### PR DESCRIPTION
## Linked issue

Closes #0
LLM-2573

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Fixes phase/tag state leaking across keyed sessions in the same process, and makes tags genuinely session-scoped.

### Problem
- Phases and tags were stored in global singletons, leaking across sessions.
- Tags were persisted to a shared config file, so `/tags add` in session A also appeared in session B.
- The `getActiveTags` lookup could pollute the shared `TagManager` cache with a read-only (no-op append) instance, causing later commands to silently drop tag mutations.

### Changes
- **`TagManager` is now session-scoped**: it loads tags from `sessionManager.getEntries()` first, and falls back to `~/.config/kimchi/tags.json` / `KIMCHI_TAGS` only for new sessions.
- **Tags travel with the session**: `add/remove/clear` persist to a session custom entry (`kimchi_active_tags`) via `pi.appendEntry`, not to the global config file.
- **`getActiveTags` takes `sessionManager`** and creates a fresh read-only `TagManager` so it never caches a no-op append instance.
- **`getCurrentPhase`/`setCurrentPhase`** remain keyed by `sessionId` in an in-memory map.
- **Callers updated**: `status-line.ts`, `agent-runner.ts`, `prompt-enrichment.ts`, and `review-write-guard.ts` pass the active session id/session manager.
- **Review-write-guard bugfix**: `getOrchestratorWriteGuard` now stores the guard in the per-session map so state persists across events.
- **Language cleanup**: env/config tags are now labeled `[default]` in the UI, and help/error messages no longer call them "static" (they are removable session overrides now).

### Behavior changes worth calling out
- `/tags add/remove/clear` no longer writes `~/.config/kimchi/tags.json`. That file is now read-only defaults for new sessions.
- Removing/clearing a default tag in a new session succeeds and creates a session-scoped override, instead of failing as "static".

### Tests
- Rewrote tag persistence tests to assert session-entry behavior and cross-session isolation.
- Added session-id assertions for `agent-runner`, `prompt-enrichment`, `status-line`, and `review-write-guard`.
- Added ACP E2E isolation test exercising two concurrent sessions.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
