### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/src/atlascloud.test.ts
+++ b/src/atlascloud.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { injectAtlasCloudProvider, readAtlasCloudModelMetadata, readAtlasCloudModelsFromConfig } from "./atlascloud.js"
+
+describe("injectAtlasCloudProvider", () => {
+	let tmpDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "kimchi-atlascloud-test-"))
+		modelsJsonPath = join(tmpDir, "models.json")
+	})
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true })
+	})
+
+	function readConfig(): {
+		providers: Record<string, { apiKey?: string; baseUrl?: string; models?: Array<{ id: string }> }>
+	} {
+		return JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+	}
+
+	it("writes Atlas Cloud while preserving existing providers", () => {
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify(
+				{
+					providers: {
+						"kimchi-dev": { models: [{ id: "kimi-k2.7" }] },
+						custom: { models: [{ id: "custom-model" }] },
+					},
+				},
+				null,
+				"\t",
+			),
+			"utf-8",
+		)
+
+		injectAtlasCloudProvider(modelsJsonPath)
+
+		const providers = readConfig().providers
+		expect(providers["kimchi-dev"]?.models?.map((m) => m.id)).toEqual(["kimi-k2.7"])
+		expect(providers.custom?.models?.map((m) => m.id)).toEqual(["custom-model"])
+		expect(providers.atlascloud).toMatchObject({
+			api: "openai-completions",
+			baseUrl: "https://api.atlascloud.ai/v1",
+			apiKey: "$ATLASCLOUD_API_KEY",
+			authHeader: true,
+		})
+		expect(providers.atlascloud?.models?.map((m) => m.id)).toEqual([
+			"qwen/qwen3.5-flash",
+			"deepseek-ai/deepseek-v4-pro",
+		])
+	})
+
+	it("does not create models.json when missing unless requested", () => {
+		injectAtlasCloudProvider(modelsJsonPath)
+		expect(readAtlasCloudModelsFromConfig(modelsJsonPath)).toEqual([])
+
+		injectAtlasCloudProvider(modelsJsonPath, { createIfMissing: true })
+		expect(readConfig().providers.atlascloud?.models?.map((m) => m.id)).toEqual([
+			"qwen/qwen3.5-flash",
+			"deepseek-ai/deepseek-v4-pro",
+		])
+	})
+
+	it("is idempotent", () => {
+		writeFileSync(modelsJsonPath, JSON.stringify({ providers: { "kimchi-dev": { models: [] } } }), "utf-8")
+
+		injectAtlasCloudProvider(modelsJsonPath)
+		const first = readFileSync(modelsJsonPath, "utf-8")
+		injectAtlasCloudProvider(modelsJsonPath)
+		const second = readFileSync(modelsJsonPath, "utf-8")
+
+		expect(second).toBe(first)
+	})
+
+	it("reads Atlas Cloud model metadata for startup model discovery", () => {
+		injectAtlasCloudProvider(modelsJsonPath, { createIfMissing: true })
+
+		expect(readAtlasCloudModelMetadata(modelsJsonPath)).toEqual([
+			expect.objectContaining({
+				slug: "qwen/qwen3.5-flash",
+				display_name: "Qwen3.5 Flash",
+				provider: "atlascloud",
+				reasoning: false,
+				limits: { context_window: 1_000_000, max_output_tokens: 67_072 },
+			}),
+			expect.objectContaining({
+				slug: "deepseek-ai/deepseek-v4-pro",
+				display_name: "DeepSeek V4 Pro",
+				provider: "atlascloud",
+				reasoning: true,
+				limits: { context_window: 1_048_576, max_output_tokens: 393_216 },
+			}),
+		])
+	})
+
+	it("is accepted by pi-mono ModelRegistry", async () => {
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-dev": {
+						api: "openai-completions",
+						baseUrl: "https://llm.kimchi.dev/openai/v1",
+						apiKey: "$KIMCHI_API_KEY",
+						models: [],
+					},
+				},
+			}),
+			"utf-8",
+		)
+
+		injectAtlasCloudProvider(modelsJsonPath)
+
+		const { AuthStorage, ModelRegistry } = await import("@earendil-works/pi-coding-agent")
+		const previousKey = process.env.ATLASCLOUD_API_KEY
+		process.env.ATLASCLOUD_API_KEY = "test-atlas-key"
+		try {
+			const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsJsonPath)
+			const qwen = registry.find("atlascloud", "qwen/qwen3.5-flash")
+			const deepseek = registry.find("atlascloud", "deepseek-ai/deepseek-v4-pro")
+
+			expect(qwen?.baseUrl).toBe("https://api.atlascloud.ai/v1")
+			expect(qwen?.api).toBe("openai-completions")
+			expect(qwen?.contextWindow).toBe(1_000_000)
+			expect(deepseek?.reasoning).toBe(true)
+			expect(registry.getError()).toBeUndefined()
+			expect(registry.hasConfiguredAuth(qwen as Parameters<typeof registry.hasConfiguredAuth>[0])).toBe(true)
+		} finally {
+			if (previousKey === undefined) {
+				delete process.env.ATLASCLOUD_API_KEY
+			} else {
+				process.env.ATLASCLOUD_API_KEY = previousKey
+			}
+		}
+	})
+})

--- a/src/atlascloud.test.ts
+++ b/src/atlascloud.test.ts
@@ -29,6 +29,7 @@ describe("injectAtlasCloudProvider", () => {
 			modelsJsonPath,
 			JSON.stringify(
 				{
+					version: 1,
 					providers: {
 						"kimchi-dev": { models: [{ id: "kimi-k2.7" }] },
 						custom: { models: [{ id: "custom-model" }] },
@@ -43,6 +44,7 @@ describe("injectAtlasCloudProvider", () => {
 		injectAtlasCloudProvider(modelsJsonPath)
 
 		const providers = readConfig().providers
+		expect(JSON.parse(readFileSync(modelsJsonPath, "utf-8")).version).toBe(1)
 		expect(providers["kimchi-dev"]?.models?.map((m) => m.id)).toEqual(["kimi-k2.7"])
 		expect(providers.custom?.models?.map((m) => m.id)).toEqual(["custom-model"])
 		expect(providers.atlascloud).toMatchObject({
@@ -77,6 +79,34 @@ describe("injectAtlasCloudProvider", () => {
 		const second = readFileSync(modelsJsonPath, "utf-8")
 
 		expect(second).toBe(first)
+	})
+
+	it("does not overwrite malformed models.json", () => {
+		const malformed = "{ not-valid-json"
+		writeFileSync(modelsJsonPath, malformed, "utf-8")
+
+		expect(() => injectAtlasCloudProvider(modelsJsonPath)).toThrow()
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(malformed)
+	})
+
+	it("does not overwrite a malformed providers value", () => {
+		const malformed = JSON.stringify({ providers: [] })
+		writeFileSync(modelsJsonPath, malformed, "utf-8")
+
+		expect(() => injectAtlasCloudProvider(modelsJsonPath)).toThrow("models.json providers must contain a JSON object")
+		expect(readFileSync(modelsJsonPath, "utf-8")).toBe(malformed)
+	})
+
+	it("filters malformed model entries before exposing metadata", () => {
+		injectAtlasCloudProvider(modelsJsonPath, { createIfMissing: true })
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		config.providers.atlascloud.models.push({ id: "missing-required-fields" })
+		writeFileSync(modelsJsonPath, JSON.stringify(config), "utf-8")
+
+		expect(readAtlasCloudModelsFromConfig(modelsJsonPath).map((model) => model.id)).toEqual([
+			"qwen/qwen3.5-flash",
+			"deepseek-ai/deepseek-v4-pro",
+		])
 	})
 
 	it("reads Atlas Cloud model metadata for startup model discovery", () => {

--- a/src/atlascloud.ts
+++ b/src/atlascloud.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+
+import type { ModelMetadata, PiModelConfig } from "./models.js"
+
+const ATLASCLOUD_PROVIDER_ID = "atlascloud"
+const ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
+const ATLASCLOUD_API_KEY = "$ATLASCLOUD_API_KEY"
+
+const ATLASCLOUD_MODELS: readonly PiModelConfig[] = [
+	{
+		id: "qwen/qwen3.5-flash",
+		name: "Qwen3.5 Flash",
+		reasoning: false,
+		input: ["text"],
+		contextWindow: 1_000_000,
+		maxTokens: 67_072,
+		cost: { input: 0.1, output: 0.4, cacheRead: 0, cacheWrite: 0 },
+		provider: ATLASCLOUD_PROVIDER_ID,
+	},
+	{
+		id: "deepseek-ai/deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		reasoning: true,
+		input: ["text"],
+		contextWindow: 1_048_576,
+		maxTokens: 393_216,
+		cost: { input: 1.68, output: 3.38, cacheRead: 0.13, cacheWrite: 0 },
+		provider: ATLASCLOUD_PROVIDER_ID,
+	},
+]
+
+function readAllProviders(modelsJsonPath: string): Record<string, unknown> {
+	if (!existsSync(modelsJsonPath)) return {}
+	try {
+		const raw = readFileSync(modelsJsonPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		const providers = parsed?.providers
+		if (!providers || typeof providers !== "object") return {}
+		return providers as Record<string, unknown>
+	} catch {
+		return {}
+	}
+}
+
+function atlasCloudProviderConfig(): {
+	api: string
+	baseUrl: string
+	apiKey: string
+	authHeader: boolean
+	models: readonly PiModelConfig[]
+} {
+	return {
+		api: "openai-completions",
+		baseUrl: ATLASCLOUD_BASE_URL,
+		apiKey: ATLASCLOUD_API_KEY,
+		authHeader: true,
+		models: ATLASCLOUD_MODELS,
+	}
+}
+
+export interface InjectAtlasCloudProviderOptions {
+	/** When true, write models.json even if it does not exist yet. */
+	createIfMissing?: boolean
+}
+
+/**
+ * Merge Atlas Cloud into models.json as an optional OpenAI-compatible provider.
+ *
+ * The provider uses `$ATLASCLOUD_API_KEY` so no secret is written to disk. It is
+ * safe to run on startup and preserves Kimchi-managed and user-added providers.
+ */
+export function injectAtlasCloudProvider(modelsJsonPath: string, options: InjectAtlasCloudProviderOptions = {}): void {
+	if (!existsSync(modelsJsonPath) && !options.createIfMissing) return
+
+	const providers = readAllProviders(modelsJsonPath)
+	const merged = {
+		providers: {
+			...providers,
+			[ATLASCLOUD_PROVIDER_ID]: atlasCloudProviderConfig(),
+		},
+	}
+	writeFileSync(modelsJsonPath, JSON.stringify(merged, null, "\t"), "utf-8")
+}
+
+export function readAtlasCloudModelsFromConfig(modelsJsonPath: string): PiModelConfig[] {
+	try {
+		const raw = readFileSync(modelsJsonPath, "utf-8")
+		const parsed = JSON.parse(raw)
+		const models = parsed?.providers?.[ATLASCLOUD_PROVIDER_ID]?.models
+		if (!Array.isArray(models)) return []
+		return models.filter(
+			(m): m is PiModelConfig => !!m && typeof m === "object" && typeof (m as { id?: unknown }).id === "string",
+		) as PiModelConfig[]
+	} catch {
+		return []
+	}
+}
+
+export function readAtlasCloudModelMetadata(modelsJsonPath: string): ModelMetadata[] {
+	return readAtlasCloudModelsFromConfig(modelsJsonPath).map((model) => ({
+		slug: model.id,
+		display_name: model.name,
+		provider: model.provider ?? ATLASCLOUD_PROVIDER_ID,
+		reasoning: model.reasoning,
+		input_modalities: model.input,
+		is_serverless: true,
+		limits: { context_window: model.contextWindow, max_output_tokens: model.maxTokens },
+	}))
+}

--- a/src/atlascloud.ts
+++ b/src/atlascloud.ts
@@ -5,6 +5,7 @@ import type { ModelMetadata, PiModelConfig } from "./models.js"
 const ATLASCLOUD_PROVIDER_ID = "atlascloud"
 const ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
 const ATLASCLOUD_API_KEY = "$ATLASCLOUD_API_KEY"
+const MODEL_INPUT_MODALITIES = new Set(["text", "image"])
 
 const ATLASCLOUD_MODELS: readonly PiModelConfig[] = [
 	{
@@ -29,17 +30,43 @@ const ATLASCLOUD_MODELS: readonly PiModelConfig[] = [
 	},
 ]
 
-function readAllProviders(modelsJsonPath: string): Record<string, unknown> {
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readModelsConfig(modelsJsonPath: string): Record<string, unknown> {
 	if (!existsSync(modelsJsonPath)) return {}
-	try {
-		const raw = readFileSync(modelsJsonPath, "utf-8")
-		const parsed = JSON.parse(raw)
-		const providers = parsed?.providers
-		if (!providers || typeof providers !== "object") return {}
-		return providers as Record<string, unknown>
-	} catch {
-		return {}
+
+	const parsed: unknown = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+	if (!isRecord(parsed)) {
+		throw new Error("models.json must contain a JSON object")
 	}
+	if (parsed.providers !== undefined && !isRecord(parsed.providers)) {
+		throw new Error("models.json providers must contain a JSON object")
+	}
+	return parsed
+}
+
+function isPiModelConfig(value: unknown): value is PiModelConfig {
+	if (!isRecord(value)) return false
+	const cost = value.cost
+	return (
+		typeof value.id === "string" &&
+		typeof value.name === "string" &&
+		typeof value.reasoning === "boolean" &&
+		Array.isArray(value.input) &&
+		value.input.every((modality) => typeof modality === "string" && MODEL_INPUT_MODALITIES.has(modality)) &&
+		typeof value.contextWindow === "number" &&
+		Number.isFinite(value.contextWindow) &&
+		typeof value.maxTokens === "number" &&
+		Number.isFinite(value.maxTokens) &&
+		typeof value.provider === "string" &&
+		isRecord(cost) &&
+		typeof cost.input === "number" &&
+		typeof cost.output === "number" &&
+		typeof cost.cacheRead === "number" &&
+		typeof cost.cacheWrite === "number"
+	)
 }
 
 function atlasCloudProviderConfig(): {
@@ -72,8 +99,10 @@ export interface InjectAtlasCloudProviderOptions {
 export function injectAtlasCloudProvider(modelsJsonPath: string, options: InjectAtlasCloudProviderOptions = {}): void {
 	if (!existsSync(modelsJsonPath) && !options.createIfMissing) return
 
-	const providers = readAllProviders(modelsJsonPath)
+	const config = readModelsConfig(modelsJsonPath)
+	const providers = (config.providers as Record<string, unknown> | undefined) ?? {}
 	const merged = {
+		...config,
 		providers: {
 			...providers,
 			[ATLASCLOUD_PROVIDER_ID]: atlasCloudProviderConfig(),
@@ -88,9 +117,7 @@ export function readAtlasCloudModelsFromConfig(modelsJsonPath: string): PiModelC
 		const parsed = JSON.parse(raw)
 		const models = parsed?.providers?.[ATLASCLOUD_PROVIDER_ID]?.models
 		if (!Array.isArray(models)) return []
-		return models.filter(
-			(m): m is PiModelConfig => !!m && typeof m === "object" && typeof (m as { id?: unknown }).id === "string",
-		) as PiModelConfig[]
+		return models.filter(isPiModelConfig)
 	} catch {
 		return []
 	}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { dispatchSubcommand } from "./commands/dispatch.js"
 // before any module can construct an InteractiveMode instance.
 import "./login-command-patch.js"
 import "./paste-to-editor-patch.js"
+import { injectAtlasCloudProvider, readAtlasCloudModelMetadata } from "./atlascloud.js"
 import {
 	DEFAULT_SKILL_PATHS,
 	ensureHideThinkingBlockDefault,
@@ -369,6 +370,8 @@ try {
 			// registry. Probe is silent on failure — startup is never blocked.
 			await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
 			models = [...models, ...readOllamaModelMetadata(modelsJsonPath)]
+			injectAtlasCloudProvider(modelsJsonPath)
+			models = [...models, ...readAtlasCloudModelMetadata(modelsJsonPath)]
 		} catch (err) {
 			const is401 = err instanceof Error && err.message.includes("401")
 			if (is401 && process.stdin.isTTY) {
@@ -391,6 +394,8 @@ try {
 				}
 				await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
 				models = [...models, ...readOllamaModelMetadata(modelsJsonPath)]
+				injectAtlasCloudProvider(modelsJsonPath)
+				models = [...models, ...readAtlasCloudModelMetadata(modelsJsonPath)]
 			} else if (isTransientModelsError(err)) {
 				// Rate limit / gateway error with no cached models to fall back on.
 				// Don't crash startup over a transient condition — continue with an

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -370,7 +370,7 @@ try {
 			// registry. Probe is silent on failure — startup is never blocked.
 			await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
 			models = [...models, ...readOllamaModelMetadata(modelsJsonPath)]
-			injectAtlasCloudProvider(modelsJsonPath)
+			injectAtlasCloudProvider(modelsJsonPath, { createIfMissing: true })
 			models = [...models, ...readAtlasCloudModelMetadata(modelsJsonPath)]
 		} catch (err) {
 			const is401 = err instanceof Error && err.message.includes("401")
@@ -394,7 +394,7 @@ try {
 				}
 				await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
 				models = [...models, ...readOllamaModelMetadata(modelsJsonPath)]
-				injectAtlasCloudProvider(modelsJsonPath)
+				injectAtlasCloudProvider(modelsJsonPath, { createIfMissing: true })
 				models = [...models, ...readAtlasCloudModelMetadata(modelsJsonPath)]
 			} else if (isTransientModelsError(err)) {
 				// Rate limit / gateway error with no cached models to fall back on.


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an optional OpenAI-compatible provider in `models.json` startup discovery
- use `$ATLASCLOUD_API_KEY` so no secret is written to disk
- include live-verified Qwen3.5 Flash and DeepSeek V4 Pro model metadata, plus focused provider tests

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run src/atlascloud.test.ts src/models.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec biome check src/atlascloud.ts src/atlascloud.test.ts src/cli.ts`
- `corepack pnpm run build`
- `git diff --check`
- Atlas live catalog confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` with the metadata used in this PR

Note: the normal `git push` path hit GitHub network errors (`HTTP2 framing layer` / port 443 timeout), so I created the same fork branch commit through the GitHub Git Data API.

README: no README changes; no sponsor/logo/credits/partner promotion.