### PR TITLE
test(orchestration): set DEFAULT_MODEL_ROLES for log-research/single-oss-baseline

### DIFF
--- a/src/extensions/orchestration/model-roles-command.test.ts
+++ b/src/extensions/orchestration/model-roles-command.test.ts
@@ -146,7 +146,7 @@ describe("isEqualAssignment", () => {
 
 describe("formatRoleDisplay", () => {
 	it("appends (default) suffix when value matches DEFAULT_MODEL_ROLES", () => {
-		const display = formatRoleDisplay("orchestrator", "kimchi-dev/kimi-k2.7")
+		const display = formatRoleDisplay("orchestrator", "kimchi-dev/glm-5.2-fp8")
 		expect(display).toMatch(/\(default\)$/)
 	})
 
@@ -186,7 +186,7 @@ describe("formatRoleSummaryBlock", () => {
 	})
 
 	it("appends (default) suffix to each model line when assignment matches default", () => {
-		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/kimi-k2.7")
+		const display = formatRoleSummaryBlock("orchestrator", "kimchi-dev/glm-5.2-fp8")
 		expect(display).toContain("(default)")
 	})
 

--- a/src/extensions/orchestration/model-roles.test.ts
+++ b/src/extensions/orchestration/model-roles.test.ts
@@ -244,35 +244,37 @@ describe("modelIdFromRef", () => {
 })
 
 describe("DEFAULT_MODEL_ROLES", () => {
-	it("orchestrator is kimi-k2.7", () => {
-		expect(DEFAULT_MODEL_ROLES.orchestrator).toBe("kimchi-dev/kimi-k2.7")
+	it("orchestrator is glm-5.2-fp8", () => {
+		expect(DEFAULT_MODEL_ROLES.orchestrator).toBe("kimchi-dev/glm-5.2-fp8")
 	})
 
-	it("builder pool contains the build role but not nemotron", () => {
+	it("builder pool contains glm-5.2-fp8 and claude-sonnet-4-6", () => {
 		const builders = normalizeRoleModels(DEFAULT_MODEL_ROLES.builder)
-		expect(builders).toContain("kimchi-dev/minimax-m3")
-		expect(builders).not.toContain("kimchi-dev/nemotron-3-ultra-fp4")
+		expect(builders).toContain("kimchi-dev/glm-5.2-fp8")
+		expect(builders).toContain("kimchi-dev/claude-sonnet-4-6")
 	})
 
-	it("reviewer pool contains kimi-k2.7 only", () => {
+	it("reviewer pool contains glm-5.2-fp8 and claude-opus-4-8", () => {
 		const reviewers = normalizeRoleModels(DEFAULT_MODEL_ROLES.reviewer)
-		expect(reviewers).toContain("kimchi-dev/kimi-k2.7")
-		expect(reviewers).not.toContain("kimchi-dev/minimax-m3")
+		expect(reviewers).toContain("kimchi-dev/glm-5.2-fp8")
+		expect(reviewers).toContain("kimchi-dev/claude-opus-4-8")
 	})
 
-	it("explorer pool contains deepseek-v4-flash", () => {
+	it("explorer pool contains nemotron-3-ultra-fp4 and minimax-m3", () => {
 		const explorers = normalizeRoleModels(DEFAULT_MODEL_ROLES.explorer)
-		expect(explorers).toContain("kimchi-dev/deepseek-v4-flash")
+		expect(explorers).toContain("kimchi-dev/nemotron-3-ultra-fp4")
+		expect(explorers).toContain("kimchi-dev/minimax-m3")
 	})
 
-	it("planner pool contains kimi-k2.7", () => {
+	it("planner pool contains claude-opus-4-8 and glm-5.2-fp8", () => {
 		const planners = normalizeRoleModels(DEFAULT_MODEL_ROLES.planner)
-		expect(planners).toContain("kimchi-dev/kimi-k2.7")
+		expect(planners).toContain("kimchi-dev/claude-opus-4-8")
+		expect(planners).toContain("kimchi-dev/glm-5.2-fp8")
 	})
 
-	it("judge defaults to orchestrator model", () => {
+	it("judge is claude-opus-4-8", () => {
 		const judges = normalizeRoleModels(DEFAULT_MODEL_ROLES.judge)
-		expect(judges).toContain(DEFAULT_MODEL_ROLES.orchestrator)
+		expect(judges).toContain("kimchi-dev/claude-opus-4-8")
 	})
 
 	it("all defaults contain a provider prefix", () => {
@@ -370,7 +372,17 @@ describe("saveModelRoles", () => {
 })
 
 describe("validateModelRoles", () => {
-	const available = new Set(["kimi-k2.6", "kimi-k2.7", "minimax-m2.7", "minimax-m3", "deepseek-v4-flash"])
+	const available = new Set([
+		"kimi-k2.6",
+		"kimi-k2.7",
+		"minimax-m2.7",
+		"minimax-m3",
+		"deepseek-v4-flash",
+		"glm-5.2-fp8",
+		"claude-opus-4-8",
+		"claude-sonnet-4-6",
+		"nemotron-3-ultra-fp4",
+	])
 
 	it("returns no unavailable roles when all defaults are available", () => {
 		const result = validateModelRoles(DEFAULT_MODEL_ROLES, available)
@@ -492,9 +504,11 @@ describe("getAllowedMultiModelRefs", () => {
 	it("returns sorted unique refs for default roles", () => {
 		applyRoleAugmentation(() => ({ ...DEFAULT_MODEL_ROLES }))
 		expect(getAllowedMultiModelRefs()).toEqual([
-			"kimchi-dev/deepseek-v4-flash",
-			"kimchi-dev/kimi-k2.7",
+			"kimchi-dev/claude-opus-4-8",
+			"kimchi-dev/claude-sonnet-4-6",
+			"kimchi-dev/glm-5.2-fp8",
 			"kimchi-dev/minimax-m3",
+			"kimchi-dev/nemotron-3-ultra-fp4",
 		])
 	})
 

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -92,13 +92,13 @@ const ROLE_KEYS: readonly (keyof Omit<ModelRoles, "compactor">)[] = ["orchestrat
 
 /** Hardcoded default model-to-role assignment. Users override via /multi-model. */
 export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
-	orchestrator: "kimchi-dev/kimi-k2.7",
-	planner: "kimchi-dev/kimi-k2.7",
-	builder: ["kimchi-dev/minimax-m3"],
-	reviewer: ["kimchi-dev/kimi-k2.7"],
-	explorer: "kimchi-dev/deepseek-v4-flash",
+	orchestrator: "kimchi-dev/glm-5.2-fp8",
+	planner: ["kimchi-dev/claude-opus-4-8", "kimchi-dev/glm-5.2-fp8"],
+	builder: ["kimchi-dev/glm-5.2-fp8", "kimchi-dev/claude-sonnet-4-6"],
+	reviewer: ["kimchi-dev/glm-5.2-fp8", "kimchi-dev/claude-opus-4-8"],
+	explorer: ["kimchi-dev/nemotron-3-ultra-fp4", "kimchi-dev/minimax-m3"],
 	researcher: "kimchi-dev/minimax-m3",
-	judge: ["kimchi-dev/kimi-k2.7"],
+	judge: "kimchi-dev/claude-opus-4-8",
 	compactor: "kimchi-dev/minimax-m3",
 }
 

--- a/src/extensions/orchestration/model-roles.ts
+++ b/src/extensions/orchestration/model-roles.ts
@@ -93,13 +93,13 @@ const ROLE_KEYS: readonly (keyof Omit<ModelRoles, "compactor">)[] = ["orchestrat
 /** Hardcoded default model-to-role assignment. Users override via /multi-model. */
 export const DEFAULT_MODEL_ROLES: Readonly<ModelRoles> = {
 	orchestrator: "kimchi-dev/glm-5.2-fp8",
-	planner: ["kimchi-dev/claude-opus-4-8", "kimchi-dev/glm-5.2-fp8"],
-	builder: ["kimchi-dev/glm-5.2-fp8", "kimchi-dev/claude-sonnet-4-6"],
-	reviewer: ["kimchi-dev/glm-5.2-fp8", "kimchi-dev/claude-opus-4-8"],
-	explorer: ["kimchi-dev/nemotron-3-ultra-fp4", "kimchi-dev/minimax-m3"],
-	researcher: "kimchi-dev/minimax-m3",
-	judge: "kimchi-dev/claude-opus-4-8",
-	compactor: "kimchi-dev/minimax-m3",
+	planner: "kimchi-dev/glm-5.2-fp8",
+	builder: "kimchi-dev/glm-5.2-fp8",
+	reviewer: "kimchi-dev/glm-5.2-fp8",
+	explorer: "kimchi-dev/glm-5.2-fp8",
+	researcher: "kimchi-dev/glm-5.2-fp8",
+	judge: "kimchi-dev/glm-5.2-fp8",
+	compactor: "kimchi-dev/glm-5.2-fp8",
 }
 
 export interface ModelRolesWarning {

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -55,7 +55,7 @@ describe("resolveOrchestrationInstructions", () => {
 
 	it("shows Your roles subsection with orchestrator roles", () => {
 		const result = resolveAsString({
-			currentModelId: "kimi-k2.7",
+			currentModelId: "glm-5.2-fp8",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})
@@ -130,10 +130,14 @@ describe("resolveOrchestrationInstructions", () => {
 	})
 
 	it("instructs orchestrator to write plans itself when orchestrator is planner", () => {
+		// Isolate the sole-planner-equals-orchestrator case: the default planner
+		// pool is multi-model, which renders a Planner team section even when the
+		// orchestrator is a member. Override to a single-model planner == orchestrator
+		// to exercise the suppression path specifically.
 		const result = resolveAsString({
-			currentModelId: "kimi-k2.7",
+			currentModelId: "glm-5.2-fp8",
 			registry,
-			roles: DEFAULT_MODEL_ROLES,
+			roles: { ...DEFAULT_MODEL_ROLES, planner: DEFAULT_MODEL_ROLES.orchestrator },
 		})
 		expect(result).not.toContain("### Planner")
 		expect(result).not.toContain("Decide whether to write the plan yourself")
@@ -254,7 +258,7 @@ describe("resolveOrchestrationInstructions", () => {
 
 	it("allows self-review when orchestrator has reviewer role", () => {
 		const result = resolveAsString({
-			currentModelId: "kimi-k2.7",
+			currentModelId: "glm-5.2-fp8",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})
@@ -342,7 +346,7 @@ describe("resolveOrchestrationInstructions", () => {
 
 	it("replaces 'self-validate' with 'validate it by re-reading'", () => {
 		const result = resolveAsString({
-			currentModelId: "kimi-k2.7",
+			currentModelId: "glm-5.2-fp8",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})

--- a/src/extensions/orchestration/orchestrator-roles.test.ts
+++ b/src/extensions/orchestration/orchestrator-roles.test.ts
@@ -8,23 +8,28 @@ import {
 } from "./orchestrator-roles.js"
 
 describe("resolveModelRoleNames", () => {
-	it("returns orchestrator and planner for default kimi-k2.7 orchestrator", () => {
-		expect(resolveModelRoleNames("kimi-k2.7", DEFAULT_MODEL_ROLES)).toEqual(["orchestrator", "planner", "reviewer"])
+	it("returns orchestrator, planner, builder, and reviewer for default glm-5.2-fp8 orchestrator", () => {
+		expect(resolveModelRoleNames("glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toEqual([
+			"orchestrator",
+			"planner",
+			"builder",
+			"reviewer",
+		])
 	})
 })
 
 describe("orchestratorShouldReceivePhaseGuidelines", () => {
 	it("never includes build or review worker guidelines", () => {
-		expect(orchestratorShouldReceivePhaseGuidelines("build", "kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(false)
-		expect(orchestratorShouldReceivePhaseGuidelines("review", "kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(false)
+		expect(orchestratorShouldReceivePhaseGuidelines("build", "glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(false)
+		expect(orchestratorShouldReceivePhaseGuidelines("review", "glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(false)
 	})
 
 	it("includes plan guidelines when orchestrator owns planner", () => {
-		expect(orchestratorShouldReceivePhaseGuidelines("plan", "kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(true)
+		expect(orchestratorShouldReceivePhaseGuidelines("plan", "glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(true)
 	})
 
 	it("omits explore guidelines when orchestrator lacks explorer", () => {
-		expect(orchestratorShouldReceivePhaseGuidelines("explore", "kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(false)
+		expect(orchestratorShouldReceivePhaseGuidelines("explore", "glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(false)
 	})
 
 	it("omits guidelines when roles are missing", () => {
@@ -34,7 +39,7 @@ describe("orchestratorShouldReceivePhaseGuidelines", () => {
 
 describe("shouldDelegatePlanning", () => {
 	it("returns false when orchestrator is the planner model", () => {
-		expect(shouldDelegatePlanning("kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(false)
+		expect(shouldDelegatePlanning("glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(false)
 	})
 
 	it("returns true when orchestrator is not the planner model", () => {
@@ -63,7 +68,7 @@ describe("shouldDelegatePlanning", () => {
 
 describe("shouldDelegateReview", () => {
 	it("returns false when orchestrator is the reviewer model", () => {
-		expect(shouldDelegateReview("kimi-k2.7", DEFAULT_MODEL_ROLES)).toBe(false)
+		expect(shouldDelegateReview("glm-5.2-fp8", DEFAULT_MODEL_ROLES)).toBe(false)
 	})
 
 	it("returns true when orchestrator is not the reviewer model", () => {

--- a/test-configs/log-research/single-oss-baseline.json
+++ b/test-configs/log-research/single-oss-baseline.json
@@ -1,0 +1,27 @@
+{
+  "testSet": [
+    "fix-git",
+    "extract-elf",
+    "mteb-leaderboard"
+  ],
+  "taskType": "log-research",
+  "variant": "single-oss-baseline",
+  "modelRoles": {
+    "orchestrator": "kimchi-dev/glm-5.2-fp8",
+    "planner": "kimchi-dev/glm-5.2-fp8",
+    "builder": "kimchi-dev/glm-5.2-fp8",
+    "reviewer": "kimchi-dev/glm-5.2-fp8",
+    "explorer": "kimchi-dev/glm-5.2-fp8",
+    "judge": "kimchi-dev/glm-5.2-fp8"
+  },
+  "maxRetries": 3,
+  "modelMetadata": {
+    "kimchi-dev/glm-5.2-fp8": {
+      "tier": "standard",
+      "vision": true
+    }
+  },
+  "multiModel": false,
+  "hideThinkingBlock": true,
+  "_purpose": "one model doing every role, no routing at all \u2014 tests whether splitting into orchestrator/planner/builder/reviewer/explorer/judge earns its complexity over a single cheap model doing the whole task"
+}


### PR DESCRIPTION
Branch-off of #885 (`feat/multimodel-default-roles`). Part of the kimchi-dev routing test-configs matrix.

**Variant:** `log-research/single-oss-baseline`
**Purpose:** Single-OSS baseline (null hypothesis): glm-5.2-fp8 in every role, multiModel off

**Changes:**
- `src/extensions/orchestration/model-roles.ts` — `DEFAULT_MODEL_ROLES` set to this config's `modelRoles` (researcher/compactor filled from orchestrator to satisfy the `ModelRoles` type).
- `test-configs/log-research/single-oss-baseline.json` — full config (maxRetries, modelMetadata, multiModel, hideThinkingBlock, judgeTrigger where present) for the test harness to apply to `settings.json`.

Draft — for Terminal-Bench 2.1 routing tests only, not for merge.
- [x] Documentation update