### PR TITLE
fix: update user-facing references from pi to kimchi

### DIFF
--- a/src/extensions/mcp-adapter/README.md
+++ b/src/extensions/mcp-adapter/README.md
@@ -22,7 +22,7 @@ But the MCP ecosystem has useful stuff - databases, browsers, APIs. This adapter
 pi install npm:pi-mcp-adapter
 ```
 
-Restart Pi after installation.
+Restart kimchi after installation.
 
 ## Quick Start
 
@@ -190,9 +190,9 @@ To exclude specific tools while still using `directTools: true`, add `excludeToo
 
 Each direct tool costs ~150-300 tokens in the system prompt (name + description + schema). Good for targeted sets of 5-20 tools. For servers with 75+ tools, stick with the proxy or pick specific tools with a `string[]`.
 
-Direct tools register from the metadata cache (`~/.pi/agent/mcp-cache.json`), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only and the cache populates in the background. Restart Pi and they'll be available. To force it: `/mcp reconnect <server>` then restart.
+Direct tools register from the metadata cache (`~/.pi/agent/mcp-cache.json`), so no server connections are needed at startup. On the first session after adding `directTools` to a new server, the cache won't exist yet — tools fall back to proxy-only and the cache populates in the background. Restart kimchi and they'll be available. To force it: `/mcp reconnect <server>` then restart.
 
-**Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers, initiate OAuth, and toggle tools between direct and proxy — all from one overlay. Changes are written to your config file; restart Pi to apply.
+**Interactive configuration:** Run `/mcp` to open an interactive panel showing all servers with connection status, tools, and direct/proxy toggles. You can reconnect servers, initiate OAuth, and toggle tools between direct and proxy — all from one overlay. Changes are written to your config file; restart kimchi to apply.
 
 **Agent integration:** Agents can request direct MCP tools in their frontmatter with `mcp:server-name` syntax.
 
@@ -253,7 +253,7 @@ npm run build
 npm run install-local
 ```
 
-Restart pi, then ask the agent to show a chart — it calls `show_chart` and opens the UI in Glimpse (macOS) or the browser. Use `npm run uninstall-local` to remove the MCP entry.
+Restart kimchi, then ask the agent to show a chart — it calls `show_chart` and opens the UI in Glimpse (macOS) or the browser. Use `npm run uninstall-local` to remove the MCP entry.
 
 ### Import Existing Configs
 

--- a/src/extensions/mcp-adapter/commands.ts
+++ b/src/extensions/mcp-adapter/commands.ts
@@ -208,7 +208,7 @@ export async function openMcpPanel(
 		},
 		onSave: (changes) => {
 			writeDirectToolsConfig(changes, provenanceMap, config)
-			ctx.ui.notify("Direct tools updated. Restart pi to apply.", "info")
+			ctx.ui.notify("Direct tools updated. Restart kimchi to apply.", "info")
 		},
 	}
 
@@ -220,7 +220,7 @@ export async function openMcpPanel(
 				return createMcpPanel(config, cache, provenanceMap, callbacks, tui, (result: McpPanelResult) => {
 					if (!result.cancelled && result.changes.size > 0) {
 						writeDirectToolsConfig(result.changes, provenanceMap, config)
-						ctx.ui.notify("Direct tools updated. Restart pi to apply.", "info")
+						ctx.ui.notify("Direct tools updated. Restart kimchi to apply.", "info")
 					}
 					done(undefined)
 					// Force a clean redraw so any overlay artifacts are cleared from

--- a/src/extensions/mcp-adapter/mcp-panel.ts
+++ b/src/extensions/mcp-adapter/mcp-panel.ts
@@ -334,7 +334,7 @@ class McpPanel {
 					})
 				})
 				this.updateDirty()
-				this.saveNotice = "Saved ✓ — restart pi to apply"
+				this.saveNotice = "Saved ✓ — restart kimchi to apply"
 			}
 			this.tui.requestRender()
 			return


### PR DESCRIPTION
## Linked issue

Closes #856

## What does this PR do?

### Summary
This PR updates outdated user-facing references from **"pi"** to **"kimchi"** for better consistency with the current project name.

### Changes made
- Updated user-facing notification messages to replace **"restart pi"** with **"restart kimchi"**.
- Updated related user-facing documentation where applicable.

These changes ensure that the UI and documentation consistently refer to the project as **Kimchi**.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed