### PR TITLE
fix(model-guard): use session_compact event for post-compaction notification

### DIFF
--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -648,22 +648,20 @@ describe("turn_end compaction guard", () => {
 		const freshCtx = makeMockCtx({
 			ui: { notify } as unknown as ExtensionContext["ui"],
 		})
-		await trigger("session_compact", {
-			type: "session_compact",
-			compactionEntry: { tokensBefore: THRESHOLD + 1 },
-			fromExtension: true,
-			reason: "manual",
-			willRetry: false,
-		}, freshCtx)
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: THRESHOLD + 1 },
+				fromExtension: true,
+				reason: "manual",
+				willRetry: false,
+			},
+			freshCtx,
+		)
 
-		expect(notify).toHaveBeenCalledWith(
-			expect.stringContaining("Context compacted"),
-			"info",
-		)
-		expect(notify).toHaveBeenCalledWith(
-			expect.stringContaining((THRESHOLD + 1).toLocaleString()),
-			"info",
-		)
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining((THRESHOLD + 1).toLocaleString()), "info")
 	})
 
 	it("does not notify from session_compact when compaction was not triggered by this guard", async () => {
@@ -676,14 +674,63 @@ describe("turn_end compaction guard", () => {
 		const ctx = makeMockCtx({
 			ui: { notify } as unknown as ExtensionContext["ui"],
 		})
-		await trigger("session_compact", {
-			type: "session_compact",
-			compactionEntry: { tokensBefore: 100_000 },
-			fromExtension: false,
-			reason: "threshold",
-			willRetry: false,
-		}, ctx)
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 100_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			ctx,
+		)
 		expect(notify).not.toHaveBeenCalled()
+	})
+
+	it("does not notify from session_compact when flag is set but fromExtension is false", async () => {
+		// fromExtension guard: even if the flag is set (e.g. a concurrent
+		// threshold compaction fires between our ctx.compact() and the event),
+		// we must not consume the flag for a non-extension compaction.
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const notify = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+		expect(compact).toHaveBeenCalledOnce()
+
+		// A threshold compaction fires before our extension-triggered one
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 100_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			ctx,
+		)
+		expect(notify).not.toHaveBeenCalled()
+
+		// Now our extension-triggered compaction fires
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: THRESHOLD + 1 },
+				fromExtension: true,
+				reason: "manual",
+				willRetry: false,
+			},
+			ctx,
+		)
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
 	})
 
 	it("warns and clears flag when onError fires (compaction failure)", async () => {
@@ -710,13 +757,17 @@ describe("turn_end compaction guard", () => {
 			const freshCtx = makeMockCtx({
 				ui: { notify } as unknown as ExtensionContext["ui"],
 			})
-			await trigger("session_compact", {
-				type: "session_compact",
-				compactionEntry: { tokensBefore: 100 },
-				fromExtension: true,
-				reason: "manual",
-				willRetry: false,
-			}, freshCtx)
+			await trigger(
+				"session_compact",
+				{
+					type: "session_compact",
+					compactionEntry: { tokensBefore: 100 },
+					fromExtension: true,
+					reason: "manual",
+					willRetry: false,
+				},
+				freshCtx,
+			)
 			expect(notify).not.toHaveBeenCalled()
 		} finally {
 			warn.mockRestore()

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -603,7 +603,32 @@ describe("turn_end compaction guard", () => {
 		expect(compact).not.toHaveBeenCalled()
 	})
 
-	it("calls compact with notification callbacks when totalTokens exceeds the compaction threshold mid-turn", async () => {
+	it("calls compact when totalTokens exceeds the compaction threshold mid-turn", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+		expect(compact).toHaveBeenCalledOnce()
+
+		// ctx.compact() must not receive onComplete — the success notification is
+		// delivered via the session_compact event with a fresh ctx, not from a
+		// stale closure.
+		const options = compact.mock.calls[0][0]
+		expect(options.onComplete).toBeUndefined()
+		expect(typeof options.onError).toBe("function")
+	})
+
+	it("notifies via session_compact event with fresh ctx after successful compaction", async () => {
+		// Regression for stale-ctx crash: ctx.compact() replaces the session
+		// internally, so the captured ctx in turn_end is stale by the time the
+		// success callback would fire. The notification is delivered from the
+		// session_compact event handler instead, which receives a fresh ctx.
+		// See: benchmark terminal-bench-2-1 run 2026-07-17 — circuit-fibsqrt
+		// and path-tracing-reverse crashed with "This extension ctx is stale".
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
 		const compact = vi.fn()
@@ -616,19 +641,86 @@ describe("turn_end compaction guard", () => {
 		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
 		expect(compact).toHaveBeenCalledOnce()
 
-		// Verify the options shape includes onComplete/onError callbacks
-		const options = compact.mock.calls[0][0]
-		expect(typeof options.onComplete).toBe("function")
-		expect(typeof options.onError).toBe("function")
+		// The stale ctx from turn_end must not be used for notification.
+		expect(notify).not.toHaveBeenCalled()
 
-		// Simulate a successful compaction callback
-		options.onComplete({ tokensBefore: THRESHOLD + 1 })
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
+		// Simulate upstream firing session_compact with a fresh ctx.
+		const freshCtx = makeMockCtx({
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		})
+		await trigger("session_compact", {
+			type: "session_compact",
+			compactionEntry: { tokensBefore: THRESHOLD + 1 },
+			fromExtension: true,
+			reason: "manual",
+			willRetry: false,
+		}, freshCtx)
 
-		// Simulate a failed compaction callback
-		notify.mockClear()
-		options.onError(new Error("summariser failed"))
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("summariser failed"), "error")
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining("Context compacted"),
+			"info",
+		)
+		expect(notify).toHaveBeenCalledWith(
+			expect.stringContaining((THRESHOLD + 1).toLocaleString()),
+			"info",
+		)
+	})
+
+	it("does not notify from session_compact when compaction was not triggered by this guard", async () => {
+		// Only the turn_end guard's compaction should trigger the notification —
+		// a compaction from /compact or threshold should not produce the
+		// mid-turn guard's message.
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const notify = vi.fn()
+		const ctx = makeMockCtx({
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		})
+		await trigger("session_compact", {
+			type: "session_compact",
+			compactionEntry: { tokensBefore: 100_000 },
+			fromExtension: false,
+			reason: "threshold",
+			willRetry: false,
+		}, ctx)
+		expect(notify).not.toHaveBeenCalled()
+	})
+
+	it("warns and clears flag when onError fires (compaction failure)", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+			const compact = vi.fn()
+			const ctx = makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+				compact,
+			})
+			await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+			const options = compact.mock.calls[0][0]
+
+			options.onError(new Error("summariser failed"))
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("mid-turn compaction failed"),
+				expect.stringContaining("summariser failed"),
+			)
+
+			// Flag must be cleared so session_compact doesn't fire a stale notification
+			const notify = vi.fn()
+			const freshCtx = makeMockCtx({
+				ui: { notify } as unknown as ExtensionContext["ui"],
+			})
+			await trigger("session_compact", {
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 100 },
+				fromExtension: true,
+				reason: "manual",
+				willRetry: false,
+			}, freshCtx)
+			expect(notify).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
 	})
 
 	it("does not compact when stopReason is not toolUse (turn already ending)", async () => {

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -105,7 +105,7 @@ export function getLatestMessagesTimestamp(): number {
 	return latestMessagesTimestamp
 }
 
-function resetImageState(): void {
+function resetSessionState(): void {
 	imagesDetected = false
 	imagesStripped = false
 	pendingMidTurnCompaction = false
@@ -117,7 +117,7 @@ function resetImageState(): void {
 /**
  * @internal Exported for unit tests — production code uses session_start/session_shutdown hooks.
  */
-export const __resetImagesDetectedForTest = resetImageState
+export const __resetImagesDetectedForTest = resetSessionState
 
 /**
  * Rough token estimation: 4 chars per token for text, images counted separately.
@@ -282,15 +282,17 @@ export function truncateMessages(messages: ContextEvent["messages"], maxTokens: 
 }
 
 export default function createModelGuardExtension(_pi: ExtensionAPI) {
-	_pi.on("session_start", resetImageState)
-	_pi.on("session_shutdown", resetImageState)
+	_pi.on("session_start", resetSessionState)
+	_pi.on("session_shutdown", resetSessionState)
 
 	// ctx.compact() replaces the session internally, invalidating the ctx
 	// captured in the turn_end handler. The session_compact event fires
 	// afterwards with a fresh ctx, so we notify from there instead of from
 	// the stale onComplete/onError closures.
 	_pi.on("session_compact", (event, ctx: ExtensionContext) => {
-		if (!pendingMidTurnCompaction) return
+		// Only consume the flag for compactions triggered by this guard's
+		// ctx.compact() call — not for /compact or threshold-triggered ones.
+		if (!pendingMidTurnCompaction || !event.fromExtension) return
 		pendingMidTurnCompaction = false
 		ctx.ui?.notify(
 			`Context compacted (${(event.compactionEntry.tokensBefore ?? 0).toLocaleString()} tokens → summary). Continue to resume.`,

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -40,6 +40,12 @@ let imagesDetected = false
 /** Module-level flag tracking whether images have been stripped for non-vision model compatibility. */
 let imagesStripped = false
 
+/** Tracks whether the turn_end mid-turn compaction guard triggered ctx.compact().
+ *  Set before calling ctx.compact() and consumed by the session_compact handler
+ *  so the notification runs against the fresh post-compaction ctx, not the stale
+ *  one captured in the turn_end handler's closure. */
+let pendingMidTurnCompaction = false
+
 /** Reference to the latest context messages (stored for /strip-images command). */
 let latestMessages: ContextEvent["messages"] = []
 
@@ -102,6 +108,7 @@ export function getLatestMessagesTimestamp(): number {
 function resetImageState(): void {
 	imagesDetected = false
 	imagesStripped = false
+	pendingMidTurnCompaction = false
 	latestMessages = []
 	latestMessagesTimestamp = 0
 	imageDescriptions.clear()
@@ -278,6 +285,19 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 	_pi.on("session_start", resetImageState)
 	_pi.on("session_shutdown", resetImageState)
 
+	// ctx.compact() replaces the session internally, invalidating the ctx
+	// captured in the turn_end handler. The session_compact event fires
+	// afterwards with a fresh ctx, so we notify from there instead of from
+	// the stale onComplete/onError closures.
+	_pi.on("session_compact", (event, ctx: ExtensionContext) => {
+		if (!pendingMidTurnCompaction) return
+		pendingMidTurnCompaction = false
+		ctx.ui?.notify(
+			`Context compacted (${(event.compactionEntry.tokensBefore ?? 0).toLocaleString()} tokens → summary). Continue to resume.`,
+			"info",
+		)
+	})
+
 	_pi.on("context", async (event, ctx: ExtensionContext) => {
 		const model = ctx.model
 		const usage = ctx.getContextUsage()
@@ -388,15 +408,14 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		// The proper upstream fix is to wire _checkCompaction into the agent loop via
 		// shouldStopAfterTurn or after_provider_response so compaction fires inside
 		// the loop with transparent retry. This handler is a pragmatic stopgap.
+		pendingMidTurnCompaction = true
 		ctx.compact({
-			onComplete: (result) => {
-				ctx.ui?.notify(
-					`Context compacted (${(result.tokensBefore ?? 0).toLocaleString()} tokens → summary). Continue to resume.`,
-					"info",
-				)
-			},
+			// onComplete fires with a stale ctx after session replacement.
+			// The actual notification is delivered via the session_compact event
+			// handler above, which receives a fresh ctx.
 			onError: (error) => {
-				ctx.ui?.notify(`Context compaction failed: ${error.message}`, "error")
+				pendingMidTurnCompaction = false
+				console.warn("[model-guard] mid-turn compaction failed:", error.message)
 			},
 		})
 	})


### PR DESCRIPTION
## Summary

Fixes a process crash caused by stale extension context after `ctx.compact()` in the model-guard `turn_end` handler.

## Problem

`ctx.compact()` replaces the session internally, which invalidates the `ctx` captured in the `turn_end` handler's closure. When the `onComplete`/`onError` callbacks fired afterward, accessing `ctx.ui` triggered `assertActive()` and threw:

```
error: This extension ctx is stale after session replacement or reload.
    at assertActive (kimchi:238316)
    at ui (kimchi:238393)
    at onError (kimchi:301663)
```

The optional chaining `ctx.ui?.notify(...)` doesn't protect against thrown errors (only `null`/`undefined`), so the error propagated uncaught and crashed the process (exit code 1).

This caused **2 deterministic crashes per terminal-bench-2-1 benchmark run** — `circuit-fibsqrt` and `path-tracing-reverse` both crashed after hitting the context compaction threshold, following the identical pattern in their session logs: `compaction` event → `agent_terminated` (reason: `signal`).

## Fix

Instead of accessing the stale `ctx` in the callbacks, the success notification now flows through the **`session_compact` event**, which upstream fires after compaction with a **fresh `ctx`**:

1. **`pendingMidTurnCompaction` flag** — set `true` before calling `ctx.compact()`, reset on `session_start`/`session_shutdown`
2. **`session_compact` handler** — checks the flag, and if set, delivers the success notification using the fresh `ctx` from the event, then clears the flag
3. **`onError` callback** — clears the flag and logs via `console.warn` (no `ctx` access, since compaction failed means no fresh ctx exists)
4. **`onComplete` removed entirely** — the `session_compact` event is the source of truth for success

## Checklist

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan

- [x] `pnpm vitest run src/extensions/model-guard.test.ts` — 56 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `npx biome lint src/extensions/model-guard.ts` — clean (test file OOMs biome in this environment, but PostToolUse `lint:fix` already ran on edit)
- [x] Regression tests cover the stale-ctx scenario by firing `session_compact` with a fresh ctx
- [x] Existing tests updated to assert the new contract (no `onComplete`, notification via event)