### PR TITLE
fix(ci): grant welcome action permissions

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   welcome:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Linked issue

Closes #919 

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The welcome workflow (actions/first-interaction@v1) posts its welcome message on PRs by creating a pull request review, which requires the pull-requests: write permission. Without an explicit permissions block, the default GITHUB_TOKEN lacked it, causing
"Resource not accessible by integration" on first-time PRs.

Added issues: write as well, since the same action posts issue comments and would hit the same class of failure on first-time issues.

