### PR TITLE
fix: fix welcome message job permissions

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - uses: actions/first-interaction@v1
         with:


### PR DESCRIPTION
Fix welcome message job permissions. It doesn't have the perms to post on open PRs.

Example: https://github.com/getkimchi/kimchi/actions/runs/27758171462/job/82125245627?pr=629