### PR TITLE
feat(experiment): cap per-turn output tokens and steer on truncation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,7 @@ import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
 import { installInlineCompactPatch } from "./upstream-inline-compact-patch.js"
 import { installInfrastructureRetryPatch } from "./upstream-retry-patch.js"
+import { installThinkingBudgetPatch } from "./upstream-thinking-budget-patch.js"
 import {
 	postProcessHtmlExport,
 	postProcessJsonlExport,
@@ -147,6 +148,9 @@ import { getVersion } from "./utils.js"
 
 installInfrastructureRetryPatch()
 installInlineCompactPatch()
+// Must run before any AgentSession is constructed: it wraps the agent's stream
+// function from inside the constructor.
+installThinkingBudgetPatch()
 installPiNativeCompatibilityShim()
 
 function getSubcommand(args: string[]): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ import loginExtension from "./extensions/login/index.js"
 import { createStartupAuthGate, createStartupAuthGateState } from "./extensions/login/startup-auth.js"
 import loopGuardExtension from "./extensions/loop-guard.js"
 import lspExtension from "./extensions/lsp.js"
+import maxOutputTokensExtension from "./extensions/max-output-tokens.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import modelGuardExtension from "./extensions/model-guard.js"
 import modelSwitchExtension from "./extensions/model-switch.js"
@@ -599,6 +600,7 @@ try {
 			piiRedactionExtension,
 			stripImagesExtension,
 			traceIdExtension,
+			maxOutputTokensExtension,
 			requestTimingExtension,
 			llmResponseLogExtension,
 			activityExtension,

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -336,7 +336,8 @@ describe("runAgent — telemetry extension", () => {
 		const ctorArg = mockDefaultResourceLoader.mock.calls[0]?.[0]
 		expect(ctorArg).toHaveProperty("extensionFactories")
 		expect(Array.isArray(ctorArg?.extensionFactories)).toBe(true)
-		expect(ctorArg?.extensionFactories).toHaveLength(3)
+		// telemetry, bash, infrastructure breaker, max-output-tokens
+		expect(ctorArg?.extensionFactories).toHaveLength(4)
 		expect(mockReadTelemetryConfig).toHaveBeenCalled()
 		expect(mockTelemetryExtension).toHaveBeenCalledWith(mockReadTelemetryConfig.mock.results[0]?.value)
 	})
@@ -398,8 +399,10 @@ describe("runAgent — telemetry extension", () => {
 
 		const linkedLoaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0]
 		const ordinaryLoaderOptions = mockDefaultResourceLoader.mock.calls[1]?.[0]
-		expect(linkedLoaderOptions?.extensionFactories).toHaveLength(4)
-		expect(ordinaryLoaderOptions?.extensionFactories).toHaveLength(3)
+		// Base set is telemetry, bash, infrastructure breaker, max-output-tokens;
+		// a Ferment-linked session appends the worker-report capability.
+		expect(linkedLoaderOptions?.extensionFactories).toHaveLength(5)
+		expect(ordinaryLoaderOptions?.extensionFactories).toHaveLength(4)
 		expect(linkedSession.setActiveToolsByName).toHaveBeenCalledWith(["submit_agent_report"])
 		expect(ordinarySession.setActiveToolsByName).toHaveBeenCalledWith([])
 	})
@@ -415,7 +418,10 @@ describe("runAgent — telemetry extension", () => {
 			abortSpy,
 			emitUsage: false,
 			promptAction: async (emit) => {
-				const factory = mockDefaultResourceLoader.mock.calls[0]?.[0]?.extensionFactories?.[3]
+				// The worker-report capability is appended after the base set, so take
+				// the last factory rather than a fixed index — adding another base
+				// extension should not break this test.
+				const factory = mockDefaultResourceLoader.mock.calls[0]?.[0]?.extensionFactories?.at(-1)
 				const registerTool = vi.fn()
 				factory?.({ registerTool } as never)
 				const tool = registerTool.mock.calls[0]?.[0]

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -18,6 +18,7 @@ import { runAsAgentWorker } from "../../agent-worker-context.js"
 import bashDefaultTimeoutExtension, { createSubagentBashClampExtension } from "../../bash-default-timeout.js"
 import { FERMENT_TOOL_NAMES } from "../../ferment/tool-names.js"
 import infrastructureBreakerExtension from "../../infrastructure-breaker.js"
+import maxOutputTokensExtension from "../../max-output-tokens.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import { ModelRegistry } from "../../orchestration/model-registry/index.js"
 import type { Phase } from "../../orchestration/model-registry/types.js"
@@ -461,7 +462,15 @@ ${skillLines}`
 			: bashDefaultTimeoutExtension
 	// Subagents share this process and its patched retry classifier, so their
 	// successes must close the shared infrastructure breaker just like the parent's.
-	const extensionFactories = [telemetryExtension(readTelemetryConfig()), bashExtension, infrastructureBreakerExtension]
+	// The output cap is registered here for the same reason it is on the parent:
+	// subagents do the long exploratory work, so an uncapped one is at least as
+	// likely to run away as the main loop.
+	const extensionFactories = [
+		telemetryExtension(readTelemetryConfig()),
+		bashExtension,
+		infrastructureBreakerExtension,
+		maxOutputTokensExtension,
+	]
 	if (options.workerReport) {
 		extensionFactories.push(createWorkerReportExtension(options.workerReport))
 	}

--- a/src/extensions/max-output-tokens.test.ts
+++ b/src/extensions/max-output-tokens.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_MAX_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS_ENV, resolveMaxOutputTokens } from "../models.js"
+import maxOutputTokensExtension, {
+	applyMaxOutputTokens,
+	contextSafetyMargin,
+	MAX_CONSECUTIVE_TRUNCATION_STEERS,
+	TRUNCATION_GAVE_UP_CUSTOM_TYPE,
+	TRUNCATION_STEER_CUSTOM_TYPE,
+} from "./max-output-tokens.js"
+
+describe("resolveMaxOutputTokens", () => {
+	it("defaults when unset or blank", () => {
+		expect(resolveMaxOutputTokens({})).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+		expect(resolveMaxOutputTokens({ [MAX_OUTPUT_TOKENS_ENV]: "   " })).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+	})
+
+	it("reads an integer override", () => {
+		expect(resolveMaxOutputTokens({ [MAX_OUTPUT_TOKENS_ENV]: "64000" })).toBe(64000)
+	})
+
+	it("treats 0 as disabled rather than as a zero-token cap", () => {
+		expect(resolveMaxOutputTokens({ [MAX_OUTPUT_TOKENS_ENV]: "0" })).toBe(0)
+	})
+
+	it("falls back to the default on malformed values instead of disabling the cap", () => {
+		// "32k" must not become 32 (the parseInt trap), and a negative or
+		// non-numeric value must not silently restore the 1M ceiling.
+		for (const bad of ["32k", "-1", "abc", "1.5"]) {
+			expect(resolveMaxOutputTokens({ [MAX_OUTPUT_TOKENS_ENV]: bad })).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
+		}
+	})
+})
+
+describe("applyMaxOutputTokens", () => {
+	it("sets max_tokens when the payload carries no limit", () => {
+		expect(applyMaxOutputTokens({ model: "glm" }, 32_000)).toEqual({ model: "glm", max_tokens: 32_000 })
+	})
+
+	it("lowers an existing limit that exceeds the cap", () => {
+		expect(applyMaxOutputTokens({ max_tokens: 1_048_576 }, 32_000)).toEqual({ max_tokens: 32_000 })
+	})
+
+	it("leaves a limit already below the cap alone", () => {
+		expect(applyMaxOutputTokens({ max_tokens: 4_000 }, 32_000)).toEqual({ max_tokens: 4_000 })
+	})
+
+	it("clamps the max_completion_tokens spelling too", () => {
+		expect(applyMaxOutputTokens({ max_completion_tokens: 900_000 }, 32_000)).toEqual({
+			max_completion_tokens: 32_000,
+		})
+	})
+
+	it("clamps both spellings when both are present, adding neither", () => {
+		expect(applyMaxOutputTokens({ max_tokens: 900_000, max_completion_tokens: 10 }, 32_000)).toEqual({
+			max_tokens: 32_000,
+			max_completion_tokens: 10,
+		})
+	})
+
+	it("is inert when disabled, preserving a caller-supplied limit", () => {
+		expect(applyMaxOutputTokens({ max_tokens: 900_000 }, 0)).toEqual({ max_tokens: 900_000 })
+		expect(applyMaxOutputTokens({ model: "glm" }, 0)).toEqual({ model: "glm" })
+	})
+
+	it("lowers the cap to fit the remaining context window", () => {
+		// 1,048,576 window, 10,485 proportional margin, 1,018,091-token prompt
+		// -> 20,000 headroom, which is below the 32k cap and must win.
+		expect(
+			applyMaxOutputTokens({ model: "glm" }, 32_000, { contextWindow: 1_048_576, promptTokens: 1_018_091 }),
+		).toEqual({ model: "glm", max_tokens: 20_000 })
+	})
+
+	it("keeps the cap when the context window leaves room", () => {
+		expect(applyMaxOutputTokens({ model: "glm" }, 32_000, { contextWindow: 1_048_576, promptTokens: 5_000 })).toEqual({
+			model: "glm",
+			max_tokens: 32_000,
+		})
+	})
+
+	it("leaves the payload untouched when headroom is too small to be useful", () => {
+		// This is the vLLM-rejection guard: prompt + max_tokens > context_window
+		// is a hard 400, and pre-extension behaviour (no limit) is safer.
+		const payload = { model: "glm", messages: [] }
+		expect(applyMaxOutputTokens(payload, 32_000, { contextWindow: 1_048_576, promptTokens: 1_048_000 })).toEqual({
+			model: "glm",
+			messages: [],
+		})
+	})
+
+	it("estimates prompt size from the payload when tokens are unknown", () => {
+		// getContextUsage() reports tokens: null right after a compaction.
+		const big = "x".repeat(30_000)
+		const payload = { model: "glm", messages: [{ role: "user", content: big }] }
+		const out = applyMaxOutputTokens(payload, 32_000, { contextWindow: 20_000 }) as Record<string, number>
+		// The walker counts every reachable string, so the "user" role adds 4 chars:
+		// ceil(30,004 / 3) = 10,002 prompt tokens. Derived rather than hardcoded so
+		// a change to the margin or chars-per-token surfaces as a real failure
+		// instead of an opaque off-by-N.
+		expect(out.max_tokens).toBe(20_000 - 10_002 - contextSafetyMargin(20_000))
+	})
+
+	it("honours a deliberately small configured cap", () => {
+		// The MIN_USABLE_CAP floor exists to stop headroom strangling a turn; it
+		// must not veto an operator who explicitly asked for a tiny cap (which is
+		// how the truncation-handling probe is run).
+		expect(applyMaxOutputTokens({ model: "glm" }, 800, { contextWindow: 1_048_576, promptTokens: 100 })).toEqual({
+			model: "glm",
+			max_tokens: 800,
+		})
+	})
+
+	it("applies the flat cap when the context window is unknown", () => {
+		expect(applyMaxOutputTokens({ model: "glm" }, 32_000, {})).toEqual({ model: "glm", max_tokens: 32_000 })
+	})
+
+	it("passes through non-object payloads without throwing", () => {
+		expect(applyMaxOutputTokens(undefined, 32_000)).toBeUndefined()
+		expect(applyMaxOutputTokens("raw", 32_000)).toBe("raw")
+		expect(applyMaxOutputTokens([1, 2], 32_000)).toEqual([1, 2])
+	})
+
+	it("replaces a non-numeric limit with the cap", () => {
+		// A string limit is malformed on the wire; it counts as "no usable limit
+		// present", so the cap is written over it rather than left to be
+		// reinterpreted downstream.
+		expect(applyMaxOutputTokens({ max_tokens: "900000" }, 32_000)).toEqual({ max_tokens: 32_000 })
+	})
+})
+
+describe("truncation steering", () => {
+	interface Recorded {
+		steers: number
+		gaveUp: number
+	}
+
+	function runExtension() {
+		const handlers = new Map<string, (event: unknown) => Promise<unknown> | unknown>()
+		const rec: Recorded = { steers: 0, gaveUp: 0 }
+		const pi = {
+			on: (name: string, fn: (event: unknown) => Promise<unknown> | unknown) => handlers.set(name, fn),
+			sendMessage: (msg: { customType: string }) => {
+				if (msg.customType === TRUNCATION_STEER_CUSTOM_TYPE) rec.steers += 1
+			},
+			appendEntry: (customType: string) => {
+				if (customType === TRUNCATION_GAVE_UP_CUSTOM_TYPE) rec.gaveUp += 1
+			},
+		}
+		// biome-ignore lint/suspicious/noExplicitAny: minimal ExtensionAPI stub
+		maxOutputTokensExtension(pi as any)
+		const end = async (stopReason: string, role = "assistant") =>
+			await handlers.get("message_end")?.({ type: "message_end", message: { role, stopReason } })
+		return { rec, end }
+	}
+
+	it("steers once per truncated turn", async () => {
+		const { rec, end } = runExtension()
+		await end("length")
+		await end("length")
+		expect(rec).toEqual({ steers: 2, gaveUp: 0 })
+	})
+
+	it("ignores turns that ended normally", async () => {
+		const { rec, end } = runExtension()
+		await end("stop")
+		await end("toolUse")
+		expect(rec).toEqual({ steers: 0, gaveUp: 0 })
+	})
+
+	it("gives up after too many CONSECUTIVE truncations", async () => {
+		const { rec, end } = runExtension()
+		for (let i = 0; i < MAX_CONSECUTIVE_TRUNCATION_STEERS + 2; i += 1) await end("length")
+		expect(rec.steers).toBe(MAX_CONSECUTIVE_TRUNCATION_STEERS)
+		expect(rec.gaveUp).toBe(2)
+	})
+
+	it("resets the counter when the model recovers", async () => {
+		// This is why the stress test never tripped the guard: the model
+		// interleaved real work between truncations.
+		const { rec, end } = runExtension()
+		for (let i = 0; i < 10; i += 1) {
+			await end("length")
+			await end("toolUse")
+		}
+		expect(rec).toEqual({ steers: 10, gaveUp: 0 })
+	})
+
+	it("does not reset on non-assistant messages", async () => {
+		const { rec, end } = runExtension()
+		await end("length")
+		await end("length")
+		await end("stop", "toolResult")
+		await end("length")
+		await end("length")
+		expect(rec.steers).toBe(MAX_CONSECUTIVE_TRUNCATION_STEERS)
+		expect(rec.gaveUp).toBe(1)
+	})
+})
+
+describe("contextSafetyMargin", () => {
+	it("scales with the context window at large sizes", () => {
+		// 1% of 1,048,576 — the regime where chars/4 estimation is least reliable
+		// and a flat 4,096 would be only 0.4% of the window.
+		expect(contextSafetyMargin(1_048_576)).toBe(10_485)
+		expect(contextSafetyMargin(500_000)).toBe(5_000)
+	})
+
+	it("holds an absolute floor for small context windows", () => {
+		// 1% of 20,000 is 200 tokens, which would be no protection at all.
+		expect(contextSafetyMargin(20_000)).toBe(4_096)
+		// kimi-k2.7's 262,144 window: 1% is 2,621, still under the floor.
+		expect(contextSafetyMargin(262_144)).toBe(4_096)
+	})
+})

--- a/src/extensions/max-output-tokens.test.ts
+++ b/src/extensions/max-output-tokens.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { DEFAULT_MAX_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS_ENV, resolveMaxOutputTokens } from "../models.js"
+import { THINKING_BUDGET_DIAGNOSTIC_TYPE } from "../upstream-thinking-budget-patch.js"
 import maxOutputTokensExtension, {
 	applyMaxOutputTokens,
 	contextSafetyMargin,
 	MAX_CONSECUTIVE_TRUNCATION_STEERS,
+	THINKING_GAVE_UP_CUSTOM_TYPE,
+	THINKING_STEER_CUSTOM_TYPE,
 	TRUNCATION_GAVE_UP_CUSTOM_TYPE,
 	TRUNCATION_STEER_CUSTOM_TYPE,
 } from "./max-output-tokens.js"
@@ -136,9 +139,11 @@ describe("truncation steering", () => {
 	function runExtension() {
 		const handlers = new Map<string, (event: unknown) => Promise<unknown> | unknown>()
 		const rec: Recorded = { steers: 0, gaveUp: 0 }
+		const queued: { customType: string; deliverAs?: string; triggerTurn?: boolean }[] = []
 		const pi = {
 			on: (name: string, fn: (event: unknown) => Promise<unknown> | unknown) => handlers.set(name, fn),
-			sendMessage: (msg: { customType: string }) => {
+			sendMessage: (msg: { customType: string }, options?: { deliverAs?: string; triggerTurn?: boolean }) => {
+				queued.push({ customType: msg.customType, deliverAs: options?.deliverAs, triggerTurn: options?.triggerTurn })
 				if (msg.customType === TRUNCATION_STEER_CUSTOM_TYPE) rec.steers += 1
 			},
 			appendEntry: (customType: string) => {
@@ -149,8 +154,47 @@ describe("truncation steering", () => {
 		maxOutputTokensExtension(pi as any)
 		const end = async (stopReason: string, role = "assistant") =>
 			await handlers.get("message_end")?.({ type: "message_end", message: { role, stopReason } })
-		return { rec, end }
+
+		/** A turn severed by the thinking budget: the patch stamps this diagnostic on it. */
+		const endThinking = async (stopReason = "length") =>
+			await handlers.get("message_end")?.({
+				type: "message_end",
+				message: {
+					role: "assistant",
+					stopReason,
+					diagnostics: [{ type: THINKING_BUDGET_DIAGNOSTIC_TYPE, timestamp: 0 }],
+				},
+			})
+
+		const input = async (source: string) => await handlers.get("input")?.({ type: "input", text: "hi", source })
+
+		return { rec, end, endThinking, queued, input }
 	}
+
+	// The trap: `triggerTurn` starts a fresh agent loop to deliver each steer, and
+	// every loop emits agent_start. Resetting the counter there would zero it on
+	// the very run it is counting, so the give-up would never fire and steering
+	// would continue forever.
+	it("does not reset the counter on the run its own steer triggers", async () => {
+		const { rec, end, input } = runExtension()
+		for (let i = 0; i < MAX_CONSECUTIVE_TRUNCATION_STEERS + 2; i += 1) {
+			await end("length")
+			await input("extension")
+		}
+		expect(rec.steers).toBe(MAX_CONSECUTIVE_TRUNCATION_STEERS)
+		expect(rec.gaveUp).toBe(2)
+	})
+
+	it("does reset when the user submits a fresh prompt", async () => {
+		const { rec, end, input } = runExtension()
+		for (let i = 0; i < MAX_CONSECUTIVE_TRUNCATION_STEERS; i += 1) await end("length")
+		await input("user")
+		await end("length")
+		// The reset gave the model its full allowance back, so this is a steer
+		// rather than the give-up it would otherwise have been.
+		expect(rec.steers).toBe(MAX_CONSECUTIVE_TRUNCATION_STEERS + 1)
+		expect(rec.gaveUp).toBe(0)
+	})
 
 	it("steers once per truncated turn", async () => {
 		const { rec, end } = runExtension()
@@ -182,6 +226,51 @@ describe("truncation steering", () => {
 			await end("toolUse")
 		}
 		expect(rec).toEqual({ steers: 10, gaveUp: 0 })
+	})
+
+	// A thinking truncation carries no tool calls at all, so the agent loop would
+	// otherwise drain nothing and end the run.
+	it("steers a thinking truncation with its own wording and customType", async () => {
+		const { endThinking, queued, rec } = runExtension()
+		await endThinking()
+
+		expect(queued).toEqual([{ customType: THINKING_STEER_CUSTOM_TYPE, deliverAs: "steer", triggerTurn: true }])
+		// It must not be counted as, or worded as, an output-cap truncation.
+		expect(rec.steers).toBe(0)
+	})
+
+	// followUp only fires when the agent would stop; a steer is drained after the
+	// very next turn, so the guidance cannot be stranded behind a long tool loop.
+	it("delivers the thinking steer as a steer, never a followUp", async () => {
+		const { endThinking, queued } = runExtension()
+		await endThinking()
+		expect(queued[0].deliverAs).toBe("steer")
+	})
+
+	it("gives up after the limit and still queues a message", async () => {
+		const { endThinking, queued } = runExtension()
+		for (let i = 0; i <= MAX_CONSECUTIVE_TRUNCATION_STEERS; i += 1) await endThinking()
+
+		expect(queued).toHaveLength(MAX_CONSECUTIVE_TRUNCATION_STEERS + 1)
+		expect(queued[queued.length - 1].customType).toBe(THINKING_GAVE_UP_CUSTOM_TYPE)
+	})
+
+	// A followUp is drained only once the agent loop runs dry, so under ferment it
+	// sat behind long tool loops and arrived too late or never. A steer is drained
+	// after every turn.
+	it("delivers the output-cap steer as a steer, never a followUp", async () => {
+		const { end, queued } = runExtension()
+		await end("length")
+		expect(queued).toEqual([{ customType: TRUNCATION_STEER_CUSTOM_TYPE, deliverAs: "steer", triggerTurn: true }])
+	})
+
+	// The other end of the same problem: a truncation with no tool calls breaks the
+	// loop, so without triggerTurn there is no turn left to carry the steer.
+	it("sets triggerTurn on every steer so an idle agent still gets one", async () => {
+		const { end, endThinking, queued } = runExtension()
+		await end("length")
+		await endThinking()
+		expect(queued.every((q) => q.triggerTurn === true)).toBe(true)
 	})
 
 	it("does not reset on non-assistant messages", async () => {

--- a/src/extensions/max-output-tokens.ts
+++ b/src/extensions/max-output-tokens.ts
@@ -21,11 +21,22 @@
  * when too little context remains for a cap to be meaningful the payload is
  * left completely alone rather than carrying a value that would trip the vLLM
  * check or strangle the turn.
+ *
+ * ── Why the steer is queued as a steer, not a follow-up ─────────────────────
+ * The follow-up queue is drained only once the agent loop runs dry, so under
+ * ferment the guidance waited behind long tool loops and arrived far too late,
+ * or never, with follow-ups stacking up behind each other. The steering queue is
+ * drained after every turn. `triggerTurn` covers the other end: a truncation
+ * with no tool calls ends the run, leaving no turn for the steer to ride.
  */
 
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { resolveMaxOutputTokens } from "../models.js"
+import {
+	suppressThinkingBudgetForNextTurn,
+	THINKING_BUDGET_DIAGNOSTIC_TYPE,
+} from "../upstream-thinking-budget-patch.js"
 
 /**
  * Both spellings are clamped when present. LiteLLM accepts `max_tokens` and
@@ -204,6 +215,39 @@ export const TRUNCATION_GAVE_UP_CUSTOM_TYPE = "max-output-tokens-truncation-gave
  */
 export const MAX_CONSECUTIVE_TRUNCATION_STEERS = 3
 
+/**
+ * Steer for a turn severed by the *thinking* budget rather than the output cap.
+ *
+ * Separate wording because the two mean different things: the output cap can
+ * sever a turn that was already acting, while this one only ever fires
+ * mid-deliberation, so "you were still thinking" is always true here.
+ */
+export const THINKING_STEER_MESSAGE =
+	"Your previous response was cut off: it exceeded the per-turn thinking budget before you produced " +
+	"any action. The reasoning you had done was discarded, so there is nothing to resume. " +
+	"Do not plan further. Take the single most useful next action now with a tool call, " +
+	"and keep any prose to one or two sentences. If the task needs many steps, do one step per turn."
+
+/** Sent instead of the steer once steering has given up, on the one uncapped turn. */
+export const THINKING_GAVE_UP_MESSAGE =
+	"Your responses have been cut off by the thinking budget several times in a row. " +
+	"This turn is not capped. Produce a concrete result now — take an action or give your answer — " +
+	"rather than reasoning further."
+
+export const THINKING_STEER_CUSTOM_TYPE = "max-thinking-tokens-truncation"
+export const THINKING_GAVE_UP_CUSTOM_TYPE = "max-thinking-tokens-truncation-gave-up"
+
+/**
+ * True when the truncation came from the thinking budget rather than the output
+ * cap. Read off the message's own diagnostics rather than a module-level
+ * callback: subagents run in the same process, so a shared notification channel
+ * would let one session's truncation be attributed to another's turn.
+ */
+export function isThinkingBudgetTruncation(message: unknown): boolean {
+	const diagnostics = (message as { diagnostics?: { type?: string }[] })?.diagnostics
+	return Array.isArray(diagnostics) && diagnostics.some((d) => d?.type === THINKING_BUDGET_DIAGNOSTIC_TYPE)
+}
+
 /** True for any assistant message, truncated or not. Exported for tests. */
 export function isAssistantMessage(message: unknown): message is AssistantMessage {
 	return typeof message === "object" && message !== null && (message as AssistantMessage).role === "assistant"
@@ -225,9 +269,17 @@ export default function maxOutputTokensExtension(pi: ExtensionAPI): void {
 	// the session rather than carrying a grudge from an earlier rough patch.
 	let consecutiveTruncations = 0
 
-	pi.on("turn_start", async () => {
-		// Belt-and-braces: a turn the user starts is a fresh attempt.
-		if (consecutiveTruncations >= MAX_CONSECUTIVE_TRUNCATION_STEERS) consecutiveTruncations = 0
+	// A prompt the *user* submits is a fresh attempt, so the allowance resets with it.
+	//
+	// Neither turn-level nor run-level events work here. A turn is one model round
+	// trip and there are many per prompt. A run is worse: `agent_start` opens every
+	// agent loop, including the one `triggerTurn` starts to carry the steer below,
+	// so the counter would reset on the run it is counting and the give-up would
+	// never fire. Only genuine user input marks a fresh attempt; the source filter
+	// excludes our own steer and every other extension-triggered turn.
+	pi.on("input", (event) => {
+		if (event.source === "extension") return
+		consecutiveTruncations = 0
 	})
 
 	pi.on("message_end", async (event) => {
@@ -237,6 +289,27 @@ export default function maxOutputTokensExtension(pi: ExtensionAPI): void {
 		}
 
 		consecutiveTruncations += 1
+
+		// The thinking budget cuts mid-deliberation, so its truncations never carry a
+		// tool call. Separate wording and customType keep the two causes apart in
+		// session analysis; delivery is the same as below.
+		if (isThinkingBudgetTruncation(event.message)) {
+			const gaveUp = consecutiveTruncations > MAX_CONSECUTIVE_TRUNCATION_STEERS
+			if (gaveUp) {
+				// Steering has stopped, so a still-capped turn would be cut off again
+				// with nothing left to recover it and the run would end empty-handed.
+				suppressThinkingBudgetForNextTurn()
+			}
+			const text = gaveUp ? THINKING_GAVE_UP_MESSAGE : THINKING_STEER_MESSAGE
+			const customType = gaveUp ? THINKING_GAVE_UP_CUSTOM_TYPE : THINKING_STEER_CUSTOM_TYPE
+			pi.sendMessage(
+				{ customType, content: [{ type: "text", text }], display: false },
+				{ deliverAs: "steer", triggerTurn: true },
+			)
+			pi.appendEntry(customType, { steered: true, gaveUp, consecutiveTruncations, text })
+			return
+		}
+
 		if (consecutiveTruncations > MAX_CONSECUTIVE_TRUNCATION_STEERS) {
 			// Give up rather than steer forever; record it so the give-up is
 			// visible in session analysis instead of looking like a clean stop.
@@ -248,16 +321,14 @@ export default function maxOutputTokensExtension(pi: ExtensionAPI): void {
 			return
 		}
 
-		// followUp + triggerTurn: the turn is already ending, so this must queue a
-		// fresh turn rather than steer the in-flight one (which has nothing left
-		// to steer).
+		// Steer rather than follow-up, and triggerTurn for the idle case; see header.
 		pi.sendMessage(
 			{
 				customType: TRUNCATION_STEER_CUSTOM_TYPE,
 				content: [{ type: "text", text: TRUNCATION_STEER_MESSAGE }],
 				display: false,
 			},
-			{ deliverAs: "followUp", triggerTurn: true },
+			{ deliverAs: "steer", triggerTurn: true },
 		)
 	})
 

--- a/src/extensions/max-output-tokens.ts
+++ b/src/extensions/max-output-tokens.ts
@@ -1,0 +1,278 @@
+/**
+ * max-output-tokens extension — bounds the output of a single provider turn.
+ *
+ * Why an extension and not `model.maxTokens`: pi-ai's `buildBaseOptions`
+ * (providers/simple-options.js) forwards `maxTokens: options?.maxTokens` and
+ * never falls back to the model's own limit, and openai-completions emits
+ * `max_tokens` only `if (options?.maxTokens)`. pi-coding-agent does not set it
+ * for ordinary turns, so on this path **no output limit is sent at all** —
+ * clamping the model's advertised limit changes the model picker and nothing
+ * else.
+ *
+ * ── Why the headroom arithmetic exists ──────────────────────────────────────
+ * vLLM rejects a request outright when `prompt + max_tokens > context_window`.
+ * Confirmed against the live gateway:
+ *
+ *   "Requested token count exceeds the model's maximum context length of
+ *    1048576 tokens. You requested a total of 1048591 tokens: 15 tokens from
+ *    the input messages and 1048576 tokens for the completion."
+ *
+ * The cap is lowered to fit the remaining context, and
+ * when too little context remains for a cap to be meaningful the payload is
+ * left completely alone rather than carrying a value that would trip the vLLM
+ * check or strangle the turn.
+ */
+
+import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { resolveMaxOutputTokens } from "../models.js"
+
+/**
+ * Both spellings are clamped when present. LiteLLM accepts `max_tokens` and
+ * maps it to `max_completion_tokens` upstream (observed in a gateway error:
+ * sending `max_tokens: 900000` produced "max_completion_tokens is too large"),
+ * and pi picks between them per-model via `compat.maxTokensField`. Clamping
+ * whichever key exists avoids depending on that detection.
+ */
+const MAX_TOKEN_FIELDS = ["max_tokens", "max_completion_tokens"] as const
+
+const DEFAULT_FIELD = "max_tokens"
+
+/**
+ * Slack between the prompt-token figure and the context window.
+ *
+ * The asymmetry that motivates any margin: undershooting the ceiling is nearly
+ * free — it costs output tokens the turn was unlikely to reach — while
+ * overshooting is a hard vLLM 400 that fails the turn outright.
+ *
+ * The margin is proportional because **the error it absorbs scales with prompt
+ * size**. Every input to the headroom sum is an estimate:
+ *
+ *   - pi's `ContextUsage.tokens` is the last real usage plus `estimateTokens()`
+ *     for each message since, and `estimateTokens` is `chars / 4`
+ *     (compaction.js:177).
+ *   - The fallback below is `chars / 3`.
+ *
+ * `chars / 4` holds for English prose but under-counts dense content: JSON,
+ * base64, minified bundles and CJK tokenize closer to 2–3 chars per token. A
+ * large tool result of that kind can therefore be under-counted by a wide
+ * margin, and the absolute size of that error grows with the prompt — so a
+ * fixed slack that is generous at 200k (2%) is thin at 1M (0.4%).
+ *
+ * 1% tracks the error; the absolute floor keeps small-context models sane,
+ * where 1% would be a few hundred tokens.
+ */
+const CONTEXT_SAFETY_MARGIN_FRACTION = 0.01
+const MIN_CONTEXT_SAFETY_MARGIN_TOKENS = 4_096
+
+/** Slack to reserve below the context window for a given model. Exported for tests. */
+export function contextSafetyMargin(contextWindow: number): number {
+	return Math.max(MIN_CONTEXT_SAFETY_MARGIN_TOKENS, Math.floor(contextWindow * CONTEXT_SAFETY_MARGIN_FRACTION))
+}
+
+/**
+ * Floor below which capping is abandoned entirely. A cap this small would
+ * truncate almost any useful turn, and the pre-extension behaviour (no limit,
+ * server decides) is strictly safer than emitting it.
+ */
+const MIN_USABLE_CAP_TOKENS = 1_024
+
+/** Conservative chars-per-token for the fallback estimate. Deliberately low so the estimate over-counts the prompt. */
+const CHARS_PER_TOKEN = 3
+
+type Payload = Record<string, unknown>
+
+export interface ContextLimits {
+	/** Model context window in tokens, when known. */
+	contextWindow?: number
+	/** Best available estimate of the prompt size, when known. */
+	promptTokens?: number
+}
+
+function isPayload(value: unknown): value is Payload {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Rough prompt size from the payload itself, used when pi reports
+ * `ContextUsage.tokens === null` (which it does right after a compaction,
+ * before the next LLM response). Counts every string it can reach in the
+ * message list and tool schemas; over-counting is the safe direction.
+ */
+export function estimatePromptTokensFromPayload(payload: unknown): number | undefined {
+	if (!isPayload(payload) || !Array.isArray(payload.messages)) return undefined
+	let chars = 0
+	const walk = (value: unknown): void => {
+		if (typeof value === "string") {
+			chars += value.length
+		} else if (Array.isArray(value)) {
+			for (const item of value) walk(item)
+		} else if (value && typeof value === "object") {
+			for (const item of Object.values(value)) walk(item)
+		}
+	}
+	walk(payload.messages)
+	// Tool schemas ride along in the same request and count against the window.
+	if (payload.tools) walk(payload.tools)
+	return Math.ceil(chars / CHARS_PER_TOKEN)
+}
+
+/**
+ * Largest output limit that still fits the model's context window, or
+ * `undefined` when there is nothing to constrain against.
+ */
+export function resolveHeadroom(payload: unknown, limits: ContextLimits): number | undefined {
+	const contextWindow = limits.contextWindow
+	if (!contextWindow || contextWindow <= 0) return undefined
+	const promptTokens = limits.promptTokens ?? estimatePromptTokensFromPayload(payload)
+	if (promptTokens === undefined) return undefined
+	return contextWindow - promptTokens - contextSafetyMargin(contextWindow)
+}
+
+/**
+ * Apply the cap to a request payload. Exported for tests.
+ *
+ * Returns the payload (mutated in place) so it can be handed straight back to
+ * the runner. A cap of `0` disables the extension and returns the payload
+ * untouched — including any limit the caller already set, which is deliberate:
+ * "disabled" means "do not interfere", not "remove existing limits".
+ */
+export function applyMaxOutputTokens(payload: unknown, cap: number, limits: ContextLimits = {}): unknown {
+	if (cap <= 0 || !isPayload(payload)) return payload
+
+	const headroom = resolveHeadroom(payload, limits)
+
+	// The floor guards against *headroom* strangling the turn — not against a
+	// deliberately small configured cap, which is the operator's call and must
+	// be honoured. When too little context remains, fall back to pre-extension
+	// behaviour (no limit, server decides); see the header note.
+	if (headroom !== undefined && headroom < MIN_USABLE_CAP_TOKENS) return payload
+
+	const effective = headroom === undefined ? cap : Math.min(cap, headroom)
+
+	let sawField = false
+	for (const field of MAX_TOKEN_FIELDS) {
+		const current = payload[field]
+		if (typeof current === "number" && Number.isFinite(current)) {
+			sawField = true
+			if (current > effective) payload[field] = effective
+		}
+	}
+	if (!sawField) payload[DEFAULT_FIELD] = effective
+	return payload
+}
+
+/**
+ * Guidance delivered after a turn is cut off by the cap.
+ *
+ * Without this the truncation is invisible to the agent loop: a `length`-stopped
+ * message carries no tool call, so the loop reads it as a finished answer and
+ * fires `agent_end`. The model is never told its own output was severed.
+ *
+ * Wording is deliberately directive about *changing* behaviour rather than
+ * merely continuing: the failure mode these caps target is unbounded
+ * deliberation, so "carry on from where you stopped" would re-enter the same
+ * loop and burn the budget again.
+ */
+const TRUNCATION_STEER_MESSAGE =
+	"Your previous response was cut off: it hit the per-turn output limit before you finished. " +
+	"This usually means too much time was spent reasoning rather than acting. Do not repeat that reasoning. " +
+	"Instead: commit to the single most useful next action and take it now, " +
+	"keep this response short and concrete, " +
+	"if the task genuinely needs many steps, do one step per turn using tool calls rather than " +
+	"planning all of them in one message."
+
+export const TRUNCATION_STEER_CUSTOM_TYPE = "max-output-tokens-truncation"
+
+/**
+ * Distinct from the steer type on purpose. Both used to share one customType,
+ * which made session analysis ambiguous — a steer message and a give-up record
+ * were indistinguishable without inspecting their fields, and a first pass over
+ * a stress-test session misread every successful steer as a give-up.
+ */
+export const TRUNCATION_GAVE_UP_CUSTOM_TYPE = "max-output-tokens-truncation-gave-up"
+
+/**
+ * Consecutive truncations after which steering stops.
+ *
+ * Each steer triggers a fresh turn, so a model that never adapts would loop
+ * forever — burning exactly the budget this extension exists to protect. In
+ * local testing the model adapted after two steers (600, 600, then 254 and 142
+ * tokens stopping naturally), so three is a deliberate margin above observed
+ * behaviour. Past the limit the turn is allowed to end as it did before this
+ * extension: truncated and silent, which is bad, but bounded.
+ */
+export const MAX_CONSECUTIVE_TRUNCATION_STEERS = 3
+
+/** True for any assistant message, truncated or not. Exported for tests. */
+export function isAssistantMessage(message: unknown): message is AssistantMessage {
+	return typeof message === "object" && message !== null && (message as AssistantMessage).role === "assistant"
+}
+
+/**
+ * True when an assistant message was severed by the output cap. Exported for tests.
+ *
+ * `"length"` is a member of pi-ai's `StopReason` union, so a typo here is a
+ * compile error rather than a silently dead branch.
+ */
+export function isTruncatedAssistantMessage(message: unknown): message is AssistantMessage {
+	return isAssistantMessage(message) && message.stopReason === "length"
+}
+
+export default function maxOutputTokensExtension(pi: ExtensionAPI): void {
+	// Consecutive truncations, reset by any assistant message that completes
+	// normally — so a model that recovers gets the full allowance again later in
+	// the session rather than carrying a grudge from an earlier rough patch.
+	let consecutiveTruncations = 0
+
+	pi.on("turn_start", async () => {
+		// Belt-and-braces: a turn the user starts is a fresh attempt.
+		if (consecutiveTruncations >= MAX_CONSECUTIVE_TRUNCATION_STEERS) consecutiveTruncations = 0
+	})
+
+	pi.on("message_end", async (event) => {
+		if (!isTruncatedAssistantMessage(event.message)) {
+			if (isAssistantMessage(event.message)) consecutiveTruncations = 0
+			return
+		}
+
+		consecutiveTruncations += 1
+		if (consecutiveTruncations > MAX_CONSECUTIVE_TRUNCATION_STEERS) {
+			// Give up rather than steer forever; record it so the give-up is
+			// visible in session analysis instead of looking like a clean stop.
+			pi.appendEntry(TRUNCATION_GAVE_UP_CUSTOM_TYPE, {
+				steered: false,
+				consecutiveTruncations,
+				reason: "max_consecutive_truncations_reached",
+			})
+			return
+		}
+
+		// followUp + triggerTurn: the turn is already ending, so this must queue a
+		// fresh turn rather than steer the in-flight one (which has nothing left
+		// to steer).
+		pi.sendMessage(
+			{
+				customType: TRUNCATION_STEER_CUSTOM_TYPE,
+				content: [{ type: "text", text: TRUNCATION_STEER_MESSAGE }],
+				display: false,
+			},
+			{ deliverAs: "followUp", triggerTurn: true },
+		)
+	})
+
+	pi.on("before_provider_request", async (event, ctx) => {
+		// Resolved per request, not at registration: benchmark A/B arms and tests
+		// flip KIMCHI_MAX_OUTPUT_TOKENS without restarting the process.
+		const cap = resolveMaxOutputTokens()
+		if (cap <= 0) return undefined
+
+		const usage = ctx.getContextUsage?.()
+		const limits: ContextLimits = {
+			contextWindow: usage?.contextWindow ?? ctx.model?.contextWindow,
+			// `tokens` is null right after compaction; fall back to the payload estimate.
+			promptTokens: usage?.tokens ?? undefined,
+		}
+		return applyMaxOutputTokens(event.payload, cap, limits)
+	})
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -30,6 +30,47 @@ export function resolveMaxOutputTokens(env: NodeJS.ProcessEnv = process.env): nu
 	return DEFAULT_MAX_OUTPUT_TOKENS
 }
 
+/**
+ * Per-turn budget for *thinking* tokens, enforced client-side by
+ * upstream-thinking-budget-patch.ts. The output cap above bounds everything the
+ * model emits, so a limit strict enough to stop runaway deliberation also severs
+ * tool calls; measuring only reasoning avoids that. `0` disables it entirely.
+ *
+ * ── Why 8k ──────────────────────────────────────────────────────────────────
+ * Thinking per turn across 37 stored terminal-bench sessions (381 thinking
+ * turns, mostly glm-5.2-fp8) runs p50 229 · p90 4.7k · p95 10k · p99 58k, so the
+ * waste sits in a very thin tail: 8k cuts ~6% of thinking turns and recovers
+ * ~37% of the thinking that survives the 32k output cap.
+ *
+ * Most of that tail is one task family reasoning 57-70k tokens per turn without
+ * ever acting. 8k also reaches `path-tracing` and `adaptive-rejection-sampler`,
+ * which is deliberate: they are coin flips in
+ * docs/benchmark-confidence-intervals.md, so they are the only tasks where the
+ * score can still move, and they deliberate 8-13k tokens without acting. 16k is
+ * the conservative alternative — the runaway family alone, half the recovery.
+ *
+ * Counted in estimated tokens (chars/4). Measurement and enforcement share those
+ * units so the threshold is self-consistent, but real reasoning tokens for a turn
+ * cut here run somewhat above 8k.
+ */
+export const DEFAULT_MAX_THINKING_TOKENS = 8_000
+export const MAX_THINKING_TOKENS_ENV = "KIMCHI_MAX_THINKING_TOKENS"
+
+/**
+ * Read per request rather than once at startup: benchmark arms and tests change
+ * the configured budget without restarting the process.
+ */
+export function resolveMaxThinkingTokens(env: NodeJS.ProcessEnv = process.env): number {
+	const raw = env[MAX_THINKING_TOKENS_ENV]
+	if (raw !== undefined && raw.trim() !== "") {
+		// Number(), not parseInt(): parseInt truncates at the first non-digit, so
+		// "8k" would become 8 and cut every turn after two words of reasoning.
+		const parsed = Number(raw.trim())
+		if (Number.isInteger(parsed) && parsed >= 0) return parsed
+	}
+	return DEFAULT_MAX_THINKING_TOKENS
+}
+
 function normalizeKimchiEndpoint(endpoint?: string): string {
 	const trimmed = endpoint?.trim()
 	if (!trimmed) return KIMCHI_API

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,6 +5,31 @@ import { getVersion } from "./utils.js"
 const KIMCHI_API = "https://llm.kimchi.dev"
 const FETCH_TIMEOUT_MS = 20000
 
+/**
+ * The OpenAI-compatible path offers no thinking-token budget: `thinkingBudgets`
+ * is implemented only for anthropic/google/bedrock, and openai-completions sends
+ * a coarse `reasoning_effort` string. `none` provably disables reasoning
+ * (0 reasoning chars observed); whether the graded levels bound its length is
+ * unverified, and `xhigh` is rejected outright by the gateway with a 400.
+ *
+ * So max output tokens is the only enforceable bound on runaway thinking. It is
+ * a blunt one: it caps the entire completion, tool calls included, and a turn
+ * cut mid-tool-call has not been tested.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 32_000
+export const MAX_OUTPUT_TOKENS_ENV = "KIMCHI_MAX_OUTPUT_TOKENS"
+
+export function resolveMaxOutputTokens(env: NodeJS.ProcessEnv = process.env): number {
+	const raw = env[MAX_OUTPUT_TOKENS_ENV]
+	if (raw !== undefined && raw.trim() !== "") {
+		// Number(), not parseInt(): parseInt truncates at the first non-digit, so
+		// "32k" would become 32 and cap every turn at 32 tokens.
+		const parsed = Number(raw.trim())
+		if (Number.isInteger(parsed) && parsed >= 0) return parsed
+	}
+	return DEFAULT_MAX_OUTPUT_TOKENS
+}
+
 function normalizeKimchiEndpoint(endpoint?: string): string {
 	const trimmed = endpoint?.trim()
 	if (!trimmed) return KIMCHI_API
@@ -196,6 +221,12 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 		reasoning: m.reasoning,
 		input: m.input_modalities,
 		contextWindow: m.limits.context_window,
+		// Deliberately NOT clamped by KIMCHI_MAX_OUTPUT_TOKENS: this value is the
+		// gateway's advertised ceiling, persisted to models.json and shown in the
+		// model picker. Clamping it here would misreport the model's real limit
+		// and would not bound anything — pi never forwards model.maxTokens into
+		// the request. The cap is enforced on the payload instead, in
+		// extensions/max-output-tokens.ts.
 		maxTokens: m.limits.max_output_tokens,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		// Store upstream provider for telemetry round-trip via models.json

--- a/src/upstream-thinking-budget-patch.test.ts
+++ b/src/upstream-thinking-budget-patch.test.ts
@@ -1,0 +1,579 @@
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEvent,
+	AssistantMessageEventStream,
+	Model,
+	ThinkingContent,
+} from "@earendil-works/pi-ai"
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai"
+import { afterEach, describe, expect, it } from "vitest"
+import { DEFAULT_MAX_THINKING_TOKENS, MAX_THINKING_TOKENS_ENV, resolveMaxThinkingTokens } from "./models.js"
+import {
+	__resetSuppression,
+	CHARS_PER_TOKEN,
+	createThinkingBudgetStreamFn,
+	installThinkingBudgetPatch,
+	suppressThinkingBudgetForNextTurn,
+	THINKING_BUDGET_DIAGNOSTIC_TYPE,
+	wrapAgentStreamFn,
+} from "./upstream-thinking-budget-patch.js"
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MODEL = {
+	id: "test-model",
+	api: "openai-completions",
+	provider: "test",
+	cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+} as unknown as Model<Api>
+
+const CONTEXT = {
+	systemPrompt: "sys",
+	messages: [{ role: "user" as const, content: "hello", timestamp: 0 }],
+}
+
+function emptyUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}
+}
+
+/**
+ * Builds a stream script around one mutable partial message, the way real
+ * providers do — every event carries the same `partial` by reference.
+ */
+function script() {
+	const partial: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		usage: emptyUsage(),
+		stopReason: "stop",
+		timestamp: 0,
+	}
+	const events: AssistantMessageEvent[] = []
+
+	const api = {
+		partial,
+		events,
+		thinking(text: string, chunk = 32) {
+			const contentIndex = partial.content.length
+			partial.content.push({ type: "thinking", thinking: "" })
+			events.push({ type: "thinking_start", contentIndex, partial })
+			for (let i = 0; i < text.length; i += chunk) {
+				const delta = text.slice(i, i + chunk)
+				;(partial.content[contentIndex] as ThinkingContent).thinking += delta
+				events.push({ type: "thinking_delta", contentIndex, delta, partial })
+			}
+			return api
+		},
+		text(body: string, chunk = 32) {
+			const contentIndex = partial.content.length
+			partial.content.push({ type: "text", text: "" })
+			events.push({ type: "text_start", contentIndex, partial })
+			for (let i = 0; i < body.length; i += chunk) {
+				const delta = body.slice(i, i + chunk)
+				const block = partial.content[contentIndex]
+				if (block.type === "text") block.text += delta
+				events.push({ type: "text_delta", contentIndex, delta, partial })
+			}
+			return api
+		},
+		/** A tool call that finishes streaming (emits toolcall_end). */
+		toolCall(name: string, args: Record<string, unknown>) {
+			const contentIndex = partial.content.length
+			const toolCall = { type: "toolCall" as const, id: `call_${contentIndex}`, name, arguments: args }
+			partial.content.push(toolCall)
+			events.push({ type: "toolcall_start", contentIndex, partial })
+			events.push({ type: "toolcall_end", contentIndex, toolCall, partial })
+			return api
+		},
+		/** A tool call whose end event never arrives — the shape an abort leaves behind. */
+		danglingToolCall(name: string) {
+			const contentIndex = partial.content.length
+			partial.content.push({ type: "toolCall", id: `call_${contentIndex}`, name, arguments: {} })
+			events.push({ type: "toolcall_start", contentIndex, partial })
+			return api
+		},
+	}
+	return api
+}
+
+interface ProviderSpy {
+	abortCount: number
+	sawSignal?: AbortSignal
+	stream?: AssistantMessageEventStream
+}
+
+/**
+ * Fake provider mimicking the openai-completions abort path: the SSE iterator
+ * swallows the abort, blocks are finalized, and a terminal `error`/"aborted"
+ * event is pushed carrying the accumulated message.
+ */
+function fakeProvider(
+	built: ReturnType<typeof script>,
+	options: { ignoreAbort?: boolean; doneReason?: "stop" | "toolUse" | "length"; finalUsage?: number } = {},
+) {
+	const spy: ProviderSpy = { abortCount: 0 }
+	const fn = async (
+		_model: Model<Api>,
+		_context: unknown,
+		streamOptions?: { signal?: AbortSignal },
+	): Promise<AssistantMessageEventStream> => {
+		const stream = createAssistantMessageEventStream()
+		spy.stream = stream
+		spy.sawSignal = streamOptions?.signal
+		streamOptions?.signal?.addEventListener("abort", () => {
+			spy.abortCount += 1
+		})
+
+		void (async () => {
+			for (const event of built.events) {
+				if (streamOptions?.signal?.aborted && !options.ignoreAbort) break
+				stream.push(event)
+				// Yield to the macrotask queue so the consumer processes this event
+				// (and can abort) before the next one is pushed.
+				await new Promise((resolve) => setTimeout(resolve, 0))
+			}
+			if (options.ignoreAbort) return
+
+			if (streamOptions?.signal?.aborted) {
+				const error: AssistantMessage = {
+					...built.partial,
+					stopReason: "aborted",
+					errorMessage: "Request was aborted",
+				}
+				stream.push({ type: "error", reason: "aborted", error })
+				stream.end(error)
+				return
+			}
+			if (options.finalUsage) {
+				built.partial.usage = { ...emptyUsage(), output: options.finalUsage, totalTokens: options.finalUsage }
+			}
+			const message: AssistantMessage = { ...built.partial, stopReason: options.doneReason ?? "stop" }
+			stream.push({ type: "done", reason: options.doneReason ?? "stop", message })
+			stream.end(message)
+		})()
+
+		return stream
+	}
+	return { fn, spy }
+}
+
+async function collect(stream: AssistantMessageEventStream) {
+	const events: AssistantMessageEvent[] = []
+	for await (const event of stream) events.push(event)
+	return { events, result: await stream.result() }
+}
+
+const agentTurn = () => true
+
+afterEach(() => {
+	__resetSuppression()
+	delete process.env[MAX_THINKING_TOKENS_ENV]
+})
+
+// ---------------------------------------------------------------------------
+
+describe("resolveMaxThinkingTokens", () => {
+	it("defaults when unset or blank", () => {
+		expect(resolveMaxThinkingTokens({})).toBe(DEFAULT_MAX_THINKING_TOKENS)
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "  " })).toBe(DEFAULT_MAX_THINKING_TOKENS)
+	})
+
+	it("reads an integer override and accepts 0 as disabled", () => {
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "8000" })).toBe(8000)
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "0" })).toBe(0)
+	})
+
+	it("falls back rather than truncating at the first non-digit", () => {
+		// parseInt would read "8k" as 8 and cut every turn after two words.
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "8k" })).toBe(DEFAULT_MAX_THINKING_TOKENS)
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "-1" })).toBe(DEFAULT_MAX_THINKING_TOKENS)
+		expect(resolveMaxThinkingTokens({ [MAX_THINKING_TOKENS_ENV]: "1.5" })).toBe(DEFAULT_MAX_THINKING_TOKENS)
+	})
+})
+
+describe("createThinkingBudgetStreamFn — pass-through", () => {
+	it("forwards every event and the terminal reason when under budget", async () => {
+		const built = script().thinking("short reasoning").text("the answer")
+		const provider = fakeProvider(built, { doneReason: "stop" })
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => 1000,
+		})
+
+		const { events, result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+
+		expect(events.map((e) => e.type)).toEqual(["thinking_start", "thinking_delta", "text_start", "text_delta", "done"])
+		expect(result.stopReason).toBe("stop")
+		expect(provider.spy.abortCount).toBe(0)
+	})
+
+	it("returns the provider's own stream untouched when the budget is 0", async () => {
+		const built = script().thinking("x".repeat(10_000), 1_000)
+		const provider = fakeProvider(built)
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => 0,
+		})
+
+		const stream = await wrapped(MODEL, CONTEXT, {})
+		expect(stream).toBe(provider.spy.stream)
+		expect((await collect(stream)).result.stopReason).toBe("stop")
+		expect(provider.spy.abortCount).toBe(0)
+	})
+
+	it("never counts text deltas, however large", async () => {
+		const built = script().text("x".repeat(200_000), 20_000)
+		const provider = fakeProvider(built)
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => 10,
+		})
+
+		const { result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+		expect(result.stopReason).toBe("stop")
+		expect(provider.spy.abortCount).toBe(0)
+	})
+
+	// The regression test for the sharpest edge in this patch: agent.streamFn also
+	// drives compaction and branch summarization, and capping thinking there would
+	// truncate the summary and silently destroy context.
+	it("exempts non-agent turns (compaction) no matter how much they think", async () => {
+		const built = script().thinking("x".repeat(100_000), 10_000)
+		const provider = fakeProvider(built)
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: () => false,
+			resolveBudget: () => 10,
+		})
+
+		const stream = await wrapped(MODEL, CONTEXT, { signal: new AbortController().signal })
+		expect(stream).toBe(provider.spy.stream)
+		expect((await collect(stream)).result.stopReason).toBe("stop")
+		expect(provider.spy.abortCount).toBe(0)
+	})
+
+	// The production predicate, not an injected one: compaction is separated from
+	// an agent turn purely by whether the call carries the run's own signal.
+	describe("the wired isAgentTurn predicate", () => {
+		const overBudget = "t".repeat(4_000)
+
+		function wrappedAgent(runSignal: AbortSignal | undefined) {
+			const provider = fakeProvider(script().thinking(overBudget, 200))
+			const agent = { streamFn: provider.fn, signal: runSignal }
+			wrapAgentStreamFn(agent, { resolveBudget: () => 10 })
+			return { agent, provider }
+		}
+
+		it("caps a call carrying the run's own signal", async () => {
+			const run = new AbortController()
+			const { agent } = wrappedAgent(run.signal)
+
+			const stream = await agent.streamFn(MODEL, CONTEXT, { signal: run.signal })
+			expect((await collect(stream)).result.stopReason).toBe("length")
+		})
+
+		it("exempts a call carrying a different signal (compaction)", async () => {
+			const run = new AbortController()
+			const compaction = new AbortController()
+			const { agent, provider } = wrappedAgent(run.signal)
+
+			const stream = await agent.streamFn(MODEL, CONTEXT, { signal: compaction.signal })
+			expect((await collect(stream)).result.stopReason).toBe("stop")
+			expect(provider.spy.abortCount).toBe(0)
+		})
+
+		it("exempts a call with no signal even when the agent is idle", async () => {
+			// Both sides undefined must not compare equal into "this is a turn".
+			const { agent, provider } = wrappedAgent(undefined)
+
+			const stream = await agent.streamFn(MODEL, CONTEXT, {})
+			expect((await collect(stream)).result.stopReason).toBe("stop")
+			expect(provider.spy.abortCount).toBe(0)
+		})
+	})
+})
+
+describe("createThinkingBudgetStreamFn — truncation", () => {
+	const budget = 10
+	const overBudgetText = "t".repeat(budget * CHARS_PER_TOKEN + 200)
+
+	it("aborts once and reports the turn as a length truncation", async () => {
+		const built = script().thinking(overBudgetText, 20)
+		const provider = fakeProvider(built)
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+		})
+
+		const { events, result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+
+		expect(provider.spy.abortCount).toBe(1)
+		const terminal = events[events.length - 1]
+		expect(terminal.type).toBe("done")
+		expect(terminal.type === "done" && terminal.reason).toBe("length")
+		expect(result.stopReason).toBe("length")
+		expect(result.errorMessage).toBeUndefined()
+		// The provider's own terminal event must not leak through.
+		expect(events.filter((e) => e.type === "error")).toHaveLength(0)
+	})
+
+	it("keeps the partial thinking and records a diagnostic", async () => {
+		const built = script().thinking(overBudgetText, 20)
+		const wrapped = createThinkingBudgetStreamFn(fakeProvider(built).fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+		})
+
+		const { result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+
+		const thinking = result.content.find((block) => block.type === "thinking")
+		expect(thinking && thinking.type === "thinking" && thinking.thinking.length).toBeGreaterThan(0)
+		const diagnostic = result.diagnostics?.find((d) => d.type === THINKING_BUDGET_DIAGNOSTIC_TYPE)
+		expect(diagnostic).toBeDefined()
+		expect(diagnostic?.details?.budget).toBe(budget)
+		expect(diagnostic?.details?.usageEstimated).toBe(true)
+	})
+
+	// A zeroed usage would become the session's authoritative "last usage",
+	// collapsing context accounting and disabling auto-compaction.
+	it("synthesizes non-zero usage when the provider never sent a usage chunk", async () => {
+		const built = script().thinking(overBudgetText, 20)
+		const wrapped = createThinkingBudgetStreamFn(fakeProvider(built).fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+		})
+
+		const { result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+
+		expect(result.usage.totalTokens).toBeGreaterThan(0)
+		expect(result.usage.input).toBeGreaterThan(0)
+		expect(result.usage.output).toBeGreaterThan(0)
+		expect(result.usage.totalTokens).toBe(result.usage.input + result.usage.output)
+		expect(result.usage.cost.total).toBeGreaterThan(0)
+	})
+
+	// Tool definitions are part of the prompt but not of `messages`; leaving them
+	// out measured ~40% low against the provider's own figure for the same request.
+	it("counts tool definitions towards the input estimate", async () => {
+		const wrapped = createThinkingBudgetStreamFn(
+			async (...args) => fakeProvider(script().thinking(overBudgetText, 20)).fn(...args),
+			{ isAgentTurn: agentTurn, resolveBudget: () => budget },
+		)
+
+		const withoutTools = (await collect(await wrapped(MODEL, CONTEXT, {}))).result
+		const withTools = (
+			await collect(
+				await wrapped(
+					MODEL,
+					{ ...CONTEXT, tools: [{ name: "bash", description: "x".repeat(4_000), parameters: {} }] } as never,
+					{},
+				),
+			)
+		).result
+
+		expect(withTools.usage.input).toBeGreaterThan(withoutTools.usage.input + 900)
+	})
+
+	it("preserves provider usage when a usage chunk did arrive", async () => {
+		const built = script().thinking(overBudgetText, 20)
+		// The provider settles with real usage before we finish reading.
+		built.partial.usage = { ...emptyUsage(), input: 111, output: 222, totalTokens: 333 }
+		const wrapped = createThinkingBudgetStreamFn(fakeProvider(built).fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+		})
+
+		const { result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+		expect(result.usage.totalTokens).toBe(333)
+		const diagnostic = result.diagnostics?.find((d) => d.type === THINKING_BUDGET_DIAGNOSTIC_TYPE)
+		expect(diagnostic?.details?.usageEstimated).toBe(false)
+	})
+
+	it("keeps tool calls that finished before the trip and drops the rest", async () => {
+		const built = script()
+			.toolCall("read_file", { path: "a.ts" })
+			.thinking(overBudgetText, 20)
+			.danglingToolCall("write_file")
+		const wrapped = createThinkingBudgetStreamFn(fakeProvider(built).fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+		})
+
+		const { result } = await collect(await wrapped(MODEL, CONTEXT, {}))
+
+		const toolCalls = result.content.filter((block) => block.type === "toolCall")
+		expect(toolCalls).toHaveLength(1)
+		expect(toolCalls[0].type === "toolCall" && toolCalls[0].name).toBe("read_file")
+	})
+
+	it("re-reads the budget on every call", async () => {
+		const wrapped = createThinkingBudgetStreamFn(
+			async (...args) => fakeProvider(script().thinking(overBudgetText, 20)).fn(...args),
+			{ isAgentTurn: agentTurn },
+		)
+
+		process.env[MAX_THINKING_TOKENS_ENV] = "0"
+		expect((await collect(await wrapped(MODEL, CONTEXT, {}))).result.stopReason).toBe("stop")
+
+		process.env[MAX_THINKING_TOKENS_ENV] = String(budget)
+		expect((await collect(await wrapped(MODEL, CONTEXT, {}))).result.stopReason).toBe("length")
+	})
+
+	// message_end consumers read `usage` without guarding (llm-response-log.ts), so
+	// a message missing it here would throw inside their handler.
+	it("emits a well-formed message when the stream throws before any event", async () => {
+		const wrapped = createThinkingBudgetStreamFn(
+			async () =>
+				({
+					[Symbol.asyncIterator]: () => ({
+						next: () => Promise.reject(new Error("transport exploded")),
+					}),
+					// Never resolves: the wrapper must settle from the throw alone.
+					result: () => new Promise<never>(() => {}),
+				}) as unknown as AssistantMessageEventStream,
+			{ isAgentTurn: agentTurn, resolveBudget: () => budget },
+		)
+
+		const result = await (await wrapped(MODEL, CONTEXT, {})).result()
+
+		expect(result.role).toBe("assistant")
+		expect(result.stopReason).toBe("error")
+		expect(result.errorMessage).toBe("transport exploded")
+		expect(result.usage.totalTokens).toBe(0)
+		expect(result.model).toBe(MODEL.id)
+	})
+
+	it("falls back to the last partial when the provider ignores the abort", async () => {
+		const built = script().thinking(overBudgetText, 20)
+		const provider = fakeProvider(built, { ignoreAbort: true })
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => budget,
+			drainTimeoutMs: 20,
+		})
+
+		const stream = await wrapped(MODEL, CONTEXT, {})
+		// Do not drain the iterator — result() alone must still settle, or a
+		// provider that ignores the signal would hang the run forever.
+		const result = await stream.result()
+		expect(result.stopReason).toBe("length")
+	})
+})
+
+describe("suppressThinkingBudgetForNextTurn", () => {
+	const budget = 10
+	const overBudgetText = "t".repeat(budget * CHARS_PER_TOKEN + 200)
+
+	function wrapped() {
+		return createThinkingBudgetStreamFn(
+			async (...args) => fakeProvider(script().thinking(overBudgetText, 20)).fn(...args),
+			{ isAgentTurn: agentTurn, resolveBudget: () => budget },
+		)
+	}
+
+	it("exempts exactly one turn, then caps again", async () => {
+		const stream = wrapped()
+		suppressThinkingBudgetForNextTurn()
+
+		expect((await collect(await stream(MODEL, CONTEXT, {}))).result.stopReason).toBe("stop")
+		expect((await collect(await stream(MODEL, CONTEXT, {}))).result.stopReason).toBe("length")
+	})
+
+	// Otherwise a compaction running between the give-up and the retry would eat
+	// the exemption, and the turn it was meant for would be cut off again.
+	it("is not consumed by a non-agent turn", async () => {
+		const capped = wrapped()
+		const summarization = createThinkingBudgetStreamFn(
+			async (...args) => fakeProvider(script().thinking(overBudgetText, 20)).fn(...args),
+			{ isAgentTurn: () => false, resolveBudget: () => budget },
+		)
+
+		suppressThinkingBudgetForNextTurn()
+		await collect(await summarization(MODEL, CONTEXT, {}))
+
+		expect((await collect(await capped(MODEL, CONTEXT, {}))).result.stopReason).toBe("stop")
+	})
+})
+
+describe("createThinkingBudgetStreamFn — genuine cancellation", () => {
+	// Rewriting a user's Esc into "length" would make the agent loop carry on
+	// after the run was told to stop.
+	it("passes an aborted turn through as aborted, not length", async () => {
+		const caller = new AbortController()
+		const built = script().thinking("t".repeat(4_000), 20)
+		const provider = fakeProvider(built)
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => 10,
+		})
+
+		const stream = await wrapped(MODEL, CONTEXT, { signal: caller.signal })
+		caller.abort()
+		const { result } = await collect(stream)
+
+		expect(result.stopReason).toBe("aborted")
+	})
+
+	it("forwards an already-aborted caller signal inward", async () => {
+		const caller = new AbortController()
+		caller.abort()
+		const provider = fakeProvider(script().thinking("hi"))
+		const wrapped = createThinkingBudgetStreamFn(provider.fn, {
+			isAgentTurn: agentTurn,
+			resolveBudget: () => 1000,
+		})
+
+		await collect(await wrapped(MODEL, CONTEXT, { signal: caller.signal }))
+		expect(provider.spy.sawSignal?.aborted).toBe(true)
+	})
+})
+
+describe("installThinkingBudgetPatch", () => {
+	function fakeSessionClass() {
+		const calls: string[] = []
+		class FakeSession {
+			agent: { streamFn: unknown; signal?: AbortSignal }
+			constructor() {
+				this.agent = { streamFn: async () => createAssistantMessageEventStream() }
+				;(this as unknown as { _installAgentToolHooks: () => void })._installAgentToolHooks()
+			}
+			_installAgentToolHooks() {
+				calls.push("original")
+			}
+		}
+		return { FakeSession, calls }
+	}
+
+	it("wraps each session's stream function exactly once", () => {
+		const { FakeSession, calls } = fakeSessionClass()
+		installThinkingBudgetPatch({ sessionClass: FakeSession as never })
+		installThinkingBudgetPatch({ sessionClass: FakeSession as never })
+
+		const session = new FakeSession()
+		const wrappedOnce = session.agent.streamFn
+		// Re-running the hook on the same agent must not nest another wrapper.
+		;(session as unknown as { _installAgentToolHooks: () => void })._installAgentToolHooks()
+
+		expect(session.agent.streamFn).toBe(wrappedOnce)
+		expect(calls.filter((c) => c === "original")).toHaveLength(2)
+	})
+
+	it("throws a named error when the upstream internals it depends on are gone", () => {
+		class Incompatible {}
+		expect(() => installThinkingBudgetPatch({ sessionClass: Incompatible as never })).toThrow(
+			/AgentSession._installAgentToolHooks/,
+		)
+	})
+})

--- a/src/upstream-thinking-budget-patch.ts
+++ b/src/upstream-thinking-budget-patch.ts
@@ -1,0 +1,405 @@
+/**
+ * thinking-budget patch — bounds the *reasoning* a single provider turn may emit.
+ *
+ * Companion to extensions/max-output-tokens.ts. That extension caps total output
+ * via `max_tokens`, which is blunt: a limit tight enough to stop runaway
+ * deliberation also severs tool calls. This one measures only thinking, so the
+ * budget can be far stricter — the turn that reasons briefly and then acts is
+ * never touched.
+ *
+ * ── Why a patch rather than an extension ────────────────────────────────────
+ * There is no server-side budget to ask for: the gateway accepts
+ * `reasoning: {max_tokens}` and `thinking: {budget_tokens}` with HTTP 200 and
+ * ignores both, and pi's `thinkingBudgets` is unimplemented for
+ * openai-completions. So the stream has to be stopped client-side, and the
+ * extension API has no stream hook — `message_update` can only watch, and its
+ * one lever, `ctx.abort()`, trips the run's own controller. An "aborted" turn
+ * ends the whole run before the steering queue is polled, which under `--print`
+ * exits 1. Aborting a private controller and synthesizing a `done`/"length"
+ * event instead leaves the run intact and reads as an ordinary truncation.
+ *
+ * ── Why compaction is excluded ──────────────────────────────────────────────
+ * `agent.streamFn` also drives manual compaction, auto-compaction and branch
+ * summarization, where a capped summary would silently destroy context. Only
+ * the agent loop passes the run's own signal, which is what `isAgentTurn` tests.
+ *
+ * ── Why usage is estimated ──────────────────────────────────────────────────
+ * openai-completions fills `usage` from the final chunk alone, so a mid-stream
+ * abort leaves it zeroed — and compaction's `getAssistantUsage` accepts
+ * "length" messages, so that zero would become the session's authoritative last
+ * usage: context accounting collapses to ~0, auto-compaction stops firing, and
+ * max-output-tokens.ts sends a full cap against a nearly-full window. Estimating
+ * high is the safe direction, since it only shrinks the next cap.
+ *
+ * Reasoning emitted as <think> text (see extensions/hide-thinking.ts) arrives as
+ * `text_delta` and is deliberately not counted — counting it would cut a model
+ * mid-answer. Such models, and non-reasoning ones, fall through untouched.
+ */
+
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageDiagnostic,
+	type AssistantMessageEvent,
+	calculateCost,
+	createAssistantMessageEventStream,
+	type Model,
+	type streamSimple,
+	type Usage,
+} from "@earendil-works/pi-ai"
+import { AgentSession, estimateTokens } from "@earendil-works/pi-coding-agent"
+import { resolveMaxThinkingTokens } from "./models.js"
+
+/**
+ * pi-agent-core's StreamFn, redeclared rather than imported: that package is
+ * only a transitive dependency, and importing it by name breaks under stricter
+ * dependency resolution, and therefore in CI.
+ */
+type StreamFn = (
+	...args: Parameters<typeof streamSimple>
+) => ReturnType<typeof streamSimple> | Promise<ReturnType<typeof streamSimple>>
+
+type StreamOptions = Parameters<StreamFn>[2]
+type StreamContext = Parameters<StreamFn>[1]
+
+/** Repo-wide estimation convention — see estimateTokens in extensions/model-guard.ts. */
+export const CHARS_PER_TOKEN = 4
+
+/**
+ * Insurance against a provider that ignores the abort signal, which would
+ * otherwise hang the run forever. The openai path never needs it: its SSE
+ * iterator swallows the abort, so the provider settles promptly on its own.
+ */
+const DEFAULT_DRAIN_TIMEOUT_MS = 5_000
+
+export const THINKING_BUDGET_DIAGNOSTIC_TYPE = "kimchi_thinking_budget_truncation"
+
+let suppressNextTurn = false
+
+/**
+ * Exempt the next agent turn from the budget. Called once steering has given up,
+ * where a still-capped turn would be cut off again with nothing left to recover
+ * it and the run would end empty-handed; one conceded turn is the cheaper trade.
+ *
+ * Process-scoped, like the breaker in upstream-retry-patch.ts. Concurrent
+ * subagents could in principle consume each other's exemption, which costs one
+ * uncapped turn — not worth threading session identity through the patch for.
+ */
+export function suppressThinkingBudgetForNextTurn(): void {
+	suppressNextTurn = true
+}
+
+/** @internal Exported for tests. */
+export function __resetSuppression(): void {
+	suppressNextTurn = false
+}
+
+export interface ThinkingBudgetStreamOptions {
+	/**
+	 * Whether this call is an agent turn rather than a summarization. Only agent
+	 * turns are capped; see the header.
+	 */
+	isAgentTurn: (options: StreamOptions) => boolean
+	/** Defaults to reading the environment per call. */
+	resolveBudget?: () => number
+	drainTimeoutMs?: number
+}
+
+/**
+ * Scratch fields the openai-completions provider hangs off tool-call blocks
+ * while streaming. It strips them itself on the paths that settle normally; the
+ * drain-timeout fallback reads a block mid-flight, so it has to strip its own.
+ */
+const SCRATCH_BLOCK_FIELDS = ["index", "partialArgs", "streamIndex"] as const
+
+function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}
+}
+
+function sanitizeBlock(block: AssistantMessage["content"][number]): AssistantMessage["content"][number] {
+	const copy: Record<string, unknown> = { ...block }
+	for (const field of SCRATCH_BLOCK_FIELDS) delete copy[field]
+	return copy as unknown as AssistantMessage["content"][number]
+}
+
+/**
+ * Tokens the prompt is worth, reusing pi's own estimator so this does not drift
+ * from the figure compaction and the context gauge already work with.
+ */
+function estimateUsage(model: Model<Api>, context: StreamContext, message: AssistantMessage): Usage {
+	let input = Math.ceil((context.systemPrompt?.length ?? 0) / CHARS_PER_TOKEN)
+	// Tool definitions are part of the prompt but not of `messages`. Omitting them
+	// measured ~40% below the usage the provider reports for the same request, and
+	// under-counting input is the unsafe direction: it leaves max-output-tokens.ts
+	// believing there is more headroom than there is.
+	if (context.tools?.length) {
+		input += Math.ceil(JSON.stringify(context.tools).length / CHARS_PER_TOKEN)
+	}
+	for (const contextMessage of context.messages) {
+		// pi's Message and AgentMessage overlap on every role that reaches a
+		// provider request; estimateTokens switches on `role` alone.
+		input += estimateTokens(contextMessage as Parameters<typeof estimateTokens>[0])
+	}
+	const output = estimateTokens(message as Parameters<typeof estimateTokens>[0])
+	const usage: Usage = {
+		input,
+		output,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	}
+	// Mutates usage.cost in place and returns it.
+	calculateCost(model, usage)
+	return usage
+}
+
+/**
+ * Wrap a stream function so an agent turn is cut short once its thinking
+ * exceeds `budget` tokens. Exported separately from the patch so it can be
+ * tested without an AgentSession.
+ */
+export function createThinkingBudgetStreamFn(inner: StreamFn, options: ThinkingBudgetStreamOptions): StreamFn {
+	const resolveBudget = options.resolveBudget ?? resolveMaxThinkingTokens
+	const drainTimeoutMs = options.drainTimeoutMs ?? DEFAULT_DRAIN_TIMEOUT_MS
+
+	return async (model, context, streamOptions) => {
+		// Compaction and branch summaries pass through untouched. Checked before the
+		// exemption so a summary cannot consume a turn's one-shot exemption.
+		if (!options.isAgentTurn(streamOptions)) {
+			return inner(model, context, streamOptions)
+		}
+		if (suppressNextTurn) {
+			suppressNextTurn = false
+			return inner(model, context, streamOptions)
+		}
+		const budget = resolveBudget()
+		if (budget <= 0) {
+			return inner(model, context, streamOptions)
+		}
+
+		const controller = new AbortController()
+		const callerSignal = streamOptions?.signal
+		// Forwarded by hand rather than via AbortSignal.any, which the packaged
+		// binary's runtime may not have. The caller's signal lives for the whole run,
+		// so the listener has to come off again once the turn settles.
+		const forwardAbort = () => controller.abort()
+		if (callerSignal) {
+			if (callerSignal.aborted) controller.abort()
+			else callerSignal.addEventListener("abort", forwardAbort, { once: true })
+		}
+
+		let underlying: Awaited<ReturnType<StreamFn>>
+		try {
+			underlying = await inner(model, context, { ...streamOptions, signal: controller.signal })
+		} catch (error) {
+			callerSignal?.removeEventListener("abort", forwardAbort)
+			throw error
+		}
+
+		const out = createAssistantMessageEventStream()
+
+		let thinkingChars = 0
+		let tripped = false
+		let settled = false
+		let lastPartial: AssistantMessage | undefined
+		let drainTimer: ReturnType<typeof setTimeout> | undefined
+		// Tool calls that finished streaming before we tripped. The provider's abort
+		// path parses partial arguments into a plausible-looking object, so a
+		// half-streamed call cannot be told from a complete one by inspection.
+		const completedToolCalls = new Set<number>()
+
+		const settleTruncated = (base: AssistantMessage) => {
+			if (settled) return
+			settled = true
+			if (drainTimer) clearTimeout(drainTimer)
+
+			const content = base.content
+				.map(sanitizeBlock)
+				.filter((block, index) => block.type !== "toolCall" || completedToolCalls.has(index))
+			const usageEstimated = !base.usage || base.usage.totalTokens <= 0
+			const estimatedThinkingTokens = Math.ceil(thinkingChars / CHARS_PER_TOKEN)
+			const diagnostic: AssistantMessageDiagnostic = {
+				type: THINKING_BUDGET_DIAGNOSTIC_TYPE,
+				timestamp: Date.now(),
+				details: { budget, thinkingChars, estimatedThinkingTokens, usageEstimated },
+			}
+			const message: AssistantMessage = {
+				...base,
+				content,
+				stopReason: "length",
+				errorMessage: undefined,
+				usage: usageEstimated ? estimateUsage(model, context, { ...base, content }) : base.usage,
+				diagnostics: [...(base.diagnostics ?? []), diagnostic],
+			}
+
+			out.push({ type: "done", reason: "length", message })
+			out.end(message)
+		}
+
+		const settlePassThrough = (event: AssistantMessageEvent | undefined, fallback?: AssistantMessage) => {
+			if (settled) return
+			settled = true
+			if (drainTimer) clearTimeout(drainTimer)
+			if (event) out.push(event)
+			// A stream that ended without a terminal event still has to resolve, or
+			// the agent loop waits on result() forever.
+			out.end(fallback)
+		}
+
+		void (async () => {
+			try {
+				let terminal: AssistantMessageEvent | undefined
+				for await (const event of underlying) {
+					if (event.type === "done" || event.type === "error") {
+						terminal = event
+						break
+					}
+					out.push(event)
+					if ("partial" in event) lastPartial = event.partial
+
+					if (tripped) continue
+					if (event.type === "toolcall_end") {
+						completedToolCalls.add(event.contentIndex)
+						continue
+					}
+					if (event.type !== "thinking_delta") continue
+
+					thinkingChars += event.delta.length
+					if (Math.ceil(thinkingChars / CHARS_PER_TOKEN) <= budget) continue
+
+					tripped = true
+					controller.abort()
+					// Insurance only; the provider normally settles well within this.
+					// `lastPartial` is always set here — this very event carried one.
+					const partialAtTrip = event.partial
+					drainTimer = setTimeout(() => {
+						const base = lastPartial ?? partialAtTrip
+						settleTruncated({ ...base, content: [...base.content] })
+					}, drainTimeoutMs)
+				}
+
+				// Rewriting a user's Esc as "length" would have the loop carry on after
+				// the run was told to stop.
+				if (!tripped || callerSignal?.aborted) {
+					// Pushing the terminal event resolves result() on its own payload;
+					// a stream that ended without one needs the fallback to resolve it.
+					settlePassThrough(terminal, terminal ? undefined : await underlying.result())
+					return
+				}
+
+				// Better than the last partial: the abort path finalizes blocks first,
+				// so arguments are parsed and scratch fields stripped.
+				settleTruncated(await underlying.result())
+			} catch (error) {
+				if (settled) return
+				settled = true
+				if (drainTimer) clearTimeout(drainTimer)
+				// Built field by field rather than spread from `lastPartial`, which is
+				// undefined when the stream throws before its first event. Consumers of
+				// message_end read `usage` without guarding (llm-response-log.ts), so a
+				// half-formed message here would throw inside their handler.
+				const message: AssistantMessage = {
+					role: "assistant",
+					content: lastPartial?.content ?? [],
+					api: lastPartial?.api ?? model.api,
+					provider: lastPartial?.provider ?? model.provider,
+					model: lastPartial?.model ?? model.id,
+					usage: lastPartial?.usage ?? emptyUsage(),
+					stopReason: "error",
+					errorMessage: error instanceof Error ? error.message : String(error),
+					timestamp: lastPartial?.timestamp ?? Date.now(),
+				}
+				out.push({ type: "error", reason: "error", error: message })
+				out.end(message)
+			} finally {
+				callerSignal?.removeEventListener("abort", forwardAbort)
+			}
+		})()
+
+		return out
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Installation
+// ---------------------------------------------------------------------------
+
+const WRAPPED = Symbol.for("kimchi.thinkingBudgetWrapped")
+
+interface PatchableAgent {
+	streamFn?: StreamFn & { [WRAPPED]?: boolean }
+	readonly signal?: AbortSignal
+}
+
+interface PatchableSession {
+	agent?: PatchableAgent
+}
+
+interface PatchableSessionPrototype {
+	_installAgentToolHooks?: (this: PatchableSession) => unknown
+	_kimchiThinkingBudgetPatch?: boolean
+}
+
+export interface ThinkingBudgetPatchOptions {
+	sessionClass?: { prototype: PatchableSessionPrototype }
+	drainTimeoutMs?: number
+	resolveBudget?: () => number
+}
+
+/**
+ * Wrap one agent's stream function, once.
+ *
+ * Session switch, fork and reload each construct a fresh AgentSession around a
+ * fresh Agent, so the marker is per-agent rather than per-prototype.
+ */
+export function wrapAgentStreamFn(agent: PatchableAgent, options: ThinkingBudgetPatchOptions = {}): void {
+	const original = agent.streamFn
+	if (typeof original !== "function" || original[WRAPPED]) return
+
+	const wrapped = createThinkingBudgetStreamFn(original, {
+		// The agent loop is the only caller that passes the run's own signal;
+		// compaction and branch summarization pass their own controllers.
+		isAgentTurn: (streamOptions) => Boolean(streamOptions?.signal) && streamOptions?.signal === agent.signal,
+		resolveBudget: options.resolveBudget,
+		drainTimeoutMs: options.drainTimeoutMs,
+	}) as StreamFn & { [WRAPPED]?: boolean }
+	wrapped[WRAPPED] = true
+	agent.streamFn = wrapped
+}
+
+/**
+ * Patch AgentSession so every session's agent gets a thinking-budgeted stream —
+ * subagents and ACP sessions included, since they use this same class.
+ *
+ * `_installAgentToolHooks` runs from the constructor once `this.agent` exists,
+ * making it the earliest point with an agent to wrap. A `streamFn` accessor on
+ * Agent.prototype would not work: it is a class field, so [[Define]] semantics
+ * shadow any accessor before the constructor assigns it.
+ */
+export function installThinkingBudgetPatch(options: ThinkingBudgetPatchOptions = {}): void {
+	const sessionClass = options.sessionClass ?? (AgentSession as unknown as { prototype: PatchableSessionPrototype })
+	const proto = sessionClass.prototype
+
+	if (typeof proto._installAgentToolHooks !== "function") {
+		throw new Error(
+			"pi-coding-agent AgentSession internals are incompatible with the Kimchi thinking budget " +
+				"(missing AgentSession._installAgentToolHooks() — upstream internals changed)",
+		)
+	}
+	if (proto._kimchiThinkingBudgetPatch) return
+
+	const original = proto._installAgentToolHooks
+	proto._installAgentToolHooks = function patchedInstallAgentToolHooks(this: PatchableSession) {
+		if (this.agent) wrapAgentStreamFn(this.agent, options)
+		return original.call(this)
+	}
+	proto._kimchiThinkingBudgetPatch = true
+}


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

 Cap per-turn output tokens and steer on truncation

 ### Problem

 TB-2.1 benchmark analysis found output tokens generated and then discarded because
 the BackendConfig (timeoutSec: 660) severs any request exceeding 11 minutes regardless of activity.
 The largest single discarded turn was 487k tokens. Nothing bounded this - the thinking dial is advisory,
 and pi never sends an output limit on the openai-completions path.

 ### Solution

 A before_provider_request extension that:

 1. Caps max_tokens fitted to remaining context window (vLLM 400s if prompt + max_tokens > context_window,
    so a flat cap would introduce a hard 400 that doesn't exist today)
 2. Detects truncation (finish_reason: "length") and sends a steering message that triggers a new turn,
    instead of the agent silently treating the truncated response as a finished answer
 3. Limits consecutive truncations to prevent infinite looping if the model never adapts

 Registered on subagent sessions as well — they do the long exploratory work most likely to run away.

 ### Configuration

 - Default: 32,000 tokens
 - Override: KIMCHI_MAX_OUTPUT_TOKENS
 - Disable: KIMCHI_MAX_OUTPUT_TOKENS=0

 32k is deliberately below the largest legitimate turn observed (40,042 tokens across 106,594 successful
 turns) to produce measurable truncation cost in the experiment. 64k was the zero-collateral value.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
