### PR TITLE
fix(teleport): fix rendering issues with zero width unicode chars

### DIFF
--- a/src/extensions/teleport/pty/terminal-component.test.ts
+++ b/src/extensions/teleport/pty/terminal-component.test.ts
@@ -199,6 +199,54 @@ describe("TerminalComponent handleInput", () => {
 	})
 })
 
+describe("TerminalComponent CJK wide-char rendering", () => {
+	it("renders hangul syllables without spaces between them", async () => {
+		const session = mockSession()
+		const component = new TerminalComponent(mockTui(), session, createXtermCore())
+		// Each hangul syllable is wide (width=2) and occupies 2 cells in xterm:
+		// lead cell holds the codepoint, continuation cell has width=0.
+		// Before the fix, continuation cells emitted a space (0x20), producing
+		// "안 녕" instead of "안녕".
+		await component.writeRemoteData("안녕")
+		const lines = component.render(80)
+		expect(stripAnsi(lines[0]).trimEnd()).toBe("안녕")
+	})
+
+	it("renders mixed ASCII and hangul without spurious spaces", async () => {
+		const session = mockSession()
+		const component = new TerminalComponent(mockTui(), session, createXtermCore())
+		await component.writeRemoteData("hi 안녕 bye")
+		const lines = component.render(80)
+		expect(stripAnsi(lines[0]).trimEnd()).toBe("hi 안녕 bye")
+	})
+
+	it("renders CJK ideographs (Chinese) without spurious spaces", async () => {
+		const session = mockSession()
+		const component = new TerminalComponent(mockTui(), session, createXtermCore())
+		await component.writeRemoteData("你好世界")
+		const lines = component.render(80)
+		expect(stripAnsi(lines[0]).trimEnd()).toBe("你好世界")
+	})
+
+	it("renders Japanese kana + kanji without spurious spaces", async () => {
+		const session = mockSession()
+		const component = new TerminalComponent(mockTui(), session, createXtermCore())
+		await component.writeRemoteData("こんにちは")
+		const lines = component.render(80)
+		expect(stripAnsi(lines[0]).trimEnd()).toBe("こんにちは")
+	})
+
+	it("preserves styling across wide chars", async () => {
+		const session = mockSession()
+		const component = new TerminalComponent(mockTui(), session, createXtermCore())
+		await component.writeRemoteData("\x1b[31m안녕\x1b[0m")
+		const lines = component.render(80)
+		expect(stripAnsi(lines[0]).trimEnd()).toBe("안녕")
+		expect(lines[0]).toContain("\x1b[31m")
+		expect(lines[0]).toContain("\x1b[0m")
+	})
+})
+
 describe("TerminalComponent writeRemoteData", () => {
 	it("processes remote data", async () => {
 		const session = mockSession()

--- a/src/extensions/teleport/pty/terminal-component.ts
+++ b/src/extensions/teleport/pty/terminal-component.ts
@@ -249,6 +249,9 @@ export class TerminalComponent implements Component {
 		let prevStyle = ""
 		for (let col = 0; col < width; col++) {
 			const cell = this.terminal.getCell(row, col)
+			// width 0 = continuation cell of a wide char (CJK/emoji);
+			// skip emitting it — the lead cell already wrote the codepoint.
+			if (cell.width === 0) continue
 			const style = cellStyle(cell)
 			if (style !== prevStyle) {
 				text += `\x1b[0m${style}`

--- a/src/extensions/teleport/pty/xterm-core.ts
+++ b/src/extensions/teleport/pty/xterm-core.ts
@@ -5,6 +5,7 @@ const DEFAULT_COLOR = 256
 
 export interface CellData {
 	char: number
+	width: number
 	fg: number
 	bg: number
 	flags: number
@@ -54,14 +55,17 @@ export class XtermCore {
 		const buffer = this.terminal.buffer.active
 		const line = buffer.getLine(buffer.viewportY + row)
 		if (!line) {
-			return { char: 32, fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, flags: 0 }
+			return { char: 32, width: 1, fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, flags: 0 }
 		}
 		const cell = line.getCell(col)
 		if (!cell) {
-			return { char: 32, fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, flags: 0 }
+			return { char: 32, width: 1, fg: DEFAULT_COLOR, bg: DEFAULT_COLOR, flags: 0 }
 		}
 
-		const char = cell.getCode() || 32
+		const width = cell.getWidth()
+		// width 0 marks the continuation cell of a wide char (CJK/emoji);
+		// expose char 0 so callers can skip it instead of rendering a space.
+		const char = width === 0 ? 0 : cell.getCode() || 32
 		let fg = DEFAULT_COLOR
 		let bg = DEFAULT_COLOR
 		let fgRgb: number | undefined
@@ -88,7 +92,7 @@ export class XtermCore {
 		if (cell.isInverse()) flags |= 0x20
 		if (cell.isStrikethrough()) flags |= 0x80
 
-		return { char, fg, bg, flags, fgRgb, bgRgb }
+		return { char, width, fg, bg, flags, fgRgb, bgRgb }
 	}
 
 	getCursor(): CursorState {


### PR DESCRIPTION
Korean characters were rendered with spaces in between characters, where there shouldn't be any. 

This PR stops rendering zero width characters in the teleport remote terminal. 

## Linked issue

Closes #0
