### PR TITLE
fix: enforce minimum token budget and default max_turns for sub-agents

### DIFF
--- a/src/extensions/agents/index.test.ts
+++ b/src/extensions/agents/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	AGENT_MODEL_PARAMETER_DESCRIPTION,
 	AGENT_TOOL_GUIDELINES,
+	clampTokenBudget,
 	resolveRoleModelRef,
 	summaryForStatus,
 } from "./index.js"
@@ -532,5 +533,28 @@ describe("resolveRoleModelRef", () => {
 
 	it("returns undefined for unknown agent types", () => {
 		expect(resolveRoleModelRef("Unknown")).toBeUndefined()
+	})
+})
+
+describe("clampTokenBudget", () => {
+	it("returns undefined when no budget is set", () => {
+		expect(clampTokenBudget(undefined, true)).toBeUndefined()
+		expect(clampTokenBudget(undefined, false)).toBeUndefined()
+	})
+
+	it("clamps up to minimum when multi-model is active and budget is below minimum", () => {
+		expect(clampTokenBudget(2000, true)).toBe(150_000)
+		expect(clampTokenBudget(8000, true)).toBe(150_000)
+		expect(clampTokenBudget(149_999, true)).toBe(150_000)
+	})
+
+	it("does not clamp when multi-model is disabled even if budget is tiny", () => {
+		expect(clampTokenBudget(2000, false)).toBe(2000)
+		expect(clampTokenBudget(8000, false)).toBe(8000)
+	})
+
+	it("does not clamp when budget is at or above minimum", () => {
+		expect(clampTokenBudget(150_000, true)).toBe(150_000)
+		expect(clampTokenBudget(200_000, true)).toBe(200_000)
 	})
 })

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -145,10 +145,7 @@ export function resolveRoleModelRef(subagentType: string): string | undefined {
  *
  * Returns undefined when no budget was set (pass-through).
  */
-export function clampTokenBudget(
-	rawBudget: number | undefined,
-	multiModelEnabled: boolean,
-): number | undefined {
+export function clampTokenBudget(rawBudget: number | undefined, multiModelEnabled: boolean): number | undefined {
 	if (rawBudget == null) return undefined
 	if (multiModelEnabled && rawBudget < AGENT_WORKER_BUDGETS.default.tokenBudget) {
 		return AGENT_WORKER_BUDGETS.default.tokenBudget
@@ -1377,7 +1374,8 @@ ${AGENT_TOOL_GUIDELINES}`,
 						: undefined
 				const agentTags: string[] = []
 				if (thinking) agentTags.push(`thinking: ${thinking}`)
-				if (resolvedConfig.tokenBudget != null) agentTags.push(`budget: ${formatTokens(effectiveTokenBudget!)}`)
+				if (resolvedConfig.tokenBudget != null && effectiveTokenBudget != null)
+					agentTags.push(`budget: ${formatTokens(effectiveTokenBudget)}`)
 				if (isolated) agentTags.push("isolated")
 				const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns)
 				const detailBase = {

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -104,6 +104,7 @@ import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 // ---- Shared helpers ----
 
 /**
+/**
  * Maps an agent persona type to its model-roles key.
  * Returns null for types that don't have a configured role.
  */
@@ -134,6 +135,25 @@ export function resolveRoleModelRef(subagentType: string): string | undefined {
 	if (!assignment) return undefined
 	const modelRefs = normalizeRoleModels(assignment)
 	return modelRefs[0]
+}
+
+/**
+ * Clamp token budget to the minimum when multi-model is active.
+ * The orchestrator often passes tiny budgets (2000-8000) that are too
+ * small for any real implementation work — a single file write can
+ * exceed 2000 output tokens. Clamps up to AGENT_WORKER_BUDGETS.default.tokenBudget.
+ *
+ * Returns undefined when no budget was set (pass-through).
+ */
+export function clampTokenBudget(
+	rawBudget: number | undefined,
+	multiModelEnabled: boolean,
+): number | undefined {
+	if (rawBudget == null) return undefined
+	if (multiModelEnabled && rawBudget < AGENT_WORKER_BUDGETS.default.tokenBudget) {
+		return AGENT_WORKER_BUDGETS.default.tokenBudget
+	}
+	return rawBudget
 }
 
 // Give aborted sub-agents a bounded chance to reach runner finally blocks.
@@ -1292,15 +1312,10 @@ ${AGENT_TOOL_GUIDELINES}`,
 				// small for any real implementation work — a single file write can
 				// exceed 2000 output tokens. Clamp to the minimum from the budget
 				// table so Builders have enough room to complete their work.
-				const MIN_TOKEN_BUDGET = AGENT_WORKER_BUDGETS.default.tokenBudget
-				const effectiveTokenBudget = (() => {
-					const raw = resolvedConfig.tokenBudget
-					if (raw == null) return undefined
-					if (getMultiModelEnabled(ctx.sessionManager) && raw < MIN_TOKEN_BUDGET) {
-						return MIN_TOKEN_BUDGET
-					}
-					return raw
-				})()
+				const effectiveTokenBudget = clampTokenBudget(
+					resolvedConfig.tokenBudget,
+					getMultiModelEnabled(ctx.sessionManager),
+				)
 				if (
 					activeBudgetRetryBlock &&
 					shouldBlockBudgetRetry(activeBudgetRetryBlock, {

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -85,7 +85,6 @@ import { resolveAgentInvocationConfig, resolveJoinMode } from "./resolution/invo
 import { type ModelRegistry, resolveModel } from "./resolution/model-resolver.js"
 import { registerResumeSubagentTool } from "./resume-tool.js"
 import { applyAndEmitLoaded, type SubagentsSettings, saveAndEmitChanged } from "./settings.js"
-import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 import {
 	type AgentActivity,
 	type AgentDetails,
@@ -100,6 +99,7 @@ import {
 	type Theme,
 	type UICtx,
 } from "./ui/agent-widget.js"
+import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 
 // ---- Shared helpers ----
 

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -38,6 +38,7 @@ import { isRawInputCaptureActive } from "../shared-input.js"
 import { isStaleCtxError } from "../stale-ctx.js"
 import { trackSubagentSpawned } from "../telemetry/index.js"
 import { AgentManager, buildAgentOutcome } from "./manager/agent-manager.js"
+import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 import {
 	getAgentConversation,
 	getDefaultMaxTurns,
@@ -1285,10 +1286,25 @@ ${AGENT_TOOL_GUIDELINES}`,
 					(params as { token_budget?: number; tokenBudget?: number }).token_budget ??
 					(params as { token_budget?: number; tokenBudget?: number }).tokenBudget
 				const activeBudgetRetryBlock = budgetRetryBlock
+
+				// Enforce minimum token budget when multi-model is active. The
+				// orchestrator often passes tiny budgets (2000-8000) that are too
+				// small for any real implementation work — a single file write can
+				// exceed 2000 output tokens. Clamp to the minimum from the budget
+				// table so Builders have enough room to complete their work.
+				const MIN_TOKEN_BUDGET = AGENT_WORKER_BUDGETS.default.tokenBudget
+				const effectiveTokenBudget = (() => {
+					const raw = resolvedConfig.tokenBudget
+					if (raw == null) return undefined
+					if (getMultiModelEnabled(ctx.sessionManager) && raw < MIN_TOKEN_BUDGET) {
+						return MIN_TOKEN_BUDGET
+					}
+					return raw
+				})()
 				if (
 					activeBudgetRetryBlock &&
 					shouldBlockBudgetRetry(activeBudgetRetryBlock, {
-						tokenBudget: resolvedConfig.tokenBudget,
+						tokenBudget: effectiveTokenBudget ?? resolvedConfig.tokenBudget,
 						subagentType,
 						description: params.description as string,
 						prompt: params.prompt as string,
@@ -1346,7 +1362,8 @@ ${AGENT_TOOL_GUIDELINES}`,
 						: undefined
 				const agentTags: string[] = []
 				if (thinking) agentTags.push(`thinking: ${thinking}`)
-				if (resolvedConfig.tokenBudget != null) agentTags.push(`budget: ${formatTokens(resolvedConfig.tokenBudget)}`)
+				if (resolvedConfig.tokenBudget != null)
+					agentTags.push(`budget: ${formatTokens(effectiveTokenBudget ?? resolvedConfig.tokenBudget)}`)
 				if (isolated) agentTags.push("isolated")
 				const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns())
 				const detailBase = {

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -1304,7 +1304,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 				if (
 					activeBudgetRetryBlock &&
 					shouldBlockBudgetRetry(activeBudgetRetryBlock, {
-						tokenBudget: effectiveTokenBudget ?? resolvedConfig.tokenBudget,
+						tokenBudget: effectiveTokenBudget,
 						subagentType,
 						description: params.description as string,
 						prompt: params.prompt as string,
@@ -1363,9 +1363,9 @@ ${AGENT_TOOL_GUIDELINES}`,
 				const agentTags: string[] = []
 				if (thinking) agentTags.push(`thinking: ${thinking}`)
 				if (resolvedConfig.tokenBudget != null)
-					agentTags.push(`budget: ${formatTokens(effectiveTokenBudget ?? resolvedConfig.tokenBudget)}`)
+					agentTags.push(`budget: ${formatTokens(effectiveTokenBudget!)}`)
 				if (isolated) agentTags.push("isolated")
-				const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns ?? getDefaultMaxTurns())
+				const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns)
 				const detailBase = {
 					displayName,
 					description: params.description as string,
@@ -1411,7 +1411,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 							visibility,
 							model: model as Parameters<typeof manager.spawn>[4]["model"],
 							maxTurns: effectiveMaxTurns,
-							tokenBudget: resolvedConfig.tokenBudget,
+							tokenBudget: effectiveTokenBudget,
 							taskRef,
 							maxDuration: resolvedConfig.maxDuration,
 							isolated,
@@ -1557,7 +1557,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 						visibility,
 						model: model as Parameters<typeof manager.spawn>[4]["model"],
 						maxTurns: effectiveMaxTurns,
-						tokenBudget: resolvedConfig.tokenBudget,
+						tokenBudget: effectiveTokenBudget,
 						taskRef,
 						maxDuration: resolvedConfig.maxDuration,
 						isolated,

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -38,7 +38,6 @@ import { isRawInputCaptureActive } from "../shared-input.js"
 import { isStaleCtxError } from "../stale-ctx.js"
 import { trackSubagentSpawned } from "../telemetry/index.js"
 import { AgentManager, buildAgentOutcome } from "./manager/agent-manager.js"
-import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 import {
 	getAgentConversation,
 	getDefaultMaxTurns,
@@ -86,6 +85,7 @@ import { resolveAgentInvocationConfig, resolveJoinMode } from "./resolution/invo
 import { type ModelRegistry, resolveModel } from "./resolution/model-resolver.js"
 import { registerResumeSubagentTool } from "./resume-tool.js"
 import { applyAndEmitLoaded, type SubagentsSettings, saveAndEmitChanged } from "./settings.js"
+import { AGENT_WORKER_BUDGETS } from "./worker-budget-policy.js"
 import {
 	type AgentActivity,
 	type AgentDetails,
@@ -1362,8 +1362,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 						: undefined
 				const agentTags: string[] = []
 				if (thinking) agentTags.push(`thinking: ${thinking}`)
-				if (resolvedConfig.tokenBudget != null)
-					agentTags.push(`budget: ${formatTokens(effectiveTokenBudget!)}`)
+				if (resolvedConfig.tokenBudget != null) agentTags.push(`budget: ${formatTokens(effectiveTokenBudget!)}`)
 				if (isolated) agentTags.push("isolated")
 				const effectiveMaxTurns = normalizeMaxTurns(resolvedConfig.maxTurns)
 				const detailBase = {

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -46,22 +46,16 @@ describe("resolveAgentInvocationConfig — tokenBudget precedence", () => {
 	})
 
 	it("params.token_budget wins over agentConfig.tokenBudget", () => {
-		const result = resolveAgentInvocationConfig(
-			{ ...agent, tokenBudget: 80_000 },
-			{
-				token_budget: 50_000,
-			} as Parameters<typeof resolveAgentInvocationConfig>[1] & { token_budget?: number },
-		)
+		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {
+			token_budget: 50_000,
+		} as Parameters<typeof resolveAgentInvocationConfig>[1] & { token_budget?: number })
 		expect(result.tokenBudget).toBe(50_000)
 	})
 
 	it("accepts tokenBudget as a compatibility alias", () => {
-		const result = resolveAgentInvocationConfig(
-			{ ...agent, tokenBudget: 80_000 },
-			{
-				tokenBudget: 50_000,
-			} as Parameters<typeof resolveAgentInvocationConfig>[1] & { tokenBudget?: number },
-		)
+		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {
+			tokenBudget: 50_000,
+		} as Parameters<typeof resolveAgentInvocationConfig>[1] & { tokenBudget?: number })
 		expect(result.tokenBudget).toBe(50_000)
 	})
 

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { resolveAgentInvocationConfig } from "./invocation-config.js"
 import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
+import { resolveAgentInvocationConfig } from "./invocation-config.js"
 
 const agent = {
 	name: "test",

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -1,6 +1,97 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { resolveAgentInvocationConfig } from "./invocation-config.js"
 import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
+
+const agent = {
+	name: "test",
+	description: "t",
+	extensions: true as const,
+	skills: true as const,
+	systemPrompt: "",
+	promptMode: "replace" as const,
+}
+
+describe("resolveAgentInvocationConfig — model selection", () => {
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("uses params.model when provided", () => {
+		const result = resolveAgentInvocationConfig(agent, { model: "kimchi-dev/minimax-m2.7" })
+		expect(result.modelInput).toBe("kimchi-dev/minimax-m2.7")
+		expect(result.modelFromParams).toBe(true)
+	})
+
+	it("modelInput is undefined when params.model is omitted", () => {
+		const result = resolveAgentInvocationConfig(agent, {})
+		expect(result.modelInput).toBeUndefined()
+		expect(result.modelFromParams).toBe(false)
+	})
+
+	it("modelInput is undefined when params.model is empty string", () => {
+		const result = resolveAgentInvocationConfig(agent, { model: "" })
+		expect(result.modelInput).toBeUndefined()
+		expect(result.modelFromParams).toBe(false)
+	})
+})
+
+describe("resolveAgentInvocationConfig — tokenBudget precedence", () => {
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("agentConfig.tokenBudget used when params has no token_budget", () => {
+		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {})
+		expect(result.tokenBudget).toBe(80_000)
+	})
+
+	it("params.token_budget wins over agentConfig.tokenBudget", () => {
+		const result = resolveAgentInvocationConfig(
+			{ ...agent, tokenBudget: 80_000 },
+			{
+				token_budget: 50_000,
+			} as Parameters<typeof resolveAgentInvocationConfig>[1] & { token_budget?: number },
+		)
+		expect(result.tokenBudget).toBe(50_000)
+	})
+
+	it("accepts tokenBudget as a compatibility alias", () => {
+		const result = resolveAgentInvocationConfig(
+			{ ...agent, tokenBudget: 80_000 },
+			{
+				tokenBudget: 50_000,
+			} as Parameters<typeof resolveAgentInvocationConfig>[1] & { tokenBudget?: number },
+		)
+		expect(result.tokenBudget).toBe(50_000)
+	})
+
+	it("tokenBudget is undefined when neither agentConfig nor params supply a value", () => {
+		const result = resolveAgentInvocationConfig(agent, {})
+		expect(result.tokenBudget).toBeUndefined()
+	})
+})
+
+describe("resolveAgentInvocationConfig — persona policy precedence", () => {
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("agentConfig.thinking used when params has no thinking", () => {
+		const result = resolveAgentInvocationConfig(
+			{ ...agent, thinking: "medium" as const },
+			{},
+		)
+		expect(result.thinking).toBe("medium")
+	})
+
+	it("params.thinking wins over agentConfig.thinking", () => {
+		const result = resolveAgentInvocationConfig(
+			{ ...agent, thinking: "medium" as const },
+			{ thinking: "high" },
+		)
+		expect(result.thinking).toBe("high")
+	})
+})
 
 describe("resolveAgentInvocationConfig — default max_turns", () => {
 	it("uses AGENT_WORKER_BUDGETS.default.maxTurns when neither caller nor persona specify max_turns", () => {

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -77,18 +77,12 @@ describe("resolveAgentInvocationConfig — persona policy precedence", () => {
 	})
 
 	it("agentConfig.thinking used when params has no thinking", () => {
-		const result = resolveAgentInvocationConfig(
-			{ ...agent, thinking: "medium" as const },
-			{},
-		)
+		const result = resolveAgentInvocationConfig({ ...agent, thinking: "medium" as const }, {})
 		expect(result.thinking).toBe("medium")
 	})
 
 	it("params.thinking wins over agentConfig.thinking", () => {
-		const result = resolveAgentInvocationConfig(
-			{ ...agent, thinking: "medium" as const },
-			{ thinking: "high" },
-		)
+		const result = resolveAgentInvocationConfig({ ...agent, thinking: "medium" as const }, { thinking: "high" })
 		expect(result.thinking).toBe("high")
 	})
 })

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -1,86 +1,31 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import { resolveAgentInvocationConfig } from "./invocation-config.js"
+import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
 
-const agent = {
-	name: "test",
-	description: "t",
-	extensions: true as const,
-	skills: true as const,
-	systemPrompt: "",
-	promptMode: "replace" as const,
-}
-
-describe("resolveAgentInvocationConfig — model selection", () => {
-	afterEach(() => {
-		vi.clearAllMocks()
+describe("resolveAgentInvocationConfig — default max_turns", () => {
+	it("uses AGENT_WORKER_BUDGETS.default.maxTurns when neither caller nor persona specify max_turns", () => {
+		const result = resolveAgentInvocationConfig(undefined, {})
+		expect(result.maxTurns).toBe(AGENT_WORKER_BUDGETS.default.maxTurns)
 	})
 
-	it("uses params.model when provided", () => {
-		const result = resolveAgentInvocationConfig(agent, { model: "kimchi-dev/minimax-m2.7" })
-		expect(result.modelInput).toBe("kimchi-dev/minimax-m2.7")
-		expect(result.modelFromParams).toBe(true)
+	it("uses caller-provided max_turns over the default", () => {
+		const result = resolveAgentInvocationConfig(undefined, { max_turns: 50 })
+		expect(result.maxTurns).toBe(50)
 	})
 
-	it("modelInput is undefined when params.model is omitted", () => {
-		const result = resolveAgentInvocationConfig(agent, {})
-		expect(result.modelInput).toBeUndefined()
-		expect(result.modelFromParams).toBe(false)
+	it("uses persona-provided maxTurns over the default", () => {
+		const result = resolveAgentInvocationConfig(
+			{ maxTurns: 20 } as Parameters<typeof resolveAgentInvocationConfig>[0],
+			{},
+		)
+		expect(result.maxTurns).toBe(20)
 	})
 
-	it("modelInput is undefined when params.model is empty string", () => {
-		const result = resolveAgentInvocationConfig(agent, { model: "" })
-		expect(result.modelInput).toBeUndefined()
-		expect(result.modelFromParams).toBe(false)
-	})
-})
-
-describe("resolveAgentInvocationConfig — tokenBudget precedence", () => {
-	afterEach(() => {
-		vi.clearAllMocks()
-	})
-
-	it("agentConfig.tokenBudget used when params has no token_budget", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {})
-		expect(result.tokenBudget).toBe(80_000)
-	})
-
-	it("params.token_budget wins over agentConfig.tokenBudget", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {
-			token_budget: 50_000,
-		} as Parameters<typeof resolveAgentInvocationConfig>[1] & { token_budget?: number })
-		expect(result.tokenBudget).toBe(50_000)
-	})
-
-	it("accepts tokenBudget as a compatibility alias", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, tokenBudget: 80_000 }, {
-			tokenBudget: 50_000,
-		} as Parameters<typeof resolveAgentInvocationConfig>[1] & { tokenBudget?: number })
-		expect(result.tokenBudget).toBe(50_000)
-	})
-
-	it("tokenBudget is undefined when neither agentConfig nor params supply a value", () => {
-		const result = resolveAgentInvocationConfig(agent, {})
-		expect(result.tokenBudget).toBeUndefined()
-	})
-})
-
-describe("resolveAgentInvocationConfig — persona policy precedence", () => {
-	afterEach(() => {
-		vi.clearAllMocks()
-	})
-
-	it("params.thinking wins over agentConfig.thinking", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, thinking: "minimal" }, { thinking: "high" })
-		expect(result.thinking).toBe("high")
-	})
-
-	it("falls back to agentConfig.thinking when params omit thinking", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, thinking: "minimal" }, {})
-		expect(result.thinking).toBe("minimal")
-	})
-
-	it("agentConfig.maxTurns wins over params.max_turns", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, maxTurns: 3 }, { max_turns: 10 })
-		expect(result.maxTurns).toBe(3)
+	it("persona maxTurns takes precedence over caller max_turns", () => {
+		const result = resolveAgentInvocationConfig(
+			{ maxTurns: 20 } as Parameters<typeof resolveAgentInvocationConfig>[0],
+			{ max_turns: 50 },
+		)
+		expect(result.maxTurns).toBe(20)
 	})
 })

--- a/src/extensions/agents/resolution/invocation-config.ts
+++ b/src/extensions/agents/resolution/invocation-config.ts
@@ -1,5 +1,5 @@
-import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
 import type { AgentConfig, IsolationMode, JoinMode, ThinkingLevel } from "../personas/types.js"
+import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
 
 interface AgentInvocationParams {
 	model?: string

--- a/src/extensions/agents/resolution/invocation-config.ts
+++ b/src/extensions/agents/resolution/invocation-config.ts
@@ -1,3 +1,4 @@
+import { AGENT_WORKER_BUDGETS } from "../worker-budget-policy.js"
 import type { AgentConfig, IsolationMode, JoinMode, ThinkingLevel } from "../personas/types.js"
 
 interface AgentInvocationParams {
@@ -54,7 +55,7 @@ export function resolveAgentInvocationConfig(
 		modelInput,
 		modelFromParams,
 		thinking: (params.thinking ?? agentConfig?.thinking) as ThinkingLevel | undefined,
-		maxTurns: agentConfig?.maxTurns ?? params.max_turns,
+		maxTurns: agentConfig?.maxTurns ?? params.max_turns ?? AGENT_WORKER_BUDGETS.default.maxTurns,
 		tokenBudget: params.token_budget ?? params.tokenBudget ?? agentConfig?.tokenBudget,
 		maxDuration: params.max_duration ?? agentConfig?.maxDuration,
 		inheritContext: agentConfig?.inheritContext ?? params.inherit_context ?? false,

--- a/src/extensions/agents/worker-budget-policy.ts
+++ b/src/extensions/agents/worker-budget-policy.ts
@@ -19,6 +19,7 @@ export const FERMENT_WORKER_BUDGETS = {
 
 /** Shared delegation budgets used by prompts and Ferment step handoffs. */
 export const AGENT_WORKER_BUDGETS = {
+	default: { maxTurns: 30, maxDuration: 600, tokenBudget: 150_000 },
 	singleFile: { maxTurns: 12, maxDuration: 300, tokenBudget: 50_000 },
 	multiFile: { maxTurns: 30, maxDuration: 600, tokenBudget: 150_000 },
 	review: { maxTurns: 20, maxDuration: 600, tokenBudget: 100_000 },


### PR DESCRIPTION
## Problem

Benchmark analysis revealed two budget-related bugs causing sub-agent aborts:

1. **Token budget not enforced:** 63 of 85 Builder aborts were `token_budget` exhaustion because the orchestrator passed tiny budgets (2000-8000 tokens). A single file write can exceed 2000 output tokens.

2. **Default max_turns not set:** 154 of 178 Builder calls had no `max_turns` set, causing undefined behavior and premature aborts.

## Fix

1. **Token budget clamp:** When multi-model is active and the passed budget is below `AGENT_WORKER_BUDGETS.default.tokenBudget` (150,000), clamp up to the minimum. Budgets above the minimum pass through unchanged. No clamping when multi-model is disabled.

2. **Default max_turns:** Default to `AGENT_WORKER_BUDGETS.default.maxTurns` (30) when neither the caller nor the persona config specifies one. Persona config takes precedence over caller params (existing behavior preserved).

3. **New `default` key** in `AGENT_WORKER_BUDGETS` — centralizes the default values used by both fixes.

## Testing

- [x] Unit tests for default max_turns resolution (4 cases: no params, caller only, persona only, both)
- [x] Type check passes
- [x] All existing tests pass

## Checklist

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update