### PR TITLE
Fix draft scoping budget fallthrough

### DIFF
--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -1446,7 +1446,7 @@ describe("registerFermentCommands", () => {
 		)
 	})
 
-	it("/ferment resume resets an exhausted draft scoping-stop budget", async () => {
+	it("/ferment resume does not reset an exhausted draft scoping-stop budget when there is nothing to resume", async () => {
 		const h = createHarness()
 		const draft = h.storage.create("Exhausted Draft")
 		h.runtime.setActive(draft)
@@ -1471,7 +1471,11 @@ describe("registerFermentCommands", () => {
 		if (!fermentCommand) throw new Error("ferment command was not registered")
 		await fermentCommand.handler("resume", h.ctx)
 
-		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({
+			kind: "claimed",
+			reason: "exhausted",
+		})
+		expect(h.ctx.ui.notify).toHaveBeenCalledWith('"Exhausted Draft" is draft; nothing to resume.')
 	})
 
 	it("implements pause → /ferment auto → /ferment resume with policy separated from lifecycle", async () => {

--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -15,6 +15,7 @@ import {
 	startInteractiveFerment,
 } from "./commands.js"
 import { clearAllLifecycleGuards, maybeInjectLifecycleObligationGuard } from "./lifecycle-obligation-guard.js"
+import { maybeInjectScopingStopNudge, resetAllScopingStopNudgeCounts } from "./nudge.js"
 import { clearAllPendingPlanReviews, getPendingPlanReview, setPendingPlanReview } from "./plan-review.js"
 import { createDefaultFermentRuntime, type FermentRuntime } from "./runtime.js"
 import type { ContinuationPolicy } from "./state.js"
@@ -58,6 +59,7 @@ afterEach(() => {
 	writeFileSyncMock.mockImplementation(actualFs.writeFileSync)
 	clearAllPendingPlanReviews()
 	clearAllLifecycleGuards()
+	resetAllScopingStopNudgeCounts()
 })
 
 interface RegisteredCommand {
@@ -1442,6 +1444,34 @@ describe("registerFermentCommands", () => {
 			}),
 			{ triggerTurn: false },
 		)
+	})
+
+	it("/ferment resume resets an exhausted draft scoping-stop budget", async () => {
+		const h = createHarness()
+		const draft = h.storage.create("Exhausted Draft")
+		h.runtime.setActive(draft)
+
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({
+			kind: "claimed",
+			reason: "exhausted",
+		})
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+		await fermentCommand.handler("resume", h.ctx)
+
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
 	})
 
 	it("implements pause → /ferment auto → /ferment resume with policy separated from lifecycle", async () => {

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -15,7 +15,7 @@ import { emitFermentCreated } from "./domain-events-emitter.js"
 import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { clearLifecycleGuard } from "./lifecycle-obligation-guard.js"
-import { appendRefEntry, resetScopingStopNudgeCount } from "./nudge.js"
+import { appendRefEntry } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import {
 	buildPhaseActionOptions,
@@ -782,8 +782,6 @@ export class FermentCommandController {
 				ctx.ui.notify("No active ferment to resume.")
 				return { handled: true }
 			}
-			resetScopingStopNudgeCount(active.id)
-
 			if (active.status !== "paused") {
 				const canContinue = active.status === "running" || active.status === "planned"
 				const message = canContinue

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -15,7 +15,7 @@ import { emitFermentCreated } from "./domain-events-emitter.js"
 import { formatFermentStatus } from "./format.js"
 import { autoInitFromEnv, ensureGitRepo } from "./git-init.js"
 import { clearLifecycleGuard } from "./lifecycle-obligation-guard.js"
-import { appendRefEntry } from "./nudge.js"
+import { appendRefEntry, resetScopingStopNudgeCount } from "./nudge.js"
 import { buildOneshotNudge } from "./oneshot.js"
 import {
 	buildPhaseActionOptions,
@@ -782,6 +782,7 @@ export class FermentCommandController {
 				ctx.ui.notify("No active ferment to resume.")
 				return { handled: true }
 			}
+			resetScopingStopNudgeCount(active.id)
 
 			if (active.status !== "paused") {
 				const canContinue = active.status === "running" || active.status === "planned"

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -822,7 +822,7 @@ describe("turn_end lifecycle obligation guard", () => {
 	})
 
 	it("caps draft-scoping stop recovery at two nudges and does not fall through to generic recovery", async () => {
-		// Regression: when the draft-specific scoping-stop budget is exhausted,
+		// when the draft-specific scoping-stop budget is exhausted,
 		// maybeInjectScopingStopNudge used to return false — indistinguishable
 		// from "not applicable" — so turn_end fell through to
 		// maybeInjectFermentStopNudge, which derived the same scope action and
@@ -862,7 +862,7 @@ describe("turn_end lifecycle obligation guard", () => {
 	})
 
 	it("does not bypass the user-input dropdown when scoping recovery is exhausted (interactive)", async () => {
-		// P1 regression: after two scoping-stop nudges, a qualifying turn that
+		// after two scoping-stop nudges, a qualifying turn that
 		// also contains a user-directed question must still reach
 		// maybeRunUserInputDropdown in interactive mode. The `claimed` outcome
 		// suppresses generic Ferment stop recovery, but it must not suppress
@@ -916,7 +916,7 @@ describe("turn_end lifecycle obligation guard", () => {
 	})
 
 	it("resets the scoping-stop budget when a new session begins", async () => {
-		// P2 regression: scopingStopNudgeCounts is process-global. Without a
+		// scopingStopNudgeCounts is process-global. Without a
 		// reset on session_start, a draft that reached exhaustion in a prior
 		// session continues to return `claimed` forever (within the same
 		// process) — no recovery message is ever sent again. After the reset,

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -14,7 +14,7 @@ import { registerFermentEvents } from "./events.js"
 import { clearAllLifecycleGuards } from "./lifecycle-obligation-guard.js"
 import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
-import { clearActiveFermentId, getFermentLockPath, writeFermentLock } from "./state.js"
+import { clearActiveFermentId, getFermentLockPath, markScopingInteractive, writeFermentLock } from "./state.js"
 import { filterSentMessages } from "./test-helpers.js"
 import { FERMENT_TOOL_NAMES } from "./tool-names.js"
 import { profileForFerment } from "./tool-scope.js"
@@ -859,6 +859,106 @@ describe("turn_end lifecycle obligation guard", () => {
 		const continuationCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_continuation_nudge")
 		expect(scopingStopCalls).toHaveLength(2)
 		expect(continuationCalls).toHaveLength(0)
+	})
+
+	it("does not bypass the user-input dropdown when scoping recovery is exhausted (interactive)", async () => {
+		// P1 regression: after two scoping-stop nudges, a qualifying turn that
+		// also contains a user-directed question must still reach
+		// maybeRunUserInputDropdown in interactive mode. The `claimed` outcome
+		// suppresses generic Ferment stop recovery, but it must not suppress
+		// interactive user handling.
+		const { pi, runtime, ferment, handlers } = setupAutomatedGuardFixture("Exhausted Dropdown", {
+			state: "draft",
+			automated: false,
+		})
+		markScopingInteractive(ferment.id)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const select = vi.fn().mockResolvedValue("No, revise")
+		const ctx = createContext({ hasUI: true, ui: { select } })
+
+		const exploringTurn = {
+			message: {
+				role: "assistant",
+				stopReason: "stop",
+				content: [{ type: "toolCall", name: "read", id: "call-1", arguments: { path: "README.md" } }],
+			},
+		}
+		// Exhaust the scoping-stop budget.
+		await turnEnd(exploringTurn, ctx)
+		await turnEnd(exploringTurn, ctx)
+
+		// A third qualifying turn that ends with a user-directed question.
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "stop",
+					content: [
+						{ type: "toolCall", name: "read", id: "call-2", arguments: { path: "src/index.ts" } },
+						{ type: "text", text: "I have enough context. Does this plan look right?" },
+					],
+				},
+			},
+			ctx,
+		)
+
+		// The dropdown must have been shown despite scoping recovery exhaustion.
+		expect(select).toHaveBeenCalled()
+		// Generic Ferment stop recovery must not have started a second budget.
+		const continuationCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_continuation_nudge")
+		expect(continuationCalls).toHaveLength(0)
+		// The scoping-stop nudge was sent exactly twice (budget exhausted on turn 3).
+		const scopingStopCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_scoping_stop_nudge")
+		expect(scopingStopCalls).toHaveLength(2)
+
+		runtime.setActive(undefined)
+	})
+
+	it("resets the scoping-stop budget when a new session begins", async () => {
+		// P2 regression: scopingStopNudgeCounts is process-global. Without a
+		// reset on session_start, a draft that reached exhaustion in a prior
+		// session continues to return `claimed` forever (within the same
+		// process) — no recovery message is ever sent again. After the reset,
+		// a resumed draft must get a fresh two-nudge budget.
+		const { pi, runtime, ferment, handlers } = setupAutomatedGuardFixture("Scoping Session Reset", {
+			state: "draft",
+			oneshot: true,
+		})
+		const turnEnd = handlers.get("turn_end")
+		const sessionStart = handlers.get("session_start")
+		if (!turnEnd || !sessionStart) throw new Error("required event handler was not registered")
+		const ctx = createContext({ hasUI: false })
+
+		const qualifyingTurn = {
+			message: {
+				role: "assistant",
+				stopReason: "stop",
+				content: [
+					{ type: "toolCall", name: "read", id: "call-1", arguments: { path: "README.md" } },
+					{ type: "text", text: "Done reading." },
+				],
+			},
+		}
+
+		// Exhaust the scoping-stop budget.
+		await turnEnd(qualifyingTurn, ctx)
+		await turnEnd(qualifyingTurn, ctx)
+		await turnEnd(qualifyingTurn, ctx) // claimed:exhausted
+		let scopingStopCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_scoping_stop_nudge")
+		expect(scopingStopCalls).toHaveLength(2)
+
+		// A new session begins (resume). session_start must clear the budget.
+		await sessionStart({}, ctx)
+		runtime.setActive(ferment)
+		vi.mocked(pi.sendMessage).mockClear()
+
+		// The same qualifying turn must schedule a nudge again — fresh budget.
+		await turnEnd(qualifyingTurn, ctx)
+		scopingStopCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_scoping_stop_nudge")
+		expect(scopingStopCalls).toHaveLength(1)
+
+		runtime.setActive(undefined)
 	})
 })
 

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -820,6 +820,46 @@ describe("turn_end lifecycle obligation guard", () => {
 			expect.objectContaining({ deliverAs: "steer" }),
 		)
 	})
+
+	it("caps draft-scoping stop recovery at two nudges and does not fall through to generic recovery", async () => {
+		// Regression: when the draft-specific scoping-stop budget is exhausted,
+		// maybeInjectScopingStopNudge used to return false — indistinguishable
+		// from "not applicable" — so turn_end fell through to
+		// maybeInjectFermentStopNudge, which derived the same scope action and
+		// started its own retry budget. One unchanged scoping obligation then
+		// received up to four recovery messages. The third qualifying turn must
+		// be claimed by the scoping mechanism (exhausted), not handed to generic
+		// Ferment stop recovery.
+		const { pi, handlers } = setupAutomatedGuardFixture("Scoping Budget Fallthrough", {
+			state: "draft",
+			oneshot: true,
+		})
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const ctx = createContext({ hasUI: false })
+
+		// A qualifying tool-call-plus-stop turn: read tools, stopReason "stop",
+		// no scoping-completion tool.
+		const qualifyingTurn = {
+			message: {
+				role: "assistant",
+				stopReason: "stop",
+				content: [
+					{ type: "toolCall", name: "read", id: "call-1", arguments: { path: "README.md" } },
+					{ type: "text", text: "Done reading." },
+				],
+			},
+		}
+
+		await turnEnd(qualifyingTurn, ctx) // scoping stop nudge 1
+		await turnEnd(qualifyingTurn, ctx) // scoping stop nudge 2
+		await turnEnd(qualifyingTurn, ctx) // budget exhausted — must NOT fall through
+
+		const scopingStopCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_scoping_stop_nudge")
+		const continuationCalls = filterSentMessages(vi.mocked(pi.sendMessage), "ferment_continuation_nudge")
+		expect(scopingStopCalls).toHaveLength(2)
+		expect(continuationCalls).toHaveLength(0)
+	})
 })
 
 describe("turn_end error recovery in one-shot mode", () => {

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -663,9 +663,14 @@ export function registerFermentEvents(
 
 			// Stop-without-scoping: the model made tool calls but ended with
 			// stopReason "stop" without calling any scoping-completion tool.
+			// Only `not_applicable` lets a later recovery mechanism evaluate the
+			// same turn. `scheduled` (a nudge was sent) and `claimed` (the
+			// scoping budget is exhausted) both retain ownership of the draft-
+			// scoping obligation so generic Ferment stop recovery cannot start a
+			// second budget for it.
 			if (stopReason === "stop") {
-				const stopNudged = maybeInjectScopingStopNudge(pi, f.id, toolNames, stopReason, { interactive })
-				if (stopNudged) return
+				const outcome = maybeInjectScopingStopNudge(pi, f.id, toolNames, stopReason, { interactive })
+				if (outcome.kind !== "not_applicable") return
 			}
 		}
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -25,6 +25,7 @@ import {
 	maybeInjectScopingProgressNudge,
 	maybeInjectScopingStopNudge,
 	onFermentToolCallSeen,
+	resetAllScopingStopNudgeCounts,
 	resetFermentStopNudgeCount,
 	resetScopingStopNudgeCount,
 } from "./nudge.js"
@@ -345,6 +346,7 @@ export function registerFermentEvents(
 		runtime.clearAllPendingScopes()
 		runtime.clearAllPendingPlanReviews()
 		runtime.clearAllPendingCompactions()
+		resetAllScopingStopNudgeCounts()
 		clearFermentCache()
 
 		const envId = getActiveFermentId()
@@ -655,6 +657,7 @@ export function registerFermentEvents(
 		// without progressing through the scoping steps. Fires for both
 		// interactive and one-shot scoping — consistency across modes is
 		// important so the model gets the same kick regardless of entry point.
+		let scopingClaimed = false
 		if (f.status === "draft" && toolCallSeen) {
 			const toolNames = getToolCallNames(content)
 			const interactive = runtime.isScopingInteractive(f.id)
@@ -663,19 +666,25 @@ export function registerFermentEvents(
 
 			// Stop-without-scoping: the model made tool calls but ended with
 			// stopReason "stop" without calling any scoping-completion tool.
-			// Only `not_applicable` lets a later recovery mechanism evaluate the
-			// same turn. `scheduled` (a nudge was sent) and `claimed` (the
-			// scoping budget is exhausted) both retain ownership of the draft-
+			// `scheduled` (a nudge was sent) owns the turn immediately. `claimed`
+			// (the scoping budget is exhausted) retains ownership of the draft-
 			// scoping obligation so generic Ferment stop recovery cannot start a
-			// second budget for it.
+			// second budget for it — but it must not bypass interactive user-input
+			// handling, so it falls through to the dropdown below and only
+			// suppresses generic recovery afterwards.
 			if (stopReason === "stop") {
 				const outcome = maybeInjectScopingStopNudge(pi, f.id, toolNames, stopReason, { interactive })
-				if (outcome.kind !== "not_applicable") return
+				if (outcome.kind === "scheduled") return
+				if (outcome.kind === "claimed") scopingClaimed = true
 			}
 		}
 
 		const userInputHandled = await maybeRunUserInputDropdown(pi, ctx, content, f, runtime)
 		if (userInputHandled) return
+		// Scoping recovery claimed this turn (budget exhausted). Interactive
+		// handling already had its chance above; suppress generic Ferment stop
+		// recovery so it cannot start a second budget for the same obligation.
+		if (scopingClaimed) return
 		if (!toolCallSeen) {
 			if (!hasPendingPlanReview(runtime)) {
 				// Zero-tool stop while a lifecycle obligation may be pending. The guard

--- a/src/extensions/ferment/nudge.test.ts
+++ b/src/extensions/ferment/nudge.test.ts
@@ -493,9 +493,9 @@ describe("maybeInjectScopingStopNudge", () => {
 
 	it("fires when stopReason is 'stop' and no scoping tool was called", () => {
 		const pi = createPi()
-		const nudged = maybeInjectScopingStopNudge(pi, fermentId, ["read", "grep"], "stop")
+		const outcome = maybeInjectScopingStopNudge(pi, fermentId, ["read", "grep"], "stop")
 
-		expect(nudged).toBe(true)
+		expect(outcome).toEqual({ kind: "scheduled" })
 		expect(pi.sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				customType: "ferment_scoping_stop_nudge",
@@ -511,37 +511,48 @@ describe("maybeInjectScopingStopNudge", () => {
 
 	it("does not fire when the turn called scope_ferment", () => {
 		const pi = createPi()
-		const nudged = maybeInjectScopingStopNudge(pi, fermentId, ["read", "scope_ferment"], "stop")
+		const outcome = maybeInjectScopingStopNudge(pi, fermentId, ["read", "scope_ferment"], "stop")
 
-		expect(nudged).toBe(false)
+		expect(outcome).toEqual({ kind: "not_applicable" })
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
 	it("does not fire when the turn called propose_ferment_scoping", () => {
 		const pi = createPi()
-		const nudged = maybeInjectScopingStopNudge(pi, fermentId, ["propose_ferment_scoping"], "stop")
+		const outcome = maybeInjectScopingStopNudge(pi, fermentId, ["propose_ferment_scoping"], "stop")
 
-		expect(nudged).toBe(false)
+		expect(outcome).toEqual({ kind: "not_applicable" })
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
 	it("does not fire when stopReason is not 'stop'", () => {
 		const pi = createPi()
-		const nudged = maybeInjectScopingStopNudge(pi, fermentId, ["read"], "end_turn")
+		const outcome = maybeInjectScopingStopNudge(pi, fermentId, ["read"], "end_turn")
 
-		expect(nudged).toBe(false)
+		expect(outcome).toEqual({ kind: "not_applicable" })
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
 	it("does not fire when no tools were called (pure text turn)", () => {
 		const pi = createPi()
-		const nudged = maybeInjectScopingStopNudge(pi, fermentId, [], "stop")
+		const outcome = maybeInjectScopingStopNudge(pi, fermentId, [], "stop")
 
-		expect(nudged).toBe(false)
+		expect(outcome).toEqual({ kind: "not_applicable" })
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 	})
 
-	it("suppresses additional nudges after the cap is hit", () => {
+	it("returns scheduled for the first two qualifying turns", () => {
+		const pi = createPi()
+
+		const first = maybeInjectScopingStopNudge(pi, fermentId, ["read"], "stop")
+		const second = maybeInjectScopingStopNudge(pi, fermentId, ["read"], "stop")
+
+		expect(first).toEqual({ kind: "scheduled" })
+		expect(second).toEqual({ kind: "scheduled" })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
+	})
+
+	it("returns claimed:exhausted after the cap is hit", () => {
 		const pi = createPi()
 
 		// Fires up to MAX_PLANNING_STOP_NUDGES times.
@@ -549,7 +560,8 @@ describe("maybeInjectScopingStopNudge", () => {
 		maybeInjectScopingStopNudge(pi, fermentId, ["read"], "stop")
 		const third = maybeInjectScopingStopNudge(pi, fermentId, ["read"], "stop")
 
-		expect(third).toBe(false)
+		expect(third).toEqual({ kind: "claimed", reason: "exhausted" })
+		// No new message on the exhausted turn — only the two scheduled nudges.
 		expect(pi.sendMessage).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -252,6 +252,10 @@ export function resetScopingStopNudgeCount(fermentId: string): void {
 	scopingStopNudgeCounts.delete(fermentId)
 }
 
+export function resetAllScopingStopNudgeCounts(): void {
+	scopingStopNudgeCounts.clear()
+}
+
 /** Outcome of evaluating a draft-scoping turn for the stop nudge.
  *
  * - `not_applicable` — the turn does not qualify for draft scoping-stop

--- a/src/extensions/ferment/nudge.ts
+++ b/src/extensions/ferment/nudge.ts
@@ -252,13 +252,29 @@ export function resetScopingStopNudgeCount(fermentId: string): void {
 	scopingStopNudgeCounts.delete(fermentId)
 }
 
+/** Outcome of evaluating a draft-scoping turn for the stop nudge.
+ *
+ * - `not_applicable` — the turn does not qualify for draft scoping-stop
+ *   recovery (no tool calls, wrong stop reason, or a scoping-completion tool
+ *   was present). Another recovery mechanism may evaluate the same turn.
+ * - `scheduled` — a scoping recovery message was injected.
+ * - `claimed` — the turn qualifies but the retry budget is exhausted. The
+ *   scoping mechanism retains ownership of the obligation; generic Ferment
+ *   stop recovery must NOT start a separate budget for the same obligation. */
+export type ScopingStopNudgeOutcome =
+	| { kind: "not_applicable" }
+	| { kind: "scheduled" }
+	| { kind: "claimed"; reason: "exhausted" }
+
 /**
  * Fires when the model made tool calls during draft scoping but ended the turn
  * with stopReason "stop" without calling any scoping-completion tool. Mirrors
  * plan-mode-supplement's stop nudge: it prevents the silent stall where the
  * model explores, decides it's done, and quits without calling scope_ferment.
  *
- * Returns true if a nudge was injected.
+ * Returns an explicit outcome so the caller can distinguish "the budget is
+ * exhausted, this mechanism still owns the obligation" from "this turn is not
+ * applicable". Only `not_applicable` allows another recovery mechanism to act.
  */
 export function maybeInjectScopingStopNudge(
 	pi: ExtensionAPI,
@@ -266,17 +282,19 @@ export function maybeInjectScopingStopNudge(
 	toolNames: string[],
 	stopReason: string | undefined,
 	opts: { interactive: boolean } = { interactive: true },
-): boolean {
+): ScopingStopNudgeOutcome {
 	const completionSignalPresent = hasFermentScopingCompletionSignal(toolNames)
 
 	if (!shouldNudge({ hasToolCall: toolNames.length > 0, stopReason, completionSignalPresent })) {
-		return false
+		return { kind: "not_applicable" }
 	}
 
 	const count = (scopingStopNudgeCounts.get(fermentId) ?? 0) + 1
 	scopingStopNudgeCounts.set(fermentId, count)
 
-	if (isNudgeSuppressed(count)) return false
+	if (isNudgeSuppressed(count)) {
+		return { kind: "claimed", reason: "exhausted" }
+	}
 
 	const nudgeText = opts.interactive ? FERMENT_SCOPING_STOP_NUDGE_INTERACTIVE : FERMENT_SCOPING_STOP_NUDGE_ONESHOT
 	safeSendMessage(
@@ -289,5 +307,5 @@ export function maybeInjectScopingStopNudge(
 		},
 		{ triggerTurn: true },
 	)
-	return true
+	return { kind: "scheduled" }
 }

--- a/src/extensions/ferment/resume.test.ts
+++ b/src/extensions/ferment/resume.test.ts
@@ -20,6 +20,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { clearFermentCache } from "../../ferment/store.js"
+import { maybeInjectScopingStopNudge, resetAllScopingStopNudgeCounts } from "./nudge.js"
 import {
 	deletePendingProposal,
 	loadPendingProposal,
@@ -110,6 +111,7 @@ afterEach(() => {
 	clearAllScopingGates()
 	clearAllPendingScopes()
 	setActive(undefined)
+	resetAllScopingStopNudgeCounts()
 	clearPendingPlanReviewTrigger()
 	if (prevFermentsDir === undefined) {
 		process.env.KIMCHI_FERMENTS_DIR = undefined
@@ -329,5 +331,34 @@ describe("resumeFerment paused-state nudge guard", () => {
 		const noticeText = pausedNotice?.content?.map((c) => c.text ?? "").join("") ?? ""
 		expect(noticeText).toContain("currently paused")
 		expect(noticeText).toContain("/ferment resume")
+	})
+})
+
+describe("resumeFerment scoping-stop budget reset", () => {
+	it("resets the scoping-stop budget so a resumed draft gets a fresh nudge budget", () => {
+		// P2 regression: /ferment resume calls resumeFerment directly without
+		// a session_start. Before the fix, the process-global
+		// scopingStopNudgeCounts was never cleared on resume, so a draft that
+		// reached exhaustion stayed permanently `claimed` — no recovery nudge
+		// was ever sent again within the same session. resumeFerment must reset
+		// the budget just like session_start does.
+		const draft = h.eventStorage.create("Exhausted Then Resumed")
+		h.runtime.setActive(draft)
+
+		// Exhaust the scoping-stop budget via the function under test.
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({
+			kind: "claimed",
+			reason: "exhausted",
+		})
+
+		// Same-session explicit resume — no session_start fires.
+		resumeFerment(h.pi, draft.id, { hasUI: false } as ExtensionCommandContext, h.runtime)
+
+		// After resume, the same qualifying turn must schedule a nudge again.
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+
+		h.runtime.setActive(undefined)
 	})
 })

--- a/src/extensions/ferment/resume.test.ts
+++ b/src/extensions/ferment/resume.test.ts
@@ -319,6 +319,13 @@ describe("resumeFerment paused-state nudge guard", () => {
 			return { ok: false, error: { code: "FERMENT_NOT_FOUND", message: "simulated resume failure" } }
 		})
 
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({ kind: "scheduled" })
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({
+			kind: "claimed",
+			reason: "exhausted",
+		})
+
 		resumeFerment(h.pi, draft.id, hasUIContext(), h.runtime)
 
 		// No resume nudge should be sent to the model.
@@ -331,6 +338,10 @@ describe("resumeFerment paused-state nudge guard", () => {
 		const noticeText = pausedNotice?.content?.map((c) => c.text ?? "").join("") ?? ""
 		expect(noticeText).toContain("currently paused")
 		expect(noticeText).toContain("/ferment resume")
+		expect(maybeInjectScopingStopNudge(h.pi, draft.id, ["read"], "stop")).toEqual({
+			kind: "claimed",
+			reason: "exhausted",
+		})
 	})
 })
 

--- a/src/extensions/ferment/resume.test.ts
+++ b/src/extensions/ferment/resume.test.ts
@@ -347,7 +347,7 @@ describe("resumeFerment paused-state nudge guard", () => {
 
 describe("resumeFerment scoping-stop budget reset", () => {
 	it("resets the scoping-stop budget so a resumed draft gets a fresh nudge budget", () => {
-		// P2 regression: /ferment resume calls resumeFerment directly without
+		// /ferment resume calls resumeFerment directly without
 		// a session_start. Before the fix, the process-global
 		// scopingStopNudgeCounts was never cleared on resume, so a draft that
 		// reached exhaustion stayed permanently `claimed` — no recovery nudge

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -69,7 +69,6 @@ export function resumeFerment(
 		return
 	}
 	clearLifecycleGuard(existing.id)
-	resetScopingStopNudgeCount(existing.id)
 
 	if (existing.status === "complete" || existing.status === "abandoned") {
 		setActiveFermentAndApplyProfile(pi, runtime, undefined)
@@ -175,6 +174,9 @@ export function resumeFerment(
 	)
 
 	if (existing.status !== "paused") {
+		// Renew draft-scoping recovery only once resume has passed every
+		// blocking check and will actually schedule another model turn.
+		resetScopingStopNudgeCount(existing.id)
 		safeSendMessage(
 			pi,
 			{

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -3,7 +3,7 @@ import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment } from "../../ferment/types.js"
 import { formatActionNudgeLine } from "./action-tool-names.js"
 import { clearLifecycleGuard } from "./lifecycle-obligation-guard.js"
-import { appendRefEntry } from "./nudge.js"
+import { appendRefEntry, resetScopingStopNudgeCount } from "./nudge.js"
 import { loadPendingProposal } from "./pending-proposal-store.js"
 import { triggerPendingPlanReview } from "./plan-review-trigger.js"
 import { defaultFermentRuntime, type FermentRuntime } from "./runtime.js"
@@ -69,6 +69,7 @@ export function resumeFerment(
 		return
 	}
 	clearLifecycleGuard(existing.id)
+	resetScopingStopNudgeCount(existing.id)
 
 	if (existing.status === "complete" || existing.status === "abandoned") {
 		setActiveFermentAndApplyProfile(pi, runtime, undefined)


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Fixes an issue where Ferment could repeatedly restart the model when it explored the codebase using tools but ended its turn without creating the required draft scope.

Previously, Ferment first sent up to two reminders asking the model to finish the scope. After those retries were exhausted, it incorrectly activated the generic continuation recovery mechanism, which could send two additional reminders. This could result in up to four recovery turns for the same unfinished scope, because two separate recovery mechanisms retried the same condition.

After this fix, Ferment sends at most two reminders for the same unfinished scope. Once that limit is reached, it stops retrying instead of falling through to another recovery mechanism. The retry budget is renewed only when a new session or genuine resume starts.

### What changed

- Replaced the boolean scoping-stop result with explicit outcomes:
    - not_applicable
    - scheduled
    - claimed: exhausted

- Prevented generic Ferment recovery from evaluating a turn already claimed by scoping recovery.
- Preserved interactive user-input handling after budget exhaustion.
- Reset the scoping recovery budget when a new session or genuine resume starts.
- Avoided resetting the budget for no-op or blocked resume attempts.

This limits an unchanged draft-scoping obligation to two recovery nudges without affecting other Ferment stop-recovery paths.

### Verification

Added regression coverage for budget exhaustion, generic recovery fallthrough, interactive handling, session resets, and explicit resume behavior. Focused tests, the full unit suite, typecheck, and lint pass.

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [X] This PR links to an open issue above
- [X] Tests pass locally (`pnpm run test`)
- [X] Lint passes (`pnpm run check`)
- [X] Documentation updated if behavior changed
