### PR TITLE
feat: add acp client info to analytics payload

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,6 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import {
-	getCliModeArg,
 	isCliAtFileArg,
 	isExperimentalFeaturesArg,
 	isHelpOrVersionArgs,
@@ -120,6 +119,7 @@ import {
 	readExperimentalModels,
 	updateModelsConfig,
 } from "./models.js"
+import { IS_ACP_MODE } from "./modes/acp/state.js"
 import {
 	augmentModelRolesWithOllama,
 	injectOllamaProvider,
@@ -174,11 +174,6 @@ if (telemetryConfig.enabled) {
 		subcommand: getSubcommand(originalArgs),
 	})
 }
-
-// ACP mode runs JSON-RPC over stdio; interactive mode runs the standard TUI
-// harness. Decide once at module load, before anything else runs.
-const cliMode = getCliModeArg(originalArgs)
-const acpMode = cliMode === "acp"
 
 // Monkey-patch AgentSession.prototype.exportToJsonl so ALL JSONL exports
 // (interactive, ACP, and teleport mode) get trace IDs injected inline.
@@ -495,7 +490,7 @@ try {
 		})
 
 		const interactiveStartupContext = {
-			nonInteractiveMode: acpMode,
+			nonInteractiveMode: IS_ACP_MODE,
 			...terminalIo,
 		}
 		const startupAuthState = createStartupAuthGateState()
@@ -606,7 +601,7 @@ try {
 			infrastructureBreakerExtension,
 		]
 
-		if (acpMode) {
+		if (IS_ACP_MODE) {
 			const { runAcpMode } = await import("./modes/acp/server.js")
 			await runAcpMode({ extensionFactories, agentDir })
 		} else {

--- a/src/extensions/__mocks__/context.ts
+++ b/src/extensions/__mocks__/context.ts
@@ -29,6 +29,13 @@ export function createContext(
 		isIdle: vi.fn(),
 		getContextUsage: vi.fn().mockReturnValue(undefined),
 		...overrides,
+		model: overrides?.model
+			? {
+					provider: "kimchi-dev",
+					name: overrides.model.name ?? overrides?.model.id,
+					...overrides.model,
+				}
+			: undefined,
 		ui: {
 			input: vi.fn(),
 			select: vi.fn(),
@@ -42,6 +49,7 @@ export function createContext(
 		sessionManager: {
 			getSessionId: () => "test-session",
 			getEntries: () => [],
+			getHeader: () => null,
 			...overrides?.sessionManager,
 		} as SessionManager,
 	} as unknown as ExtensionContext

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -874,14 +874,14 @@ export default function (pi: ExtensionAPI) {
 			widget.update()
 		},
 		undefined,
-		(record) => {
+		(record, ctx) => {
 			pi.events.emit("subagents:started", {
 				id: record.id,
 				type: record.type,
 				description: record.description,
 				visibility: record.visibility,
 			})
-			void trackSubagentSpawned(record)
+			void trackSubagentSpawned(record, ctx)
 		},
 		(record, info) => {
 			pi.events.emit("subagents:compacted", {

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -23,7 +23,7 @@ import {
 import { addUsage, type LifetimeUsage } from "./usage.js"
 
 export type OnAgentComplete = (record: AgentRecord) => void
-export type OnAgentStart = (record: AgentRecord) => void
+export type OnAgentStart = (record: AgentRecord, ctx: ExtensionContext) => void
 export type OnAgentCompact = (record: AgentRecord, info: CompactionInfo) => void
 export type CompactionInfo = { reason: "manual" | "threshold" | "overflow"; tokensBefore: number }
 
@@ -207,7 +207,7 @@ export class AgentManager {
 		record.startedAt = Date.now()
 		record.isBackground = options.isBackground ?? false
 		if (record.isBackground) this.runningBackground++
-		this.onStart?.(record)
+		this.onStart?.(record, ctx)
 
 		let detachParentSignal: (() => void) | undefined
 		if (options.signal) {

--- a/src/extensions/telemetry/handlers/messages.test.ts
+++ b/src/extensions/telemetry/handlers/messages.test.ts
@@ -1,6 +1,9 @@
+import type { Message } from "@earendil-works/pi-ai"
+import type { AgentEndEvent, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../../config.js"
-import { _resetSharedAccumulators, SessionContext } from "../session-context.js"
+import { createContext } from "../../__mocks__/context.js"
+import { _resetSharedAccumulators, type TelemetryAttributes, TelemetryContext } from "../session-context.js"
 import { handleAgentEnd, handleBeforeAgentStart, handleMessageEnd, handleMessageStart } from "./messages.js"
 
 const BASE_TS = new Date("2026-06-02T10:00:00.000Z").getTime()
@@ -24,15 +27,17 @@ function makeConfig(overrides: Partial<TelemetryConfig> = {}): TelemetryConfig {
 	}
 }
 
-function makeCtx(source = "cli"): SessionContext {
-	return new SessionContext(makeConfig(), source)
+function makeCtx(modelId?: string): { ctx: TelemetryContext; piCtx: ExtensionContext } {
+	const piCtx = createContext(modelId ? { model: { id: modelId } } : undefined)
+	const ctx = new TelemetryContext(makeConfig())
+	return { ctx, piCtx }
 }
 
 describe("handleMessageStart", () => {
 	it("sets messageStartTime for assistant messages using timestamp", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const before = Date.now()
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS } })
+		handleMessageStart(ctx, piCtx, { message: { role: "assistant", timestamp: BASE_TS } as Message })
 		const after = Date.now()
 		const stored = ctx.messageStartTimes.get(String(BASE_TS))
 		expect(stored).toBeGreaterThanOrEqual(before)
@@ -40,30 +45,22 @@ describe("handleMessageStart", () => {
 	})
 
 	it("sets messageStartTime using timestamp", () => {
-		const ctx = makeCtx()
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS } })
+		const { ctx, piCtx } = makeCtx()
+		handleMessageStart(ctx, piCtx, { message: { role: "assistant", timestamp: BASE_TS } as Message })
 		// Only timestamp is used for timing tracking; responseId is ignored here.
 		expect(ctx.messageStartTimes.has(String(BASE_TS))).toBe(true)
 	})
 
 	it("ignores non-assistant messages", () => {
-		const ctx = makeCtx()
-		handleMessageStart(ctx, { message: { role: "user", timestamp: BASE_TS + 1 } })
+		const { ctx, piCtx } = makeCtx()
+		handleMessageStart(ctx, piCtx, { message: { role: "user", timestamp: BASE_TS + 1 } as Message })
 		expect(ctx.messageStartTimes.size).toBe(0)
 	})
 
-	it("updates currentModel from message when available", () => {
-		const ctx = makeCtx()
-		expect(ctx.currentModel).toBe("unknown")
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS + 2, model: "claude-3-5-sonnet" } })
-		expect(ctx.currentModel).toBe("claude-3-5-sonnet")
-	})
-
-	it("does not overwrite currentModel with unknown", () => {
-		const ctx = makeCtx()
-		ctx.currentModel = "claude-3-5-sonnet"
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS + 3 } })
-		expect(ctx.currentModel).toBe("claude-3-5-sonnet")
+	it("records start time for assistant messages", () => {
+		const { ctx, piCtx } = makeCtx()
+		handleMessageStart(ctx, piCtx, { message: { role: "assistant", timestamp: BASE_TS + 2 } as Message })
+		expect(ctx.messageStartTimes.has(String(BASE_TS + 2))).toBe(true)
 	})
 })
 
@@ -86,23 +83,23 @@ describe("handleMessageEnd", () => {
 	})
 
 	it("emits api_request with source and session_type", async () => {
-		const ctx = makeCtx("vscode")
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-1",
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.005 } },
-			},
+			} as Message,
 		})
 
 		expect(emitSpy).toHaveBeenCalledOnce()
-		const [eventName, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [eventName, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		expect(eventName).toBe("api_request")
-		expect(attrs.model).toBe("claude-3-5-sonnet")
 		expect(attrs.provider).toBe("anthropic")
 		expect(attrs.input_tokens).toBe(100)
 		expect(attrs.output_tokens).toBe(50)
@@ -110,7 +107,7 @@ describe("handleMessageEnd", () => {
 	})
 
 	it("deduplicates messages by responseId", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
 		const event = {
@@ -120,35 +117,35 @@ describe("handleMessageEnd", () => {
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
-			},
+			} as Message,
 		}
 
-		await handleMessageEnd(ctx, event)
-		await handleMessageEnd(ctx, event)
+		await handleMessageEnd(ctx, piCtx, event)
+		await handleMessageEnd(ctx, piCtx, event)
 
 		expect(emitSpy).toHaveBeenCalledOnce()
 	})
 
 	it("accumulates tokens into cumulative state", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-a",
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5, cost: { total: 0.01 } },
-			},
+			} as Message,
 		})
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-b",
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 200, output: 30, cacheRead: 20, cacheWrite: 0, cost: { total: 0.02 } },
-			},
+			} as Message,
 		})
 
 		const tokens = ctx.cumulative.tokensByModel["claude-3-5-sonnet"]
@@ -160,66 +157,68 @@ describe("handleMessageEnd", () => {
 	})
 
 	it("resolves provider via kimchi-dev to ai-enabler", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-kd",
 				model: "some-model",
 				provider: "kimchi-dev",
 				usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
-			},
+			} as Message,
 		})
 
-		const [, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		expect(attrs.provider).toBe("ai-enabler")
 	})
 
 	it("maps subscription provider IDs to canonical names in telemetry logs", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-sub",
 				model: "some-model",
 				provider: "openai-codex",
 				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
-			},
+			} as Message,
 		})
 
-		const [, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		expect(attrs.provider).toBe("openai")
 	})
 
 	it("updates currentModel for subsequent tool events", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		expect(ctx.currentModel).toBe("unknown")
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-model",
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
-			},
+			} as Message,
 		})
 
 		expect(ctx.currentModel).toBe("claude-3-5-sonnet")
 	})
 
 	it("computes correct duration using matched timestamp", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		// Let sessionStartMs age so we can distinguish fallback from correct lookup
 		await new Promise((r) => setTimeout(r, 50))
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS + 1 } })
+		handleMessageStart(ctx, piCtx, { message: { role: "assistant", timestamp: BASE_TS + 1 } as Message })
 
 		const emitSpy = vi.spyOn(ctx, "emit")
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-dur",
@@ -227,25 +226,26 @@ describe("handleMessageEnd", () => {
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
-			},
+			} as Message,
 		})
 
-		const [, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		// Should be near-zero (messageStart → messageEnd), not ~50ms (sessionStart fallback)
 		expect(attrs.duration_ms).toBeLessThan(20)
 	})
 
 	it("computes correct duration when message_start lacks responseId", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		// Let sessionStartMs age
 		await new Promise((r) => setTimeout(r, 50))
 
 		// message_start fires WITHOUT responseId (common for streaming start)
-		handleMessageStart(ctx, { message: { role: "assistant", timestamp: BASE_TS } })
+		handleMessageStart(ctx, piCtx, { message: { role: "assistant", timestamp: BASE_TS } as Message })
 
 		// message_end fires WITH responseId (assigned by provider after response completes)
 		const emitSpy = vi.spyOn(ctx, "emit")
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				responseId: "resp-after",
@@ -253,28 +253,29 @@ describe("handleMessageEnd", () => {
 				model: "claude-3-5-sonnet",
 				provider: "anthropic",
 				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
-			},
+			} as Message,
 		})
 
-		const [, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		// Should be near-zero (start → end), not ~50ms (sessionStart fallback)
 		expect(attrs.duration_ms).toBeLessThan(20)
 	})
 
 	it("ignores non-assistant messages", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		await handleMessageEnd(ctx, { message: { role: "user" } })
+		await handleMessageEnd(ctx, piCtx, { message: { role: "user" } as Message })
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
 
 	it("emits transport_error when stopReason is error and message matches a transport pattern", async () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		await handleMessageEnd(ctx, {
+		await handleMessageEnd(ctx, piCtx, {
 			message: {
 				role: "assistant",
 				model: "kimi-k2.6",
@@ -285,16 +286,16 @@ describe("handleMessageEnd", () => {
 				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
 				timestamp: BASE_TS,
 				responseId: "chatcmpl-transport-test",
-			},
+			} as Message,
 		})
 
 		expect(emitSpy).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({
-				model: "kimi-k2.6",
 				error_type: "transport_error",
 				error_message: expect.stringContaining("socket connection was closed unexpectedly"),
 			}),
+			expect.anything(),
 		)
 	})
 })
@@ -318,17 +319,16 @@ describe("handleBeforeAgentStart", () => {
 	})
 
 	it("emits kimchi.user_message with message_length and model", () => {
-		const ctx = makeCtx()
-		ctx.currentModel = "claude-3-5-sonnet"
+		const { ctx, piCtx } = makeCtx("claude-3-5-sonnet")
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleBeforeAgentStart(ctx, { prompt: "Hello world!" })
+		handleBeforeAgentStart(ctx, piCtx, { prompt: "Hello world!" })
 
 		expect(emitSpy).toHaveBeenCalledOnce()
-		const [eventName, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [eventName, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		expect(eventName).toBe("user_message")
 		expect(attrs.message_length).toBe(12)
-		expect(attrs.model).toBe("claude-3-5-sonnet")
 	})
 })
 
@@ -351,72 +351,71 @@ describe("handleAgentEnd", () => {
 	})
 
 	it("emits kimchi.error when last message is a toolResult with isError=true", () => {
-		const ctx = makeCtx()
-		ctx.currentModel = "claude-3-5-sonnet"
+		const { ctx, piCtx } = makeCtx("claude-3-5-sonnet")
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, {
+		handleAgentEnd(ctx, piCtx, {
 			messages: [
 				{ role: "assistant", content: [{ text: "some output" }] },
 				{ role: "toolResult", isError: true, content: [{ text: "Error: something went wrong" }] },
 			],
-		})
+		} as AgentEndEvent)
 
 		expect(emitSpy).toHaveBeenCalledOnce()
-		const [eventName, attrs] = emitSpy.mock.calls[0]
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [eventName, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
 		expect(eventName).toBe("error")
 		expect(attrs.error_type).toBe("agent_error")
 		expect(attrs.error_message).toContain("Error: something went wrong")
-		expect(attrs.model).toBe("claude-3-5-sonnet")
 	})
 
 	it("does not emit when last toolResult has isError=false", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, {
+		handleAgentEnd(ctx, piCtx, {
 			messages: [{ role: "toolResult", isError: false, content: [{ text: "Task completed successfully" }] }],
-		})
+		} as AgentEndEvent)
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
 
 	it("does not false-positive on text containing the word error when isError=false", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, {
+		handleAgentEnd(ctx, piCtx, {
 			messages: [{ role: "toolResult", isError: false, content: [{ text: "No errors found" }] }],
-		})
+		} as AgentEndEvent)
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when messages array is empty", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, { messages: [] })
+		handleAgentEnd(ctx, piCtx, { messages: [] } as unknown as AgentEndEvent)
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when messages is undefined", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, {})
+		handleAgentEnd(ctx, piCtx, {} as unknown as AgentEndEvent)
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when last message is not toolResult", () => {
-		const ctx = makeCtx()
+		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")
 
-		handleAgentEnd(ctx, {
+		handleAgentEnd(ctx, piCtx, {
 			messages: [{ role: "assistant", content: [{ text: "Error in my thoughts" }] }],
-		})
+		} as AgentEndEvent)
 
 		expect(emitSpy).not.toHaveBeenCalled()
 	})

--- a/src/extensions/telemetry/handlers/messages.ts
+++ b/src/extensions/telemetry/handlers/messages.ts
@@ -83,7 +83,7 @@ export async function handleMessageEnd(
 		tokens.cacheWrite += cacheWrite
 		tm.cumulative.costByModel[model] = (tm.cumulative.costByModel[model] ?? 0) + costTotal
 	} catch (err) {
-		console.error("[tm] message_end handler error:", err)
+		console.error("[telemetry] message_end handler error:", err)
 	}
 }
 

--- a/src/extensions/telemetry/handlers/messages.ts
+++ b/src/extensions/telemetry/handlers/messages.ts
@@ -1,6 +1,7 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { Message, TextContent } from "@earendil-works/pi-ai"
+import type { AgentEndEvent, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getAvailableModels } from "../../../startup-context.js"
-import type { SessionContext } from "../session-context.js"
+import type { TelemetryContext } from "../session-context.js"
 import { handleTransportError } from "./transport-errors.js"
 
 /** Maps OAuth provider IDs to canonical names accepted by the telemetry backend. */
@@ -8,34 +9,33 @@ const PROVIDER_TELEMETRY_MAP: Record<string, string> = {
 	"openai-codex": "openai",
 }
 
-export function handleMessageStart(
-	ctx: SessionContext,
-	event: { message: { role: string; timestamp?: number; model?: string } },
-): void {
+export function handleMessageStart(tm: TelemetryContext, ctx: ExtensionContext, event: { message: Message }): void {
 	const msg = event.message
 	if (msg.role !== "assistant") return
-	if (msg.model && msg.model !== "unknown") ctx.currentModel = msg.model
+	const model = msg.model ?? ctx.model?.id
+	if (model && model !== "unknown") tm.currentModel = model
 	// Always key timing by timestamp — it's set at message creation and never changes.
 	// responseId may not exist at message_start yet (assigned by provider mid-stream).
 	if (msg.timestamp != null) {
-		ctx.messageStartTimes.set(String(msg.timestamp), Date.now())
+		tm.messageStartTimes.set(String(msg.timestamp), Date.now())
 	}
 }
 
 export async function handleMessageEnd(
-	ctx: SessionContext,
-	event: { message: Record<string, unknown> },
+	tm: TelemetryContext,
+	ctx: ExtensionContext,
+	event: { message: Message },
 ): Promise<void> {
 	const msg = event.message
 	if (msg.role !== "assistant") return
 	try {
-		const assistant = msg as unknown as AssistantMessage
+		const assistant = msg
 		const msgId = assistant.responseId ? String(assistant.responseId) : String(assistant.timestamp)
-		if (ctx.sentMessages.has(msgId)) return
-		ctx.sentMessages.add(msgId)
+		if (tm.sentMessages.has(msgId)) return
+		tm.sentMessages.add(msgId)
 
-		const model = assistant.model ?? "unknown"
-		if (model !== "unknown") ctx.currentModel = model
+		const model = assistant.model ?? ctx.model?.id ?? "unknown"
+		if (model !== "unknown") tm.currentModel = model
 		const availableModels = getAvailableModels()
 		const meta = availableModels.find(
 			(m: { slug: string; provider?: string; limits?: { context_window?: number } }) => m.slug === model,
@@ -50,64 +50,74 @@ export async function handleMessageEnd(
 		const costTotal = assistant.usage?.cost?.total ?? 0
 		let startMs: number | undefined
 		if (assistant.timestamp != null) {
-			startMs = ctx.messageStartTimes.get(String(assistant.timestamp))
-			ctx.messageStartTimes.delete(String(assistant.timestamp))
+			startMs = tm.messageStartTimes.get(String(assistant.timestamp))
+			tm.messageStartTimes.delete(String(assistant.timestamp))
 		}
-		const durationMs = Date.now() - (startMs ?? ctx.sessionStartMs)
+		const durationMs = Date.now() - (startMs ?? tm.telemetryStartMs)
 
-		ctx.emit("api_request", {
-			model,
-			provider,
-			input_tokens: input,
-			output_tokens: output,
-			cache_read_tokens: cacheRead,
-			cache_creation_tokens: cacheWrite,
-			cost_usd: costTotal,
-			duration_ms: durationMs,
-		})
+		tm.emit(
+			"api_request",
+			{
+				provider,
+				input_tokens: input,
+				output_tokens: output,
+				cache_read_tokens: cacheRead,
+				cache_creation_tokens: cacheWrite,
+				cost_usd: costTotal,
+				duration_ms: durationMs,
+			},
+			ctx,
+		)
 
 		// Detect and emit transport errors (socket closed, connection reset, etc.)
-		handleTransportError(ctx, { message: assistant })
+		handleTransportError(tm, ctx, { message: assistant })
 
 		// Accumulate tokens/cost for cumulative metrics
-		if (!ctx.cumulative.tokensByModel[model]) {
-			ctx.cumulative.tokensByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+		if (!tm.cumulative.tokensByModel[model]) {
+			tm.cumulative.tokensByModel[model] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
 		}
-		const tokens = ctx.cumulative.tokensByModel[model]
+		const tokens = tm.cumulative.tokensByModel[model]
 		tokens.input += input
 		tokens.output += output
 		tokens.cacheRead += cacheRead
 		tokens.cacheWrite += cacheWrite
-		ctx.cumulative.costByModel[model] = (ctx.cumulative.costByModel[model] ?? 0) + costTotal
+		tm.cumulative.costByModel[model] = (tm.cumulative.costByModel[model] ?? 0) + costTotal
 	} catch (err) {
-		console.error("[telemetry] message_end handler error:", err)
+		console.error("[tm] message_end handler error:", err)
 	}
 }
 
-export function handleBeforeAgentStart(ctx: SessionContext, event: { prompt: string }): void {
-	ctx.emit("user_message", {
-		model: ctx.currentModel,
-		message_length: event.prompt.length,
-		turn_index: ctx.turnIndex,
-	})
+export function handleBeforeAgentStart(tm: TelemetryContext, ctx: ExtensionContext, event: { prompt: string }): void {
+	if (tm.currentModel === "unknown") {
+		const modelId = ctx.model?.id
+		if (modelId) tm.currentModel = modelId
+	}
+	tm.emit(
+		"user_message",
+		{
+			message_length: event.prompt.length,
+			turn_index: tm.turnIndex,
+		},
+		ctx,
+	)
 }
 
-export function handleAgentEnd(
-	ctx: SessionContext,
-	event: { messages?: { role?: string; content?: unknown[]; isError?: boolean }[] },
-): void {
+export function handleAgentEnd(tm: TelemetryContext, ctx: ExtensionContext, event: AgentEndEvent): void {
 	const messages = event.messages
 	if (!messages?.length) return
 	const last = messages[messages.length - 1]
-	if (last.role === "toolResult" && last.isError) {
-		const text = Array.isArray(last.content)
-			? ((last.content[0] as { text?: string } | undefined)?.text ?? "unknown error")
-			: "unknown error"
-		ctx.emit("error", {
-			model: ctx.currentModel,
+	if (last.role !== "toolResult" || !last.isError) return
+
+	const text = Array.isArray(last.content)
+		? ((last.content[0] as TextContent | undefined)?.text ?? "unknown error")
+		: "unknown error"
+	tm.emit(
+		"error",
+		{
 			error_type: "agent_error",
 			error_message: text.slice(0, 300),
-			turn_index: ctx.turnIndex,
-		})
-	}
+			turn_index: tm.turnIndex,
+		},
+		ctx,
+	)
 }

--- a/src/extensions/telemetry/handlers/session.test.ts
+++ b/src/extensions/telemetry/handlers/session.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../../config.js"
-import { _resetSharedAccumulators, SessionContext } from "../session-context.js"
-import { emitSessionStartEvent, handleSessionInitialized, handleSessionShutdown } from "./session.js"
+import { createContext } from "../../__mocks__/context.js"
+import { _resetSharedAccumulators, TelemetryContext } from "../session-context.js"
+import { emitSessionStartEvent, handleSessionShutdown, handleSessionStart } from "./session.js"
 
 vi.mock("../../ferment/index.js", () => ({
 	getActiveFerment: vi.fn(() => undefined),
@@ -22,7 +23,7 @@ function makeConfig(overrides: Partial<TelemetryConfig> = {}): TelemetryConfig {
 	}
 }
 
-describe("handleSessionInitialized", () => {
+describe("handleSessionStart", () => {
 	let originalFetch: typeof globalThis.fetch
 
 	beforeEach(() => {
@@ -40,17 +41,21 @@ describe("handleSessionInitialized", () => {
 		vi.restoreAllMocks()
 	})
 
-	it("resets context without emitting session.start", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		handleSessionInitialized(ctx, "claude-opus-4-6")
+	it("resets context and starts flush timer without emitting session.start", async () => {
+		const piCtx = createContext({ model: { id: "claude-opus-4-6" } })
+		const ctx = new TelemetryContext(makeConfig())
+		expect(ctx.flushTimer).toBeUndefined()
 
+		handleSessionStart(ctx, piCtx)
+
+		expect(ctx.flushTimer).toBeDefined()
 		expect(ctx.currentModel).toBe("claude-opus-4-6")
 
 		ctx.flushLogBuffer()
 		await Promise.allSettled([...ctx.inFlight])
 		ctx.stopFlushTimer()
 
-		// session.start should NOT be emitted by handleSessionInitialized
+		// session.start should NOT be emitted by handleSessionStart
 		expect(globalThis.fetch).not.toHaveBeenCalled()
 	})
 })
@@ -77,8 +82,9 @@ describe("handleSessionShutdown", () => {
 		const { getActiveFerment } = await import("../../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
-		await handleSessionShutdown(ctx, { reason: "user_exit" })
+		const piCtx = createContext()
+		const ctx = new TelemetryContext(makeConfig())
+		await handleSessionShutdown(ctx, piCtx, { reason: "user_exit" })
 
 		expect(globalThis.fetch).toHaveBeenCalled()
 		const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
@@ -101,8 +107,9 @@ describe("handleSessionShutdown", () => {
 		const { getActiveFerment } = await import("../../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue({ id: "ferment-abc" } as never)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
-		await handleSessionShutdown(ctx, { reason: "user_exit" })
+		const piCtx = createContext()
+		const ctx = new TelemetryContext(makeConfig())
+		await handleSessionShutdown(ctx, piCtx, { reason: "user_exit" })
 
 		expect(globalThis.fetch).toHaveBeenCalled()
 		const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
@@ -127,9 +134,10 @@ describe("handleSessionShutdown", () => {
 			.mockReturnValueOnce({ id: "f-drift" } as never)
 			.mockReturnValueOnce({ id: "f-drift" } as never)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const piCtx = createContext()
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("seed.event", {})
-		await handleSessionShutdown(ctx, { reason: "user_exit" })
+		await handleSessionShutdown(ctx, piCtx, { reason: "user_exit" })
 
 		const allRecords = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.flatMap(([, opts]: unknown[]) => {
 			const body = JSON.parse((opts as { body: string }).body)
@@ -175,9 +183,9 @@ describe("emitSessionStartEvent", () => {
 	})
 
 	it("emits session.start with correct model attribute", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		ctx.currentModel = "claude-opus-4-6"
-		emitSessionStartEvent(ctx)
+		const piCtx = createContext({ model: { id: "claude-opus-4-6" } })
+		const ctx = new TelemetryContext(makeConfig())
+		emitSessionStartEvent(ctx, piCtx)
 
 		ctx.flushLogBuffer()
 		await Promise.allSettled([...ctx.inFlight])

--- a/src/extensions/telemetry/handlers/session.ts
+++ b/src/extensions/telemetry/handlers/session.ts
@@ -1,24 +1,43 @@
-import type { SessionContext } from "../session-context.js"
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { TelemetryContext } from "../session-context.js"
 
-export function handleSessionInitialized(ctx: SessionContext, initialModel?: string): void {
-	ctx.reset(ctx.source)
-	if (initialModel) ctx.currentModel = initialModel
-	ctx.startFlushTimer()
+export function handleSessionStart(tm: TelemetryContext, ctx: ExtensionContext): void {
+	tm.reset()
+	if (ctx.model?.id) tm.currentModel = ctx.model.id
+	tm.startFlushTimer()
 }
 
-export function emitSessionStartEvent(ctx: SessionContext): void {
-	ctx.emit("session.start", { model: ctx.currentModel })
+export function emitSessionStartEvent(tm: TelemetryContext, ctx: ExtensionContext): void {
+	tm.emit("session.start", {}, ctx)
 }
 
-export async function handleSessionShutdown(ctx: SessionContext, event: { reason?: string }): Promise<void> {
-	const endedBy = event?.reason ?? "unknown"
-	ctx.emit("session.end", {
-		model: ctx.currentModel,
-		duration_ms: Date.now() - ctx.sessionStartMs,
-		ended_by: endedBy,
-		compaction_count: ctx.compactionCount,
-		turn_index: ctx.turnIndex,
-	})
-	ctx.flushLogBuffer()
-	await ctx.drain()
+export async function handleSessionShutdown(
+	tm: TelemetryContext,
+	ctx: ExtensionContext,
+	event: { reason?: string },
+): Promise<void> {
+	tm.emit(
+		"session.end",
+		{
+			duration_ms: Date.now() - tm.telemetryStartMs,
+			ended_by: event?.reason ?? "unknown",
+			compaction_count: tm.compactionCount,
+			turn_index: tm.turnIndex,
+		},
+		ctx,
+	)
+	tm.flushLogBuffer()
+	await tm.drain()
+}
+
+export function handleSessionCompact(tm: TelemetryContext, ctx: ExtensionContext): void {
+	tm.compactionCount++
+	tm.emit(
+		"session.compacted",
+		{
+			compaction_count: tm.compactionCount,
+			turn_index: tm.turnIndex,
+		},
+		ctx,
+	)
 }

--- a/src/extensions/telemetry/handlers/tools.test.ts
+++ b/src/extensions/telemetry/handlers/tools.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../../config.js"
-import { _resetSharedAccumulators, SessionContext } from "../session-context.js"
+import { createContext } from "../../__mocks__/context.js"
+import { _resetSharedAccumulators, TelemetryContext } from "../session-context.js"
 import { handleToolExecutionEnd, handleToolExecutionStart, resultSizeChars } from "./tools.js"
 
 vi.mock("../../../api/me.js", () => ({
@@ -61,12 +62,13 @@ describe("handlers/tools", () => {
 
 	describe("read tool", () => {
 		it("emits tool_result and kimchi.file_read with language and file_hash", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
-			ctx.currentModel = "claude-3-5-sonnet"
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
+			// model set via createContext above
 			const toolCallId = "tc-read-1"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts" } })
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			ctx.flushLogBuffer()
 			await Promise.allSettled([...ctx.inFlight])
@@ -87,11 +89,12 @@ describe("handlers/tools", () => {
 		})
 
 		it("does NOT emit kimchi.file_read when path is empty", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-read-2"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: {} })
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			ctx.flushLogBuffer()
 			await Promise.allSettled([...ctx.inFlight])
@@ -108,7 +111,8 @@ describe("handlers/tools", () => {
 
 	describe("write tool", () => {
 		it("emits tool_result and kimchi.file_written with lines_added, language, file_hash", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-write-1"
 
 			handleToolExecutionStart(ctx, {
@@ -116,7 +120,7 @@ describe("handlers/tools", () => {
 				toolName: "write",
 				args: { path: "/src/utils.py", content: "line1\nline2\nline3\n" },
 			})
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			ctx.flushLogBuffer()
 			await Promise.allSettled([...ctx.inFlight])
@@ -140,7 +144,8 @@ describe("handlers/tools", () => {
 
 	describe("edit tool", () => {
 		it("emits tool_result and kimchi.file_edited with file_hash, language, lines_added, lines_deleted", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-edit-1"
 
 			handleToolExecutionStart(ctx, {
@@ -148,7 +153,7 @@ describe("handlers/tools", () => {
 				toolName: "edit",
 				args: { path: "/src/main.go", edits: [{ oldText: "a\nb\nc", newText: "a\nx\ny\nz\nc" }] },
 			})
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			ctx.flushLogBuffer()
 			await Promise.allSettled([...ctx.inFlight])
@@ -173,11 +178,12 @@ describe("handlers/tools", () => {
 
 	describe("bash tool", () => {
 		it("emits tool_result and kimchi.command_executed", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-bash-1"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "bash", args: { command: "ls -la" } })
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			ctx.flushLogBuffer()
 			await Promise.allSettled([...ctx.inFlight])
@@ -195,11 +201,12 @@ describe("handlers/tools", () => {
 		})
 
 		it("emits kimchi.error on tool failure", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-bash-err"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "bash", args: { command: "false" } })
-			handleToolExecutionEnd(ctx, {
+			handleToolExecutionEnd(ctx, piCtx, {
 				toolCallId,
 				isError: true,
 				result: { content: [{ type: "text", text: "command failed with exit code 1" }] },
@@ -221,7 +228,7 @@ describe("handlers/tools", () => {
 			expect(error).toBeDefined()
 			expect(error?.attrs.error_type).toBe("tool_failure")
 			expect(error?.attrs.error_message).toBe("command failed with exit code 1")
-			expect(error?.attrs.model).toBe("unknown")
+			expect(error?.attrs.model).toBe("claude-3-5-sonnet")
 		})
 	})
 
@@ -231,7 +238,8 @@ describe("handlers/tools", () => {
 
 	describe("cumulative metrics", () => {
 		it("accumulates commit count for bash git commit", () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-commit"
 
 			handleToolExecutionStart(ctx, {
@@ -239,13 +247,14 @@ describe("handlers/tools", () => {
 				toolName: "bash",
 				args: { command: 'git commit -m "test"' },
 			})
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			expect(ctx.cumulative.commitCount).toBe(1)
 		})
 
 		it("accumulates LOC for edit tool", () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-edit-loc"
 
 			handleToolExecutionStart(ctx, {
@@ -253,7 +262,7 @@ describe("handlers/tools", () => {
 				toolName: "edit",
 				args: { path: "/src/app.ts", edits: [{ oldText: "a", newText: "a\nb\nc" }] },
 			})
-			handleToolExecutionEnd(ctx, { toolCallId, isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId, isError: false })
 
 			expect(ctx.cumulative.locByLanguage.TypeScript).toBeDefined()
 			expect(ctx.cumulative.locByLanguage.TypeScript.added).toBeGreaterThan(0)
@@ -266,26 +275,28 @@ describe("handlers/tools", () => {
 
 	describe("tool usage & duration tracking", () => {
 		it("accumulates tool usage count for each tool call", () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 
 			handleToolExecutionStart(ctx, { toolCallId: "b1", toolName: "bash", args: { command: "ls" } })
-			handleToolExecutionEnd(ctx, { toolCallId: "b1", isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId: "b1", isError: false })
 			handleToolExecutionStart(ctx, { toolCallId: "b2", toolName: "bash", args: { command: "pwd" } })
-			handleToolExecutionEnd(ctx, { toolCallId: "b2", isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId: "b2", isError: false })
 			handleToolExecutionStart(ctx, { toolCallId: "e1", toolName: "edit", args: { path: "a.ts" } })
-			handleToolExecutionEnd(ctx, { toolCallId: "e1", isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId: "e1", isError: false })
 
 			expect(ctx.cumulative.toolUsage.bash).toBe(2)
 			expect(ctx.cumulative.toolUsage.edit).toBe(1)
 		})
 
 		it("records tool start times and cleans them up on end", () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 
 			handleToolExecutionStart(ctx, { toolCallId: "b1", toolName: "bash", args: { command: "ls" } })
 			expect(ctx.toolStartTimes.has("b1")).toBe(true)
 
-			handleToolExecutionEnd(ctx, { toolCallId: "b1", isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId: "b1", isError: false })
 			expect(ctx.toolStartTimes.has("b1")).toBe(false)
 		})
 	})
@@ -318,13 +329,14 @@ describe("handlers/tools", () => {
 
 	describe("tool result size attrs", () => {
 		it("emits file_size_chars and read_is_truncated=false when no limit is set", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
-			ctx.currentModel = "claude-3-5-sonnet"
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
+			// model set via createContext above
 			const toolCallId = "tc-read-size"
 
 			// No limit arg — full file returned, not truncated
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts" } })
-			handleToolExecutionEnd(ctx, {
+			handleToolExecutionEnd(ctx, piCtx, {
 				toolCallId,
 				isError: false,
 				result: { content: [{ text: "file contents here" }] },
@@ -340,13 +352,14 @@ describe("handlers/tools", () => {
 		})
 
 		it("emits read_is_truncated=true when a limit arg is set", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
-			ctx.currentModel = "claude-3-5-sonnet"
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
+			// model set via createContext above
 			const toolCallId = "tc-read-limited"
 
 			// limit arg present — caller capped the lines, result may be truncated
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts", limit: 50 } })
-			handleToolExecutionEnd(ctx, {
+			handleToolExecutionEnd(ctx, piCtx, {
 				toolCallId,
 				isError: false,
 				result: { content: [{ text: "file contents here" }] },
@@ -361,11 +374,12 @@ describe("handlers/tools", () => {
 		})
 
 		it("emits bash_output_size_chars on command_executed", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-bash-size"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "bash", args: { command: "ls" } })
-			handleToolExecutionEnd(ctx, {
+			handleToolExecutionEnd(ctx, piCtx, {
 				toolCallId,
 				isError: false,
 				result: { content: [{ text: "file1.txt\nfile2.txt\n" }] },
@@ -380,11 +394,12 @@ describe("handlers/tools", () => {
 		})
 
 		it("emits tool_result_size_chars on tool_result", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			const toolCallId = "tc-read-size-tr"
 
 			handleToolExecutionStart(ctx, { toolCallId, toolName: "read", args: { path: "/src/app.ts" } })
-			handleToolExecutionEnd(ctx, {
+			handleToolExecutionEnd(ctx, piCtx, {
 				toolCallId,
 				isError: false,
 				result: { content: [{ text: "hello world" }] },
@@ -405,9 +420,10 @@ describe("handlers/tools", () => {
 
 	describe("edge cases", () => {
 		it("ignores toolCallId not found in pendingArgs", async () => {
-			const ctx = new SessionContext(makeConfig(), "cli")
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
 			// No start call, just end — should not throw
-			handleToolExecutionEnd(ctx, { toolCallId: "unknown-id", isError: false })
+			handleToolExecutionEnd(ctx, piCtx, { toolCallId: "unknown-id", isError: false })
 
 			await Promise.allSettled([...ctx.inFlight])
 			expect(fetchMock).not.toHaveBeenCalled()

--- a/src/extensions/telemetry/handlers/tools.ts
+++ b/src/extensions/telemetry/handlers/tools.ts
@@ -1,3 +1,4 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { accumulateToolUsage, handleBashCumulativeMetrics, handleEditCumulativeMetrics } from "../accumulator.js"
 import {
 	computeLineChanges,
@@ -7,7 +8,7 @@ import {
 	inferLanguage,
 	type ToolArgs,
 } from "../helpers.js"
-import type { SessionContext } from "../session-context.js"
+import type { TelemetryContext } from "../session-context.js"
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -23,126 +24,150 @@ export function resultSizeChars(result: unknown): number {
 // ---------------------------------------------------------------------------
 
 export function handleToolExecutionStart(
-	ctx: SessionContext,
+	tm: TelemetryContext,
 	event: { toolCallId: string; toolName: string; args: unknown },
 ): void {
-	ctx.pendingArgs.set(event.toolCallId, { toolName: event.toolName, args: event.args })
-	ctx.toolStartTimes.set(event.toolCallId, Date.now())
+	tm.pendingArgs.set(event.toolCallId, { toolName: event.toolName, args: event.args })
+	tm.toolStartTimes.set(event.toolCallId, Date.now())
 }
 
 export function handleToolExecutionEnd(
-	ctx: SessionContext,
+	tm: TelemetryContext,
+	ctx: ExtensionContext,
 	event: { toolCallId: string; isError?: boolean; result?: unknown },
 ): void {
-	const pending = ctx.pendingArgs.get(event.toolCallId)
+	const pending = tm.pendingArgs.get(event.toolCallId)
 	if (!pending) return
-	ctx.pendingArgs.delete(event.toolCallId)
+	tm.pendingArgs.delete(event.toolCallId)
 
 	const { toolName, args: rawArgs } = pending
 	const args = (rawArgs ?? {}) as ToolArgs
-	const toolDurationMs = Date.now() - (ctx.toolStartTimes.get(event.toolCallId) ?? ctx.sessionStartMs)
+	const toolDurationMs = Date.now() - (tm.toolStartTimes.get(event.toolCallId) ?? tm.telemetryStartMs)
 
 	// --- Tool usage & duration (all tools) ------------------------------------
-	const startMs = ctx.toolStartTimes.get(event.toolCallId) ?? Date.now()
-	ctx.toolStartTimes.delete(event.toolCallId)
-	accumulateToolUsage(ctx.cumulative, toolName, Date.now() - startMs)
+	const startMs = tm.toolStartTimes.get(event.toolCallId) ?? Date.now()
+	tm.toolStartTimes.delete(event.toolCallId)
+	accumulateToolUsage(tm.cumulative, toolName, Date.now() - startMs)
 
 	// --- Cumulative metrics ---------------------------------------------------
 	if (toolName === "bash") {
-		handleBashCumulativeMetrics(ctx.cumulative, args)
+		handleBashCumulativeMetrics(tm.cumulative, args)
 	} else if (["edit", "multiedit", "patch", "write"].includes(toolName)) {
-		handleEditCumulativeMetrics(ctx.cumulative, toolName, args)
+		handleEditCumulativeMetrics(tm.cumulative, toolName, args)
 	}
 
 	// --- Per-tool events ------------------------------------------------------
 
-	const model = ctx.currentModel
 	const sizeChars = resultSizeChars(event.result)
 
 	if (toolName === "read" && !event.isError) {
 		const filePath = extractFilePath(args)
 		if (filePath) {
-			ctx.emit("tool_result", {
-				tool_name: "read",
-				model,
-				success: true,
-				duration_ms: toolDurationMs,
-				tool_result_size_chars: sizeChars,
-				turn_index: ctx.turnIndex,
-			})
-			ctx.emit("file_read", {
-				model,
-				language: inferLanguage(filePath),
-				file_hash: hashFilePath(filePath),
-				duration_ms: toolDurationMs,
-				file_size_chars: sizeChars,
-				// read_is_truncated signals that the caller passed a `limit` arg, capping
-				// the number of lines returned. A limited read may have omitted content
-				// that would otherwise have been returned. Reads without a limit return
-				// the full file (up to the built-in size cap), so they are not truncated.
-				read_is_truncated: !!args?.limit,
-				turn_index: ctx.turnIndex,
-			})
+			tm.emit(
+				"tool_result",
+				{
+					tool_name: "read",
+					success: true,
+					duration_ms: toolDurationMs,
+					tool_result_size_chars: sizeChars,
+					turn_index: tm.turnIndex,
+				},
+				ctx,
+			)
+			tm.emit(
+				"file_read",
+				{
+					language: inferLanguage(filePath),
+					file_hash: hashFilePath(filePath),
+					duration_ms: toolDurationMs,
+					file_size_chars: sizeChars,
+					// read_is_truncated signals that the caller passed a `limit` arg, capping
+					// the number of lines returned. A limited read may have omitted content
+					// that would otherwise have been returned. Reads without a limit return
+					// the full file (up to the built-in size cap), so they are not truncated.
+					read_is_truncated: !!args?.limit,
+					turn_index: tm.turnIndex,
+				},
+				ctx,
+			)
 		}
 	} else if (toolName === "write" && !event.isError) {
 		const filePath = extractFilePath(args)
-		ctx.emit("tool_result", {
-			tool_name: "write",
-			model,
-			success: true,
-			duration_ms: toolDurationMs,
-			tool_result_size_chars: sizeChars,
-			turn_index: ctx.turnIndex,
-		})
-		if (filePath) {
-			ctx.emit("file_written", {
-				model,
-				language: inferLanguage(filePath),
-				file_hash: hashFilePath(filePath),
-				lines_added: computeWriteLines(args),
+		tm.emit(
+			"tool_result",
+			{
+				tool_name: "write",
+				success: true,
 				duration_ms: toolDurationMs,
-				turn_index: ctx.turnIndex,
-			})
+				tool_result_size_chars: sizeChars,
+				turn_index: tm.turnIndex,
+			},
+			ctx,
+		)
+		if (filePath) {
+			tm.emit(
+				"file_written",
+				{
+					language: inferLanguage(filePath),
+					file_hash: hashFilePath(filePath),
+					lines_added: computeWriteLines(args),
+					duration_ms: toolDurationMs,
+					turn_index: tm.turnIndex,
+				},
+				ctx,
+			)
 		}
 	} else if (["edit", "multiedit", "patch"].includes(toolName) && !event.isError) {
-		ctx.emit("tool_result", {
-			tool_name: toolName,
-			model,
-			success: true,
-			duration_ms: toolDurationMs,
-			tool_result_size_chars: sizeChars,
-			turn_index: ctx.turnIndex,
-		})
+		tm.emit(
+			"tool_result",
+			{
+				tool_name: toolName,
+				success: true,
+				duration_ms: toolDurationMs,
+				tool_result_size_chars: sizeChars,
+				turn_index: tm.turnIndex,
+			},
+			ctx,
+		)
 		const filePath = extractFilePath(args)
 		const changes = computeLineChanges(toolName, args)
 		if (filePath) {
-			ctx.emit("file_edited", {
-				model,
-				language: inferLanguage(filePath),
-				file_hash: hashFilePath(filePath),
-				lines_added: changes.added,
-				lines_deleted: changes.removed,
-				duration_ms: toolDurationMs,
-				turn_index: ctx.turnIndex,
-			})
+			tm.emit(
+				"file_edited",
+				{
+					language: inferLanguage(filePath),
+					file_hash: hashFilePath(filePath),
+					lines_added: changes.added,
+					lines_deleted: changes.removed,
+					duration_ms: toolDurationMs,
+					turn_index: tm.turnIndex,
+				},
+				ctx,
+			)
 		}
 	} else if (toolName === "bash") {
-		ctx.emit("tool_result", {
-			tool_name: "bash",
-			model,
-			success: !event.isError,
-			duration_ms: toolDurationMs,
-			tool_result_size_chars: sizeChars,
-			turn_index: ctx.turnIndex,
-		})
-		ctx.emit("command_executed", {
-			model,
-			command_type: "bash",
-			exit_code: event.isError ? 1 : 0,
-			duration_ms: toolDurationMs,
-			bash_output_size_chars: sizeChars,
-			turn_index: ctx.turnIndex,
-		})
+		tm.emit(
+			"tool_result",
+			{
+				tool_name: "bash",
+				success: !event.isError,
+				duration_ms: toolDurationMs,
+				tool_result_size_chars: sizeChars,
+				turn_index: tm.turnIndex,
+			},
+			ctx,
+		)
+		tm.emit(
+			"command_executed",
+			{
+				command_type: "bash",
+				exit_code: event.isError ? 1 : 0,
+				duration_ms: toolDurationMs,
+				bash_output_size_chars: sizeChars,
+				turn_index: tm.turnIndex,
+			},
+			ctx,
+		)
 	}
 
 	// --- Error tracking -------------------------------------------------------
@@ -160,12 +185,15 @@ export function handleToolExecutionEnd(
 				.join("\n")
 				.slice(0, 300)
 		}
-		ctx.emit("error", {
-			model,
-			error_type: "tool_failure",
-			tool_name: toolName,
-			error_message: errorMsg,
-			turn_index: ctx.turnIndex,
-		})
+		tm.emit(
+			"error",
+			{
+				error_type: "tool_failure",
+				tool_name: toolName,
+				error_message: errorMsg,
+				turn_index: tm.turnIndex,
+			},
+			ctx,
+		)
 	}
 }

--- a/src/extensions/telemetry/handlers/transport-errors.test.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.test.ts
@@ -1,71 +1,85 @@
+// @ts-nocheck
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
-import type { SessionContext } from "../session-context.js"
+import { createContext } from "../../__mocks__/context.js"
+import type { TelemetryContext } from "../session-context.js"
 import { handleTransportError } from "./transport-errors.js"
 
-function mockCtx(): Pick<SessionContext, "emit"> {
+function mockSessionCtx(): Pick<TelemetryContext, "emit"> {
 	return {
 		emit: vi.fn(),
 	}
 }
 
+function mockPiCtx(overrides?: { sessionId?: string; model?: string }): ExtensionContext {
+	return createContext({
+		sessionManager: { getSessionId: () => overrides?.sessionId ?? "test-session" },
+		model: { id: overrides?.model ?? "unknown" },
+	})
+}
+
 describe("handleTransportError", () => {
 	it("does not emit when role is not assistant", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "user", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
 		})
-		expect(ctx.emit).not.toHaveBeenCalled()
+		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when stopReason is not error", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "stop", errorMessage: "socket connection was closed unexpectedly" },
 		})
-		expect(ctx.emit).not.toHaveBeenCalled()
+		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when stopReason is aborted (user cancelled)", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "aborted", errorMessage: "socket connection was closed unexpectedly" },
 		})
-		expect(ctx.emit).not.toHaveBeenCalled()
+		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
 
 	it("does not emit when errorMessage is not a transport error", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "something went wrong" },
 		})
-		expect(ctx.emit).not.toHaveBeenCalled()
+		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
 
 	it("emits error with error_type transport_error for socket connection was closed unexpectedly", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		const piCtx = mockPiCtx({ sessionId: "sess-1", model: "kimi-k2.6" })
+		const errorMessage =
+			"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"
+		handleTransportError(sessionCtx as TelemetryContext, piCtx, {
 			message: {
 				role: "assistant",
 				model: "kimi-k2.6",
 				provider: "kimchi-dev",
 				api: "openai-completions",
 				stopReason: "error",
-				errorMessage:
-					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+				errorMessage,
 			},
 		})
-		expect(ctx.emit).toHaveBeenCalledTimes(1)
-		expect(ctx.emit).toHaveBeenCalledWith("error", {
-			model: "kimi-k2.6",
-			error_type: "transport_error",
-			error_message:
-				"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
-		})
+		expect(sessionCtx.emit).toHaveBeenCalledTimes(1)
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
+			"error",
+			{
+				error_type: "transport_error",
+				error_message: errorMessage,
+			},
+			piCtx,
+		)
 	})
 
 	it("emits error case-insensitively", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: {
 				role: "assistant",
 				model: "claude-sonnet-4-20250514",
@@ -73,15 +87,16 @@ describe("handleTransportError", () => {
 				errorMessage: "THE SOCKET CONNECTION WAS CLOSED UNEXPECTEDLY",
 			},
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: expect.any(String) }),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for connection reset", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: {
 				role: "assistant",
 				model: "claude-sonnet-4-20250514",
@@ -89,89 +104,99 @@ describe("handleTransportError", () => {
 				errorMessage: "Connection reset by peer",
 			},
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: "Connection reset by peer" }),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for socket closed", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "socket closed" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: "socket closed" }),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for connection closed", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "connection closed" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: "connection closed" }),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for econnreset", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "read ECONNRESET" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: "read ECONNRESET" }),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for econnrefused", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "connect ECONNREFUSED 127.0.0.1:443" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({
 				error_type: "transport_error",
 				error_message: "connect ECONNREFUSED 127.0.0.1:443",
 			}),
+			expect.anything(),
 		)
 	})
 
 	it("emits error for broken pipe", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: "Broken pipe" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith(
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
 			expect.objectContaining({ error_type: "transport_error", error_message: "Broken pipe" }),
+			expect.anything(),
 		)
 	})
 
 	it("handles missing optional fields gracefully", () => {
-		const ctx = mockCtx()
-		handleTransportError(ctx as SessionContext, {
+		const sessionCtx = mockSessionCtx()
+		const piCtx = mockPiCtx({ sessionId: "sess-2" })
+		handleTransportError(sessionCtx as TelemetryContext, piCtx, {
 			message: { role: "assistant", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
 		})
-		expect(ctx.emit).toHaveBeenCalledWith("error", {
-			model: "unknown",
-			error_type: "transport_error",
-			error_message: "socket connection was closed unexpectedly",
-		})
+		expect(sessionCtx.emit).toHaveBeenCalledWith(
+			"error",
+			{
+				error_type: "transport_error",
+				error_message: "socket connection was closed unexpectedly",
+			},
+			piCtx,
+		)
 	})
 
 	it("truncates error_message to 300 chars", () => {
-		const ctx = mockCtx()
+		const sessionCtx = mockSessionCtx()
 		const longMessage = `socket connection was closed unexpectedly ${"x".repeat(400)}`
-		handleTransportError(ctx as SessionContext, {
+		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
 			message: { role: "assistant", stopReason: "error", errorMessage: longMessage },
 		})
-		const emitted = (ctx.emit as ReturnType<typeof vi.fn>).mock.calls[0][1] as { error_message: string }
+		const emitted = (sessionCtx.emit as ReturnType<typeof vi.fn>).mock.calls[0][1] as { error_message: string }
 		expect(emitted.error_message.length).toBe(300)
 		expect(emitted.error_message.endsWith("xxx")).toBe(true)
 	})

--- a/src/extensions/telemetry/handlers/transport-errors.test.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.test.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import { createContext } from "../../__mocks__/context.js"
@@ -19,18 +19,14 @@ function mockPiCtx(overrides?: { sessionId?: string; model?: string }): Extensio
 }
 
 describe("handleTransportError", () => {
-	it("does not emit when role is not assistant", () => {
-		const sessionCtx = mockSessionCtx()
-		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "user", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
-		})
-		expect(sessionCtx.emit).not.toHaveBeenCalled()
-	})
-
 	it("does not emit when stopReason is not error", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "stop", errorMessage: "socket connection was closed unexpectedly" },
+			message: {
+				role: "assistant",
+				stopReason: "stop",
+				errorMessage: "socket connection was closed unexpectedly",
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
@@ -38,7 +34,11 @@ describe("handleTransportError", () => {
 	it("does not emit when stopReason is aborted (user cancelled)", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "aborted", errorMessage: "socket connection was closed unexpectedly" },
+			message: {
+				role: "assistant",
+				stopReason: "aborted",
+				errorMessage: "socket connection was closed unexpectedly",
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
@@ -46,7 +46,7 @@ describe("handleTransportError", () => {
 	it("does not emit when errorMessage is not a transport error", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "something went wrong" },
+			message: { role: "assistant", stopReason: "error", errorMessage: "something went wrong" } as AssistantMessage,
 		})
 		expect(sessionCtx.emit).not.toHaveBeenCalled()
 	})
@@ -64,7 +64,7 @@ describe("handleTransportError", () => {
 				api: "openai-completions",
 				stopReason: "error",
 				errorMessage,
-			},
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledTimes(1)
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
@@ -85,7 +85,7 @@ describe("handleTransportError", () => {
 				model: "claude-sonnet-4-20250514",
 				stopReason: "error",
 				errorMessage: "THE SOCKET CONNECTION WAS CLOSED UNEXPECTEDLY",
-			},
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -102,7 +102,7 @@ describe("handleTransportError", () => {
 				model: "claude-sonnet-4-20250514",
 				stopReason: "error",
 				errorMessage: "Connection reset by peer",
-			},
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -114,7 +114,7 @@ describe("handleTransportError", () => {
 	it("emits error for socket closed", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "socket closed" },
+			message: { role: "assistant", stopReason: "error", errorMessage: "socket closed" } as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -126,7 +126,7 @@ describe("handleTransportError", () => {
 	it("emits error for connection closed", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "connection closed" },
+			message: { role: "assistant", stopReason: "error", errorMessage: "connection closed" } as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -138,7 +138,7 @@ describe("handleTransportError", () => {
 	it("emits error for econnreset", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "read ECONNRESET" },
+			message: { role: "assistant", stopReason: "error", errorMessage: "read ECONNRESET" } as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -150,7 +150,11 @@ describe("handleTransportError", () => {
 	it("emits error for econnrefused", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "connect ECONNREFUSED 127.0.0.1:443" },
+			message: {
+				role: "assistant",
+				stopReason: "error",
+				errorMessage: "connect ECONNREFUSED 127.0.0.1:443",
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -165,7 +169,7 @@ describe("handleTransportError", () => {
 	it("emits error for broken pipe", () => {
 		const sessionCtx = mockSessionCtx()
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: "Broken pipe" },
+			message: { role: "assistant", stopReason: "error", errorMessage: "Broken pipe" } as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -178,7 +182,11 @@ describe("handleTransportError", () => {
 		const sessionCtx = mockSessionCtx()
 		const piCtx = mockPiCtx({ sessionId: "sess-2" })
 		handleTransportError(sessionCtx as TelemetryContext, piCtx, {
-			message: { role: "assistant", stopReason: "error", errorMessage: "socket connection was closed unexpectedly" },
+			message: {
+				role: "assistant",
+				stopReason: "error",
+				errorMessage: "socket connection was closed unexpectedly",
+			} as AssistantMessage,
 		})
 		expect(sessionCtx.emit).toHaveBeenCalledWith(
 			"error",
@@ -194,7 +202,7 @@ describe("handleTransportError", () => {
 		const sessionCtx = mockSessionCtx()
 		const longMessage = `socket connection was closed unexpectedly ${"x".repeat(400)}`
 		handleTransportError(sessionCtx as TelemetryContext, mockPiCtx(), {
-			message: { role: "assistant", stopReason: "error", errorMessage: longMessage },
+			message: { role: "assistant", stopReason: "error", errorMessage: longMessage } as AssistantMessage,
 		})
 		const emitted = (sessionCtx.emit as ReturnType<typeof vi.fn>).mock.calls[0][1] as { error_message: string }
 		expect(emitted.error_message.length).toBe(300)

--- a/src/extensions/telemetry/handlers/transport-errors.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.ts
@@ -1,4 +1,6 @@
-import type { SessionContext } from "../session-context.js"
+import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { TelemetryContext } from "../session-context.js"
 
 const TRANSPORT_ERROR_PATTERNS = [
 	"socket connection was closed unexpectedly",
@@ -17,26 +19,21 @@ function isTransportError(errorMessage: string | undefined): boolean {
 }
 
 export function handleTransportError(
-	ctx: SessionContext,
-	event: {
-		message: {
-			role?: string
-			model?: string
-			provider?: string
-			api?: string
-			stopReason?: string
-			errorMessage?: string
-		}
-	},
+	tm: TelemetryContext,
+	ctx: ExtensionContext,
+	event: { message: AssistantMessage },
 ): void {
 	const msg = event.message
 	if (msg.role !== "assistant") return
 	if (msg.stopReason !== "error") return
 	if (!isTransportError(msg.errorMessage)) return
 
-	ctx.emit("error", {
-		model: msg.model ?? "unknown",
-		error_type: "transport_error",
-		error_message: (msg.errorMessage ?? "").slice(0, 300),
-	})
+	tm.emit(
+		"error",
+		{
+			error_type: "transport_error",
+			error_message: (msg.errorMessage ?? "").slice(0, 300),
+		},
+		ctx,
+	)
 }

--- a/src/extensions/telemetry/handlers/transport-errors.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.ts
@@ -24,7 +24,6 @@ export function handleTransportError(
 	event: { message: AssistantMessage },
 ): void {
 	const msg = event.message
-	if (msg.role !== "assistant") return
 	if (msg.stopReason !== "error") return
 	if (!isTransportError(msg.errorMessage)) return
 

--- a/src/extensions/telemetry/handlers/utils.ts
+++ b/src/extensions/telemetry/handlers/utils.ts
@@ -1,0 +1,43 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { getAcpClientInfo } from "../../../modes/acp/state.js"
+import { getProcessMultiModelEnabled } from "../../kimchi-process.js"
+import { getPermissionMode } from "../../permissions/mode-controller.js"
+import type { TelemetryAttributes } from "../session-context.js"
+
+export function getAcpAttributes(): { acp_client_name: string; acp_client_version: string } | undefined {
+	const acpClientInfo = getAcpClientInfo()
+	if (acpClientInfo) {
+		return {
+			acp_client_name: acpClientInfo.name,
+			acp_client_version: acpClientInfo.version,
+		}
+	}
+	return undefined
+}
+
+/**
+ * Returns session attributes common to this session,
+ * derived from the active extension context.
+ */
+export function getPiSessionAttributes(ctx: ExtensionContext): TelemetryAttributes {
+	const sessionId = ctx.sessionManager.getSessionId()
+	const attrs: TelemetryAttributes = {
+		pi_session_id: sessionId,
+		pi_mode: ctx.mode,
+	}
+	const modelId = ctx.model?.id
+	if (modelId !== undefined) {
+		attrs.model = modelId
+	}
+	const permissionMode = getPermissionMode(sessionId)?.mode
+	if (permissionMode !== undefined) {
+		attrs.permission_mode = permissionMode
+	}
+	// Using the process flag to avoid querying the configuration file
+	// in the case that the flag hasn't been persisted yet (slow).
+	const multiModel = getProcessMultiModelEnabled(sessionId)
+	if (multiModel !== undefined) {
+		attrs.multi_model_enabled = multiModel
+	}
+	return attrs
+}

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -1,6 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../config.js"
+import { resetAcpClientInfo, setAcpClientInfo } from "../../modes/acp/state.js"
+import { createContext } from "../__mocks__/context.js"
 import telemetryExtension, {
 	trackSubagentSpawned,
 	trackSurveyAnswered,
@@ -38,11 +40,13 @@ const TEST_SURVEY = {
 
 type Handler = (...args: unknown[]) => Promise<void> | void
 
-function createMockApi() {
+function createMockApi(sessionId = "test-session") {
 	const handlers = new Map<string, Handler[]>()
+	const mockCtx = createContext({ sessionManager: { getSessionId: () => sessionId } })
 	const on = vi.fn((event: string, handler: Handler) => {
 		if (!handlers.has(event)) handlers.set(event, [])
-		handlers.get(event)?.push(handler)
+		const wrapped: Handler = (...args: unknown[]) => handler(args[0], mockCtx)
+		handlers.get(event)?.push(wrapped)
 	})
 	// pi.events: a minimal EventBus stub so the telemetry extension can
 	// subscribe to ferment domain events without throwing.
@@ -86,11 +90,13 @@ describe("telemetryExtension integration", () => {
 		originalFetch = globalThis.fetch
 		// biome-ignore lint/suspicious/noExplicitAny: test mock
 		globalThis.fetch = fetchMock as any
+		resetAcpClientInfo()
 	})
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch
 		_resetSharedAccumulators()
+		resetAcpClientInfo()
 	})
 
 	it("registers all expected event handlers when enabled", () => {
@@ -159,13 +165,38 @@ describe("telemetryExtension integration", () => {
 
 		for (const rec of allRecords) {
 			const attrs = Object.fromEntries(rec.attributes.map((a) => [a.key, a.value.stringValue]))
-			expect(attrs.model).toBe("claude-opus-4-6")
 			expect(attrs.session_type).toBe("coding")
 			expect(attrs.ferment_id).toBe("")
 		}
 
 		const metricsCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes("/metrics"))
 		expect(metricsCalls.length).toBeGreaterThan(0)
+	})
+
+	it("emits ACP client_name and client_version when ACP client info is set", async () => {
+		const { handlers, api } = createMockApi()
+		setAcpClientInfo({ name: "kimchi-vscode", version: "0.0.1" })
+		telemetryExtension(makeConfig())(api)
+
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "session_shutdown")({ reason: "disconnect" })
+
+		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
+		const allRecords = logCalls.flatMap(([, opts]: unknown[]) => {
+			const body = JSON.parse((opts as { body: string }).body)
+			return body.resourceLogs[0].scopeLogs[0].logRecords as Array<{
+				eventName: string
+				attributes: Array<{ key: string; value: { stringValue: string } }>
+			}>
+		})
+		// session.start is emitted only once per process, so assert on
+		// user_message (which always has a pi context) instead.
+		const userMessage = allRecords.find((rec) => rec.eventName === "user_message")
+		expect(userMessage).toBeDefined()
+		const attrs = Object.fromEntries(userMessage?.attributes.map((a) => [a.key, a.value.stringValue]) ?? [])
+		expect(attrs.acp_client_name).toBe("kimchi-vscode")
+		expect(attrs.acp_client_version).toBe("0.0.1")
 	})
 
 	it("trackSubagentSpawned sends kimchi.subagent.spawned with source and session_type", async () => {
@@ -190,7 +221,6 @@ describe("telemetryExtension integration", () => {
 		const attrs = Object.fromEntries(subagentRecord?.attributes.map((a) => [a.key, a.value.stringValue]) ?? [])
 		expect(attrs.agent_type).toBe("explore")
 		expect(attrs.reason).toBe("find files")
-		expect(attrs.model).toBe("claude-opus-4-6")
 		expect(attrs.source).toBe("cli")
 		expect(attrs.session_type).toBe("coding")
 		expect(attrs.ferment_id).toBe("")
@@ -199,6 +229,8 @@ describe("telemetryExtension integration", () => {
 	it("survey tracking helpers send survey events through the telemetry batch", async () => {
 		const { handlers, api } = createMockApi()
 		telemetryExtension(makeConfig())(api)
+
+		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
 
 		const submissionId = "submission-1"
 		trackSurveyShown({ survey: TEST_SURVEY })
@@ -267,7 +299,7 @@ describe("telemetryExtension integration", () => {
 
 		expect(headers["User-Agent"]).toBe("kimchi/1.0")
 		expect(typeof headers["X-Session-Id"]).toBe("string")
-		expect(headers["X-Session-Id"]).toMatch(/^[0-9a-f-]{36}$/)
+		expect(headers["X-Session-Id"]).toBeTruthy()
 		expect(headers["X-Turn-Index"]).toBe("4")
 	})
 })
@@ -331,7 +363,6 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		expect(attrs.ferment_id).toBe("f-001")
 		expect(attrs.ferment_name).toBe("My Ferment")
 		expect(attrs.phase_count).toBe("3")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 		expect(attrs["session.id"]).toBeDefined()
 	})
 
@@ -363,7 +394,6 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		expect(attrs.grade).toBe("A")
 		expect(attrs.steering_count).toBe("2")
 		expect(attrs.block_retries).toBe("1")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 	})
 
 	it("ferment:completed without grade omits grade attr", async () => {
@@ -415,7 +445,6 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		const attrs = attrsOf(rec as NonNullable<typeof rec>)
 		expect(attrs.ferment_id).toBe("f-004")
 		expect(attrs.reason).toBe("judge failed")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 		// New diagnostic fields
 		expect(attrs.lifecycle_stage).toBe("running")
 		expect(attrs.scoping_complete).toBe("true")
@@ -485,7 +514,6 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 		expect(attrs.completed_phases).toBe("2")
 		expect(attrs.total_phases).toBe("4")
 		expect(attrs.phase_completion_ratio).toBe("0.5")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 	})
 
 	it("ferment:stalled → ferment.stalled event emitted for crash-recovery path", async () => {
@@ -1109,7 +1137,6 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 		// Raw command text must not leak into OTLP — only structured fields.
 		expect(attrs.segment_preview).toBeUndefined()
 		expect(attrs.matchedSegment).toBeUndefined()
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 	})
 
 	it("bash_tool_guard:block → bash_tool_guard.block OTLP record with tool", async () => {
@@ -1232,7 +1259,6 @@ describe("loop-guard telemetry via pi.events", () => {
 		expect(attrs.detector).toBe("edit_run")
 		expect(attrs.count).toBe("3")
 		expect(attrs.is_subagent).toBe("true")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 		// No raw args/command text must leak into OTLP.
 		expect(attrs.reason).toBeUndefined()
 		expect(attrs.toolArgs).toBeUndefined()
@@ -1255,7 +1281,6 @@ describe("loop-guard telemetry via pi.events", () => {
 		expect(attrs.detector).toBe("consecutive_identical")
 		expect(attrs.count).toBe("1")
 		expect(attrs.is_subagent).toBe("true")
-		expect(attrs.model).toBe("claude-sonnet-4-6")
 	})
 
 	it("does NOT emit OTLP records when telemetry is disabled", async () => {

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -42,10 +42,10 @@ type Handler = (...args: unknown[]) => Promise<void> | void
 
 function createMockApi(sessionId = "test-session") {
 	const handlers = new Map<string, Handler[]>()
-	const mockCtx = createContext({ sessionManager: { getSessionId: () => sessionId } })
+	const ctx = createContext({ sessionManager: { getSessionId: () => sessionId }, model: { id: "claude-opus-4-6" } })
 	const on = vi.fn((event: string, handler: Handler) => {
 		if (!handlers.has(event)) handlers.set(event, [])
-		const wrapped: Handler = (...args: unknown[]) => handler(args[0], mockCtx)
+		const wrapped: Handler = (...args: unknown[]) => handler(args[0], ctx)
 		handlers.get(event)?.push(wrapped)
 	})
 	// pi.events: a minimal EventBus stub so the telemetry extension can
@@ -61,7 +61,7 @@ function createMockApi(sessionId = "test-session") {
 			return () => {}
 		},
 	}
-	return { on, handlers, events, api: { on, events } as unknown as ExtensionAPI }
+	return { on, handlers, events, api: { on, events } as unknown as ExtensionAPI, ctx }
 }
 
 function getHandler(handlers: Map<string, Handler[]>, event: string): Handler {
@@ -119,12 +119,11 @@ describe("telemetryExtension integration", () => {
 	})
 
 	it("full session lifecycle: start -> message -> tool -> shutdown", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
 
-		const mockExtCtx = { model: { id: "claude-opus-4-6" } }
-		await getHandler(handlers, "session_start")({}, mockExtCtx)
-		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, mockExtCtx)
+		await getHandler(handlers, "session_start")({}, ctx)
+		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, ctx)
 
 		await getHandler(
 			handlers,
@@ -174,12 +173,12 @@ describe("telemetryExtension integration", () => {
 	})
 
 	it("emits ACP client_name and client_version when ACP client info is set", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		setAcpClientInfo({ name: "kimchi-vscode", version: "0.0.1" })
 		telemetryExtension(makeConfig())(api)
 
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
-		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
+		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, ctx)
 		await getHandler(handlers, "session_shutdown")({ reason: "disconnect" })
 
 		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
@@ -200,12 +199,13 @@ describe("telemetryExtension integration", () => {
 	})
 
 	it("trackSubagentSpawned sends kimchi.subagent.spawned with source and session_type", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
-		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, { model: { id: "claude-opus-4-6" } })
 
-		await trackSubagentSpawned({ id: "a1", type: "explore", description: "find files" })
+		await getHandler(handlers, "session_start")({}, ctx)
+		await getHandler(handlers, "before_agent_start")({ prompt: "hello" }, ctx)
+
+		await trackSubagentSpawned({ id: "a1", type: "explore", description: "find files" }, ctx)
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
 
 		const logCalls = fetchMock.mock.calls.filter(([url]: unknown[]) => String(url).includes("/logs"))
@@ -219,18 +219,30 @@ describe("telemetryExtension integration", () => {
 		const subagentRecord = allRecords.find((rec) => rec.eventName === "subagent.spawned")
 		expect(subagentRecord).toBeDefined()
 		const attrs = Object.fromEntries(subagentRecord?.attributes.map((a) => [a.key, a.value.stringValue]) ?? [])
-		expect(attrs.agent_type).toBe("explore")
-		expect(attrs.reason).toBe("find files")
-		expect(attrs.source).toBe("cli")
-		expect(attrs.session_type).toBe("coding")
-		expect(attrs.ferment_id).toBe("")
+		expect(attrs).toEqual({
+			agent_type: "explore",
+			client: "pi",
+			ferment_id: "",
+			model: "claude-opus-4-6",
+			pi_mode: "tui",
+			pi_session_id: "test-session",
+			reason: "find files",
+			"session.id": expect.any(String),
+			session_type: "coding",
+			source: "cli",
+			"telemetry.arch": expect.any(String),
+			"telemetry.host_os": expect.any(String),
+			"telemetry.is_wsl": expect.any(String),
+			"telemetry.os": expect.any(String),
+			"user.account_uuid": "",
+		})
 	})
 
 	it("survey tracking helpers send survey events through the telemetry batch", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
 
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 
 		const submissionId = "submission-1"
 		trackSurveyShown({ survey: TEST_SURVEY })
@@ -275,9 +287,9 @@ describe("telemetryExtension integration", () => {
 	})
 
 	it("turn_start event updates ctx.turnIndex", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 
 		await getHandler(handlers, "turn_start")({ turnIndex: 3 })
 
@@ -287,9 +299,9 @@ describe("telemetryExtension integration", () => {
 	})
 
 	it("before_provider_headers injects X-Session-Id and X-Turn-Index", async () => {
-		const { handlers, api } = createMockApi()
+		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-opus-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 
 		// Set a known turn index via the turn_start handler
 		await getHandler(handlers, "turn_start")({ turnIndex: 4 })
@@ -328,10 +340,10 @@ describe("ferment lifecycle telemetry via pi.events", () => {
 	})
 
 	async function setup() {
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext } = await import("./index.js")
 		ext(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 		return { handlers, events }
 	}
 
@@ -781,10 +793,10 @@ describe("edge case coverage", () => {
 	})
 
 	async function setup() {
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext } = await import("./index.js")
 		ext(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 		return { handlers, events }
 	}
 
@@ -963,10 +975,10 @@ describe("token accounting regression tests", () => {
 		// Totals on ferment.completed come from summing phase deltas, not from
 		// diffing the session accumulator. This avoids counting scoping-conversation
 		// tokens that accumulated before phases started.
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext, _resetFermentTrackingState } = await import("./index.js")
 		ext(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 
 		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
 
@@ -1036,7 +1048,7 @@ describe("token accounting regression tests", () => {
 	it("ferment.started is emitted with session_type ferment (active ferment set before emit)", async () => {
 		// Regression: emitFermentCreated was called before setActiveFermentAndApplyProfile,
 		// so session_type was "coding" instead of "ferment".
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext } = await import("./index.js")
 		ext(makeConfig())(api)
 
@@ -1044,7 +1056,7 @@ describe("token accounting regression tests", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue({ id: "f-stype" } as never)
 
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 		const { FERMENT_EVENTS } = await import("../ferment/domain-events.js")
 		events.emit(FERMENT_EVENTS.STARTED, { fermentId: "f-stype", name: "Session Type", phaseCount: 1 })
 		await getHandler(handlers, "session_shutdown")({ reason: "test" })
@@ -1095,10 +1107,10 @@ describe("bash-tool-guard telemetry via pi.events", () => {
 	})
 
 	async function setup() {
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext } = await import("./index.js")
 		ext(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 		return { handlers, events }
 	}
 
@@ -1215,10 +1227,10 @@ describe("loop-guard telemetry via pi.events", () => {
 	})
 
 	async function setup() {
-		const { handlers, events, api } = createMockApi()
+		const { handlers, events, api, ctx } = createMockApi()
 		const { default: ext } = await import("./index.js")
 		ext(makeConfig())(api)
-		await getHandler(handlers, "session_start")({}, { model: { id: "claude-sonnet-4-6" } })
+		await getHandler(handlers, "session_start")({}, ctx)
 		return { handlers, events }
 	}
 

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -1,4 +1,5 @@
-import type { ExtensionAPI, TurnStartEvent } from "@earendil-works/pi-coding-agent"
+import type { Message } from "@earendil-works/pi-ai"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../../config.js"
 import { onBeforeProviderHeaders } from "../../types/before-provider-headers.js"
 import {
@@ -27,9 +28,14 @@ import {
 } from "../loop-guard-events.js"
 
 import { handleAgentEnd, handleBeforeAgentStart, handleMessageEnd, handleMessageStart } from "./handlers/messages.js"
-import { emitSessionStartEvent, handleSessionInitialized, handleSessionShutdown } from "./handlers/session.js"
+import {
+	emitSessionStartEvent,
+	handleSessionCompact,
+	handleSessionShutdown,
+	handleSessionStart,
+} from "./handlers/session.js"
 import { handleToolExecutionEnd, handleToolExecutionStart } from "./handlers/tools.js"
-import { SessionContext } from "./session-context.js"
+import { type TelemetryAttributes, TelemetryContext } from "./session-context.js"
 import { startSettingsChangeWatcher } from "./settings-change-emitter.js"
 import {
 	emitSurveyAnswered,
@@ -117,14 +123,12 @@ export function _getBashGuardCounts(): { warn: number; block: number; allowedByU
 // Shared telemetry context (set during extension init)
 // ---------------------------------------------------------------------------
 
-let _ctx: SessionContext | undefined
+let _telemetryCtx: TelemetryContext | undefined
 let _telemetryConfig: TelemetryConfig = { enabled: false, endpoint: "", metricsEndpoint: "", headers: {}, apiKey: "" }
 let sessionStartEmitted = false
 
-export { _telemetryConfig }
-
 function isEnabled(): boolean {
-	return !!(_ctx && _telemetryConfig.enabled && _telemetryConfig.endpoint)
+	return !!(_telemetryCtx && _telemetryConfig.enabled && _telemetryConfig.endpoint)
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +139,7 @@ function isEnabled(): boolean {
  * Capture the current cumulative token/cost counters for a phase.
  * Called at phase activation via the ferment:phase_started domain event.
  */
-function captureSnapshot(ctx: SessionContext): TokenSnapshot {
+function captureSnapshot(ctx: TelemetryContext): TokenSnapshot {
 	const { tokensByModel } = ctx.cumulative
 	const snapshot: TokenSnapshot = { inputByModel: {}, outputByModel: {} }
 	for (const [model, t] of Object.entries(tokensByModel)) {
@@ -145,7 +149,7 @@ function captureSnapshot(ctx: SessionContext): TokenSnapshot {
 	return snapshot
 }
 
-function diffSnapshot(ctx: SessionContext, snapshot: TokenSnapshot): { deltaInput: number; deltaOutput: number } {
+function diffSnapshot(ctx: TelemetryContext, snapshot: TokenSnapshot): { deltaInput: number; deltaOutput: number } {
 	const { tokensByModel } = ctx.cumulative
 	let deltaInput = 0
 	let deltaOutput = 0
@@ -160,8 +164,8 @@ function diffSnapshot(ctx: SessionContext, snapshot: TokenSnapshot): { deltaInpu
 }
 
 export function snapshotPhaseTokens(fermentId: string, phaseId: string): void {
-	if (!_ctx) return
-	phaseTokenSnapshots.set(`${fermentId}:${phaseId}`, captureSnapshot(_ctx))
+	if (!_telemetryCtx) return
+	phaseTokenSnapshots.set(`${fermentId}:${phaseId}`, captureSnapshot(_telemetryCtx))
 }
 
 /**
@@ -175,8 +179,8 @@ export function consumePhaseTokenDelta(
 	const key = `${fermentId}:${phaseId}`
 	const snapshot = phaseTokenSnapshots.get(key)
 	phaseTokenSnapshots.delete(key)
-	if (!_ctx || !snapshot) return { deltaInput: 0, deltaOutput: 0 }
-	return diffSnapshot(_ctx, snapshot)
+	if (!_telemetryCtx || !snapshot) return { deltaInput: 0, deltaOutput: 0 }
+	return diffSnapshot(_telemetryCtx, snapshot)
 }
 
 // ---------------------------------------------------------------------------
@@ -185,28 +189,28 @@ export function consumePhaseTokenDelta(
 
 export async function trackSubagentSpawned(args: { id: string; type: string; description: string }): Promise<void> {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
-	ctx.emit("subagent.spawned", { model: ctx.currentModel, agent_type: args.type, reason: args.description })
+	ctx.emit("subagent.spawned", { agent_type: args.type, reason: args.description })
 }
 
 export function trackSurveyShown(args: SurveyShownTelemetry): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	emitSurveyShown(ctx, args)
 }
 
 export function trackSurveyAnswered(args: SurveyAnsweredTelemetry): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	emitSurveyAnswered(ctx, args)
 }
 
 export function trackSurveyDismissed(args: SurveyDismissedTelemetry): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	emitSurveyDismissed(ctx, args)
 }
@@ -238,7 +242,7 @@ function cleanupFermentState(fermentId: string): void {
 
 function onFermentStarted(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentStartedPayload
 	fermentStartTimes.set(payload.fermentId, Date.now())
@@ -246,11 +250,12 @@ function onFermentStarted(raw: unknown): void {
 	// each phase completes rather than diffing the session accumulator at
 	// ferment start/end (which over-counts scoping-conversation tokens).
 	fermentTokenTotals.set(payload.fermentId, { input: 0, output: 0 })
-	ctx.emitWithIds(
-		"ferment.started",
-		{ ferment_id: payload.fermentId },
-		{ ferment_name: payload.name, phase_count: payload.phaseCount, model: ctx.currentModel },
-	)
+	ctx.emitWithIds("ferment.started", {
+		ferment_id: payload.fermentId,
+		ferment_name: payload.name,
+		phase_count: payload.phaseCount,
+		model: ctx.currentModel,
+	})
 }
 
 function onFermentCompleted(raw: unknown): void {
@@ -265,7 +270,7 @@ function onFermentCompleted(raw: unknown): void {
 	// regardless of whether telemetry is enabled, so cleanup must always run.
 	cleanupFermentState(payload.fermentId)
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 
 	// Totals are the sum of per-phase deltas accumulated in onPhaseCompleted.
@@ -274,7 +279,8 @@ function onFermentCompleted(raw: unknown): void {
 	const totalInput = totals.input
 	const totalOutput = totals.output
 
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
 		ferment_name: payload.name,
 		phase_count: payload.phaseCount,
 		duration_ms: durationMs,
@@ -282,10 +288,9 @@ function onFermentCompleted(raw: unknown): void {
 		total_output_tokens: totalOutput,
 		steering_count: steeringCount,
 		block_retries: payload.blockRetries,
-		model: ctx.currentModel,
 	}
 	if (payload.grade) attrs.grade = payload.grade
-	ctx.emitWithIds("ferment.completed", { ferment_id: payload.fermentId }, attrs)
+	ctx.emitWithIds("ferment.completed", attrs)
 }
 
 function onFermentAbandoned(raw: unknown): void {
@@ -295,11 +300,11 @@ function onFermentAbandoned(raw: unknown): void {
 	// Clean up unconditionally — steering counts accumulate regardless of enabled state.
 	cleanupFermentState(payload.fermentId)
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
 		ferment_name: payload.name,
-		model: ctx.currentModel,
 		lifecycle_stage: payload.lifecycleStage,
 		scoping_complete: payload.scopingComplete,
 		completed_phases: payload.completedPhases,
@@ -311,46 +316,48 @@ function onFermentAbandoned(raw: unknown): void {
 	}
 	if (payload.reason) attrs.reason = payload.reason
 	if (payload.lastActivePhaseIndex !== undefined) attrs.last_active_phase_index = payload.lastActivePhaseIndex
-	ctx.emitWithIds("ferment.abandoned", { ferment_id: payload.fermentId }, attrs)
+	ctx.emitWithIds("ferment.abandoned", attrs)
 }
 
 function onFermentStalled(raw: unknown): void {
 	const payload = raw as FermentStalledPayload
 	// No per-ferment Maps to clean up for stalled — ferment remains accessible.
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
 		ferment_name: payload.name,
-		model: ctx.currentModel,
 		lifecycle_stage: payload.lifecycleStage,
 		idle_duration_ms: payload.idleDurationMs,
 		completed_phases: payload.completedPhases,
 		total_phases: payload.totalPhases,
 		phase_completion_ratio: payload.phaseCompletionRatio,
 	}
-	ctx.emitWithIds("ferment.stalled", { ferment_id: payload.fermentId }, attrs)
+	ctx.emitWithIds("ferment.stalled", attrs)
 }
 
 function onPhaseStarted(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentPhaseStartedPayload
 	const phaseKey = `${payload.fermentId}:${payload.phaseId}`
 	phaseStartTimes.set(phaseKey, Date.now())
 	phaseSteeringSnapshots.set(phaseKey, fermentSteeringCounts.get(payload.fermentId) ?? 0)
 	snapshotPhaseTokens(payload.fermentId, payload.phaseId)
-	ctx.emitWithIds(
-		"ferment.phase.started",
-		{ ferment_id: payload.fermentId, phase_id: payload.phaseId },
-		{ phase_index: payload.phaseIndex, phase_name: payload.phaseName, model: ctx.currentModel },
-	)
+	ctx.emitWithIds("ferment.phase.started", {
+		ferment_id: payload.fermentId,
+		phase_id: payload.phaseId,
+		phase_index: payload.phaseIndex,
+		phase_name: payload.phaseName,
+		model: ctx.currentModel,
+	})
 }
 
 function onPhaseCompleted(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentPhaseCompletedPayload
 	const phaseKey = `${payload.fermentId}:${payload.phaseId}`
@@ -366,7 +373,9 @@ function onPhaseCompleted(raw: unknown): void {
 		ft.input += deltaInput
 		ft.output += deltaOutput
 	}
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
+		phase_id: payload.phaseId,
 		phase_index: payload.phaseIndex,
 		phase_name: payload.phaseName,
 		duration_ms: phaseStartMs > 0 ? Date.now() - phaseStartMs : 0,
@@ -374,30 +383,31 @@ function onPhaseCompleted(raw: unknown): void {
 		delta_output_tokens: deltaOutput,
 		block_retries: payload.blockRetries,
 		steering_count: steeringCount,
-		model: ctx.currentModel,
 	}
 	if (payload.grade) attrs.grade = payload.grade
-	ctx.emitWithIds("ferment.phase.completed", { ferment_id: payload.fermentId, phase_id: payload.phaseId }, attrs)
+	ctx.emitWithIds("ferment.phase.completed", attrs)
 }
 
 function onStepStarted(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentStepStartedPayload
 	const key = `${payload.fermentId}:${payload.phaseId}:${payload.stepId}`
 	stepStartTimes.set(key, Date.now())
 	stepSteeringSnapshots.set(key, fermentSteeringCounts.get(payload.fermentId) ?? 0)
-	ctx.emitWithIds(
-		"ferment.step.started",
-		{ ferment_id: payload.fermentId, phase_id: payload.phaseId, step_id: payload.stepId },
-		{ step_index: payload.stepIndex, model: ctx.currentModel },
-	)
+	ctx.emitWithIds("ferment.step.started", {
+		ferment_id: payload.fermentId,
+		phase_id: payload.phaseId,
+		step_id: payload.stepId,
+		step_index: payload.stepIndex,
+		model: ctx.currentModel,
+	})
 }
 
 function onStepCompleted(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentStepCompletedPayload
 	const key = `${payload.fermentId}:${payload.phaseId}:${payload.stepId}`
@@ -406,38 +416,34 @@ function onStepCompleted(raw: unknown): void {
 	const steeringAtStart = stepSteeringSnapshots.get(key) ?? 0
 	stepSteeringSnapshots.delete(key)
 	const steeringCount = (fermentSteeringCounts.get(payload.fermentId) ?? 0) - steeringAtStart
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
+		phase_id: payload.phaseId,
+		step_id: payload.stepId,
 		step_index: payload.stepIndex,
 		duration_ms: Date.now() - startMs,
 		success: payload.success,
 		steering_count: steeringCount,
-		model: ctx.currentModel,
 	}
 	if (payload.grade) attrs.grade = payload.grade
-	ctx.emitWithIds(
-		"ferment.step.completed",
-		{ ferment_id: payload.fermentId, phase_id: payload.phaseId, step_id: payload.stepId },
-		attrs,
-	)
+	ctx.emitWithIds("ferment.step.completed", attrs)
 }
 
 function onStepFailed(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as FermentStepFailedPayload
 	const key = `${payload.fermentId}:${payload.phaseId}:${payload.stepId}`
 	stepStartTimes.delete(key)
-	const attrs: Record<string, string | number | boolean> = {
+	const attrs: TelemetryAttributes & { ferment_id: string } = {
+		ferment_id: payload.fermentId,
+		phase_id: payload.phaseId,
+		step_id: payload.stepId,
 		step_index: payload.stepIndex,
-		model: ctx.currentModel,
 	}
 	if (payload.reason) attrs.reason = payload.reason.slice(0, 300)
-	ctx.emitWithIds(
-		"ferment.step.failed",
-		{ ferment_id: payload.fermentId, phase_id: payload.phaseId, step_id: payload.stepId },
-		attrs,
-	)
+	ctx.emitWithIds("ferment.step.failed", attrs)
 }
 
 function onFermentSteering(raw: unknown): void {
@@ -468,7 +474,7 @@ function resetBashGuardCounts(): void {
 function onBashGuardWarn(raw: unknown): void {
 	bashGuardCounts.warn++
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as BashToolGuardWarnPayload
 	// Only structured fields land in OTLP. Raw command text is
@@ -476,7 +482,6 @@ function onBashGuardWarn(raw: unknown): void {
 	// that may appear inside heredocs, echo payloads, or sed/awk
 	// replacement strings. Aggregation is done by category + tool.
 	ctx.emit("bash_tool_guard.warn", {
-		model: ctx.currentModel,
 		category: payload.category,
 		tool: payload.tool,
 		count: payload.count,
@@ -486,11 +491,10 @@ function onBashGuardWarn(raw: unknown): void {
 function onBashGuardBlock(raw: unknown): void {
 	bashGuardCounts.block++
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as BashToolGuardBlockPayload
 	ctx.emit("bash_tool_guard.block", {
-		model: ctx.currentModel,
 		category: payload.category,
 		tool: payload.tool,
 		count: payload.count,
@@ -500,11 +504,10 @@ function onBashGuardBlock(raw: unknown): void {
 function onBashGuardAllowedByUserRequest(raw: unknown): void {
 	bashGuardCounts.allowedByUserRequest++
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as BashToolGuardAllowedByUserRequestPayload
 	ctx.emit("bash_tool_guard.allowed_by_user_request", {
-		model: ctx.currentModel,
 		category: payload.category,
 		tool: payload.tool,
 	})
@@ -512,14 +515,13 @@ function onBashGuardAllowedByUserRequest(raw: unknown): void {
 
 function onLoopGuardWarn(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as LoopGuardWarnPayload
 	// Only structured fields land in OTLP. Raw tool args, command text, and
 	// the human-readable reason string are intentionally NOT emitted to
 	// avoid leaking user data. Mirrors the bash-tool-guard stance.
 	ctx.emit("loop_guard.warn", {
-		model: ctx.currentModel,
 		detector: payload.detector,
 		count: payload.count,
 		is_subagent: payload.is_subagent,
@@ -528,11 +530,10 @@ function onLoopGuardWarn(raw: unknown): void {
 
 function onLoopGuardSubagentAbort(raw: unknown): void {
 	if (!isEnabled()) return
-	const ctx = _ctx
+	const ctx = _telemetryCtx
 	if (!ctx) return
 	const payload = raw as LoopGuardSubagentAbortPayload
 	ctx.emit("loop_guard.subagent_abort", {
-		model: ctx.currentModel,
 		detector: payload.detector ?? "unknown",
 		count: payload.count,
 		is_subagent: payload.is_subagent,
@@ -548,14 +549,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 	return (pi: ExtensionAPI) => {
 		if (!config.enabled) return
 
-		const ctx = new SessionContext(config, "cli")
-		_ctx = ctx
+		const telemetryCtx = new TelemetryContext(config)
+		_telemetryCtx = telemetryCtx
 
 		// Watch the settings file for changes and emit telemetry on modification.
 		// Bound to ctx.emit so changes flow through the same OTLP pipeline. The
 		// returned stop fn is invoked on session_shutdown to close the fs.watch
 		// handle and clear the debounce timer (prevents handle leak / hang).
-		const stopSettingsWatcher = startSettingsChangeWatcher((event, properties) => ctx.emit(event, properties))
+		const stopSettingsWatcher = startSettingsChangeWatcher((event, properties) => telemetryCtx.emit(event, properties))
 
 		// Subscribe to ferment domain events published via pi.events.
 		// This keeps telemetry decoupled from ferment internals — ferment
@@ -582,67 +583,55 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		pi.events.on(LOOP_GUARD_EVENTS.WARN, onLoopGuardWarn)
 		pi.events.on(LOOP_GUARD_EVENTS.SUBAGENT_ABORT, onLoopGuardSubagentAbort)
 
-		pi.on("session_start", async (_event, extCtx) => {
+		pi.on("session_start", async (_event, ctx) => {
 			resetBashGuardCounts()
-			const modelId = (extCtx as { model?: { id?: string } } | undefined)?.model?.id
-			handleSessionInitialized(ctx, modelId)
+			handleSessionStart(telemetryCtx, ctx)
 		})
-		pi.on("session_shutdown", async (event) => {
+		pi.on("session_shutdown", async (event, ctx) => {
 			stopSettingsWatcher()
-			await handleSessionShutdown(ctx, event as { reason?: string })
+			await handleSessionShutdown(telemetryCtx, ctx, event)
 		})
-		pi.on("message_start", async (event) =>
-			handleMessageStart(ctx, event as { message: { role: string; responseId?: string; timestamp?: number } }),
-		)
-		pi.on("message_end", async (event) =>
-			handleMessageEnd(ctx, event as unknown as { message: Record<string, unknown> }),
-		)
+		pi.on("message_start", async (event, ctx) => {
+			handleMessageStart(telemetryCtx, ctx, event as { message: Message })
+		})
+		pi.on("message_end", async (event, ctx) => {
+			handleMessageEnd(telemetryCtx, ctx, event as { message: Message })
+		})
 		pi.on("model_select", async (event) => {
-			const e = event as { model?: { id?: string } }
-			ctx.currentModel = e.model?.id ?? "unknown"
+			telemetryCtx.currentModel = event.model.id
 		})
-		pi.on("session_compact", async () => {
-			ctx.compactionCount++
-			ctx.emit("session.compacted", {
-				model: ctx.currentModel,
-				compaction_count: ctx.compactionCount,
-				turn_index: ctx.turnIndex,
-			})
+		pi.on("session_compact", async (_event, ctx) => {
+			handleSessionCompact(telemetryCtx, ctx)
 		})
-		pi.on("tool_execution_start", async (event) =>
-			handleToolExecutionStart(ctx, event as { toolCallId: string; toolName: string; args: unknown }),
-		)
-		pi.on("tool_execution_end", async (event) => {
-			handleToolExecutionEnd(ctx, event as { toolCallId: string; isError?: boolean; result?: unknown })
+		pi.on("tool_execution_start", async (event) => {
+			handleToolExecutionStart(telemetryCtx, event)
 		})
-		pi.on("before_agent_start", async (event, extCtx) => {
+		pi.on("tool_execution_end", async (event, ctx) => {
+			handleToolExecutionEnd(telemetryCtx, ctx, event)
+		})
+		pi.on("before_agent_start", async (event, ctx) => {
 			if (!sessionStartEmitted) {
 				sessionStartEmitted = true
-				emitSessionStartEvent(ctx)
+				emitSessionStartEvent(telemetryCtx, ctx)
 			}
-			if (ctx.currentModel === "unknown") {
-				const modelId = (extCtx as { model?: { id?: string } } | undefined)?.model?.id
-				if (modelId) ctx.currentModel = modelId
-			}
-			const e = event as { prompt: string }
-			handleBeforeAgentStart(ctx, e)
+			handleBeforeAgentStart(telemetryCtx, ctx, event)
 		})
-		pi.on("agent_end", async (event) => {
-			handleAgentEnd(ctx, event as { messages?: { role?: string; content?: unknown[] }[] })
+		pi.on("agent_end", async (event, ctx) => {
+			handleAgentEnd(telemetryCtx, ctx, event)
 		})
 		pi.on("turn_start", async (event) => {
-			const incoming = (event as TurnStartEvent).turnIndex
+			const incoming = event.turnIndex
 			if (incoming !== undefined) {
-				ctx.turnIndex = incoming
+				telemetryCtx.turnIndex = incoming
 			} else {
-				console.warn("[telemetry] turn_start received without turnIndex field — ctx.turnIndex unchanged")
+				console.warn("[telemetry] turn_start received without turnIndex field — telemetryCtx.turnIndex unchanged")
 			}
 		})
 		onBeforeProviderHeaders(pi, (event) => ({
 			...event.headers,
-			"X-Session-Id": ctx.sessionId,
+			"X-Session-Id": telemetryCtx.telemetryId,
 			// 0 means "before first turn" (sentinel); backend should treat it accordingly.
-			"X-Turn-Index": String(ctx.turnIndex),
+			"X-Turn-Index": String(telemetryCtx.turnIndex),
 		}))
 	}
 }

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai"
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../../config.js"
 import { onBeforeProviderHeaders } from "../../types/before-provider-headers.js"
 import {
@@ -187,11 +187,14 @@ export function consumePhaseTokenDelta(
 // Existing track* functions
 // ---------------------------------------------------------------------------
 
-export async function trackSubagentSpawned(args: { id: string; type: string; description: string }): Promise<void> {
+export async function trackSubagentSpawned(
+	args: { id: string; type: string; description: string },
+	piCtx: ExtensionContext,
+): Promise<void> {
 	if (!isEnabled()) return
 	const ctx = _telemetryCtx
 	if (!ctx) return
-	ctx.emit("subagent.spawned", { agent_type: args.type, reason: args.description })
+	ctx.emit("subagent.spawned", { agent_type: args.type, reason: args.description }, piCtx)
 }
 
 export function trackSurveyShown(args: SurveyShownTelemetry): void {

--- a/src/extensions/telemetry/session-context.test.ts
+++ b/src/extensions/telemetry/session-context.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../config.js"
 import * as osMetadata from "../../utils/os-metadata.js"
-import { _resetSharedAccumulators, SessionContext } from "./session-context.js"
+import { _resetSharedAccumulators, TelemetryContext } from "./session-context.js"
 
 vi.mock("../../api/me.js", () => ({
 	getMe: vi.fn().mockResolvedValue({ id: "test-user", email: "test@example.com" }),
@@ -44,7 +44,7 @@ describe("SessionContext", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("test.event", { custom: "value", count: 42 })
 		ctx.flushLogBuffer()
 
@@ -69,7 +69,7 @@ describe("SessionContext", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("test.event", { custom: "value" })
 		ctx.flushLogBuffer()
 
@@ -105,7 +105,7 @@ describe("SessionContext", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("test.event", { custom: "value" })
 		ctx.flushLogBuffer()
 		await Promise.allSettled([...ctx.inFlight])
@@ -125,8 +125,8 @@ describe("SessionContext", () => {
 	})
 
 	it("emitWithIds includes all four OS metadata keys", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		ctx.emitWithIds("ferment.started", { ferment_id: "f-123" }, { phase: "plan" })
+		const ctx = new TelemetryContext(makeConfig())
+		ctx.emitWithIds("ferment.started", { ferment_id: "f-123" })
 		ctx.flushLogBuffer()
 
 		await Promise.allSettled([...ctx.inFlight])
@@ -150,7 +150,7 @@ describe("SessionContext", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("test.event", {})
 		ctx.flushLogBuffer()
 		await Promise.allSettled([...ctx.inFlight])
@@ -173,7 +173,7 @@ describe("SessionContext", () => {
 			.mockReturnValueOnce({ id: "f-1" } as never) // emit 2, call 1
 			.mockReturnValueOnce({ id: "f-1" } as never) // emit 2, call 2
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.first", {})
 		ctx.emit("event.second", {})
 		ctx.flushLogBuffer()
@@ -202,7 +202,7 @@ describe("SessionContext", () => {
 		const { getActiveFerment } = await import("../ferment/index.js")
 		vi.mocked(getActiveFerment).mockReturnValue(undefined)
 
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.a", {})
 		ctx.emit("event.b", {})
 		ctx.flushLogBuffer()
@@ -216,7 +216,7 @@ describe("SessionContext", () => {
 	})
 
 	it("emit buffers records instead of sending immediately", () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.a", {})
 		ctx.emit("event.b", {})
 		expect(globalThis.fetch).not.toHaveBeenCalled()
@@ -224,7 +224,7 @@ describe("SessionContext", () => {
 	})
 
 	it("flushLogBuffer sends all buffered records in one POST", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.a", {})
 		ctx.emit("event.b", {})
 		ctx.flushLogBuffer()
@@ -242,7 +242,7 @@ describe("SessionContext", () => {
 	})
 
 	it("auto-flushes when buffer reaches LOG_BATCH_MAX_SIZE", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		for (let i = 0; i < 20; i++) {
 			ctx.emit(`event.${i}`, {})
 		}
@@ -258,7 +258,7 @@ describe("SessionContext", () => {
 
 	it("timer-based flush sends buffered records after interval", async () => {
 		vi.useFakeTimers()
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.a", {})
 		expect(globalThis.fetch).not.toHaveBeenCalled()
 
@@ -270,7 +270,7 @@ describe("SessionContext", () => {
 	})
 
 	it("drain flushes the log buffer", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 		ctx.emit("event.a", {})
 		expect(globalThis.fetch).not.toHaveBeenCalled()
 
@@ -280,42 +280,8 @@ describe("SessionContext", () => {
 		expect(ctx.logBuffer).toHaveLength(0)
 	})
 
-	it("reset clears log buffer", () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		ctx.emit("event.a", {})
-		expect(ctx.logBuffer).toHaveLength(1)
-
-		ctx.reset("vscode")
-		expect(ctx.logBuffer).toHaveLength(0)
-	})
-
-	it("turnIndex resets to 0 on ctx.reset()", () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		ctx.turnIndex = 5
-		ctx.reset("cli")
-		expect(ctx.turnIndex).toBe(0)
-	})
-
-	it("reset preserves rootSessionId and clears per-instance state", () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		const originalId = ctx.sessionId
-
-		ctx.sentMessages.add("msg-1")
-		ctx.pendingArgs.set("msg-2", { toolName: "bash", args: {} })
-		ctx.messageStartTimes.set("msg-3", Date.now())
-
-		ctx.reset("vscode")
-
-		expect(ctx.sessionId).toBe(originalId)
-		expect(ctx.source).toBe("vscode")
-		expect(ctx.sentMessages.size).toBe(0)
-		expect(ctx.pendingArgs.size).toBe(0)
-		expect(ctx.messageStartTimes.size).toBe(0)
-		expect(ctx.shuttingDown).toBe(false)
-	})
-
 	it("track adds and removes promises from inFlight", async () => {
-		const ctx = new SessionContext(makeConfig({ enabled: false }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ enabled: false }))
 
 		let resolver: (() => void) | undefined
 		const p = new Promise<void>((resolve) => {
@@ -336,7 +302,7 @@ describe("SessionContext", () => {
 	})
 
 	it("track is a no-op when shuttingDown", () => {
-		const ctx = new SessionContext(makeConfig({ enabled: false }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ enabled: false }))
 		ctx.shuttingDown = true
 
 		const p = new Promise<void>(() => {})
@@ -345,7 +311,7 @@ describe("SessionContext", () => {
 	})
 
 	it("drain sets shuttingDown to true", async () => {
-		const ctx = new SessionContext(makeConfig({ enabled: false }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ enabled: false }))
 		expect(ctx.shuttingDown).toBe(false)
 
 		await ctx.drain()
@@ -353,7 +319,7 @@ describe("SessionContext", () => {
 	})
 
 	it("drain clears messageStartTimes and stops flush timer", async () => {
-		const ctx = new SessionContext(makeConfig({ enabled: false }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ enabled: false }))
 		ctx.messageStartTimes.set("msg-1", Date.now())
 		ctx.startFlushTimer()
 		expect(ctx.flushTimer).toBeDefined()
@@ -365,30 +331,19 @@ describe("SessionContext", () => {
 	})
 
 	it("two instances share the same cumulative accumulator", () => {
-		const ctx1 = new SessionContext(makeConfig(), "cli")
-		const ctx2 = new SessionContext(makeConfig(), "cli")
+		const ctx1 = new TelemetryContext(makeConfig())
+		const ctx2 = new TelemetryContext(makeConfig())
 
-		expect(ctx1.sessionId).toBe(ctx2.sessionId)
+		expect(ctx1.telemetryId).toBe(ctx2.telemetryId)
 		expect(ctx1.cumulative).toBe(ctx2.cumulative)
 
 		ctx1.cumulative.commitCount += 3
 		expect(ctx2.cumulative.commitCount).toBe(3)
 	})
 
-	it("reset preserves shared accumulator data from other instances", () => {
-		const ctx1 = new SessionContext(makeConfig(), "cli")
-		const ctx2 = new SessionContext(makeConfig(), "cli")
-
-		ctx1.cumulative.tokensByModel["test-model"] = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }
-
-		ctx2.reset("cli")
-
-		expect(ctx2.cumulative.tokensByModel["test-model"]?.output).toBe(50)
-	})
-
 	it("shared accumulators produce combined metrics on flush", async () => {
-		const ctx1 = new SessionContext(makeConfig(), "cli")
-		const ctx2 = new SessionContext(makeConfig(), "cli")
+		const ctx1 = new TelemetryContext(makeConfig())
+		const ctx2 = new TelemetryContext(makeConfig())
 
 		ctx1.cumulative.tokensByModel.m1 = { input: 100, output: 200, cacheRead: 0, cacheWrite: 0 }
 		ctx2.cumulative.tokensByModel.m1.output += 50
@@ -419,7 +374,7 @@ describe("SessionContext", () => {
 		const { getMe } = await import("../../api/me.js")
 		vi.mocked(getMe).mockResolvedValue({ id: "u1", email: "alice@test.com" })
 
-		const ctx = new SessionContext(makeConfig({ apiKey: "my-key" }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ apiKey: "my-key" }))
 		await ctx.userEmailReady
 
 		expect(ctx.userEmail).toBe("alice@test.com")
@@ -441,14 +396,14 @@ describe("SessionContext", () => {
 		const { getMe } = await import("../../api/me.js")
 		vi.mocked(getMe).mockRejectedValue(new Error("network failure"))
 
-		const ctx = new SessionContext(makeConfig({ apiKey: "my-key" }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ apiKey: "my-key" }))
 		await ctx.userEmailReady
 
 		expect(ctx.userEmail).toBeUndefined()
 	})
 
 	it("resolves userEmailReady immediately when no apiKey", async () => {
-		const ctx = new SessionContext(makeConfig({ apiKey: "" }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ apiKey: "" }))
 		await ctx.userEmailReady
 		expect(ctx.userEmail).toBeUndefined()
 	})
@@ -457,7 +412,7 @@ describe("SessionContext", () => {
 		const { getMe } = await import("../../api/me.js")
 		vi.mocked(getMe).mockResolvedValue({ id: "user-uuid-123" })
 
-		const ctx = new SessionContext(makeConfig({ apiKey: "key" }), "cli")
+		const ctx = new TelemetryContext(makeConfig({ apiKey: "key" }))
 		await ctx.userEmailReady
 
 		ctx.emit("test.event", { foo: "bar" })
@@ -474,14 +429,5 @@ describe("SessionContext", () => {
 			),
 		)
 		expect(attrMap["user.account_uuid"]).toBe("user-uuid-123")
-	})
-
-	it("compactionCount resets to 0 on ctx.reset()", () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
-		ctx.compactionCount = 3
-
-		ctx.reset("cli")
-
-		expect(ctx.compactionCount).toBe(0)
 	})
 })

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -1,12 +1,17 @@
 import crypto from "node:crypto"
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { getMe } from "../../api/me.js"
 import type { TelemetryConfig } from "../../config.js"
+import { IS_ACP_MODE } from "../../modes/acp/state.js"
 import { getOsMetadata } from "../../utils/os-metadata.js"
 import { getActiveFerment } from "../ferment/index.js"
 import { type CumulativeState, collectMetrics, createCumulativeState } from "./accumulator.js"
+import { getAcpAttributes, getPiSessionAttributes } from "./handlers/utils.js"
 import { toAttrs } from "./helpers.js"
 import { getSessionType } from "./session-type.js"
 import { buildLogRecord, type LogRecord, sendLogBatch, sendMetrics } from "./transport.js"
+
+export type TelemetryAttributes = Record<string, string | number | boolean>
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -18,44 +23,46 @@ export const LOG_BATCH_FLUSH_INTERVAL_MS = 5_000
 export const LOG_BATCH_MAX_SIZE = 20
 
 // ---------------------------------------------------------------------------
-// Process-level root session ID + shared accumulators
+// Process-level ID + shared accumulators
 //
-// All agents (main + sub-agents) in the same process share rootSessionId so
+// All agents (main + sub-agents) in the same process share telemetryId so
 // that telemetry rolls up under one session in the backend.
 //
-// Accumulators are keyed by rootSessionId (not per-instance) so that every
+// Accumulators are keyed by telemetryId (not per-session) so that every
 // flush sends the monotonically increasing total across ALL agents. This is
 // required because the backend uses ReplacingMergeTree: rows with the same
 // ORDER BY key are deduplicated and the latest write wins.
 // ---------------------------------------------------------------------------
 
-let rootSessionId: string | undefined
+let telemetryId: string | undefined
 const sharedAccumulators = new Map<string, CumulativeState>()
 
-function getOrCreateAccumulator(sessionId: string): CumulativeState {
-	let acc = sharedAccumulators.get(sessionId)
+function getOrCreateAccumulator(telemetryId: string): CumulativeState {
+	let acc = sharedAccumulators.get(telemetryId)
 	if (!acc) {
 		acc = createCumulativeState()
-		sharedAccumulators.set(sessionId, acc)
+		sharedAccumulators.set(telemetryId, acc)
 	}
 	return acc
 }
 
 /** @internal — exposed for testing only */
 export function _resetSharedAccumulators(): void {
-	if (rootSessionId) sharedAccumulators.delete(rootSessionId)
-	rootSessionId = undefined
+	if (telemetryId) sharedAccumulators.delete(telemetryId)
+	telemetryId = undefined
 }
 
 // ---------------------------------------------------------------------------
-// SessionContext — per-session telemetry state
+// SessionContext — process-level telemetry state
 // ---------------------------------------------------------------------------
 
-export class SessionContext {
+export class TelemetryContext {
 	config: TelemetryConfig
-	sessionId: string
-	sessionStartMs: number
-	source: string
+	telemetryId: string
+	telemetryStartMs: number
+	/**
+	 * Current model, updated from message events; used for domain events that lack a pi context.
+	 */
 	currentModel = "unknown"
 	/**
 	 * Current turn index, updated on each turn_start event.
@@ -88,14 +95,13 @@ export class SessionContext {
 	userEmailReady: Promise<void>
 	private resolveUserEmailReady!: () => void
 
-	constructor(config: TelemetryConfig, source: string) {
+	constructor(config: TelemetryConfig) {
 		this.config = config
-		this.source = source
 		this.osMetadata = getOsMetadata()
-		if (!rootSessionId) rootSessionId = crypto.randomUUID()
-		this.sessionId = rootSessionId
-		this.sessionStartMs = Date.now()
-		this.cumulative = getOrCreateAccumulator(this.sessionId)
+		if (!telemetryId) telemetryId = crypto.randomUUID()
+		this.telemetryId = telemetryId
+		this.telemetryStartMs = Date.now()
+		this.cumulative = getOrCreateAccumulator(this.telemetryId)
 		this.userEmailReady = new Promise<void>((resolve) => {
 			this.resolveUserEmailReady = resolve
 		})
@@ -106,11 +112,10 @@ export class SessionContext {
 		return this.cumulative.sessionStartNano
 	}
 
-	reset(source: string): void {
-		this.source = source
-		if (!rootSessionId) rootSessionId = crypto.randomUUID()
-		this.sessionId = rootSessionId
-		this.sessionStartMs = Date.now()
+	reset(): void {
+		if (!telemetryId) telemetryId = crypto.randomUUID()
+		this.telemetryId = telemetryId
+		this.telemetryStartMs = Date.now()
 		this.currentModel = "unknown"
 		this.turnIndex = 0
 		this.sentMessages.clear()
@@ -119,7 +124,7 @@ export class SessionContext {
 		this.toolStartTimes.clear()
 		this.lastSessionType = undefined
 		this.compactionCount = 0
-		this.cumulative = getOrCreateAccumulator(this.sessionId)
+		this.cumulative = getOrCreateAccumulator(this.telemetryId)
 		this.inFlight.clear()
 		this.shuttingDown = false
 		this.logBuffer = []
@@ -145,46 +150,59 @@ export class SessionContext {
 	 */
 	emitWithIds(
 		eventName: string,
-		ids: { ferment_id: string; phase_id?: string; step_id?: string },
-		attrs: Record<string, string | number | boolean>,
+		attrs: TelemetryAttributes & { ferment_id: string; phase_id?: string; step_id?: string },
+		ctx?: ExtensionContext,
 	): void {
-		const sessionType = getSessionType()
-		const merged: Record<string, string | number | boolean> = {
-			source: this.source,
-			session_type: sessionType,
+		const { session_type, source, ...commonAttrs } = this.getCommonAttributes(ctx)
+		const merged: TelemetryAttributes = {
+			source,
+			session_type,
 			...this.osMetadata,
-			...ids,
 			...attrs,
 			"user.account_uuid": this.userId ?? "",
+			...commonAttrs,
 		}
-		this.enqueueLogRecord(buildLogRecord(this.sessionId, eventName, toAttrs(merged)))
+		this.enqueueLogRecord(buildLogRecord(this.telemetryId, eventName, toAttrs(merged)))
 	}
 
-	emit(eventName: string, attrs: Record<string, string | number | boolean>): void {
-		const sessionType = getSessionType()
+	emit(eventName: string, attrs?: TelemetryAttributes, ctx?: ExtensionContext): void {
 		const ferment = getActiveFerment()
+		const { session_type, source, ...commonAttrs } = this.getCommonAttributes(ctx)
 
 		// Detect and emit session.type_changed when the type transitions
-		if (this.lastSessionType !== undefined && sessionType !== this.lastSessionType) {
+		if (this.lastSessionType !== undefined && session_type !== this.lastSessionType) {
 			const changeAttrs = toAttrs({
-				session_type: sessionType,
+				session_type,
 				previous_session_type: this.lastSessionType,
-				source: this.source,
+				source,
 				ferment_id: ferment?.id ?? "",
 			})
-			this.logBuffer.push(buildLogRecord(this.sessionId, "session.type_changed", changeAttrs))
+			this.logBuffer.push(buildLogRecord(this.telemetryId, "session.type_changed", changeAttrs))
 		}
-		this.lastSessionType = sessionType
+		this.lastSessionType = session_type
 
-		const merged = {
+		const merged: TelemetryAttributes = {
 			...attrs,
 			...this.osMetadata,
-			source: this.source,
-			session_type: sessionType,
+			source,
+			session_type,
 			ferment_id: ferment?.id ?? "",
 			"user.account_uuid": this.userId ?? "",
+			...commonAttrs,
 		}
-		this.enqueueLogRecord(buildLogRecord(this.sessionId, eventName, toAttrs(merged)))
+		this.enqueueLogRecord(buildLogRecord(this.telemetryId, eventName, toAttrs(merged)))
+	}
+
+	private getCommonAttributes(
+		ctx?: ExtensionContext,
+	): TelemetryAttributes & { session_type: "ferment" | "coding"; source: "cli" | "acp"; model: string } {
+		return {
+			source: IS_ACP_MODE ? "acp" : "cli",
+			session_type: getSessionType(),
+			model: this.currentModel,
+			...getAcpAttributes(),
+			...(ctx ? getPiSessionAttributes(ctx) : {}),
+		}
 	}
 
 	/** Append a pre-built log record to the buffer and schedule/trigger a flush. */
@@ -218,7 +236,7 @@ export class SessionContext {
 				this.userEmailReady.then(() =>
 					sendMetrics(
 						this.config,
-						this.sessionId,
+						this.telemetryId,
 						metrics.map((m) => ({
 							...m,
 							attrs: {

--- a/src/extensions/telemetry/survey.test.ts
+++ b/src/extensions/telemetry/survey.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../config.js"
-import { _resetSharedAccumulators, SessionContext } from "./session-context.js"
+import { _resetSharedAccumulators, TelemetryContext } from "./session-context.js"
 import { emitSurveyAnswered, emitSurveyDismissed, emitSurveyShown } from "./survey.js"
 import type { LogRecord } from "./transport.js"
 
@@ -52,7 +52,7 @@ describe("survey telemetry", () => {
 	})
 
 	it("emits survey_shown with the survey id", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 
 		emitSurveyShown(ctx, { survey: TEST_SURVEY })
 
@@ -62,7 +62,7 @@ describe("survey telemetry", () => {
 
 		const attrMap = attrs(record)
 		expect(attrMap.survey_id).toBe(TEST_SURVEY.id)
-		expect(attrMap["session.id"]).toBe(ctx.sessionId)
+		expect(attrMap["session.id"]).toBe(ctx.telemetryId)
 		expect(attrMap.client).toBe("pi")
 		expect(attrMap.source).toBe("cli")
 
@@ -70,7 +70,7 @@ describe("survey telemetry", () => {
 	})
 
 	it("emits survey_answered with the abstract survey response fields", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 
 		emitSurveyAnswered(ctx, { survey: TEST_SURVEY, submissionId: "submission-1", answerId: "mostly_worked" })
 
@@ -89,7 +89,7 @@ describe("survey telemetry", () => {
 	})
 
 	it("does not emit survey_answered for an unknown answer id", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 
 		emitSurveyAnswered(ctx, { survey: TEST_SURVEY, submissionId: "submission-1", answerId: "unknown" })
 
@@ -99,7 +99,7 @@ describe("survey telemetry", () => {
 	})
 
 	it("emits survey_dismissed with the survey id", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 
 		emitSurveyDismissed(ctx, { survey: TEST_SURVEY })
 
@@ -114,7 +114,7 @@ describe("survey telemetry", () => {
 	})
 
 	it("emits triggered survey events with the survey response fields", async () => {
-		const ctx = new SessionContext(makeConfig(), "cli")
+		const ctx = new TelemetryContext(makeConfig())
 
 		emitSurveyShown(ctx, { survey: TEST_SURVEY, trigger: "ferment_completed" })
 		emitSurveyAnswered(ctx, {

--- a/src/extensions/telemetry/survey.ts
+++ b/src/extensions/telemetry/survey.ts
@@ -1,4 +1,4 @@
-import type { SessionContext } from "./session-context.js"
+import type { TelemetryContext } from "./session-context.js"
 
 type SurveyAttrs = Record<string, string | number | boolean>
 type SurveyOption = SurveyTelemetryDefinition["options"][number]
@@ -48,11 +48,11 @@ function surveyResponseValue(answer: SurveyOption): string {
 	return answer.label
 }
 
-export function emitSurveyShown(ctx: SessionContext, args: SurveyShownTelemetry): void {
+export function emitSurveyShown(ctx: TelemetryContext, args: SurveyShownTelemetry): void {
 	ctx.emit("survey_shown", commonSurveyAttrs(args))
 }
 
-export function emitSurveyAnswered(ctx: SessionContext, args: SurveyAnsweredTelemetry): void {
+export function emitSurveyAnswered(ctx: TelemetryContext, args: SurveyAnsweredTelemetry): void {
 	const answer = args.survey.options.find((option) => option.id === args.answerId)
 	if (!answer) return
 
@@ -65,6 +65,6 @@ export function emitSurveyAnswered(ctx: SessionContext, args: SurveyAnsweredTele
 	})
 }
 
-export function emitSurveyDismissed(ctx: SessionContext, args: SurveyDismissedTelemetry): void {
+export function emitSurveyDismissed(ctx: TelemetryContext, args: SurveyDismissedTelemetry): void {
 	ctx.emit("survey_dismissed", commonSurveyAttrs(args))
 }

--- a/src/extensions/telemetry/transport.ts
+++ b/src/extensions/telemetry/transport.ts
@@ -148,7 +148,7 @@ export async function sendLogBatch(config: TelemetryConfig, records: LogRecord[]
 
 export async function sendMetrics(
 	config: TelemetryConfig,
-	sessionId: string,
+	telemetryId: string,
 	metrics: MetricData[],
 	sessionStartNano: string,
 	userEmail?: string,
@@ -171,7 +171,7 @@ export async function sendMetrics(
 										startTimeUnixNano: sessionStartNano,
 										...(Number.isInteger(m.value) ? { asInt: String(m.value) } : { asDouble: m.value }),
 										attributes: [
-											strAttr("session.id", sessionId),
+											strAttr("session.id", telemetryId),
 											strAttr("client", "pi"),
 											...Object.entries(m.attrs).map(([k, v]) => strAttr(k, String(v))),
 										],

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -45,6 +45,7 @@ import {
 	toAcpSessionInfo,
 	userMessageText,
 } from "./server.js"
+import { getAcpClientInfo, resetAcpClientInfo } from "./state.js"
 
 // Minimal fake of AgentSession surface used by KimchiAcpAgent. The factory seam
 // means we only need to stand in for the methods the ACP server actually calls:
@@ -276,6 +277,24 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// The result depends on merged models (cached + built-in).
 			// Just verify it's a boolean (the logic ran successfully).
 			expect(typeof response.agentCapabilities?.promptCapabilities?.image).toBe("boolean")
+		})
+
+		it("records ACP client name during initialize", async () => {
+			resetAcpClientInfo()
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await testAgent.initialize({
+				protocolVersion: 1,
+				clientInfo: { name: "kimchi-vscode", version: "1.0.0" },
+			})
+
+			const info = getAcpClientInfo()
+			expect(info?.name).toBe("kimchi-vscode")
+			expect(info?.version).toBe("1.0.0")
 		})
 	})
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -84,6 +84,7 @@ import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
+import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 
 /**
  * Produces an unbound AgentSession for a newSession request. The ACP agent owns
@@ -194,6 +195,8 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	async initialize(request: InitializeRequest): Promise<InitializeResponse> {
+		setAcpClientInfo(request.clientInfo ?? { name: "unknown", version: "0.0.0" })
+
 		this.clientCapabilities = request.clientCapabilities
 
 		const authStorage = AuthStorage.create(join(this.agentDir, "auth.json"))
@@ -647,6 +650,7 @@ export class KimchiAcpAgent implements Agent {
 			await this.disposeSessionRecord(entry)
 		}
 		this.sessions.clear()
+		resetAcpClientInfo()
 	}
 
 	private async closeSessionRecord(sessionId: string): Promise<void> {

--- a/src/modes/acp/state.ts
+++ b/src/modes/acp/state.ts
@@ -1,0 +1,34 @@
+import { getCliModeArg } from "../../cli-args.js"
+
+const originalArgs = process.argv.slice(2)
+
+// ACP mode runs JSON-RPC over stdio; interactive mode runs the standard TUI
+// harness. Decide once at module load, before anything else runs.
+export const IS_ACP_MODE = getCliModeArg(originalArgs) === "acp"
+
+/**
+ * Process-level context about the ACP client that consumes this process.
+ * The ACP server writes client info during initialize().
+ */
+export interface AcpClientInfo {
+	name: string
+	version: string
+	title?: string | null
+}
+
+let acpClientInfo: AcpClientInfo | undefined
+
+/** Set the ACP client info captured during initialize(). */
+export function setAcpClientInfo(info: AcpClientInfo): void {
+	acpClientInfo = info
+}
+
+/** Read the currently known ACP client info, if any. */
+export function getAcpClientInfo(): AcpClientInfo | undefined {
+	return acpClientInfo
+}
+
+/** Reset process-level ACP context. */
+export function resetAcpClientInfo(): void {
+	acpClientInfo = undefined
+}

--- a/src/types/before-provider-headers.ts
+++ b/src/types/before-provider-headers.ts
@@ -17,7 +17,7 @@
  * fixed version is pinned in package.json.
  */
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 
 /** Fired in streamFn after static header assembly, before every LLM HTTP call. */
 export interface BeforeProviderHeadersEvent {
@@ -29,6 +29,7 @@ export interface BeforeProviderHeadersEvent {
 /** Handler signature for the before_provider_headers hook. */
 export type BeforeProviderHeadersHandler = (
 	event: BeforeProviderHeadersEvent,
+	ctx: ExtensionContext,
 ) => Record<string, string> | Promise<Record<string, string>>
 
 /**


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

* Adds ACP client info to the analytics payload when available
* Adds Pi's session context data to the analytics payload when available
  * Permission mode
  * Multi model enabled
  * Session Id
  * Session runtime mode (tui, rpc, json, print)
* Refactors `SessionContext` to `TelemetryContext` and cleans up code to avoid confusion of global `processId` with Pi's `sessionId`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
