### PR TITLE
feat: JetBrains IDE diff approval and selection indicator

### DIFF
--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -27,6 +27,7 @@ export class PromptEditor extends CustomEditor {
 	private expandHandler?: () => void
 	private _pendingImageIndicator: string | null = null
 	private _sessionIndicator: string | null = null
+	private _ideSelectionIndicator: string | null = null
 
 	constructor(tui: TUI, editorTheme: EditorTheme, keybindings: KeybindingsManager, appTheme: Theme) {
 		super(tui, editorTheme, keybindings)
@@ -62,13 +63,24 @@ export class PromptEditor extends CustomEditor {
 	}
 
 	/**
-	 * Compose the current session + pending-image indicators into a single
-	 * raw string, or null if neither is set.
+	 * Show the current IDE selection (e.g. `@src/foo.ts:10-20`) right-aligned
+	 * on the prompt's first row, next to the other indicators. Pass `null` to clear.
+	 */
+	setIdeSelectionIndicator(text: string | null) {
+		if (this._ideSelectionIndicator === text) return
+		this._ideSelectionIndicator = text
+		this.tui.requestRender()
+	}
+
+	/**
+	 * Compose the current session + pending-image + ide-selection indicators
+	 * into a single raw string, or null if none is set.
 	 */
 	private combinedIndicator(): string | null {
 		const parts: string[] = []
 		if (this._sessionIndicator) parts.push(this._sessionIndicator)
 		if (this._pendingImageIndicator) parts.push(this._pendingImageIndicator)
+		if (this._ideSelectionIndicator) parts.push(this._ideSelectionIndicator)
 		return parts.length > 0 ? parts.join(" ") : null
 	}
 

--- a/src/extensions/ide-adapter/ARCHITECTURE.md
+++ b/src/extensions/ide-adapter/ARCHITECTURE.md
@@ -27,7 +27,9 @@ When the agent calls a proxied IDE tool (`ide_<name>`), the harness forwards it 
 
 ### `selection_changed`
 
-The harness stores the latest selection in memory. Other IDE tools (or future harness logic) can retrieve it via `getLatestSelection`.
+The harness renders the current IDE selection as a live input-box chip (`@file:range`) and auto-attaches it to the next prompt on send. The selection is **sticky** — it stays attached on every send until a new `selection_changed` overwrites it (unlike `at_mentioned`, which is drained on send). If the user explicitly at-mentions the same range they have selected, the selection prefix is suppressed to avoid duplication.
+
+**Note:** the harness does not auto-clear the selection on its own — it relies on the plugin's next notification to overwrite it. The indicator is only explicitly cleared on `session_shutdown`.
 
 ## Lockfile Matching
 
@@ -63,6 +65,15 @@ User selects code and clicks "Send to Kimchi"
    └─> IDE sends at_mentioned notification
    └─> harness pastes immediately if UI active, else queues
    └─> on next user input, any queued mentions are prepended as @file:range
+
+IDE cursor/selection moves
+   └─> IDE sends selection_changed notification (plugin-side ~150 ms debounce)
+   └─> harness renders @file:range as an input-box indicator chip
+   └─> harness stores selection as sticky _latestSelection
+
+User submits a prompt
+   └─> pi.on('input') prepends @file:range from _latestSelection (sticky, not consumed)
+   └─> dedups against any explicitly queued at-mention of the same range
 
 IDE closes project
    └─> deletes lockfile

--- a/src/extensions/ide-adapter/CONTRACT.md
+++ b/src/extensions/ide-adapter/CONTRACT.md
@@ -94,6 +94,12 @@ Sent when the cursor/selection moves. The IDE should debounce this (e.g. ~150 ms
 }
 ```
 
+**Harness behaviour on receipt:**
+
+The selection is rendered as a live input-box chip (`@file:range`) and auto-attached to the next prompt on send. The selection is **sticky** — it re-attaches on every send until a new `selection_changed` overwrites it (unlike `at_mentioned`, which is drained on send). If the user explicitly at-mentions the same range, the selection prefix is suppressed to avoid duplication.
+
+**Note:** the harness does not auto-clear the selection — it relies on the plugin's next notification to overwrite it. Plugins that want a collapsed selection to clear the chip should send a `selection_changed` with `lineStart: 0, lineEnd: 0`.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -110,7 +116,7 @@ IDE opens project
 Kimchi discovers and connects
    └─> scans lockfile directory
    └─> matches workspace folder (or any alive lockfile)
-   └─> connects WebSocket (x-secret-key + ?token=)
+   └─> connects WebSocket (?token=)
    └─> MCP initialize / initialized handshake
    └─> calls tools/list
    └─> registers tools as ide_<name>
@@ -126,4 +132,4 @@ IDE closes project
 ## Design Notes
 
 - **No IDE-specific logic** in the harness. Any IDE supporting the lockfile + WebSocket MCP protocol can integrate without harness changes.
-- The harness uses a **custom WebSocket transport** (wrapping the `ws` package) because the official `@modelcontextprotocol/sdk` WebSocket transport does not support custom auth headers.
+- The harness uses a **custom WebSocket transport** (wrapping the `ws` package) because the official `@modelcontextprotocol/sdk` WebSocket transport does not support custom auth via query parameters on the WebSocket URL.

--- a/src/extensions/ide-adapter/edit-apply.test.ts
+++ b/src/extensions/ide-adapter/edit-apply.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest"
+import { applyEditInput, applyEdits, normaliseEditOperations } from "./edit-apply.js"
+
+describe("normaliseEditOperations", () => {
+	it("normalises the single-operation form", () => {
+		const ops = normaliseEditOperations({ oldText: "a", newText: "b" })
+		expect(ops).toEqual([{ oldText: "a", newText: "b" }])
+	})
+
+	it("normalises the single-operation form with snake_case fallbacks", () => {
+		const ops = normaliseEditOperations({ old_text: "a", new_text: "b" })
+		expect(ops).toEqual([{ oldText: "a", newText: "b" }])
+	})
+
+	it("normalises the array form", () => {
+		const ops = normaliseEditOperations({
+			edits: [
+				{ oldText: "a", newText: "b" },
+				{ oldText: "c", newText: "d" },
+			],
+		})
+		expect(ops).toEqual([
+			{ oldText: "a", newText: "b" },
+			{ oldText: "c", newText: "d" },
+		])
+	})
+
+	it("normalises the array form with snake_case fallbacks", () => {
+		const ops = normaliseEditOperations({
+			edits: [{ old_text: "a", new_text: "b" }],
+		})
+		expect(ops).toEqual([{ oldText: "a", newText: "b" }])
+	})
+
+	it("filters out empty oldText", () => {
+		const ops = normaliseEditOperations({ edits: [{ oldText: "", newText: "b" }] })
+		expect(ops).toEqual([])
+	})
+
+	it("filters out no-op edits where oldText === newText", () => {
+		const ops = normaliseEditOperations({ edits: [{ oldText: "a", newText: "a" }] })
+		expect(ops).toEqual([])
+	})
+
+	it("returns an empty array when no edits are present", () => {
+		const ops = normaliseEditOperations({})
+		expect(ops).toEqual([])
+	})
+})
+
+describe("applyEdits", () => {
+	it("applies a single operation", () => {
+		expect(applyEdits("hello world", [{ oldText: "world", newText: "kimchi" }])).toBe("hello kimchi")
+	})
+
+	it("applies multiple operations sequentially", () => {
+		expect(
+			applyEdits("a b c", [
+				{ oldText: "a", newText: "x" },
+				{ oldText: "b", newText: "y" },
+				{ oldText: "c", newText: "z" },
+			]),
+		).toBe("x y z")
+	})
+
+	it("replaces only the first occurrence", () => {
+		expect(applyEdits("a a a", [{ oldText: "a", newText: "x" }])).toBe("x a a")
+	})
+
+	it("returns null when oldText is not found", () => {
+		expect(applyEdits("hello", [{ oldText: "world", newText: "kimchi" }])).toBeNull()
+	})
+
+	it("returns null when a later operation's oldText is not found after earlier mutations", () => {
+		// After replacing "a" with "x", "a" is no longer present
+		expect(
+			applyEdits("a b", [
+				{ oldText: "a", newText: "x" },
+				{ oldText: "a", newText: "y" },
+			]),
+		).toBeNull()
+	})
+
+	it("can insert text by matching an empty-ish anchor via surrounding context", () => {
+		// oldText with surrounding context acts as an insertion point
+		expect(applyEdits("function() {}", [{ oldText: "()", newText: "(arg)" }])).toBe("function(arg) {}")
+	})
+
+	it("returns the original when operations is empty", () => {
+		expect(applyEdits("hello", [])).toBe("hello")
+	})
+
+	it("handles multi-line oldText", () => {
+		const original = "line1\nline2\nline3"
+		const oldText = "line1\nline2"
+		const newText = "line1\nLINE2"
+		expect(applyEdits(original, [{ oldText, newText }])).toBe("line1\nLINE2\nline3")
+	})
+
+	it("handles large content efficiently", () => {
+		const original = "x".repeat(100_000)
+		const newText = "y".repeat(100_000)
+		expect(applyEdits(original, [{ oldText: original, newText }])).toBe(newText)
+	})
+})
+
+describe("applyEditInput", () => {
+	it("normalises and applies the single-operation form", () => {
+		expect(applyEditInput("hello world", { oldText: "world", newText: "kimchi" })).toBe("hello kimchi")
+	})
+
+	it("normalises and applies the array form", () => {
+		expect(
+			applyEditInput("a b c", {
+				edits: [
+					{ oldText: "a", newText: "x" },
+					{ oldText: "c", newText: "z" },
+				],
+			}),
+		).toBe("x b z")
+	})
+
+	it("returns null when an operation fails", () => {
+		expect(
+			applyEditInput("hello", {
+				edits: [{ oldText: "world", newText: "kimchi" }],
+			}),
+		).toBeNull()
+	})
+
+	it("returns the original when no operations are present", () => {
+		expect(applyEditInput("hello", {})).toBe("hello")
+	})
+})

--- a/src/extensions/ide-adapter/edit-apply.ts
+++ b/src/extensions/ide-adapter/edit-apply.ts
@@ -1,0 +1,53 @@
+/** Compute the content a `write`/`edit` tool call would produce, so the
+ * ide-adapter can send it to the IDE's diff viewer *before* the tool runs.
+ * Semantics mirror `getEditOperations` in `src/extensions/tool-rendering.ts`. */
+
+export interface EditOperation {
+	oldText: string
+	newText: string
+}
+
+/** Normalise raw `edit` tool input into edit operations. Accepts array and
+ * single-operation forms, with `old_text`/`new_text` snake_case fallbacks.
+ * Filters out empty and no-op entries, matching the upstream `edit` tool. */
+export function normaliseEditOperations(input: {
+	oldText?: string
+	old_text?: string
+	newText?: string
+	new_text?: string
+	edits?: Array<{ oldText?: string; old_text?: string; newText?: string; new_text?: string }>
+}): Array<EditOperation> {
+	if (Array.isArray(input?.edits)) {
+		return input.edits
+			.map((edit) => ({
+				oldText:
+					typeof edit?.oldText === "string" ? edit.oldText : typeof edit?.old_text === "string" ? edit.old_text : "",
+				newText:
+					typeof edit?.newText === "string" ? edit.newText : typeof edit?.new_text === "string" ? edit.new_text : "",
+			}))
+			.filter((edit) => edit.oldText && edit.oldText !== edit.newText)
+	}
+	const oldText =
+		typeof input?.oldText === "string" ? input.oldText : typeof input?.old_text === "string" ? input.old_text : ""
+	const newText =
+		typeof input?.newText === "string" ? input.newText : typeof input?.new_text === "string" ? input.new_text : ""
+	return oldText && oldText !== newText ? [{ oldText, newText }] : []
+}
+
+/** Apply operations sequentially, replacing the first occurrence of each
+ * `oldText`. Returns `null` if any `oldText` is not found — matching the
+ * edit tool's all-or-nothing semantics. */
+export function applyEdits(original: string, operations: Array<EditOperation>): string | null {
+	let content = original
+	for (const op of operations) {
+		const idx = content.indexOf(op.oldText)
+		if (idx === -1) return null
+		content = content.slice(0, idx) + op.newText + content.slice(idx + op.oldText.length)
+	}
+	return content
+}
+
+/** Convenience: normalise and apply in one call. */
+export function applyEditInput(original: string, input: Parameters<typeof normaliseEditOperations>[0]): string | null {
+	return applyEdits(original, normaliseEditOperations(input))
+}

--- a/src/extensions/ide-adapter/index.test.ts
+++ b/src/extensions/ide-adapter/index.test.ts
@@ -18,6 +18,12 @@ vi.mock("./lockfile.js", () => ({
 	isProcessAlive: vi.fn().mockReturnValue(true),
 }))
 
+vi.mock("node:fs", () => ({
+	readFileSync: vi.fn(),
+}))
+
+import { readFileSync } from "node:fs"
+
 describe("ide-adapter extension", () => {
 	function createFakeExtensionAPI(): ExtensionAPI & {
 		_handlers: Record<string, ((...args: unknown[]) => unknown)[]>
@@ -59,6 +65,7 @@ describe("ide-adapter extension", () => {
 			removeContextFiles: vi.fn(),
 			defineCommand: vi.fn(),
 			requireApproval: vi.fn(),
+			sendMessage: vi.fn(),
 			setSystemPrompt: vi.fn(),
 			setCustomSystemPrompt: vi.fn(),
 			setModelRole: vi.fn(),
@@ -115,6 +122,20 @@ describe("ide-adapter extension", () => {
 			expect(pi._handlers.session_shutdown).toHaveLength(1)
 		})
 	})
+
+	/**
+	 * Build a mock MCP `tools/call` response envelope matching the shape that
+	 * `McpJsonRpc.kt` produces on the IDE side:
+	 * `{ content: [{ type: "text", text: "<json-stringified-payload>" }] }`.
+	 *
+	 * Tests must use this (not the raw payload) because `requestIdeApproval`
+	 * unwraps the MCP content envelope before reading `approved`.
+	 */
+	function mcpEnvelope(payload: Record<string, unknown>): unknown {
+		return {
+			content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+		}
+	}
 
 	describe("input handler", () => {
 		it("passes through when no pending mentions", () => {
@@ -183,7 +204,7 @@ describe("ide-adapter extension", () => {
 
 			handler({ method: "at_mentioned", params: { filePath: "/a/b.ts", lineStart: 10, lineEnd: 20 } })
 
-			expect(pasteToEditor).toHaveBeenCalledWith("@../a/b.ts:10-20")
+			expect(pasteToEditor).toHaveBeenCalledWith("@/a/b.ts:10-20")
 			expect(ctx.ui.setStatus).toHaveBeenCalledWith("ide-adapter-mention", undefined)
 			// Should NOT queue when pasted immediately
 			const inputResult = pi._handlers.input[0]({ text: "hello" })
@@ -235,11 +256,11 @@ describe("ide-adapter extension", () => {
 
 			handler({ method: "at_mentioned", params: { filePath: "/a/b.ts", lineStart: 10, lineEnd: 20 } })
 
-			expect(pasteToEditor).toHaveBeenCalledWith("@../a/b.ts:10-20")
+			expect(pasteToEditor).toHaveBeenCalledWith("@/a/b.ts:10-20")
 			expect(ctx.ui.setStatus).not.toHaveBeenCalled()
 			// Falls back to queue — next input should prepend the mention
 			const inputResult = pi._handlers.input[0]({ text: "hello" })
-			expect(inputResult).toEqual({ action: "transform", text: "@../a/b.ts:10-20 hello" })
+			expect(inputResult).toEqual({ action: "transform", text: "@/a/b.ts:10-20 hello" })
 		})
 
 		it("queues mention when UI is not available", async () => {
@@ -286,7 +307,7 @@ describe("ide-adapter extension", () => {
 
 			expect(ctx.ui.pasteToEditor).not.toHaveBeenCalled()
 			const inputResult = pi._handlers.input[0]({ text: "hello" })
-			expect(inputResult).toEqual({ action: "transform", text: "@../a/b.ts:10-20 hello" })
+			expect(inputResult).toEqual({ action: "transform", text: "@/a/b.ts:10-20 hello" })
 		})
 	})
 
@@ -429,6 +450,267 @@ describe("ide-adapter extension", () => {
 
 			warnSpy.mockRestore()
 			logSpy.mockRestore()
+		})
+	})
+
+	describe("tool_call approval hook", () => {
+		beforeEach(() => {
+			vi.useFakeTimers()
+			vi.mocked(connectToIde).mockReset()
+			vi.mocked(scanLockfiles).mockReset()
+			vi.mocked(parseLockfile).mockReset()
+			vi.mocked(findMatchingLockfile).mockReset()
+			vi.mocked(getLockfileDir).mockReset()
+			vi.mocked(readFileSync).mockReset()
+		})
+
+		afterEach(() => {
+			vi.useRealTimers()
+		})
+
+		/**
+		 * Wire up a fake IDE connection synchronously and fire session_start so
+		 * the adapter's module-local `connection` variable is populated.
+		 */
+		async function setupWithConnection(callToolImpl: ReturnType<typeof vi.fn>): Promise<{
+			pi: ReturnType<typeof createFakeExtensionAPI>
+			ctx: ReturnType<typeof createFakeCtx>
+		}> {
+			const fakeConnection = {
+				lockfile: { ideName: "TestIDE" },
+				listTools: vi.fn().mockResolvedValue([]),
+				callTool: callToolImpl,
+				close: vi.fn().mockResolvedValue(undefined),
+				setNotificationHandler: vi.fn(),
+			}
+			vi.mocked(connectToIde).mockResolvedValue(fakeConnection as unknown as Awaited<ReturnType<typeof connectToIde>>)
+			vi.mocked(getLockfileDir).mockReturnValue("/tmp/locks")
+			vi.mocked(scanLockfiles).mockReturnValue(["/tmp/locks/ide.lock"])
+			vi.mocked(parseLockfile).mockReturnValue({
+				port: 12345,
+				pid: 1,
+				ideName: "TestIDE",
+				ideVersion: "1.0",
+				transport: "ws",
+				workspaceFolders: ["/tmp"],
+				authToken: "tok",
+			} as LockfileData)
+			vi.mocked(findMatchingLockfile).mockReturnValue({
+				port: 12345,
+				pid: 1,
+				ideName: "TestIDE",
+				ideVersion: "1.0",
+				transport: "ws",
+				workspaceFolders: ["/tmp"],
+				authToken: "tok",
+			} as LockfileData)
+
+			const pi = createFakeExtensionAPI()
+			const ctx = createFakeCtx({ hasUI: false })
+			ideAdapterExtension(pi)
+			pi._handlers.session_start[0](null, ctx)
+			// Flush the discoverAndConnect microtask so `connection` is populated
+			// before tool_call runs. Without this the approval hook short-circuits
+			// on the "IDE not connected" branch.
+			await vi.advanceTimersByTimeAsync(0)
+			return { pi, ctx }
+		}
+
+		it("ignores tool calls that are not write or edit", async () => {
+			const { pi, ctx } = await setupWithConnection(vi.fn().mockResolvedValue({ approved: true }))
+			const result = await pi._handlers.tool_call[0]({ toolName: "read", input: { path: "/tmp/a" } }, ctx)
+			expect(result).toBeUndefined()
+		})
+
+		it("is a no-op when no IDE is connected", async () => {
+			// No lockfiles → no connection
+			vi.mocked(getLockfileDir).mockReturnValue("/tmp/locks")
+			vi.mocked(scanLockfiles).mockReturnValue([])
+
+			const pi = createFakeExtensionAPI()
+			const ctx = createFakeCtx({ hasUI: false })
+			ideAdapterExtension(pi)
+			pi._handlers.session_start[0](null, ctx)
+			await vi.advanceTimersByTimeAsync(0)
+
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+		})
+
+		it("blocks when the user rejects the change", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: false }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("User rejected the proposed change"),
+			})
+			expect(result).toMatchObject({ block: true })
+			expect(callTool).toHaveBeenCalledWith(
+				"proposeChange",
+				expect.objectContaining({
+					originalContent: "old",
+					newContent: "new",
+				}),
+			)
+		})
+
+		it("lets the tool proceed when the user approves", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+			expect(callTool).toHaveBeenCalledWith(
+				"proposeChange",
+				expect.objectContaining({
+					originalContent: "old",
+					newContent: "new",
+				}),
+			)
+		})
+
+		it("computes newContent for edit by applying operations", async () => {
+			vi.mocked(readFileSync).mockReturnValue("hello world")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			await pi._handlers.tool_call[0](
+				{
+					toolName: "edit",
+					input: { path: "a.txt", edits: [{ oldText: "world", newText: "kimchi" }] },
+				},
+				ctx,
+			)
+			expect(callTool).toHaveBeenCalledWith(
+				"proposeChange",
+				expect.objectContaining({
+					originalContent: "hello world",
+					newContent: "hello kimchi",
+				}),
+			)
+		})
+
+		it("defers to the tool when edit oldText is not found", async () => {
+			vi.mocked(readFileSync).mockReturnValue("hello")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const result = await pi._handlers.tool_call[0](
+				{
+					toolName: "edit",
+					input: { path: "a.txt", edits: [{ oldText: "missing", newText: "x" }] },
+				},
+				ctx,
+			)
+			expect(result).toBeUndefined()
+			expect(callTool).not.toHaveBeenCalled()
+		})
+
+		it("falls back to no-op when the IDE call itself fails", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockRejectedValue(new Error("ws closed"))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("proposeChange call failed"))
+			warnSpy.mockRestore()
+		})
+
+		it("treats a malformed IDE response as a failed call (no block)", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ weirdShape: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toBeUndefined()
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("proposeChange call failed"))
+			warnSpy.mockRestore()
+		})
+
+		it("handles write to a new file (empty originalContent)", async () => {
+			vi.mocked(readFileSync).mockImplementation(() => {
+				throw new Error("ENOENT")
+			})
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			await pi._handlers.tool_call[0]({ toolName: "write", input: { path: "new.txt", content: "fresh" } }, ctx)
+			expect(callTool).toHaveBeenCalledWith(
+				"proposeChange",
+				expect.objectContaining({
+					originalContent: "",
+					newContent: "fresh",
+				}),
+			)
+		})
+
+		it("overrides write.input.content when the user hand-edits the proposed content", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			// IDE returns approved=true with newContent = the user's edited version,
+			// which differs from the agent's original proposal ("new").
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true, newContent: "user-edited content" }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const eventInput: Record<string, unknown> = { path: "a.txt", content: "new" }
+			const result = await pi._handlers.tool_call[0]({ toolName: "write", input: eventInput }, ctx)
+			expect(result).toBeUndefined()
+			// The hook must have mutated the input so the write tool applies the user's text.
+			expect(eventInput.content).toBe("user-edited content")
+		})
+
+		it("does not override write.input when the user did not edit the proposed content", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			// IDE returns approved=true with newContent = the agent's original proposal.
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true, newContent: "new" }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const eventInput: Record<string, unknown> = { path: "a.txt", content: "new" }
+			await pi._handlers.tool_call[0]({ toolName: "write", input: eventInput }, ctx)
+			// No override — the agent's original content is preserved.
+			expect(eventInput.content).toBe("new")
+		})
+
+		it("overrides edit.input.edits with a full-file replacement when the user hand-edits the proposed content", async () => {
+			vi.mocked(readFileSync).mockReturnValue("hello world")
+			// Agent proposes replacing "world" -> "kimchi" (final newContent = "hello kimchi").
+			// User then hand-edits the proposed pane to "hello KIMCHI". The hook must
+			// rewrite input.edits as a single full-file replace.
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true, newContent: "hello KIMCHI" }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const eventInput: Record<string, unknown> = {
+				path: "a.txt",
+				edits: [{ oldText: "world", newText: "kimchi" }],
+			}
+			const result = await pi._handlers.tool_call[0]({ toolName: "edit", input: eventInput }, ctx)
+			expect(result).toBeUndefined()
+			// input.edits is rewritten to a single full-file replacement operation.
+			expect(eventInput.edits).toEqual([{ oldText: "hello world", newText: "hello KIMCHI" }])
+			// Legacy single-operation fields are cleared.
+			expect(eventInput.oldText).toBeUndefined()
+			expect(eventInput.newText).toBeUndefined()
 		})
 	})
 })

--- a/src/extensions/ide-adapter/index.test.ts
+++ b/src/extensions/ide-adapter/index.test.ts
@@ -10,6 +10,10 @@ vi.mock("../ui.js", () => ({
 	setIdeSelectionIndicator: vi.fn(),
 }))
 
+vi.mock("../permissions/mode-controller.js", () => ({
+	getPermissionMode: vi.fn(() => ({ mode: "default", source: "config", initiatedBy: "user" })),
+}))
+
 vi.mock("./mcp-client.js", () => ({
 	connectToIde: vi.fn(),
 }))
@@ -107,6 +111,7 @@ describe("ide-adapter extension", () => {
 		hasUI: boolean
 		ui: { pasteToEditor: ReturnType<typeof vi.fn>; setStatus: ReturnType<typeof vi.fn> }
 		cwd: string
+		sessionManager: { getSessionId: () => string }
 	} {
 		return {
 			hasUI: options.hasUI ?? true,
@@ -115,6 +120,7 @@ describe("ide-adapter extension", () => {
 				setStatus: options.setStatus ?? vi.fn(),
 			},
 			cwd: "/tmp",
+			sessionManager: { getSessionId: () => "test-session" },
 		}
 	}
 

--- a/src/extensions/ide-adapter/index.test.ts
+++ b/src/extensions/ide-adapter/index.test.ts
@@ -560,6 +560,7 @@ describe("ide-adapter extension", () => {
 					originalContent: "old",
 					newContent: "new",
 				}),
+				undefined,
 			)
 		})
 
@@ -579,6 +580,7 @@ describe("ide-adapter extension", () => {
 					originalContent: "old",
 					newContent: "new",
 				}),
+				undefined,
 			)
 		})
 
@@ -600,6 +602,7 @@ describe("ide-adapter extension", () => {
 					originalContent: "hello world",
 					newContent: "hello kimchi",
 				}),
+				undefined,
 			)
 		})
 
@@ -619,7 +622,7 @@ describe("ide-adapter extension", () => {
 			expect(callTool).not.toHaveBeenCalled()
 		})
 
-		it("falls back to no-op when the IDE call itself fails", async () => {
+		it("blocks when the IDE call itself fails (fail-closed)", async () => {
 			vi.mocked(readFileSync).mockReturnValue("old")
 			const callTool = vi.fn().mockRejectedValue(new Error("ws closed"))
 			const { pi, ctx } = await setupWithConnection(callTool)
@@ -629,12 +632,15 @@ describe("ide-adapter extension", () => {
 				{ toolName: "write", input: { path: "a.txt", content: "new" } },
 				ctx,
 			)
-			expect(result).toBeUndefined()
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("IDE approval failed"),
+			})
 			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("proposeChange call failed"))
 			warnSpy.mockRestore()
 		})
 
-		it("treats a malformed IDE response as a failed call (no block)", async () => {
+		it("blocks when the IDE returns a malformed response (fail-closed)", async () => {
 			vi.mocked(readFileSync).mockReturnValue("old")
 			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ weirdShape: true }))
 			const { pi, ctx } = await setupWithConnection(callTool)
@@ -644,9 +650,47 @@ describe("ide-adapter extension", () => {
 				{ toolName: "write", input: { path: "a.txt", content: "new" } },
 				ctx,
 			)
-			expect(result).toBeUndefined()
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("IDE approval failed"),
+			})
 			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("proposeChange call failed"))
 			warnSpy.mockRestore()
+		})
+
+		it("blocks without calling the IDE when the signal is already aborted", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const controller = new AbortController()
+			controller.abort()
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				{ ...ctx, signal: controller.signal },
+			)
+			expect(callTool).not.toHaveBeenCalled()
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("IDE approval failed"),
+			})
+		})
+
+		it("forwards the abort signal to connection.callTool", async () => {
+			vi.mocked(readFileSync).mockReturnValue("old")
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+
+			const controller = new AbortController()
+			await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				{ ...ctx, signal: controller.signal },
+			)
+			expect(callTool).toHaveBeenCalledWith(
+				"proposeChange",
+				expect.objectContaining({ filePath: expect.stringContaining("a.txt") }),
+				controller.signal,
+			)
 		})
 
 		it("handles write to a new file (empty originalContent)", async () => {
@@ -663,6 +707,7 @@ describe("ide-adapter extension", () => {
 					originalContent: "",
 					newContent: "fresh",
 				}),
+				undefined,
 			)
 		})
 

--- a/src/extensions/ide-adapter/index.test.ts
+++ b/src/extensions/ide-adapter/index.test.ts
@@ -1,9 +1,14 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { setIdeSelectionIndicator } from "../ui.js"
 import ideAdapterExtension from "./index.js"
 import { findMatchingLockfile, getLockfileDir, parseLockfile, scanLockfiles } from "./lockfile.js"
 import { connectToIde } from "./mcp-client.js"
 import type { LockfileData } from "./types.js"
+
+vi.mock("../ui.js", () => ({
+	setIdeSelectionIndicator: vi.fn(),
+}))
 
 vi.mock("./mcp-client.js", () => ({
 	connectToIde: vi.fn(),
@@ -606,7 +611,7 @@ describe("ide-adapter extension", () => {
 			)
 		})
 
-		it("defers to the tool when edit oldText is not found", async () => {
+		it("blocks when edit oldText is not found (fail-closed)", async () => {
 			vi.mocked(readFileSync).mockReturnValue("hello")
 			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
 			const { pi, ctx } = await setupWithConnection(callTool)
@@ -618,7 +623,10 @@ describe("ide-adapter extension", () => {
 				},
 				ctx,
 			)
-			expect(result).toBeUndefined()
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("Could not compute the proposed change"),
+			})
 			expect(callTool).not.toHaveBeenCalled()
 		})
 
@@ -695,7 +703,9 @@ describe("ide-adapter extension", () => {
 
 		it("handles write to a new file (empty originalContent)", async () => {
 			vi.mocked(readFileSync).mockImplementation(() => {
-				throw new Error("ENOENT")
+				const err = new Error("ENOENT") as Error & { code: string }
+				err.code = "ENOENT"
+				throw err
 			})
 			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
 			const { pi, ctx } = await setupWithConnection(callTool)
@@ -756,6 +766,93 @@ describe("ide-adapter extension", () => {
 			// Legacy single-operation fields are cleared.
 			expect(eventInput.oldText).toBeUndefined()
 			expect(eventInput.newText).toBeUndefined()
+		})
+
+		it("blocks when file is unreadable for non-ENOENT reasons", async () => {
+			vi.mocked(readFileSync).mockImplementation(() => {
+				const err = new Error("permission denied") as Error & { code: string }
+				err.code = "EACCES"
+				throw err
+			})
+			const callTool = vi.fn().mockResolvedValue(mcpEnvelope({ approved: true }))
+			const { pi, ctx } = await setupWithConnection(callTool)
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+			const result = await pi._handlers.tool_call[0](
+				{ toolName: "write", input: { path: "a.txt", content: "new" } },
+				ctx,
+			)
+			expect(result).toEqual({
+				block: true,
+				reason: expect.stringContaining("Could not compute the proposed change"),
+			})
+			expect(callTool).not.toHaveBeenCalled()
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to read"), expect.any(Error))
+			warnSpy.mockRestore()
+		})
+	})
+
+	describe("selection_changed notification", () => {
+		beforeEach(() => {
+			vi.useFakeTimers()
+			vi.mocked(connectToIde).mockReset()
+			vi.mocked(scanLockfiles).mockReset()
+			vi.mocked(parseLockfile).mockReset()
+			vi.mocked(findMatchingLockfile).mockReset()
+			vi.mocked(getLockfileDir).mockReset()
+			vi.mocked(setIdeSelectionIndicator).mockReset()
+		})
+
+		afterEach(() => {
+			vi.useRealTimers()
+		})
+
+		it("clears the selection indicator when lineStart:0 and lineEnd:0", async () => {
+			const fakeConnection = {
+				lockfile: { ideName: "TestIDE" },
+				listTools: vi.fn().mockResolvedValue([]),
+				callTool: vi.fn(),
+				close: vi.fn().mockResolvedValue(undefined),
+				setNotificationHandler: vi.fn(),
+			}
+			vi.mocked(connectToIde).mockResolvedValue(fakeConnection as unknown as Awaited<ReturnType<typeof connectToIde>>)
+			vi.mocked(getLockfileDir).mockReturnValue("/tmp/locks")
+			vi.mocked(scanLockfiles).mockReturnValue(["/tmp/locks/ide.lock"])
+			vi.mocked(parseLockfile).mockReturnValue({
+				port: 12345,
+				pid: 1,
+				ideName: "TestIDE",
+				ideVersion: "1.0",
+				transport: "ws",
+				workspaceFolders: ["/tmp"],
+				authToken: "tok",
+			} as LockfileData)
+			vi.mocked(findMatchingLockfile).mockReturnValue({
+				port: 12345,
+				pid: 1,
+				ideName: "TestIDE",
+				ideVersion: "1.0",
+				transport: "ws",
+				workspaceFolders: ["/tmp"],
+				authToken: "tok",
+			} as LockfileData)
+
+			const pi = createFakeExtensionAPI()
+			const ctx = createFakeCtx({ hasUI: true })
+			ideAdapterExtension(pi)
+			pi._handlers.session_start[0](null, ctx)
+			await vi.advanceTimersByTimeAsync(0)
+
+			const handler = vi.mocked(fakeConnection.setNotificationHandler).mock.calls[0][0]
+
+			// First, set a selection
+			handler({ method: "selection_changed", params: { filePath: "/a/b.ts", lineStart: 10, lineEnd: 20 } })
+			expect(setIdeSelectionIndicator).toHaveBeenCalledWith("@/a/b.ts:10-20")
+
+			// Then send a 0:0 selection — should clear per CONTRACT.md
+			vi.mocked(setIdeSelectionIndicator).mockClear()
+			handler({ method: "selection_changed", params: { filePath: "/a/b.ts", lineStart: 0, lineEnd: 0 } })
+			expect(setIdeSelectionIndicator).toHaveBeenCalledWith(null)
 		})
 	})
 })

--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -1,12 +1,25 @@
-import { relative } from "node:path"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
+import { setIdeSelectionIndicator } from "../ui.js"
 import { formatAtMention } from "./at-mentions.js"
+import { applyEditInput } from "./edit-apply.js"
 import { findMatchingLockfile, getLockfileDir, parseLockfile, scanLockfiles } from "./lockfile.js"
 import { connectToIde } from "./mcp-client.js"
 import type { AtMentionNotification, IdeConnection, IdeTool, SelectionChangedNotification } from "./types.js"
 
 const POLL_INTERVAL_MS = 5000
+
+/** Module-level flag indicating whether the current process has an active IDE connection.
+ * Used by other extensions (e.g. permissions) to decide whether to defer to the IDE.
+ * This is coarse-grained by design: there is at most one active IDE session per Kimchi process. */
+let ideConnectionActive = false
+
+/** Return true if an IDE connection is currently active. */
+export function isIdeConnected(): boolean {
+	return ideConnectionActive
+}
 
 /** Max number of at-mentions to queue before dropping oldest. */
 const MAX_PENDING_MENTIONS = 100
@@ -14,10 +27,132 @@ const MAX_PENDING_MENTIONS = 100
 /** Max reconnect attempts before giving up on discovery polling. */
 const MAX_RECONNECT_RETRIES = 3
 
+/** Tool names that mutate files and must be gated by IDE approval when enabled. */
+const APPROVAL_GATED_TOOLS = new Set(["write", "edit"])
+
+/** Short unique id for IDE tool-window queue tracking. */
+function generateChangeId(): string {
+	return `chg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+/** Read a file's current contents, returning "" if missing or unreadable. */
+function readCurrentContent(filePath: string): string {
+	try {
+		return readFileSync(filePath, "utf-8")
+	} catch {
+		return ""
+	}
+}
+
+/** Compute the proposed new content for a `write`/`edit` call. Returns `null`
+ * on malformed input (e.g. edit `oldText` not found) so the hook defers to
+ * the tool's own validation. */
+function computeProposedChange(
+	toolName: string,
+	input: Record<string, unknown>,
+	cwd: string,
+): { filePath: string; originalContent: string; newContent: string } | null {
+	const rawPath =
+		typeof input.path === "string" ? input.path : typeof input.file_path === "string" ? input.file_path : ""
+	if (!rawPath) return null
+	const filePath = resolve(cwd, rawPath)
+	const originalContent = readCurrentContent(filePath)
+
+	if (toolName === "write") {
+		const newContent = typeof input.content === "string" ? input.content : ""
+		return { filePath, originalContent, newContent }
+	}
+
+	// edit
+	const newContent = applyEditInput(originalContent, input as Parameters<typeof applyEditInput>[1])
+	if (newContent === null) return null
+	return { filePath, originalContent, newContent }
+}
+
+/** Result of an IDE approval request. `approved: true` carries the user's
+ * (possibly hand-edited) `newContent`; `approved: false` means rejected.
+ * `null` means the IDE call failed — the hook falls back to letting the
+ * write proceed (best-effort, never a hard block). */
+interface IdeApprovalResult {
+	approved: boolean
+	newContent: string | null
+}
+
+/** Call the IDE's `proposeChange` tool and return the approval result, or
+ * `null` on failure (network error, malformed response). The MCP response is
+ * an envelope — see `unwrapMcpToolResult`. */
+async function requestIdeApproval(
+	connection: IdeConnection,
+	params: { filePath: string; originalContent: string; newContent: string; changeId: string },
+	signal: AbortSignal | undefined,
+): Promise<IdeApprovalResult | null> {
+	try {
+		const result = await connection.callTool("proposeChange", params)
+		if (signal?.aborted) return null
+		const payload = unwrapMcpToolResult(result)
+		if (payload && typeof payload === "object" && "approved" in payload) {
+			const approved = Boolean((payload as { approved: unknown }).approved)
+			const newContent = approved ? stringValue((payload as { newContent?: unknown }).newContent) : null
+			return { approved, newContent }
+		}
+		return null
+	} catch {
+		return null
+	}
+}
+
+/** Coerce to string or null. */
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" ? value : null
+}
+
+/** Override the agent's write/edit input with the user's hand-edited content
+ * from the IDE diff viewer. `write` sets `input.content`; `edit` rewrites
+ * `input.edits` as a single full-file replacement (robust vs. fragment-level
+ * reconstruction). Both branches normalise `path`/`file_path`. */
+function applyEditedContent(
+	input: Record<string, unknown>,
+	toolName: string,
+	editedNewContent: string,
+	originalContent: string,
+): void {
+	if (toolName === "write") {
+		input.content = editedNewContent
+		if (typeof input.path !== "string" && typeof input.file_path === "string") input.path = input.file_path
+		return
+	}
+	// edit → rewrite as a single full-file replacement.
+	input.edits = [{ oldText: originalContent, newText: editedNewContent }]
+	// Drop legacy single-operation fields so the tool doesn't see conflicting shapes.
+	input.oldText = undefined
+	input.newText = undefined
+	input.old_text = undefined
+	input.new_text = undefined
+	if (typeof input.path !== "string" && typeof input.file_path === "string") input.path = input.file_path
+}
+
+/** Extract the JSON payload from an MCP `CallToolResult` envelope:
+ * `{ content: [{ type: "text", text: "<json-stringified-result>" }] }`.
+ * Returns `null` on malformed envelopes or invalid JSON. */
+function unwrapMcpToolResult(result: unknown): unknown {
+	if (!result || typeof result !== "object") return null
+	const envelope = result as { content?: unknown }
+	const content = envelope.content
+	if (!Array.isArray(content) || content.length === 0) return null
+	const first = content[0]
+	if (!first || typeof first !== "object") return null
+	const text = (first as { text?: unknown }).text
+	if (typeof text !== "string") return null
+	try {
+		return JSON.parse(text)
+	} catch {
+		return null
+	}
+}
+
 export default function ideAdapterExtension(pi: ExtensionAPI): void {
 	let connection: IdeConnection | null = null
 	let pollTimer: ReturnType<typeof setInterval> | null = null
-	let _registeredToolNames: string[] = []
 	let isShuttingDown = false
 	let reconnectRetries = 0
 
@@ -70,6 +205,7 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 				return
 			}
 			connection = newConnection
+			ideConnectionActive = true
 			reconnectRetries = 0
 		} catch (err) {
 			reconnectRetries++
@@ -92,7 +228,7 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		// Wire disconnect callback so we can null the handle and reconnect later
 		connection.onDisconnect = () => {
 			connection = null
-			_registeredToolNames = []
+			ideConnectionActive = false
 		}
 
 		try {
@@ -101,7 +237,6 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 				if (isShuttingDown) break
 				registerIdeTool(pi, tool)
 			}
-			_registeredToolNames = tools.map((t) => t.name)
 		} catch (err) {
 			console.warn("[ide-adapter] Failed to list IDE tools:", err)
 		}
@@ -162,9 +297,10 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 
 		if (m.method === "at_mentioned") {
 			if (typeof params.filePath === "string") {
-				const filePath = currentCtx?.cwd
-					? relative(currentCtx.cwd, params.filePath).replace(/\\/g, "/")
-					: params.filePath
+				// The IDE is the authority on file paths (CONTRACT.md): it sends
+				// absolute paths and the agent's tools resolve them regardless of
+				// cwd, so pass the path through verbatim.
+				const filePath = params.filePath
 				const mention: AtMentionNotification = {
 					filePath,
 					lineStart: typeof params.lineStart === "number" ? params.lineStart : 0,
@@ -186,11 +322,22 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 			}
 		} else if (m.method === "selection_changed") {
 			if (typeof params.filePath === "string") {
-				localSetLatestSelection({
-					filePath: params.filePath,
+				// Pass the IDE-supplied absolute path through verbatim (see
+				// `at_mentioned` above).
+				const filePath = params.filePath
+				const selection: SelectionChangedNotification = {
+					filePath,
 					lineStart: typeof params.lineStart === "number" ? params.lineStart : 0,
 					lineEnd: typeof params.lineEnd === "number" ? params.lineEnd : 0,
-				})
+				}
+				localSetLatestSelection(selection)
+				// Surface as a right-aligned indicator inside the input box's top
+				// border — a dedicated segment alongside (not replacing) the pending
+				// image indicator. The selection is also kept sticky in
+				// `_latestSelection` for auto-attach on send (see `pi.on('input')`).
+				if (currentCtx?.hasUI) {
+					setIdeSelectionIndicator(formatAtMention(selection))
+				}
 			}
 		}
 	}
@@ -205,10 +352,73 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 			// Prevent onDisconnect from clearing a stale handle after we intentionally close
 			const conn = connection
 			connection = null
-			_registeredToolNames = []
+			ideConnectionActive = false
 			conn.close().catch((err) => console.warn("[ide-adapter] Disconnect error:", err))
 		}
 	}
+
+	pi.on("tool_call", async (event, ctx) => {
+		const toolName = event.toolName
+		if (!toolName || !APPROVAL_GATED_TOOLS.has(toolName)) return undefined
+
+		// No IDE connected → no approval surface is available; let the tool run.
+		// The IDE diff viewer is automatically used whenever an IDE is connected.
+		if (!connection) {
+			return undefined
+		}
+
+		const input = (event.input ?? {}) as Record<string, unknown>
+		const proposed = computeProposedChange(toolName, input, ctx.cwd)
+		if (!proposed) {
+			// Malformed inputs (e.g. edit oldText not found) — defer to the tool's
+			// own validation surface. Don't block; let the tool fail with its own
+			// error message.
+			return undefined
+		}
+
+		const changeId = generateChangeId()
+		const approval = await requestIdeApproval(connection, { ...proposed, changeId }, ctx.signal)
+		if (approval === null) {
+			// IDE call failed — best-effort approval, fall through.
+			console.warn(`[ide-adapter] proposeChange call failed for ${proposed.filePath}; letting ${toolName} proceed`)
+			return undefined
+		}
+		if (!approval.approved) {
+			return {
+				block: true,
+				reason: `User rejected the proposed change to ${proposed.filePath} in the IDE diff viewer.`,
+			}
+		}
+
+		// Approved. If the user hand-edited the proposed content in the IDE diff
+		// viewer, override the tool's input so the agent applies the user's final
+		// version instead of its original proposal.
+		if (approval.newContent !== null && approval.newContent !== proposed.newContent) {
+			applyEditedContent(
+				event.input as Record<string, unknown>,
+				toolName,
+				approval.newContent,
+				proposed.originalContent,
+			)
+			// Steer the LLM so its summary reflects what was actually written, not
+			// its original proposal. Without this, the agent confidently reports
+			// the proposed value even though the user changed it in the diff viewer.
+			pi.sendMessage(
+				{
+					customType: "ide-adapter-edit-steer",
+					content: [
+						{
+							type: "text",
+							text: `The user hand-edited your proposed change to ${proposed.filePath} in the IDE diff viewer before it was applied. The actual content written to disk differs from your original proposal — do not assume your proposed content was applied verbatim. If you need to reference the exact value, read the file from disk.`,
+						},
+					],
+					display: false,
+				},
+				{ deliverAs: "steer" },
+			)
+		}
+		return undefined
+	})
 
 	pi.on("session_start", (_event, ctx: ExtensionContext) => {
 		currentCtx = ctx
@@ -230,12 +440,22 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 	})
 
 	pi.on("input", (event) => {
-		if (!localHasPendingAtMentions()) return
+		// Drain pending at-mentions (manual Cmd+Option+K path). Empty if none queued.
+		const mentions = localHasPendingAtMentions() ? localDrainAtMentions() : []
 
-		const mentions = localDrainAtMentions()
-		if (mentions.length === 0) return
+		// Auto-attach the current IDE selection (sticky). The selection is NOT
+		// consumed — it stays "in sync" with the IDE so every send re-attaches
+		// whatever is currently selected, until a new selection_changed overwrites it.
+		const selectionMention = _latestSelection ? formatAtMention(_latestSelection) : null
 
-		const prefix = mentions.join(" ")
+		// Dedup: if the user explicitly at-mentioned the same range they have
+		// selected (e.g. Cmd+Option+K on the active selection), don't double-prefix.
+		const selectionPrefix = selectionMention && !mentions.includes(selectionMention) ? selectionMention : null
+
+		const prefixes = selectionPrefix ? [...mentions, selectionPrefix] : mentions
+		if (prefixes.length === 0) return
+
+		const prefix = prefixes.join(" ")
 		const text = event.text.trimStart()
 		const newText = text ? `${prefix} ${text}` : prefix
 
@@ -245,6 +465,9 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", () => {
 		currentCtx = null
 		isShuttingDown = true
+		// Clear the input-box selection indicator so it doesn't persist into
+		// the next session (the PromptEditor instance is reused).
+		setIdeSelectionIndicator(null)
 		disconnect()
 	})
 }

--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
+import { getPermissionMode } from "../permissions/mode-controller.js"
 import { setIdeSelectionIndicator } from "../ui.js"
 import { formatAtMention } from "./at-mentions.js"
 import { applyEditInput } from "./edit-apply.js"
@@ -375,6 +376,14 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 	pi.on("tool_call", async (event, ctx) => {
 		const toolName = event.toolName
 		if (!toolName || !APPROVAL_GATED_TOOLS.has(toolName)) return undefined
+
+		// IDE diff approval only applies in default mode. In auto/yolo the user
+		// has explicitly opted out of per-file approval, and in plan mode
+		// write/edit are already blocked by the permissions extension.
+		const mode = ctx.sessionManager ? getPermissionMode(ctx.sessionManager.getSessionId())?.mode : undefined
+		if (mode !== "default") {
+			return undefined
+		}
 
 		// When an IDE session is active, the permissions extension skips its
 		// terminal approval prompt for write/edit, deferring to the IDE diff

--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -105,7 +105,8 @@ async function requestIdeApproval(
 			return { approved, newContent }
 		}
 		return null
-	} catch {
+	} catch (err) {
+		console.warn("[ide-adapter] proposeChange request failed:", err)
 		return null
 	}
 }
@@ -234,10 +235,15 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 			return
 		}
 
-		// Wire disconnect callback so we can null the handle and reconnect later
+		// Wire disconnect callback so we can null the handle and reconnect later.
+		// Capture the connection reference so a stale WebSocket closing after
+		// a reconnect doesn't wipe the live handle.
+		const connRef = connection
 		connection.onDisconnect = () => {
-			connection = null
-			ideConnectionActive = false
+			if (connection === connRef) {
+				connection = null
+				ideConnectionActive = false
+			}
 		}
 
 		try {
@@ -434,12 +440,8 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		// viewer, override the tool's input so the agent applies the user's final
 		// version instead of its original proposal.
 		if (approval.newContent !== null && approval.newContent !== proposed.newContent) {
-			applyEditedContent(
-				event.input as Record<string, unknown>,
-				toolName,
-				approval.newContent,
-				proposed.originalContent,
-			)
+			applyEditedContent(input, toolName, approval.newContent, proposed.originalContent)
+			event.input = input
 			// Steer the LLM so its summary reflects what was actually written, not
 			// its original proposal. Without this, the agent confidently reports
 			// the proposed value even though the user changed it in the diff viewer.

--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -79,15 +79,15 @@ interface IdeApprovalResult {
 }
 
 /** Call the IDE's `proposeChange` tool and return the approval result, or
- * `null` on failure (network error, malformed response). The MCP response is
- * an envelope — see `unwrapMcpToolResult`. */
+ * `null` on failure (network error, malformed response, abort). */
 async function requestIdeApproval(
 	connection: IdeConnection,
 	params: { filePath: string; originalContent: string; newContent: string; changeId: string },
 	signal: AbortSignal | undefined,
 ): Promise<IdeApprovalResult | null> {
+	if (signal?.aborted) return null
 	try {
-		const result = await connection.callTool("proposeChange", params)
+		const result = await connection.callTool("proposeChange", params, signal)
 		if (signal?.aborted) return null
 		const payload = unwrapMcpToolResult(result)
 		if (payload && typeof payload === "object" && "approved" in payload) {
@@ -379,9 +379,13 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		const changeId = generateChangeId()
 		const approval = await requestIdeApproval(connection, { ...proposed, changeId }, ctx.signal)
 		if (approval === null) {
-			// IDE call failed — best-effort approval, fall through.
-			console.warn(`[ide-adapter] proposeChange call failed for ${proposed.filePath}; letting ${toolName} proceed`)
-			return undefined
+			// IDE call failed (network error, malformed response, or abort).
+			// block the tool so it cannot execute without either IDE or terminal approval.
+			console.warn(`[ide-adapter] proposeChange call failed for ${proposed.filePath}; blocking ${toolName}`)
+			return {
+				block: true,
+				reason: `IDE approval failed for ${proposed.filePath}. The IDE could not be reached or returned a malformed response. Try again, or disconnect the IDE to fall back to terminal approval.`,
+			}
 		}
 		if (!approval.approved) {
 			return {

--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -35,12 +35,18 @@ function generateChangeId(): string {
 	return `chg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
 }
 
-/** Read a file's current contents, returning "" if missing or unreadable. */
-function readCurrentContent(filePath: string): string {
+/** Read a file's current contents. Returns "" for missing files (ENOENT),
+ * or `null` if the file exists but cannot be read (e.g. permission denied).
+ * A `null` return propagates to `computeProposedChange` → `null`, which the
+ * `tool_call` handler treats as a hard block so the user is never shown a
+ * diff that hides the file's real contents. */
+function readCurrentContent(filePath: string): string | null {
 	try {
 		return readFileSync(filePath, "utf-8")
-	} catch {
-		return ""
+	} catch (err) {
+		if ((err as { code?: string }).code === "ENOENT") return ""
+		console.warn(`[ide-adapter] Failed to read ${filePath}:`, err)
+		return null
 	}
 }
 
@@ -57,6 +63,7 @@ function computeProposedChange(
 	if (!rawPath) return null
 	const filePath = resolve(cwd, rawPath)
 	const originalContent = readCurrentContent(filePath)
+	if (originalContent === null) return null
 
 	if (toolName === "write") {
 		const newContent = typeof input.content === "string" ? input.content : ""
@@ -71,8 +78,9 @@ function computeProposedChange(
 
 /** Result of an IDE approval request. `approved: true` carries the user's
  * (possibly hand-edited) `newContent`; `approved: false` means rejected.
- * `null` means the IDE call failed — the hook falls back to letting the
- * write proceed (best-effort, never a hard block). */
+ * `null` means the IDE call failed (network error, malformed response, or
+ * abort). The caller treats `null` as a hard block — the tool will not
+ * execute without either IDE or terminal approval. */
 interface IdeApprovalResult {
 	approved: boolean
 	newContent: string | null
@@ -182,7 +190,7 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		return pendingAtMentions.length > 0
 	}
 
-	function localSetLatestSelection(selection: SelectionChangedNotification): void {
+	function localSetLatestSelection(selection: SelectionChangedNotification | null): void {
 		_latestSelection = selection
 	}
 
@@ -322,21 +330,28 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 			}
 		} else if (m.method === "selection_changed") {
 			if (typeof params.filePath === "string") {
-				// Pass the IDE-supplied absolute path through verbatim (see
-				// `at_mentioned` above).
+				// Pass the IDE-supplied absolute path through verbatim (see `at_mentioned` above).
 				const filePath = params.filePath
-				const selection: SelectionChangedNotification = {
-					filePath,
-					lineStart: typeof params.lineStart === "number" ? params.lineStart : 0,
-					lineEnd: typeof params.lineEnd === "number" ? params.lineEnd : 0,
-				}
-				localSetLatestSelection(selection)
-				// Surface as a right-aligned indicator inside the input box's top
-				// border — a dedicated segment alongside (not replacing) the pending
-				// image indicator. The selection is also kept sticky in
-				// `_latestSelection` for auto-attach on send (see `pi.on('input')`).
-				if (currentCtx?.hasUI) {
-					setIdeSelectionIndicator(formatAtMention(selection))
+				const lineStart = typeof params.lineStart === "number" ? params.lineStart : 0
+				const lineEnd = typeof params.lineEnd === "number" ? params.lineEnd : 0
+
+				if (lineStart === 0 && lineEnd === 0) {
+					// Per CONTRACT.md: lineStart: 0 and lineEnd: 0 mean "no range" —
+					// clear the selection indicator and sticky selection.
+					localSetLatestSelection(null)
+					if (currentCtx?.hasUI) {
+						setIdeSelectionIndicator(null)
+					}
+				} else {
+					const selection: SelectionChangedNotification = { filePath, lineStart, lineEnd }
+					localSetLatestSelection(selection)
+					// Surface as a right-aligned indicator inside the input box's top
+					// border — a dedicated segment alongside (not replacing) the pending
+					// image indicator. The selection is also kept sticky in
+					// `_latestSelection` for auto-attach on send (see `pi.on('input')`).
+					if (currentCtx?.hasUI) {
+						setIdeSelectionIndicator(formatAtMention(selection))
+					}
 				}
 			}
 		}
@@ -361,19 +376,31 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		const toolName = event.toolName
 		if (!toolName || !APPROVAL_GATED_TOOLS.has(toolName)) return undefined
 
-		// No IDE connected → no approval surface is available; let the tool run.
-		// The IDE diff viewer is automatically used whenever an IDE is connected.
-		if (!connection) {
+		// When an IDE session is active, the permissions extension skips its
+		// terminal approval prompt for write/edit, deferring to the IDE diff
+		// viewer. This makes the ide-adapter the sole approval authority — every
+		// failure path must block to prevent ungated execution.
+		if (!ideConnectionActive) {
 			return undefined
+		}
+
+		if (!connection) {
+			// IDE was active but the connection dropped before this hook ran.
+			return {
+				block: true,
+				reason: `IDE connection was lost. ${toolName} is blocked to prevent ungated execution. Try again, or disconnect the IDE to fall back to terminal approval.`,
+			}
 		}
 
 		const input = (event.input ?? {}) as Record<string, unknown>
 		const proposed = computeProposedChange(toolName, input, ctx.cwd)
 		if (!proposed) {
-			// Malformed inputs (e.g. edit oldText not found) — defer to the tool's
-			// own validation surface. Don't block; let the tool fail with its own
-			// error message.
-			return undefined
+			// Can't build a proposal (malformed input, unreadable file, etc.).
+			// Block rather than deferring, since permissions already skipped.
+			return {
+				block: true,
+				reason: `Could not compute the proposed change for ${toolName}. The input may be malformed or the file unreadable. Try again, or disconnect the IDE to fall back to terminal approval.`,
+			}
 		}
 
 		const changeId = generateChangeId()
@@ -407,19 +434,23 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 			// Steer the LLM so its summary reflects what was actually written, not
 			// its original proposal. Without this, the agent confidently reports
 			// the proposed value even though the user changed it in the diff viewer.
-			pi.sendMessage(
-				{
-					customType: "ide-adapter-edit-steer",
-					content: [
-						{
-							type: "text",
-							text: `The user hand-edited your proposed change to ${proposed.filePath} in the IDE diff viewer before it was applied. The actual content written to disk differs from your original proposal — do not assume your proposed content was applied verbatim. If you need to reference the exact value, read the file from disk.`,
-						},
-					],
-					display: false,
-				},
-				{ deliverAs: "steer" },
-			)
+			try {
+				pi.sendMessage(
+					{
+						customType: "ide-adapter-edit-steer",
+						content: [
+							{
+								type: "text",
+								text: `The user hand-edited your proposed change to ${proposed.filePath} in the IDE diff viewer before it was applied. The actual content written to disk differs from your original proposal — do not assume your proposed content was applied verbatim. If you need to reference the exact value, read the file from disk.`,
+							},
+						],
+						display: false,
+					},
+					{ deliverAs: "steer" },
+				)
+			} catch (err) {
+				console.warn("[ide-adapter] Failed to send steer message:", err)
+			}
 		}
 		return undefined
 	})
@@ -429,6 +460,11 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 		const cwd = ctx.cwd
 		isShuttingDown = false
 		reconnectRetries = 0
+
+		// Reset stale connection state from a prior session so that
+		// `ideConnectionActive` doesn't carry over after the old IDE disconnected.
+		connection = null
+		ideConnectionActive = false
 
 		// Prevent duplicate poll timers on reconnect
 		if (pollTimer) {

--- a/src/extensions/ide-adapter/lockfile.test.ts
+++ b/src/extensions/ide-adapter/lockfile.test.ts
@@ -133,5 +133,21 @@ describe("lockfile", () => {
 			const match = findMatchingLockfile(lockfiles, "/home/user/project")
 			expect(match).toBeUndefined()
 		})
+
+		it("returns undefined when alive lockfile exists but workspace doesn't match", () => {
+			const lockfiles = [
+				{
+					port: 1,
+					pid: process.pid,
+					ideName: "GoLand",
+					ideVersion: "1",
+					transport: "ws",
+					workspaceFolders: ["/home/user/goland-project"],
+					authToken: "t1",
+				},
+			]
+			const match = findMatchingLockfile(lockfiles, "/home/user/webstorm-project")
+			expect(match).toBeUndefined()
+		})
 	})
 })

--- a/src/extensions/ide-adapter/lockfile.ts
+++ b/src/extensions/ide-adapter/lockfile.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs"
+import { readdirSync, readFileSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import type { LockfileData } from "./types.js"
@@ -65,17 +65,30 @@ export function isProcessAlive(pid: number): boolean {
 	}
 }
 
-/** Find a lockfile whose workspaceFolders contains the given cwd.
+/** Canonicalize a path (resolve symlinks).
  *
- * Falls back to any alive lockfile when none matches the cwd.
- */
+ * IntelliJ's VFS returns real paths while the CLI's `cwd` and lockfile `workspaceFolders` may
+ * be in symlink form — comparing across these without canonicalization produces broken results.
+ *
+ * Falls back to the original path if `realpathSync` fails (e.g. missing path, stale lockfile). */
+export function realpathSafe(p: string): string {
+	try {
+		return realpathSync(p)
+	} catch {
+		return p
+	}
+}
+
+/** Find the lockfile whose `workspaceFolders` contains cwd. Both sides are
+ * canonicalized via `realpathSafe` so symlinked project roots match. Falls
+ * back to the first lockfile with a live process when none matches the cwd. */
 export function findMatchingLockfile(lockfiles: LockfileData[], cwd: string): LockfileData | undefined {
 	const alive = lockfiles.filter((l) => isProcessAlive(l.pid))
+	const cwdReal = realpathSafe(cwd).replace(/\\/g, "/")
 	const exactMatch = alive.find((l) =>
 		l.workspaceFolders.some((wf) => {
-			const normalized = wf.replace(/\\/g, "/")
-			const cwdNormalized = cwd.replace(/\\/g, "/")
-			return normalized === cwdNormalized || cwdNormalized.startsWith(`${normalized}/`)
+			const wfReal = realpathSafe(wf).replace(/\\/g, "/")
+			return wfReal === cwdReal || cwdReal.startsWith(`${wfReal}/`)
 		}),
 	)
 	return exactMatch ?? alive[0]

--- a/src/extensions/ide-adapter/lockfile.ts
+++ b/src/extensions/ide-adapter/lockfile.ts
@@ -80,16 +80,16 @@ export function realpathSafe(p: string): string {
 }
 
 /** Find the lockfile whose `workspaceFolders` contains cwd. Both sides are
- * canonicalized via `realpathSafe` so symlinked project roots match. Falls
- * back to the first lockfile with a live process when none matches the cwd. */
+ * canonicalized via `realpathSafe` so symlinked project roots match.
+ * Returns `undefined` when no alive lockfile matches — the CLI will not
+ * connect to an IDE whose workspace doesn't contain the current project. */
 export function findMatchingLockfile(lockfiles: LockfileData[], cwd: string): LockfileData | undefined {
 	const alive = lockfiles.filter((l) => isProcessAlive(l.pid))
 	const cwdReal = realpathSafe(cwd).replace(/\\/g, "/")
-	const exactMatch = alive.find((l) =>
+	return alive.find((l) =>
 		l.workspaceFolders.some((wf) => {
 			const wfReal = realpathSafe(wf).replace(/\\/g, "/")
 			return wfReal === cwdReal || cwdReal.startsWith(`${wfReal}/`)
 		}),
 	)
-	return exactMatch ?? alive[0]
 }

--- a/src/extensions/ide-adapter/mcp-client.test.ts
+++ b/src/extensions/ide-adapter/mcp-client.test.ts
@@ -223,7 +223,9 @@ describe("connectToIde", () => {
 		const conn = await connectToIde(lockfile)
 		const result = await conn.callTool("saveFile", { path: "/a.txt" })
 		expect(result).toEqual({ content: [{ type: "text", text: "done" }] })
-		expect(mockCallTool).toHaveBeenCalledWith({ name: "saveFile", arguments: { path: "/a.txt" } })
+		expect(mockCallTool).toHaveBeenCalledWith({ name: "saveFile", arguments: { path: "/a.txt" } }, undefined, {
+			signal: undefined,
+		})
 	})
 
 	it("routes notifications through setNotificationHandler", async () => {

--- a/src/extensions/ide-adapter/mcp-client.ts
+++ b/src/extensions/ide-adapter/mcp-client.ts
@@ -6,7 +6,8 @@ import type { IdeConnection, LockfileData } from "./types.js"
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000
 
-/** Minimal custom WebSocket transport that sends an auth header on handshake. */
+/** Minimal custom WebSocket transport that authenticates via a `?token=`
+ * query parameter on the WebSocket URL during the upgrade handshake. */
 class IdeWebSocketTransport implements Transport {
 	private ws: WebSocket | null = null
 	onclose?: () => void

--- a/src/extensions/ide-adapter/mcp-client.ts
+++ b/src/extensions/ide-adapter/mcp-client.ts
@@ -182,8 +182,10 @@ export async function connectToIde(lockfile: LockfileData): Promise<IdeConnectio
 				inputSchema: t.inputSchema,
 			}))
 		},
-		callTool: async (name, args) => {
-			const res = await client.callTool({ name, arguments: args as Record<string, unknown> | undefined })
+		callTool: async (name, args, signal) => {
+			const res = await client.callTool({ name, arguments: args as Record<string, unknown> | undefined }, undefined, {
+				signal,
+			})
 			return res
 		},
 		setNotificationHandler: (handler: (msg: unknown) => void) => {

--- a/src/extensions/ide-adapter/types.ts
+++ b/src/extensions/ide-adapter/types.ts
@@ -24,8 +24,8 @@ export interface IdeConnection {
 	close(): Promise<void>
 	/** List tools exposed by this IDE */
 	listTools(): Promise<IdeTool[]>
-	/** Call a tool by name */
-	callTool(name: string, args: unknown): Promise<unknown>
+	/** Call a tool by name. Pass `signal` to abort an in-flight request. */
+	callTool(name: string, args: unknown, signal?: AbortSignal): Promise<unknown>
 	/** Register a callback for JSON-RPC notifications from the IDE */
 	setNotificationHandler(handler: (msg: unknown) => void): void
 	/** Optional callback invoked when the transport closes unexpectedly */

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -59,6 +59,10 @@ function cleanPermissionEnv(): void {
 beforeEach(cleanPermissionEnv)
 afterEach(cleanPermissionEnv)
 
+vi.mock("../ide-adapter/index.js", () => ({
+	isIdeConnected: vi.fn(() => false),
+}))
+
 const testEnv: EnvironmentInfo = {
 	os: "Linux",
 	rawPlatform: "linux",

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -789,8 +789,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
 
 			// IDE approval deferral: when the ide-adapter extension has an active
-			// IDE connection, write/edit approvals are handled via the IDE diff viewer.
-			if ((toolName === "write" || toolName === "edit") && isIdeConnected()) {
+			// IDE connection AND we're in default mode, write/edit approvals are
+			// handled via the IDE diff viewer. In auto/yolo the user has opted out
+			// of per-file approval, so don't defer.
+			if ((toolName === "write" || toolName === "edit") && mode === "default" && isIdeConnected()) {
 				// Skip the terminal prompt so the user isn't asked twice.
 				return undefined
 			}

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -27,6 +27,7 @@ import { hasActiveFerment, notifyFermentActive, onActiveFermentChange } from "..
 import { createApplyAndPersist } from "../ferment/tool-helpers.js"
 import { isFermentToolName, isUserFacingFermentToolName } from "../ferment/tool-names.js"
 import { setActiveFermentAndApplyProfile } from "../ferment/tool-scope.js"
+import { isIdeConnected } from "../ide-adapter/index.js"
 import { createSystemPromptBlocks } from "../prompt-construction/index.js"
 import type { SystemPromptBlock } from "../prompt-construction/system-prompt-blocks.js"
 import { createToolVisibility, type ToolVisibilityAPI } from "../prompt-construction/tool-visibility.js"
@@ -786,6 +787,13 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			}
 
 			if (BUILTIN_ALLOW_TOOL_NAMES.includes(toolName)) return undefined
+
+			// IDE approval deferral: when the ide-adapter extension has an active
+			// IDE connection, write/edit approvals are handled via the IDE diff viewer.
+			if ((toolName === "write" || toolName === "edit") && isIdeConnected()) {
+				// Skip the terminal prompt so the user isn't asked twice.
+				return undefined
+			}
 
 			// Ferment tools are internal state-management operations; bypass user rules and classifier prompts.
 			// User-facing ferment tools (`ask_user`) are listed in USER_FACING_FERMENT_TOOL_NAMES and skip this bypass.

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -113,6 +113,7 @@ function getEnabledModelIds(): Set<string> | null {
 let currentEditor: PromptEditor | undefined
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
+let currentIdeSelectionIndicatorText: string | null = null
 
 // Own timer for the exit stage — upstream's lastSigintTime isn't updated when
 // the abort stage consumes the event, so we can't rely on it.
@@ -170,6 +171,17 @@ export function setPasteImageHandler(handler: () => void): void {
  */
 export function setPendingImageIndicator(text: string | null): void {
 	currentEditor?.setPendingImageIndicator(text)
+}
+
+/**
+ * Show or clear the current IDE selection (e.g. `@src/foo.ts:10-20`) on the
+ * prompt's first row, as a separate segment from the pending-image indicator.
+ * Used by the ide-adapter extension to surface the live selection. Pass `null`
+ * to clear.
+ */
+export function setIdeSelectionIndicator(text: string | null): void {
+	currentIdeSelectionIndicatorText = text
+	currentEditor?.setIdeSelectionIndicator(text)
 }
 
 /**
@@ -382,6 +394,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 			}
 			if (currentSessionIndicatorText) {
 				editor.setSessionIndicator(currentSessionIndicatorText)
+			}
+			if (currentIdeSelectionIndicatorText !== null) {
+				editor.setIdeSelectionIndicator(currentIdeSelectionIndicatorText)
 			}
 			return editor
 		})


### PR DESCRIPTION
## Linked issue

Closes #994

## What does this PR do?

Add functionality that allows:

- integrating the IDE diff viewer for write/edit approvals
- surfacing the current IDE selection as a live chip in the prompt
- auto-attaching files from the IDE selection

<img width="1238" height="578" alt="image" src="https://github.com/user-attachments/assets/a638658f-58b4-4eab-adfa-2bd76b049f89" />

<img width="1245" height="720" alt="image" src="https://github.com/user-attachments/assets/a43190b2-8829-46cc-bf61-8efb62239e4b" />

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
