### PR TITLE
feat: add PR status-line segment and expose PR data to scripts

### DIFF
--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -5,6 +5,7 @@ import type { StatusLineElementId } from "../config/status-line-config.js"
 import * as AGENTS from "../extensions/agents/index.js"
 import { setBillingStatusForTest } from "../extensions/billing/status.js"
 import * as FERMENT from "../extensions/ferment/index.js"
+import { setPrStatusForTest } from "../extensions/pr-status.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
 import * as TAGS from "../extensions/tags.js"
 import {
@@ -97,7 +98,16 @@ function createMockStatusLineData(opts?: {
 }
 
 describe("buildScriptPayload", () => {
-	afterEach(() => setBillingStatusForTest(undefined))
+	afterEach(() => {
+		setBillingStatusForTest(undefined)
+		setPrStatusForTest(undefined)
+	})
+
+	it("passes PR number and URL to custom status-line scripts", () => {
+		setPrStatusForTest({ number: 42, url: "https://github.com/owner/repo/pull/42" })
+		const payload = buildScriptPayload(createMockContext(), "idle", 0, 0, 0)
+		expect(payload.pr).toEqual({ number: 42, url: "https://github.com/owner/repo/pull/42" })
+	})
 
 	it("passes credits and budget to custom status-line scripts", () => {
 		setBillingStatusForTest({
@@ -425,6 +435,7 @@ describe("StatusLine segment coverage", () => {
 	afterEach(() => {
 		vi.restoreAllMocks()
 		setBillingStatusForTest(undefined)
+		setPrStatusForTest(undefined)
 		restorePlatform()
 	})
 
@@ -591,6 +602,33 @@ describe("StatusLine segment coverage", () => {
 			renderVisible(sl, 200)
 			expect(getCurrentPhaseSpy).toHaveBeenCalledWith("test-session")
 			expect(getActiveTagsSpy).toHaveBeenCalledWith(ctx.sessionManager)
+		})
+	})
+
+	it("pr segment shows PR number when pinned and PR info is available", () => {
+		withPinned(["pr"], () => {
+			setPrStatusForTest({ number: 42, url: "https://github.com/owner/repo/pull/42" })
+			const sl = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+			const visible = renderVisible(sl, 200)
+			expect(visible).toContain("PR:")
+			expect(visible).toContain("#42")
+		})
+	})
+
+	it("pr segment is hidden when unpinned and no PR info is available", () => {
+		setPrStatusForTest(undefined)
+		const sl = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+		const visible = renderVisible(sl, 200)
+		expect(visible).not.toContain("PR:")
+	})
+
+	it("pr segment shows placeholder when pinned but no PR info is available", () => {
+		withPinned(["pr"], () => {
+			setPrStatusForTest(undefined)
+			const sl = new StatusLine(createMockContext(), theme, createMockStatusLineData())
+			const visible = renderVisible(sl, 200)
+			expect(visible).toContain("PR:")
+			expect(visible).toContain("—")
 		})
 	})
 })

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -5,8 +5,8 @@ import type { StatusLineElementId } from "../config/status-line-config.js"
 import * as AGENTS from "../extensions/agents/index.js"
 import { setBillingStatusForTest } from "../extensions/billing/status.js"
 import * as FERMENT from "../extensions/ferment/index.js"
-import { setPrStatusForTest } from "../extensions/pr-status.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
+import { setPrStatusForTest } from "../extensions/pr-status.js"
 import * as TAGS from "../extensions/tags.js"
 import {
 	buildContextCompact,

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -15,6 +15,7 @@ import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-lin
 import { formatCount } from "../extensions/format.js"
 import { getMultiModelEnabled } from "../extensions/multi-model.js"
 import { getPermissionMode } from "../extensions/permissions/mode-controller.js"
+import { getPrStatusLine } from "../extensions/pr-status.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
@@ -31,6 +32,7 @@ type SegmentId =
 	| "credits"
 	| "budget"
 	| "lsp"
+	| "pr"
 
 /** Raw inputs preserved on segments that have compact forms, so compaction
  *  steps can rebuild the colorized text without round-tripping through ANSI.
@@ -161,6 +163,7 @@ export function buildScriptPayload(
 			enabled: getMultiModelEnabled(ctx.sessionManager),
 		},
 		phase: getCurrentPhase(sessionId),
+		pr: getPrStatusLine(),
 	}
 }
 
@@ -530,6 +533,17 @@ export class StatusLine implements Component {
 		return { id: "agents", text, width: visibleWidth(text) }
 	}
 
+	private prSegment(pinned = false): Segment | null {
+		const pr = getPrStatusLine()
+		if (!pr) {
+			if (!pinned) return null
+			const text = `${this.dim("PR:")} ${this.dim("—")}`
+			return { id: "pr", text, width: visibleWidth(text) }
+		}
+		const text = `${this.dim("PR:")} ${this.accent(`#${pr.number}`)}`
+		return { id: "pr", text, width: visibleWidth(text) }
+	}
+
 	private fermentSegment(pinned = false): Segment | null {
 		const display = formatFermentStatusLineDisplay(getActiveFerment(), getFermentContinuationPolicy(), {
 			dim: (s) => this.dim(s),
@@ -594,6 +608,7 @@ export class StatusLine implements Component {
 			this.tagsSegment(tags, pinnedSet.has("tags")),
 			this.teamSegment(tags, pinnedSet.has("team")),
 			this.lspSegment(),
+			this.prSegment(pinnedSet.has("pr")),
 		].filter((s): s is Segment => s !== null)
 
 		const unpinnedSegments = allSegments.filter((s) => !pinnedSet.has(s.id))

--- a/src/config/status-line-config.test.ts
+++ b/src/config/status-line-config.test.ts
@@ -46,8 +46,8 @@ afterEach(() => {
 // ── STATUS_LINE_ELEMENTS metadata ────────────────────────────────────────────
 
 describe("STATUS_LINE_ELEMENTS", () => {
-	it("has 11 entries", () => {
-		expect(STATUS_LINE_ELEMENTS).toHaveLength(11)
+	it("has 12 entries", () => {
+		expect(STATUS_LINE_ELEMENTS).toHaveLength(12)
 	})
 
 	it("every entry has id, label, description", () => {
@@ -72,6 +72,7 @@ describe("STATUS_LINE_ELEMENTS", () => {
 			"team",
 			"credits",
 			"budget",
+			"pr",
 		].sort()
 		expect(ids).toEqual(expected)
 	})

--- a/src/config/status-line-config.ts
+++ b/src/config/status-line-config.ts
@@ -14,6 +14,7 @@ export type StatusLineElementId =
 	| "team"
 	| "credits"
 	| "budget"
+	| "pr"
 
 export type StatusLineConfig = { pinned: StatusLineElementId[] }
 
@@ -85,6 +86,11 @@ export const STATUS_LINE_ELEMENTS: Array<{
 		id: "budget",
 		label: "Budget",
 		description: "Budget usage and limit",
+	},
+	{
+		id: "pr",
+		label: "Pull request",
+		description: "PR number and link for the current branch",
 	},
 ]
 

--- a/src/extensions/pr-status.test.ts
+++ b/src/extensions/pr-status.test.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
+import { spawn } from "node:child_process"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createPrStatusWatcher, getPrStatusLine, setPrStatusForTest, type PrInfo } from "./pr-status.js"
+import { createPrStatusWatcher, getPrStatusLine, type PrInfo, setPrStatusForTest } from "./pr-status.js"
 
 vi.mock("node:child_process", () => ({ spawn: vi.fn() }))
 
@@ -12,14 +12,22 @@ function fakeChild(): ChildProcess & { emitStdout(data: string): void; emitClose
 	const child = {
 		stdout: {
 			on: (event: string, cb: (data: Buffer) => void) => {
-				if (!events.has(event)) events.set(event, new Set())
-				events.get(event)!.add(cb as (...args: unknown[]) => void)
+				let set = events.get(event)
+				if (!set) {
+					set = new Set()
+					events.set(event, set)
+				}
+				set.add(cb as (...args: unknown[]) => void)
 			},
 		},
 		stderr: { on: vi.fn() },
 		on: (event: string, cb: (...args: unknown[]) => void) => {
-			if (!events.has(event)) events.set(event, new Set())
-			events.get(event)!.add(cb)
+			let set = events.get(event)
+			if (!set) {
+				set = new Set()
+				events.set(event, set)
+			}
+			set.add(cb)
 		},
 		emitStdout: (data: string) => {
 			for (const cb of events.get("data") ?? []) (cb as (data: Buffer) => void)(Buffer.from(data))

--- a/src/extensions/pr-status.test.ts
+++ b/src/extensions/pr-status.test.ts
@@ -1,0 +1,121 @@
+import { spawn } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createPrStatusWatcher, getPrStatusLine, setPrStatusForTest, type PrInfo } from "./pr-status.js"
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }))
+
+const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>
+
+function fakeChild(): ChildProcess & { emitStdout(data: string): void; emitClose(code: number): void } {
+	const events = new Map<string, Set<(...args: unknown[]) => void>>()
+	const child = {
+		stdout: {
+			on: (event: string, cb: (data: Buffer) => void) => {
+				if (!events.has(event)) events.set(event, new Set())
+				events.get(event)!.add(cb as (...args: unknown[]) => void)
+			},
+		},
+		stderr: { on: vi.fn() },
+		on: (event: string, cb: (...args: unknown[]) => void) => {
+			if (!events.has(event)) events.set(event, new Set())
+			events.get(event)!.add(cb)
+		},
+		emitStdout: (data: string) => {
+			for (const cb of events.get("data") ?? []) (cb as (data: Buffer) => void)(Buffer.from(data))
+		},
+		emitClose: (code: number) => {
+			for (const cb of events.get("close") ?? []) (cb as (code: number) => void)(code)
+		},
+	} as unknown as ChildProcess & { emitStdout(data: string): void; emitClose(code: number): void }
+	return child
+}
+
+beforeEach(() => {
+	setPrStatusForTest(undefined)
+	vi.useFakeTimers()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+	mockSpawn.mockReset()
+})
+
+describe("createPrStatusWatcher", () => {
+	it("fetches PR info on start and exposes it via getPrStatusLine", async () => {
+		const child = fakeChild()
+		mockSpawn.mockReturnValueOnce(child)
+
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		const changes: (PrInfo | undefined)[] = []
+		watcher.start(() => changes.push(getPrStatusLine()))
+
+		child.emitStdout(JSON.stringify({ number: 42, url: "https://github.com/owner/repo/pull/42" }))
+		child.emitClose(0)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(getPrStatusLine()).toEqual({ number: 42, url: "https://github.com/owner/repo/pull/42" })
+		expect(changes).toEqual([{ number: 42, url: "https://github.com/owner/repo/pull/42" }])
+
+		watcher.stop()
+	})
+
+	it("clears PR info when gh exits non-zero", async () => {
+		const child = fakeChild()
+		mockSpawn.mockReturnValueOnce(child)
+
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		watcher.start(() => {})
+
+		child.emitStdout("no pull requests match your search")
+		child.emitClose(1)
+		await vi.advanceTimersByTimeAsync(0)
+
+		expect(getPrStatusLine()).toBeUndefined()
+		watcher.stop()
+	})
+
+	it("refreshes when the branch changes", async () => {
+		const children = [fakeChild(), fakeChild()]
+		mockSpawn.mockReturnValueOnce(children[0]).mockReturnValueOnce(children[1])
+
+		let branch = "feature-x"
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => branch })
+		watcher.start(() => {})
+
+		children[0].emitStdout(JSON.stringify({ number: 42, url: "https://github.com/owner/repo/pull/42" }))
+		children[0].emitClose(0)
+		await vi.advanceTimersByTimeAsync(0)
+		expect(getPrStatusLine()?.number).toBe(42)
+
+		branch = "feature-y"
+		await vi.advanceTimersByTimeAsync(30_000)
+
+		children[1].emitStdout(JSON.stringify({ number: 43, url: "https://github.com/owner/repo/pull/43" }))
+		children[1].emitClose(0)
+		await vi.advanceTimersByTimeAsync(0)
+		expect(getPrStatusLine()?.number).toBe(43)
+
+		watcher.stop()
+	})
+
+	it("stops polling and clears state on stop", async () => {
+		const child = fakeChild()
+		mockSpawn.mockReturnValueOnce(child)
+
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		watcher.start(() => {})
+
+		child.emitStdout(JSON.stringify({ number: 42, url: "https://github.com/owner/repo/pull/42" }))
+		child.emitClose(0)
+		await vi.advanceTimersByTimeAsync(0)
+		expect(getPrStatusLine()).toBeDefined()
+
+		watcher.stop()
+		expect(getPrStatusLine()).toBeUndefined()
+		expect(mockSpawn).toHaveBeenCalledOnce()
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(mockSpawn).toHaveBeenCalledOnce()
+	})
+})

--- a/src/extensions/pr-status.test.ts
+++ b/src/extensions/pr-status.test.ts
@@ -54,7 +54,7 @@ describe("createPrStatusWatcher", () => {
 		const child = fakeChild()
 		mockSpawn.mockReturnValueOnce(child)
 
-		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo" })
 		const changes: (PrInfo | undefined)[] = []
 		watcher.start(() => changes.push(getPrStatusLine()))
 
@@ -72,7 +72,7 @@ describe("createPrStatusWatcher", () => {
 		const child = fakeChild()
 		mockSpawn.mockReturnValueOnce(child)
 
-		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo" })
 		watcher.start(() => {})
 
 		child.emitStdout("no pull requests match your search")
@@ -83,12 +83,11 @@ describe("createPrStatusWatcher", () => {
 		watcher.stop()
 	})
 
-	it("refreshes when the branch changes", async () => {
+	it("refreshes periodically", async () => {
 		const children = [fakeChild(), fakeChild()]
 		mockSpawn.mockReturnValueOnce(children[0]).mockReturnValueOnce(children[1])
 
-		let branch = "feature-x"
-		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => branch })
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo" })
 		watcher.start(() => {})
 
 		children[0].emitStdout(JSON.stringify({ number: 42, url: "https://github.com/owner/repo/pull/42" }))
@@ -96,7 +95,6 @@ describe("createPrStatusWatcher", () => {
 		await vi.advanceTimersByTimeAsync(0)
 		expect(getPrStatusLine()?.number).toBe(42)
 
-		branch = "feature-y"
 		await vi.advanceTimersByTimeAsync(30_000)
 
 		children[1].emitStdout(JSON.stringify({ number: 43, url: "https://github.com/owner/repo/pull/43" }))
@@ -111,7 +109,7 @@ describe("createPrStatusWatcher", () => {
 		const child = fakeChild()
 		mockSpawn.mockReturnValueOnce(child)
 
-		const watcher = createPrStatusWatcher({ getCwd: () => "/repo", getBranch: () => "feature-x" })
+		const watcher = createPrStatusWatcher({ getCwd: () => "/repo" })
 		watcher.start(() => {})
 
 		child.emitStdout(JSON.stringify({ number: 42, url: "https://github.com/owner/repo/pull/42" }))

--- a/src/extensions/pr-status.ts
+++ b/src/extensions/pr-status.ts
@@ -1,0 +1,116 @@
+import { spawn } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
+
+export interface PrInfo {
+	number: number
+	url: string
+}
+
+let currentPrInfo: PrInfo | undefined
+
+export function getPrStatusLine(): PrInfo | undefined {
+	return currentPrInfo
+}
+
+export function setPrStatusForTest(info: PrInfo | undefined): void {
+	currentPrInfo = info
+}
+
+export interface PrStatusWatcherDeps {
+	getCwd: () => string
+	getBranch: () => string | undefined
+	spawnGh?: (cwd: string) => ChildProcess
+}
+
+const PR_REFRESH_INTERVAL_MS = 30_000
+
+function defaultSpawnGh(cwd: string): ChildProcess {
+	return spawn("gh", ["pr", "view", "--json", "number,url"], { cwd })
+}
+
+export function createPrStatusWatcher(deps: PrStatusWatcherDeps) {
+	let lastKnownBranch: string | undefined
+	let timer: ReturnType<typeof setInterval> | undefined
+	let onChangeCallback: (() => void) | undefined
+	let inFlight = false
+
+	function parseGhOutput(stdout: string): PrInfo | undefined {
+		try {
+			const parsed = JSON.parse(stdout) as unknown
+			if (
+				parsed &&
+				typeof parsed === "object" &&
+				"number" in parsed &&
+				"url" in parsed &&
+				typeof parsed.number === "number" &&
+				typeof parsed.url === "string"
+			) {
+				return { number: parsed.number, url: parsed.url }
+			}
+		} catch {
+			// ignore parse errors
+		}
+		return undefined
+	}
+
+	function runGh(cwd: string, callback: (info: PrInfo | undefined) => void): void {
+		const child = (deps.spawnGh ?? defaultSpawnGh)(cwd)
+		let stdout = ""
+		child.stdout?.on("data", (d: Buffer) => {
+			stdout += d.toString()
+		})
+		child.on("close", (code: number | null) => {
+			if (code !== 0) {
+				callback(undefined)
+				return
+			}
+			callback(parseGhOutput(stdout))
+		})
+		child.on("error", () => {
+			callback(undefined)
+		})
+	}
+
+	function setInfo(info: PrInfo | undefined): void {
+		if (info === currentPrInfo) return
+		currentPrInfo = info
+		onChangeCallback?.()
+	}
+
+	function refresh(): void {
+		if (inFlight) return
+		inFlight = true
+		runGh(deps.getCwd(), (info) => {
+			inFlight = false
+			setInfo(info)
+		})
+	}
+
+	function tick(silent = false): void {
+		const branch = deps.getBranch()
+		const branchChanged = branch !== lastKnownBranch
+		if (!branchChanged && !silent) return
+		lastKnownBranch = branch
+		refresh()
+	}
+
+	function start(onChange: () => void): void {
+		stop()
+		onChangeCallback = onChange
+		tick(true)
+		timer = setInterval(() => tick(), PR_REFRESH_INTERVAL_MS)
+	}
+
+	function stop(): void {
+		if (timer) {
+			clearInterval(timer)
+			timer = undefined
+		}
+		lastKnownBranch = undefined
+		onChangeCallback = undefined
+		inFlight = false
+		currentPrInfo = undefined
+	}
+
+	return { start, stop, refresh }
+}

--- a/src/extensions/pr-status.ts
+++ b/src/extensions/pr-status.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
+import { spawn } from "node:child_process"
 
 export interface PrInfo {
 	number: number

--- a/src/extensions/pr-status.ts
+++ b/src/extensions/pr-status.ts
@@ -18,7 +18,7 @@ export function setPrStatusForTest(info: PrInfo | undefined): void {
 
 export interface PrStatusWatcherDeps {
 	getCwd: () => string
-	getBranch: () => string | undefined
+	getBranch?: () => string | undefined
 	spawnGh?: (cwd: string) => ChildProcess
 }
 
@@ -29,7 +29,6 @@ function defaultSpawnGh(cwd: string): ChildProcess {
 }
 
 export function createPrStatusWatcher(deps: PrStatusWatcherDeps) {
-	let lastKnownBranch: string | undefined
 	let timer: ReturnType<typeof setInterval> | undefined
 	let onChangeCallback: (() => void) | undefined
 	let inFlight = false
@@ -86,19 +85,11 @@ export function createPrStatusWatcher(deps: PrStatusWatcherDeps) {
 		})
 	}
 
-	function tick(silent = false): void {
-		const branch = deps.getBranch()
-		const branchChanged = branch !== lastKnownBranch
-		if (!branchChanged && !silent) return
-		lastKnownBranch = branch
-		refresh()
-	}
-
 	function start(onChange: () => void): void {
 		stop()
 		onChangeCallback = onChange
-		tick(true)
-		timer = setInterval(() => tick(), PR_REFRESH_INTERVAL_MS)
+		refresh()
+		timer = setInterval(() => refresh(), PR_REFRESH_INTERVAL_MS)
 	}
 
 	function stop(): void {
@@ -106,7 +97,6 @@ export function createPrStatusWatcher(deps: PrStatusWatcherDeps) {
 			clearInterval(timer)
 			timer = undefined
 		}
-		lastKnownBranch = undefined
 		onChangeCallback = undefined
 		inFlight = false
 		currentPrInfo = undefined

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -297,7 +297,6 @@ export default function uiExtension(pi: ExtensionAPI) {
 		prWatcher?.stop()
 		prWatcher = createPrStatusWatcher({
 			getCwd: () => ctx.cwd,
-			getBranch: () => branchPoller.getBranch(),
 		})
 		prWatcher.start(() => uiTui?.requestRender())
 
@@ -324,6 +323,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 		})
 		ctx.ui.setFooter((tui, theme, statusLineData) => {
 			uiTui = tui
+			prWatcher?.start(() => uiTui?.requestRender())
 			const cmd = readStatusLineCommand()
 			if (!cmd) {
 				scriptCmd = null

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -22,6 +22,7 @@ import { formatDuration } from "./format.js"
 import { sessionHasImages } from "./model-guard.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "./multi-model.js"
 import { getOrchestratorModelId, getOrchestratorModelRef, splitModelRef } from "./orchestration/model-roles.js"
+import { createPrStatusWatcher } from "./pr-status.js"
 import { isRawInputCaptureActive } from "./shared-input.js"
 import {
 	isSessionModeOnboardingStatusLineSuppressed,
@@ -30,7 +31,6 @@ import {
 } from "./shared-status-line.js"
 import { createWorkingAnimator } from "./spinner.js"
 import { createBranchPoller } from "./ui-branch-poll.js"
-import { createPrStatusWatcher } from "./pr-status.js"
 
 export { requestSharedStatusLineRender, setSessionModeOnboardingStatusLineSuppressed } from "./shared-status-line.js"
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -30,6 +30,7 @@ import {
 } from "./shared-status-line.js"
 import { createWorkingAnimator } from "./spinner.js"
 import { createBranchPoller } from "./ui-branch-poll.js"
+import { createPrStatusWatcher } from "./pr-status.js"
 
 export { requestSharedStatusLineRender, setSessionModeOnboardingStatusLineSuppressed } from "./shared-status-line.js"
 
@@ -246,6 +247,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 	let uiTui: TUI | null = null
 	let headerTui: TUI | null = null
 	let unregisterBillingStatus: (() => void) | undefined
+	let prWatcher: ReturnType<typeof createPrStatusWatcher> | undefined
 	let scriptCmd: string | null = null
 	let scriptPending = false
 	let scriptGeneration = 0
@@ -292,9 +294,20 @@ export default function uiExtension(pi: ExtensionAPI) {
 			uiTui?.requestRender()
 		})
 
+		prWatcher?.stop()
+		prWatcher = createPrStatusWatcher({
+			getCwd: () => ctx.cwd,
+			getBranch: () => branchPoller.getBranch(),
+		})
+		prWatcher.start(() => uiTui?.requestRender())
+
 		ctx.ui.setHeader((tui, theme) => {
 			headerTui = tui
-			branchPoller.start(() => tui.requestRender())
+			branchPoller.start(() => {
+				tui.requestRender()
+				uiTui?.requestRender()
+				prWatcher?.refresh()
+			})
 			const logo = new LogoHeader(theme, {
 				getBranch: () => branchPoller.getBranch(),
 				getRightColumnNotice: getCommunityTierHeaderNotice,
@@ -500,6 +513,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 		stopWorkingAnimation = undefined
 		currentCtx = null
 		branchPoller.stop()
+		prWatcher?.stop()
+		prWatcher = undefined
 	})
 
 	pi.on("input", (event, ctx) => {

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -323,7 +323,10 @@ export default function uiExtension(pi: ExtensionAPI) {
 		})
 		ctx.ui.setFooter((tui, theme, statusLineData) => {
 			uiTui = tui
-			prWatcher?.start(() => uiTui?.requestRender())
+			prWatcher?.start(() => {
+				uiTui?.requestRender()
+				refresh("idle")
+			})
 			const cmd = readStatusLineCommand()
 			if (!cmd) {
 				scriptCmd = null


### PR DESCRIPTION
## What does this PR do?

Adds a native "Pull request" status-line segment that detects the PR for the current branch via `gh pr view --json number,url`.

- New `pr` pinnable status-line element in `/customize-status-line`.
- Background PR resolver (`src/extensions/pr-status.ts`) refreshes on branch changes and every 30s.
- Native segment renders `PR: #N` when a PR is found.
- `buildScriptPayload()` now includes `pr: { number, url }` so custom `statusLine.command` scripts can use it.
- Adds unit tests for the resolver, config, and status-line segment.

## Linked issue

N/A — small feature addition requested in-session.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (targeted test files)
- [x] Lint passes (via pre-commit hook)
- [ ] Documentation updated if behavior changed