### PR TITLE
feat(lsp): resolve tsserver path from main repo in git worktrees

### DIFF
--- a/src/extensions/lsp/client.test.ts
+++ b/src/extensions/lsp/client.test.ts
@@ -1,0 +1,361 @@
+// extensions/lsp/client.test.ts
+//
+// Regression tests for the LSP JSON-RPC message reader.
+//
+// The core bug: when the server emitted a valid-JSON but non-object frame
+// (e.g. bare `null`, a number) or an unparseable body, `JSON.parse` either
+// returned a primitive (causing `"id" in message` to throw TypeError) or threw
+// directly. The thrown error propagated to the reader's catch block, which
+// rejected all pending requests and left a zombie client in the registry —
+// every subsequent LSP operation then failed with timeouts.
+//
+// These tests verify:
+//   1. Non-object frames (bare null, number) are skipped — reader survives.
+//   2. Unparseable JSON frames are skipped — reader survives.
+//   3. Valid frames after skipped ones still process.
+//   4. On reader crash, the zombie client is removed from the registry.
+//
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { getAllClients, getOrCreateClient, sendRequest, shutdownAll } from "./client.js"
+import type { BunProcess, ServerConfig } from "./types.js"
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const CWD = "/tmp/lsp-client-test"
+
+const FAKE_CONFIG: ServerConfig = {
+	name: "typescript-language-server",
+	command: "typescript-language-server",
+	args: ["--stdio"],
+	extensions: ["ts"],
+}
+
+function frame(msg: unknown): string {
+	const content = JSON.stringify(msg)
+	return `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`
+}
+
+/** Frame a raw string body (for invalid JSON or non-object payloads). */
+function frameRaw(content: string): string {
+	return `Content-Length: ${Buffer.byteLength(content, "utf-8")}\r\n\r\n${content}`
+}
+
+function encode(s: string): Uint8Array {
+	return new TextEncoder().encode(s)
+}
+
+interface FakeProc {
+	proc: BunProcess
+	written: string[]
+	enqueue: (msg: unknown) => void
+	enqueueRaw: (content: string) => void
+	closeStdout: () => void
+	errorStdout: (err: Error) => void
+	isKilled: () => boolean
+}
+
+function createFakeProc(): FakeProc {
+	let stdoutController: ReadableStreamDefaultController<Uint8Array> | null = null
+	let stderrController: ReadableStreamDefaultController<Uint8Array> | null = null
+	const stdout = new ReadableStream<Uint8Array>({
+		start(c) {
+			stdoutController = c
+		},
+	})
+	const stderr = new ReadableStream<Uint8Array>({
+		start(c) {
+			stderrController = c
+		},
+	})
+	const written: string[] = []
+	let killed = false
+	const proc: BunProcess = {
+		stdin: {
+			write(data: Uint8Array | string) {
+				written.push(typeof data === "string" ? data : Buffer.from(data).toString())
+			},
+			flush() {
+				return Promise.resolve()
+			},
+			end() {
+				/* no-op */
+			},
+		},
+		stdout,
+		stderr,
+		kill() {
+			killed = true
+			try {
+				stdoutController?.close()
+			} catch {
+				/* already closed */
+			}
+			try {
+				stderrController?.close()
+			} catch {
+				/* already closed */
+			}
+		},
+		exited: new Promise<void>(() => {}),
+		exitCode: null,
+	}
+	return {
+		proc,
+		written,
+		enqueue: (msg: unknown) => {
+			stdoutController?.enqueue(encode(frame(msg)))
+		},
+		enqueueRaw: (content: string) => {
+			stdoutController?.enqueue(encode(frameRaw(content)))
+		},
+		closeStdout: () => {
+			try {
+				stdoutController?.close()
+			} catch {
+				/* already closed */
+			}
+		},
+		errorStdout: (err: Error) => {
+			try {
+				stdoutController?.error(err)
+			} catch {
+				/* already closed */
+			}
+		},
+		isKilled: () => killed,
+	}
+}
+
+/** Parse the initialize request the client writes on getOrCreateClient. */
+function parseWrittenRequest(s: string): { id: number; method: string } | null {
+	const idx = s.indexOf("\r\n\r\n")
+	if (idx === -1) return null
+	try {
+		return JSON.parse(s.slice(idx + 4))
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Complete the initialize handshake so getOrCreateClient can resolve.
+ * Must be called concurrently with the getOrCreateClient promise — the
+ * client writes the initialize request synchronously inside getOrCreateClient,
+ * but awaits the response + projectLoaded promise before returning.
+ *
+ * Usage:
+ *   const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+ *   await answerInitialize(fake)
+ *   const client = await clientPromise
+ */
+async function answerInitialize(fake: FakeProc): Promise<void> {
+	await Promise.resolve()
+	await Promise.resolve()
+	const initReq = parseWrittenRequest(fake.written[0])
+	if (!initReq) throw new Error("no initialize request written")
+
+	// Respond to initialize
+	fake.enqueue({ jsonrpc: "2.0", id: initReq.id, result: { capabilities: {} } })
+	// Resolve projectLoaded via $/progress end with empty token set
+	fake.enqueue({
+		jsonrpc: "2.0",
+		method: "$/progress",
+		params: { token: "test", value: { kind: "end" } },
+	})
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+// biome-ignore lint/suspicious/noExplicitAny: Bun global is untyped in tests
+let originalBun: any
+
+beforeAll(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: Bun global is untyped in tests
+	originalBun = (globalThis as any).Bun
+})
+
+afterAll(() => {
+	// biome-ignore lint/suspicious/noExplicitAny: Bun global is untyped in tests
+	;(globalThis as any).Bun = originalBun
+})
+
+afterEach(() => {
+	shutdownAll()
+})
+
+describe("LSP client reader — malformed frame resilience", () => {
+	let fake: FakeProc
+
+	beforeEach(() => {
+		fake = createFakeProc()
+		// biome-ignore lint/suspicious/noExplicitAny: Bun global is untyped in tests
+		;(globalThis as any).Bun = {
+			spawn: () => fake.proc,
+		}
+	})
+
+	it("skips a bare null frame and continues processing valid frames", async () => {
+		const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+		await answerInitialize(fake)
+		const client = await clientPromise
+
+		// Enqueue a bare `null` (valid JSON, non-object) — this used to crash
+		// the reader via `"id" in null` TypeError.
+		fake.enqueueRaw("null")
+
+		// Enqueue a valid publishDiagnostics notification — reader must still
+		// be alive to process it.
+		const uri = "file:///tmp/lsp-client-test/foo.ts"
+		fake.enqueue({
+			jsonrpc: "2.0",
+			method: "textDocument/publishDiagnostics",
+			params: {
+				uri,
+				diagnostics: [
+					{
+						message: "test error",
+						range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+						severity: 1,
+					},
+				],
+			},
+		})
+
+		// Give the reader a moment to process
+		await new Promise((r) => setTimeout(r, 200))
+
+		// Reader survived — diagnostics were stored
+		const entry = client.diagnostics.get(uri)
+		expect(entry).toBeDefined()
+		expect(entry?.diagnostics).toHaveLength(1)
+		expect(entry?.diagnostics[0].message).toBe("test error")
+	})
+
+	it("skips a bare number frame and continues processing valid frames", async () => {
+		const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+		await answerInitialize(fake)
+		const client = await clientPromise
+
+		// Bare number — `typeof 42 !== "object"` → skipped
+		fake.enqueueRaw("42")
+
+		const uri = "file:///tmp/lsp-client-test/bar.ts"
+		fake.enqueue({
+			jsonrpc: "2.0",
+			method: "textDocument/publishDiagnostics",
+			params: { uri, diagnostics: [] },
+		})
+
+		await new Promise((r) => setTimeout(r, 200))
+
+		// Reader survived — empty diagnostics entry was stored
+		expect(client.diagnostics.has(uri)).toBe(true)
+		expect(client.diagnostics.get(uri)?.diagnostics).toHaveLength(0)
+	})
+
+	it("skips an unparseable JSON frame and continues processing valid frames", async () => {
+		const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+		await answerInitialize(fake)
+		const client = await clientPromise
+
+		// Invalid JSON body
+		fake.enqueueRaw("{not valid json}")
+
+		const uri = "file:///tmp/lsp-client-test/baz.ts"
+		fake.enqueue({
+			jsonrpc: "2.0",
+			method: "textDocument/publishDiagnostics",
+			params: {
+				uri,
+				diagnostics: [
+					{ message: "after garbage", range: { start: { line: 1, character: 0 }, end: { line: 1, character: 5 } } },
+				],
+			},
+		})
+
+		await new Promise((r) => setTimeout(r, 200))
+
+		// Reader survived — diagnostics were stored
+		const entry = client.diagnostics.get(uri)
+		expect(entry).toBeDefined()
+		expect(entry?.diagnostics[0].message).toBe("after garbage")
+	})
+
+	it("processes multiple valid frames interleaved with malformed ones", async () => {
+		const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+		await answerInitialize(fake)
+		const client = await clientPromise
+
+		const uri1 = "file:///tmp/lsp-client-test/a.ts"
+		const uri2 = "file:///tmp/lsp-client-test/b.ts"
+
+		// Valid → garbage → valid → non-object → valid
+		fake.enqueue({ jsonrpc: "2.0", method: "textDocument/publishDiagnostics", params: { uri: uri1, diagnostics: [] } })
+		fake.enqueueRaw("garbage content")
+		fake.enqueue({ jsonrpc: "2.0", method: "textDocument/publishDiagnostics", params: { uri: uri2, diagnostics: [] } })
+		fake.enqueueRaw("null")
+		fake.enqueue({
+			jsonrpc: "2.0",
+			method: "textDocument/publishDiagnostics",
+			params: {
+				uri: uri1,
+				diagnostics: [
+					{ message: "updated", range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } } },
+				],
+			},
+		})
+
+		await new Promise((r) => setTimeout(r, 300))
+
+		// All three valid frames were processed; garbage and null were skipped
+		expect(client.diagnostics.get(uri1)?.diagnostics[0].message).toBe("updated")
+		expect(client.diagnostics.has(uri2)).toBe(true)
+	})
+})
+
+describe("LSP client reader — zombie cleanup on crash", () => {
+	let fake: FakeProc
+
+	beforeEach(() => {
+		fake = createFakeProc()
+		// biome-ignore lint/suspicious/noExplicitAny: Bun global is untyped in tests
+		;(globalThis as any).Bun = {
+			spawn: () => fake.proc,
+		}
+	})
+
+	it("removes the client from the registry when the reader crashes", async () => {
+		const clientPromise = getOrCreateClient(FAKE_CONFIG, CWD)
+		await answerInitialize(fake)
+		const client = await clientPromise
+
+		// Verify client is registered
+		expect(getAllClients()).toHaveLength(1)
+
+		// Start a pending request so we can verify it gets rejected
+		const requestPromise = sendRequest(client, "textDocument/hover", {}).catch(() => "rejected")
+
+		// Crash the reader by erroring the stdout stream
+		fake.errorStdout(new Error("simulated stream error"))
+
+		// Wait for the rejection to propagate
+		const result = await Promise.race([
+			requestPromise,
+			new Promise<string>((r) => setTimeout(() => r("timeout"), 2000)),
+		])
+
+		expect(result).toBe("rejected")
+
+		// Give the catch block a moment to clean up
+		await new Promise((r) => setTimeout(r, 100))
+
+		// Zombie client should be removed — next getOrCreateClient would spawn fresh
+		expect(getAllClients()).toHaveLength(0)
+		// Process should have been killed
+		expect(fake.isKilled()).toBe(true)
+	})
+})

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -1,4 +1,5 @@
 // extensions/lsp/client.ts
+import { resolveTsserverPath } from "./servers.js"
 import type {
 	BunProcess,
 	DiagnosticWaiter,
@@ -248,12 +249,17 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 		})()
 
 		try {
+			const initOpts = { ...(config.initOptions ?? {}) }
+			if (config.command === "typescript-language-server") {
+				const tsserverPath = resolveTsserverPath(cwd)
+				if (tsserverPath) initOpts.tsserver = { path: tsserverPath }
+			}
 			await sendRequest(client, "initialize", {
 				processId: process.pid,
 				rootUri: fileToUri(cwd),
 				rootPath: cwd,
 				capabilities: CLIENT_CAPABILITIES,
-				initializationOptions: config.initOptions ?? {},
+				initializationOptions: initOpts,
 				workspaceFolders: [{ uri: fileToUri(cwd), name: cwd.split("/").pop() ?? "workspace" }],
 			})
 			await sendNotification(client, "initialized", {})

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -252,7 +252,10 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 			const initOpts = { ...(config.initOptions ?? {}) }
 			if (config.command === "typescript-language-server") {
 				const tsserverPath = resolveTsserverPath(cwd)
-				if (tsserverPath) initOpts.tsserver = { path: tsserverPath }
+				if (tsserverPath) {
+					const existing = typeof initOpts.tsserver === "object" && initOpts.tsserver !== null ? initOpts.tsserver : {}
+					initOpts.tsserver = { ...existing, path: tsserverPath }
+				}
 			}
 			await sendRequest(client, "initialize", {
 				processId: process.pid,

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -53,7 +53,12 @@ function findHeaderEnd(buf: Buffer): number {
 	return -1
 }
 
-function parseMessage(buf: Buffer): { message: LspJsonRpcResponse | LspJsonRpcNotification; remaining: Buffer } | null {
+function parseMessage(
+	buf: Buffer,
+):
+	| { message: LspJsonRpcResponse | LspJsonRpcNotification; remaining: Buffer }
+	| { skipped: true; remaining: Buffer }
+	| null {
 	const headerEnd = findHeaderEnd(buf)
 	if (headerEnd === -1) return null
 
@@ -66,8 +71,27 @@ function parseMessage(buf: Buffer): { message: LspJsonRpcResponse | LspJsonRpcNo
 	const end = start + contentLen
 	if (buf.length < end) return null
 
+	const content = buf.slice(start, end).toString()
+	let message: unknown
+	try {
+		message = JSON.parse(content)
+	} catch {
+		// Corrupted JSON body — skip the frame entirely rather than crashing
+		// the reader (which would reject all pending requests and leave a
+		// zombie client). Log the raw content for production debugging.
+		console.error(`LSP: skipping unparseable frame (${contentLen} bytes):`, content.slice(0, 200))
+		return { skipped: true, remaining: buf.subarray(end) }
+	}
+
+	if (typeof message !== "object" || message === null) {
+		// Valid JSON but not an object (e.g. bare `null`, a number, a string).
+		// The `in` operator used below throws on primitives, so skip these.
+		console.error(`LSP: skipping non-object frame (${contentLen} bytes):`, content.slice(0, 200))
+		return { skipped: true, remaining: buf.subarray(end) }
+	}
+
 	return {
-		message: JSON.parse(buf.slice(start, end).toString()),
+		message: message as LspJsonRpcResponse | LspJsonRpcNotification,
 		remaining: buf.subarray(end),
 	}
 }
@@ -99,6 +123,11 @@ async function startMessageReader(client: LspClient): Promise<void> {
 			client.messageBuffer = Buffer.concat([client.messageBuffer, value])
 			let parsed = parseMessage(client.messageBuffer)
 			while (parsed) {
+				if ("skipped" in parsed) {
+					client.messageBuffer = parsed.remaining
+					parsed = parseMessage(client.messageBuffer)
+					continue
+				}
 				const { message, remaining } = parsed
 				client.messageBuffer = remaining
 
@@ -152,10 +181,17 @@ async function startMessageReader(client: LspClient): Promise<void> {
 			}
 		}
 	} catch (err) {
+		const closed = new Error(`LSP connection closed: ${err}`)
 		for (const pending of client.pendingRequests.values()) {
-			pending.reject(new Error(`LSP connection closed: ${err}`))
+			pending.reject(closed)
 		}
 		client.pendingRequests.clear()
+		// Remove the zombie client so the next getOrCreateClient spawns a
+		// fresh server instead of returning a dead client whose reader has
+		// stopped. Kill the process in case it's still alive.
+		clients.delete(client.name)
+		clientLocks.delete(client.name)
+		client.proc.kill()
 	} finally {
 		reader.releaseLock()
 		client.isReading = false

--- a/src/extensions/lsp/servers.test.ts
+++ b/src/extensions/lsp/servers.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 vi.mock("node:fs", () => ({
 	default: {
 		existsSync: vi.fn(),
+		statSync: vi.fn(),
+		readFileSync: vi.fn(),
 	},
 }))
 
@@ -13,15 +15,19 @@ vi.mock("node:child_process", () => ({
 	spawnSync: vi.fn(),
 }))
 
-import { detectMissingCandidates, detectServers } from "./servers.js"
+import { detectMissingCandidates, detectServers, findMainRepoRoot, resolveTsserverPath } from "./servers.js"
 
 const mockExistsSync = vi.mocked(fs.existsSync)
 const mockSpawnSync = vi.mocked(spawnSync)
+const mockStatSync = vi.mocked(fs.statSync)
+const mockReadFileSync = vi.mocked(fs.readFileSync)
 
 // Suppress Bun global so exists() uses the spawnSync path
 beforeEach(() => {
 	mockExistsSync.mockReset()
 	mockSpawnSync.mockReset()
+	mockStatSync.mockReset()
+	mockReadFileSync.mockReset()
 	// biome-ignore lint/suspicious/noExplicitAny: suppress Bun global for deterministic Node-path testing
 	;(globalThis as any).Bun = undefined
 })
@@ -126,5 +132,87 @@ describe("detectMissingCandidates", () => {
 		const result = detectMissingCandidates("/project/services/autoscaler")
 		expect(result).toHaveLength(1)
 		expect(result[0].name).toBe("gopls")
+	})
+})
+
+describe("findMainRepoRoot", () => {
+	it("returns main repo path when .git is a file with valid gitdir line", () => {
+		const cwd = "/worktree/foo"
+		const dotGit = `${cwd}/.git`
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("gitdir: /main-repo/.git/worktrees/foo\n")
+		expect(findMainRepoRoot(cwd)).toBe("/main-repo")
+	})
+
+	it("returns undefined when .git is a directory", () => {
+		const cwd = "/normal-repo"
+		const dotGit = `${cwd}/.git`
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => true } as unknown as fs.Stats)
+		expect(findMainRepoRoot(cwd)).toBeUndefined()
+	})
+
+	it("returns undefined when .git doesn't exist", () => {
+		mockExistsSync.mockReturnValue(false)
+		expect(findMainRepoRoot("/no-git")).toBeUndefined()
+	})
+
+	it("returns undefined when .git content doesn't match gitdir pattern", () => {
+		const cwd = "/weird"
+		const dotGit = `${cwd}/.git`
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("this is not a gitdir file\n")
+		expect(findMainRepoRoot(cwd)).toBeUndefined()
+	})
+
+	it("returns undefined when gitdir doesn't match worktrees pattern", () => {
+		const cwd = "/submodule"
+		const dotGit = `${cwd}/.git`
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("gitdir: /other-repo/.git/modules/foo\n")
+		expect(findMainRepoRoot(cwd)).toBeUndefined()
+	})
+})
+
+describe("resolveTsserverPath", () => {
+	const localTsserver = "/cwd/node_modules/typescript/lib/tsserver.js"
+	const mainTsserver = "/main-repo/node_modules/typescript/lib/tsserver.js"
+
+	beforeEach(() => {
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("gitdir: /main-repo/.git/worktrees/cwd\n")
+	})
+
+	it("returns local tsserver.js when node_modules/typescript exists in cwd", () => {
+		mockExistsSync.mockImplementation((p: unknown) => p === localTsserver)
+		expect(resolveTsserverPath("/cwd")).toBe(localTsserver)
+	})
+
+	it("returns main repo tsserver.js when cwd is a worktree without local node_modules", () => {
+		const dotGit = "/cwd/.git"
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit || p === mainTsserver)
+		expect(resolveTsserverPath("/cwd")).toBe(mainTsserver)
+	})
+
+	it("returns undefined when not in a worktree and no local TypeScript", () => {
+		// .git doesn't exist -> findMainRepoRoot returns undefined early
+		mockExistsSync.mockReturnValue(false)
+		expect(resolveTsserverPath("/cwd")).toBeUndefined()
+	})
+
+	it("returns undefined when .git is a directory and no local TypeScript", () => {
+		const dotGit = "/cwd/.git"
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => true } as unknown as fs.Stats)
+		expect(resolveTsserverPath("/cwd")).toBeUndefined()
+	})
+
+	it("prefers local over main repo when both exist", () => {
+		const dotGit = "/cwd/.git"
+		mockExistsSync.mockImplementation((p: unknown) => p === localTsserver || p === dotGit || p === mainTsserver)
+		expect(resolveTsserverPath("/cwd")).toBe(localTsserver)
 	})
 })

--- a/src/extensions/lsp/servers.test.ts
+++ b/src/extensions/lsp/servers.test.ts
@@ -175,6 +175,15 @@ describe("findMainRepoRoot", () => {
 		mockReadFileSync.mockReturnValue("gitdir: /other-repo/.git/modules/foo\n")
 		expect(findMainRepoRoot(cwd)).toBeUndefined()
 	})
+
+	it("resolves relative gitdir paths against cwd", () => {
+		const cwd = "/worktree/foo"
+		const dotGit = `${cwd}/.git`
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit)
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("gitdir: ../main-repo/.git/worktrees/foo\n")
+		expect(findMainRepoRoot(cwd)).toBe("/worktree/main-repo")
+	})
 })
 
 describe("resolveTsserverPath", () => {

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -89,6 +89,49 @@ export function serverForFile(filePath: string, servers: ServerConfig[]): Server
 	return servers.find((s) => s.extensions.includes(ext)) ?? null
 }
 
+/**
+ * If cwd is a git worktree, return the main repository root.
+ * Returns undefined if cwd is not a worktree (no .git, .git is a directory,
+ * or the gitdir line doesn't point at a worktrees entry).
+ */
+export function findMainRepoRoot(cwd: string): string | undefined {
+	const dotGitPath = path.join(cwd, ".git")
+	if (!fs.existsSync(dotGitPath)) return undefined
+
+	// If .git is a directory, this is a normal repo root, not a worktree.
+	const stat = fs.statSync(dotGitPath)
+	if (stat.isDirectory()) return undefined
+
+	const content = fs.readFileSync(dotGitPath, "utf-8").trim()
+	const gitdirMatch = content.match(/^gitdir:\s*(.+)$/m)
+	if (!gitdirMatch) return undefined
+
+	const gitdir = gitdirMatch[1]
+	// gitdir looks like /path/to/main-repo/.git/worktrees/<name>
+	const worktreeMatch = gitdir.match(/^(.+?\/\.git)\/worktrees\/[^/]+$/)
+	if (!worktreeMatch) return undefined
+
+	return path.dirname(worktreeMatch[1])
+}
+
+/**
+ * Resolve the tsserver.js path for the given cwd.
+ * Checks cwd's node_modules first, then the main repo root if cwd is a
+ * git worktree. Returns undefined if nothing is found.
+ */
+export function resolveTsserverPath(cwd: string): string | undefined {
+	const localTsserver = path.join(cwd, "node_modules/typescript/lib/tsserver.js")
+	if (fs.existsSync(localTsserver)) return localTsserver
+
+	const mainRepo = findMainRepoRoot(cwd)
+	if (mainRepo) {
+		const mainTsserver = path.join(mainRepo, "node_modules/typescript/lib/tsserver.js")
+		if (fs.existsSync(mainTsserver)) return mainTsserver
+	}
+
+	return undefined
+}
+
 const ROOT_MARKERS: Record<string, string[]> = {
 	gopls: ["go.mod"],
 	"typescript-language-server": ["tsconfig.json", "package.json"],

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -111,7 +111,8 @@ export function findMainRepoRoot(cwd: string): string | undefined {
 	const worktreeMatch = gitdir.match(/^(.+?\/\.git)\/worktrees\/[^/]+$/)
 	if (!worktreeMatch) return undefined
 
-	return path.dirname(worktreeMatch[1])
+	const mainRoot = path.dirname(worktreeMatch[1])
+	return path.isAbsolute(mainRoot) ? mainRoot : path.resolve(cwd, mainRoot)
 }
 
 /**


### PR DESCRIPTION
## Linked issue

Closes #917

## What does this PR do?

When running kimchi in a git worktree that has no `node_modules`, the `typescript-language-server` could not resolve `tsserver.js` and failed to provide TypeScript intelligence.

This PR resolves `tsserver.js` from the main repository root when the cwd is a git worktree:

- **`src/extensions/lsp/servers.ts`** — adds `findMainRepoRoot(cwd)` which detects a git worktree by reading `<cwd>/.git` (a file in worktrees, a directory in normal repos), parsing the `gitdir:` line, and extracting the main repo root. Adds `resolveTsserverPath(cwd)` which checks the local `node_modules/typescript/lib/tsserver.js` first, then falls back to the main repo root copy if cwd is a worktree.
- **`src/extensions/lsp/client.ts`** — wires `resolveTsserverPath` into `getOrCreateClient`: when `config.command === "typescript-language-server"`, it sets `initOptions.tsserver.path` to the resolved path before the LSP `initialize` request. Existing `initOptions` are preserved.
- **`src/extensions/lsp/servers.test.ts`** — new test file covering `findMainRepoRoot` (5 cases: valid worktree, .git is a directory, no .git, no gitdir pattern, non-worktrees gitdir) and `resolveTsserverPath` (5 cases: local tsserver, main repo fallback, not-a-worktree, .git directory, local preference).

Local preference is preserved: if `node_modules/typescript` exists in the worktree itself, it is used over the main repo copy.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
