### PR TITLE
fix: remove "minimal" thinking level (LLM-2595)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -73,7 +73,7 @@ models: ["<provider>/<id>", ...] # Optional: set of allowed models for this pers
                                  # tier/strengths. If omitted at the call site, the runtime falls back to
                                  # the first entry (a stable default, not a complexity-aware pick). Omit
                                  # `models` entirely to inherit the parent's model.
-thinking: <string>               # off | minimal | low | medium | high | xhigh
+thinking: <string>               # off | low | medium | high | xhigh
 tools: <csv>                     # Comma-separated built-in tools, "none", or omit (= inherit all)
 disallowed_tools: <csv>          # Comma-separated tools to deny even if otherwise inherited
 extensions: <bool|csv>           # true (inherit MCP/extension tools) | false (disable) | comma-list

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -20,7 +20,7 @@ interface FlagDoc {
 const KIMCHI_FLAGS: FlagDoc[] = [
 	{ name: "--provider <name>", description: "Provider (default: kimchi-dev)" },
 	{ name: "--model <pattern>", description: "Model id or pattern, optionally `provider/id` and/or `:<thinking>`" },
-	{ name: "--thinking <level>", description: "Thinking level: off, minimal, low, medium, high, xhigh" },
+	{ name: "--thinking <level>", description: "Thinking level: off, low, medium, high, xhigh" },
 	{ name: "--mode <mode>", description: "Output mode: text (default), json, rpc, acp" },
 	{ name: "--print, -p", description: "Non-interactive mode: process prompt and exit" },
 	{ name: "--continue, -c", description: "Resume the most recent session" },

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -1070,10 +1070,19 @@ ${AGENT_TOOL_GUIDELINES}`,
 					}),
 				),
 				thinking: Type.Optional(
-					Type.String({
-						description:
-							"Requested thinking level: off, low, medium, high, xhigh. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
-					}),
+					Type.Union(
+						[
+							Type.Literal("off"),
+							Type.Literal("low"),
+							Type.Literal("medium"),
+							Type.Literal("high"),
+							Type.Literal("xhigh"),
+						],
+						{
+							description:
+								"Requested thinking level: off, low, medium, high, xhigh. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
+						},
+					),
 				),
 				max_turns: Type.Optional(
 					Type.Number({

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -1072,7 +1072,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 				thinking: Type.Optional(
 					Type.String({
 						description:
-							"Requested thinking level: off, minimal, low, medium, high, xhigh. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
+							"Requested thinking level: off, low, medium, high, xhigh. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
 					}),
 				),
 				max_turns: Type.Optional(
@@ -2300,7 +2300,7 @@ The file format is a markdown file with YAML frontmatter and a system prompt bod
 description: <one-line description shown in UI>
 tools: <comma-separated built-in tools: read, bash, edit, write, grep, find, ls. Use "none" for no tools. Omit for all tools>
 models: <optional ordered list of models, e.g. ["kimchi-dev/minimax-m2.7"]. Omit to inherit parent model>
-thinking: <optional thinking level: off, minimal, low, medium, high, xhigh. Omit to inherit>
+thinking: <optional thinking level: off, low, medium, high, xhigh. Omit to inherit>
 max_turns: <optional max agentic turns. 0 or omit for unlimited (default)>
 token_budget: <optional maximum total tokens for this agent. Omit for no profile budget>
 prompt_mode: <"replace" (body IS the full system prompt) or "append" (body is appended to default prompt). Default: replace>
@@ -2381,15 +2381,7 @@ Write the file using the write tool. Only write the file, nothing else.`
 			if (customModel) modelLine = `\nmodels: ["${customModel}"]`
 		}
 
-		const thinkingChoice = await ctx.ui.select("Thinking level", [
-			"inherit",
-			"off",
-			"minimal",
-			"low",
-			"medium",
-			"high",
-			"xhigh",
-		])
+		const thinkingChoice = await ctx.ui.select("Thinking level", ["inherit", "off", "low", "medium", "high", "xhigh"])
 		if (!thinkingChoice) return
 
 		let thinkingLine = ""

--- a/src/extensions/agents/personas/custom-agents.ts
+++ b/src/extensions/agents/personas/custom-agents.ts
@@ -14,6 +14,21 @@ import { getInstalledPackageResourceDirs } from "../package-resources.js"
 import { BUILTIN_TOOL_NAMES } from "./agent-types.js"
 import type { AgentConfig, MemoryScope, ThinkingLevel } from "./types.js"
 
+/** Thinking levels that are valid in the current harness. */
+const VALID_THINKING_LEVELS = new Set<ThinkingLevel>(["off", "low", "medium", "high", "xhigh"])
+
+/**
+ * Coerce a raw thinking string (from YAML frontmatter or runtime params)
+ * into a valid ThinkingLevel. The `minimal` level was removed and is silently
+ * mapped to `low` for backward compatibility with existing agent profiles.
+ */
+export function coerceThinkingLevel(raw: string | undefined): ThinkingLevel | undefined {
+	if (!raw) return undefined
+	if (raw === "minimal") return "low"
+	if (VALID_THINKING_LEVELS.has(raw as ThinkingLevel)) return raw as ThinkingLevel
+	return undefined
+}
+
 /**
  * Scan for custom agent .md files from multiple locations.
  */
@@ -62,7 +77,7 @@ function loadFromDir(dir: string, agentsMap: Map<string, AgentConfig>, source: "
 			extensions: inheritField(fm.extensions ?? fm.inherit_extensions),
 			skills: inheritField(fm.skills ?? fm.inherit_skills),
 			models: modelToArray(fm),
-			thinking: str(fm.thinking) as ThinkingLevel | undefined,
+			thinking: coerceThinkingLevel(str(fm.thinking)) as ThinkingLevel | undefined,
 			maxTurns: nonNegativeInt(fm.max_turns),
 			tokenBudget: positiveInt(fm.token_budget),
 			maxDuration: positiveInt(fm.max_duration),

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -9,7 +9,7 @@ import type { LifetimeUsage } from "../manager/usage.js"
 import type { FermentWorkerBudgetTier } from "../worker-budget-policy.js"
 
 /** Thinking/reasoning level for models that support it. */
-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
+export type ThinkingLevel = "off" | "low" | "medium" | "high" | "xhigh"
 
 export type AgentAbortReason = "max_turns" | "token_budget" | "inactivity" | "max_duration"
 export type AgentOutcomeKind = "completed" | "budget_exhausted" | "failed" | "stopped"

--- a/src/extensions/agents/resolution/invocation-config.test.ts
+++ b/src/extensions/agents/resolution/invocation-config.test.ts
@@ -70,13 +70,13 @@ describe("resolveAgentInvocationConfig — persona policy precedence", () => {
 	})
 
 	it("params.thinking wins over agentConfig.thinking", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, thinking: "minimal" }, { thinking: "high" })
+		const result = resolveAgentInvocationConfig({ ...agent, thinking: "low" }, { thinking: "high" })
 		expect(result.thinking).toBe("high")
 	})
 
 	it("falls back to agentConfig.thinking when params omit thinking", () => {
-		const result = resolveAgentInvocationConfig({ ...agent, thinking: "minimal" }, {})
-		expect(result.thinking).toBe("minimal")
+		const result = resolveAgentInvocationConfig({ ...agent, thinking: "low" }, {})
+		expect(result.thinking).toBe("low")
 	})
 
 	it("agentConfig.maxTurns wins over params.max_turns", () => {

--- a/src/extensions/agents/resolution/invocation-config.ts
+++ b/src/extensions/agents/resolution/invocation-config.ts
@@ -1,3 +1,4 @@
+import { coerceThinkingLevel } from "../personas/custom-agents.js"
 import type { AgentConfig, IsolationMode, JoinMode, ThinkingLevel } from "../personas/types.js"
 
 interface AgentInvocationParams {
@@ -53,7 +54,9 @@ export function resolveAgentInvocationConfig(
 	return {
 		modelInput,
 		modelFromParams,
-		thinking: (params.thinking ?? agentConfig?.thinking) as ThinkingLevel | undefined,
+		thinking: coerceThinkingLevel((params.thinking ?? agentConfig?.thinking) as string | undefined) as
+			| ThinkingLevel
+			| undefined,
 		maxTurns: agentConfig?.maxTurns ?? params.max_turns,
 		tokenBudget: params.token_budget ?? params.tokenBudget ?? agentConfig?.tokenBudget,
 		maxDuration: params.max_duration ?? agentConfig?.maxDuration,

--- a/src/extensions/agents/thinking-level-policy.test.ts
+++ b/src/extensions/agents/thinking-level-policy.test.ts
@@ -3,12 +3,13 @@ import {
 	bumpThinkingLevel,
 	renderDelegationThinkingLevelTable,
 	resolveDelegationThinkingLevel,
+	THINKING_LEVEL_ORDER,
 	thinkingScopeForSubagentType,
 } from "./thinking-level-policy.js"
 
 describe("resolveDelegationThinkingLevel", () => {
-	it("maps explore simple to minimal and complex to low", () => {
-		expect(resolveDelegationThinkingLevel("explore", "simple")).toBe("minimal")
+	it("maps explore simple to low and complex to low", () => {
+		expect(resolveDelegationThinkingLevel("explore", "simple")).toBe("low")
 		expect(resolveDelegationThinkingLevel("explore", "complex")).toBe("low")
 	})
 
@@ -59,5 +60,10 @@ describe("renderDelegationThinkingLevelTable", () => {
 		const table = renderDelegationThinkingLevelTable()
 		expect(table).toContain("| Build chunk | Builder |")
 		expect(table).toContain("complex chunk")
+	})
+
+	it("does not contain the removed 'minimal' level", () => {
+		expect(THINKING_LEVEL_ORDER).not.toContain("minimal")
+		expect(renderDelegationThinkingLevelTable()).not.toContain("minimal")
 	})
 })

--- a/src/extensions/agents/thinking-level-policy.ts
+++ b/src/extensions/agents/thinking-level-policy.ts
@@ -13,17 +13,10 @@ export type ThinkingTaskScope =
 	| "orchestrator-coord"
 	| "orchestrator-judge"
 
-export const THINKING_LEVEL_ORDER: readonly ThinkingLevel[] = [
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
-] as const
+export const THINKING_LEVEL_ORDER: readonly ThinkingLevel[] = ["off", "low", "medium", "high", "xhigh"] as const
 
 const DELEGATION_THINKING_BASE: Record<ThinkingTaskScope, Record<ChunkComplexity, ThinkingLevel>> = {
-	explore: { simple: "minimal", complex: "low" },
+	explore: { simple: "low", complex: "low" },
 	research: { simple: "low", complex: "medium" },
 	plan: { simple: "high", complex: "high" },
 	build: { simple: "medium", complex: "high" },
@@ -83,7 +76,7 @@ export function resolveDelegationThinkingLevel(
 
 export function renderDelegationThinkingLevelTable(): string {
 	const rows: Array<[string, string, ThinkingLevel, ThinkingLevel, ThinkingLevel]> = [
-		["Explore (bounded fact-finding)", "Explore", "minimal", "low", "medium"],
+		["Explore (bounded fact-finding)", "Explore", "low", "low", "medium"],
 		["Research note", "Researcher", "low", "medium", "high"],
 		["Plan or plan verification", "Plan", "high", "high", "high"],
 		["Build chunk", "Builder", "medium", "high", "xhigh"],

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -41,6 +41,15 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).toContain("## Orchestration")
 	})
 
+	it("does not contain the removed 'minimal' thinking level", () => {
+		const result = resolveAsString({
+			currentModelId: "kimi-k2.6",
+			registry,
+			roles: DEFAULT_MODEL_ROLES,
+		})
+		expect(result).not.toContain("minimal")
+	})
+
 	it("shows role assignments with Your team subsection", () => {
 		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -41,13 +41,14 @@ describe("resolveOrchestrationInstructions", () => {
 		expect(result).toContain("## Orchestration")
 	})
 
-	it("does not contain the removed 'minimal' thinking level", () => {
+	it("does not contain the removed 'minimal' thinking level and lists the valid levels", () => {
 		const result = resolveAsString({
 			currentModelId: "kimi-k2.6",
 			registry,
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).not.toContain("minimal")
+		expect(result).toContain("off, low, medium, high, xhigh")
 	})
 
 	it("shows role assignments with Your team subsection", () => {

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -182,7 +182,7 @@ Always pass a \`thinking\` parameter on every Agent call — never omit it. Use 
 
 const THINKING_LEVELS = `### Thinking levels
 
-\`thinking\` controls extended reasoning for the orchestrator and each delegated worker. Levels (lowest to highest): off, minimal, low, medium, high, xhigh. Use the lowest level that fits the task — higher thinking costs more tokens and time.
+\`thinking\` controls extended reasoning for the orchestrator and each delegated worker. Levels (lowest to highest): off, low, medium, high, xhigh. Use the lowest level that fits the task — higher thinking costs more tokens and time.
 
 **Orchestrator (main thread):** keep thinking low while coordinating (spawning agents, reading artifact paths). Raise only when classifying the pipeline, self-validating a plan, or interpreting ambiguous subagent reports.
 

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -499,7 +499,7 @@ const SetPhaseParams = Type.Object({
 		Type.String({
 			description:
 				"Optional thinking level to use when the orchestrator performs this phase itself (not delegating). Set per the Orchestration Thinking levels table.",
-			enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+			enum: ["off", "low", "medium", "high", "xhigh"],
 		}),
 	),
 })


### PR DESCRIPTION
## Linked issue

Closes #915

## What does this PR do?

Removes the `minimal` thinking level from the harness. This level causes errors with vLLM/sglang providers (LLM-2595). The proxy already maps `minimal` to `low`; this stops the harness from offering a broken level.

**Changes:**
- Remove `minimal` from `ThinkingLevel` type union (`personas/types.ts`)
- Remove `minimal` from `THINKING_LEVEL_ORDER` array; change `DELEGATION_THINKING_BASE.explore.simple` from `minimal` to `low`; update `renderDelegationThinkingLevelTable()` Explore row (`thinking-level-policy.ts`)
- Remove `minimal` from Agent tool schema description and agent config help text (`agents/index.ts`)
- Remove `minimal` from agent wizard thinking-level select menu (`agents/index.ts`)
- Remove `minimal` from `set_phase` tool thinking parameter enum (`tags.ts`)
- Remove `minimal` from CLI `--thinking` help text (`commands/help.ts`)
- Update `THINKING_LEVELS` prose in orchestration instructions (`orchestration-instructions.ts`)
- Update `docs/agents.md` frontmatter reference
- Update `invocation-config.test.ts` to use `low` instead of `minimal`
- Update `thinking-level-policy.test.ts` assertions and add regression test for absence of `minimal`
- Add assertion in `orchestration-instructions.test.ts` that rendered instructions do not contain `minimal`

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed