### PR TITLE
feat(permissions): treat shell fd redirect as safe

### DIFF
--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -404,6 +404,28 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("cat foo 2>/dev/null")).toBe(true)
 	})
 
+	it("allows fd-to-fd redirects (2>&1, 1>&2)", () => {
+		// `2>&1` merges stderr into stdout — pure fd duplication, no file access.
+		expect(isReadOnlyBashCommand("git log --oneline HEAD 2>&1")).toBe(true)
+		expect(isReadOnlyBashCommand("git status 2>&1")).toBe(true)
+		expect(isReadOnlyBashCommand("ls -la 2>&1")).toBe(true)
+		// `1>&2` redirects stdout to stderr — also safe
+		expect(isReadOnlyBashCommand("echo hello 1>&2")).toBe(true)
+		// Bare `>&1` (no source fd) is also safe
+		expect(isReadOnlyBashCommand("echo hello >&1")).toBe(true)
+		// In a pipeline — each segment is individually checked
+		expect(isReadOnlyBashCommand("git log --oneline HEAD 2>&1 | head -30")).toBe(true)
+		expect(isReadOnlyBashCommand("git diff HEAD 2>&1 | grep foo")).toBe(true)
+	})
+
+	it("blocks file-target >& redirects", () => {
+		// `>& /tmp/evil` redirects to a file — a write, must be blocked
+		expect(isReadOnlyBashCommand("echo hello >& /tmp/evil")).toBe(false)
+		expect(isReadOnlyBashCommand("cat foo >& /tmp/out")).toBe(false)
+		// `>&-` closes the fd — not a digit, conservatively blocked
+		expect(isReadOnlyBashCommand("echo hello >&-")).toBe(false)
+	})
+
 	it("blocks hard-blocked patterns", () => {
 		expect(isReadOnlyBashCommand("sudo cat foo")).toBe(false)
 		expect(isReadOnlyBashCommand("rm -rf /")).toBe(false)

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -426,6 +426,15 @@ describe("isReadOnlyBashCommand", () => {
 		expect(isReadOnlyBashCommand("echo hello >&-")).toBe(false)
 	})
 
+	it("blocks bash &> combined redirect", () => {
+		// `&>` redirects both stdout+stderr to a file — shell-quote decomposes it
+		// into `&` + `>`, so the `&` (backgrounding) op blocks it transitively.
+		// Regression test: pins this incidental safety against future `&` relaxation.
+		expect(isReadOnlyBashCommand("cat foo &> /tmp/out")).toBe(false)
+		expect(isReadOnlyBashCommand("cat foo &>/tmp/out")).toBe(false)
+		expect(isReadOnlyBashCommand("echo hi &> /tmp/evil")).toBe(false)
+	})
+
 	it("blocks hard-blocked patterns", () => {
 		expect(isReadOnlyBashCommand("sudo cat foo")).toBe(false)
 		expect(isReadOnlyBashCommand("rm -rf /")).toBe(false)

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -308,6 +308,9 @@ const HARD_BLOCK_PROGRAMS = new Set(["sudo", "su", "shutdown", "reboot", "halt",
 // Operators we never want to see in a read-only command.
 //   - `>` / `>>`: writes (except `/dev/null|stdout|stderr` targets, handled
 //      separately in isReadOnlyBashCommand)
+//   - `>&`: fd/file redirect — safe when target is a pure digit (fd-to-fd
+//      duplication like `2>&1`), handled separately in isReadOnlyBashCommand.
+//      File-target redirects (`>& /tmp/evil`) remain blocked.
 //   - `<`: input redirect — also appears twice in a row for heredocs (<<EOF)
 //   - `<(` / `(`: process substitution / subshell — can hide arbitrary code
 //   - `&`: backgrounding
@@ -395,11 +398,11 @@ export function splitCompoundCommand(command: string): string[] | null {
 				currentTokens.push(entry.op)
 				continue
 			}
-			if ((op === ">" || op === ">>") && typeof entries[i + 1] === "string") {
-				// Consume the redirect target.
-				// NOTE: We intentionally handle only > and >>. Other redirects (<, >&, <<)
-				// are intentionally not supported — they would not change the program
-				// classification outcome for permission evaluation.
+			if ((op === ">" || op === ">>" || op === ">&") && typeof entries[i + 1] === "string") {
+				// Consume the redirect target (also covers `>&1` fd-to-fd redirects).
+				// NOTE: Other redirects (<, <<) are intentionally not supported —
+				// they would not change the program classification outcome for
+				// permission evaluation.
 				currentTokens.push(entry.op)
 				currentTokens.push(entries[i + 1] as string)
 				i++
@@ -497,6 +500,9 @@ export function isReadOnlyBashCommand(command: string): boolean {
 		for (const op of segment.ops) {
 			if (!DANGEROUS_OPS.has(op.op)) continue
 			if ((op.op === ">" || op.op === ">>") && op.target && READ_ONLY_REDIRECT_TARGETS.has(op.target)) continue
+			// `>&` with a pure-digit target is fd-to-fd duplication (e.g. `2>&1`), which cannot read or write files.
+			// File-target `>& /tmp/evil` stays blocked because the target is not a digit.
+			if (op.op === ">&" && op.target && /^[0-9]+$/.test(op.target)) continue
 			return false
 		}
 		if (!isSegmentReadOnly(segment.tokens)) return false
@@ -604,7 +610,7 @@ export function parseCommandSegments(command: string): Segment[] {
 				current = { tokens: [], ops: [] }
 				continue
 			}
-			if ((op === ">" || op === ">>") && typeof entries[i + 1] === "string") {
+			if ((op === ">" || op === ">>" || op === ">&") && typeof entries[i + 1] === "string") {
 				current.ops.push({ op, target: entries[i + 1] as string })
 				i++ // consume the redirect target
 				continue

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -314,6 +314,10 @@ const HARD_BLOCK_PROGRAMS = new Set(["sudo", "su", "shutdown", "reboot", "halt",
 //   - `<`: input redirect — also appears twice in a row for heredocs (<<EOF)
 //   - `<(` / `(`: process substitution / subshell — can hide arbitrary code
 //   - `&`: backgrounding
+//   - `&>` (combined stdout+stderr redirect-to-file): shell-quote decomposes
+//      this into `&` + `>`, so it is blocked transitively via the `&` rule.
+//      This safety is incidental — if `&` were ever relaxed, `&>` would need
+//      explicit handling.
 const DANGEROUS_OPS = new Set<ControlOperator>([">", ">>", ">&", "<", "<(", "(", ")", "&"])
 
 // `>` / `>>` targets that are allowed because they discard or duplicate


### PR DESCRIPTION
## What does this PR do?

The PR allows commands that end with `2>&1` ("redirect stderr to stdout") to be always allowed in 'default' mode.
It is very annoying when using GLM.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
