### PR TITLE
fix(tui): prevent terminal color probe input replay

### DIFF
--- a/src/extensions/__mocks__/extension-api.ts
+++ b/src/extensions/__mocks__/extension-api.ts
@@ -1,0 +1,25 @@
+import type { ExtensionAPI, ExtensionHandler } from "@earendil-works/pi-coding-agent"
+import { vi } from "vitest"
+
+type RegisteredHandler = ExtensionHandler<unknown, unknown>
+
+export function createExtensionApi(): {
+	api: ExtensionAPI
+	getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R>
+} {
+	const handlers = new Map<string, RegisteredHandler[]>()
+	const on = vi.fn((event: string, handler: RegisteredHandler) => {
+		const registered = handlers.get(event) ?? []
+		registered.push(handler)
+		handlers.set(event, registered)
+	})
+
+	return {
+		api: { on } as unknown as ExtensionAPI,
+		getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R> {
+			const handler = handlers.get(event)?.[0]
+			if (!handler) throw new Error(`Extension did not register a ${event} handler`)
+			return handler as ExtensionHandler<E, R>
+		},
+	}
+}

--- a/src/extensions/terminal-colors.test.ts
+++ b/src/extensions/terminal-colors.test.ts
@@ -1,0 +1,67 @@
+import type { ExtensionUIContext, SessionShutdownEvent, SessionStartEvent } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { __resetSettingsWatcherForTest } from "../settings-watcher.js"
+import { createContext } from "./__mocks__/context.js"
+import { createExtensionApi } from "./__mocks__/extension-api.js"
+import terminalColorsExtension from "./terminal-colors.js"
+
+const PROCESS_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] as const satisfies readonly NodeJS.Signals[]
+
+function setIsTTY(stream: NodeJS.ReadStream | NodeJS.WriteStream, isTTY: boolean): () => void {
+	const original = Object.getOwnPropertyDescriptor(stream, "isTTY")
+	Object.defineProperty(stream, "isTTY", { configurable: true, value: isTTY })
+	return () => {
+		if (original) Object.defineProperty(stream, "isTTY", original)
+		else Reflect.deleteProperty(stream, "isTTY")
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	__resetSettingsWatcherForTest()
+})
+
+describe("terminalColorsExtension", () => {
+	it("does not query terminal colors after the interactive session has started", async () => {
+		const restoreStdinTTY = setIsTTY(process.stdin, true)
+		const restoreStdoutTTY = setIsTTY(process.stdout, true)
+		const originalExitListeners = new Set(process.listeners("exit"))
+		const originalSignalListeners = new Map(
+			PROCESS_SIGNALS.map((signal) => [signal, new Set(process.listeners(signal))]),
+		)
+		const originalAgentDir = process.env.KIMCHI_CODING_AGENT_DIR
+		delete process.env.KIMCHI_CODING_AGENT_DIR
+		const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+		try {
+			const pi = createExtensionApi()
+			terminalColorsExtension(pi.api)
+			const ctx = createContext({
+				ui: {
+					setWidget: vi.fn(),
+					theme: { name: "kimchi-minimal" } as ExtensionUIContext["theme"],
+				},
+			})
+
+			await pi.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+			expect(stdoutWrite).not.toHaveBeenCalled()
+
+			await pi.getHandler<SessionShutdownEvent>("session_shutdown")({ type: "session_shutdown", reason: "quit" }, ctx)
+		} finally {
+			for (const listener of process.listeners("exit")) {
+				if (!originalExitListeners.has(listener)) process.removeListener("exit", listener)
+			}
+			for (const signal of PROCESS_SIGNALS) {
+				const original = originalSignalListeners.get(signal)
+				for (const listener of process.listeners(signal)) {
+					if (!original?.has(listener)) process.removeListener(signal, listener)
+				}
+			}
+			if (originalAgentDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
+			else process.env.KIMCHI_CODING_AGENT_DIR = originalAgentDir
+			restoreStdinTTY()
+			restoreStdoutTTY()
+		}
+	})
+})

--- a/src/extensions/terminal-colors.ts
+++ b/src/extensions/terminal-colors.ts
@@ -3,10 +3,7 @@ import { basename, resolve } from "node:path"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { isProtocolOrPrintMode } from "../cli-args.js"
 import { getActiveThemeName, onThemeChange } from "../settings-watcher.js"
-import { getRawBgPayload, QUERY_BG } from "../terminal-bg-probe.js"
-
-const QUERY_FG = "\x1b]10;?\x07"
-const QUERY_TIMEOUT_MS = 200
+import { getRawBgPayload, getRawFgPayload } from "../terminal-bg-probe.js"
 
 /** Converts hex color (#RRGGBB) to OSC rgb format (rgb:RR/GG/BB). */
 function hexToOscRgb(hex: string): string | null {
@@ -141,58 +138,16 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 		process.once("SIGHUP", () => signalRestore("SIGHUP"))
 	}
 
-	const probeAndSave = (then: () => void) => {
-		// cli.ts already probed OSC 11 at startup and cached the raw payload —
-		// reuse it instead of running a second probe. FG still needs probing.
+	const loadCachedColors = () => {
+		// cli.ts probed OSC 10/11 at startup (before pi-mono took stdin) and
+		// cached the raw payloads. Reuse them — running a second probe here
+		// would attach a stdin listener during the live session, race with
+		// pi-mono's input handling, and replay buffered keystrokes back into
+		// stdin on cleanup (corrupting the user's first command).
+		const cachedFg = getRawFgPayload()
+		if (cachedFg) savedFg = cachedFg
 		const cachedBg = getRawBgPayload()
 		if (cachedBg) savedBg = cachedBg
-
-		let buffer = ""
-		let gotFg = false
-		let gotBg = savedBg !== null
-		const handler = (data: Buffer | string) => {
-			buffer += data.toString()
-
-			if (!gotFg) {
-				// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
-				const fgMatch = buffer.match(/\x1b\]10;(.+?)(?:\x07|\x1b\\)/)
-				if (fgMatch) {
-					savedFg = fgMatch[1]
-					gotFg = true
-				}
-			}
-			if (!gotBg) {
-				// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
-				const bgMatch = buffer.match(/\x1b\]11;(.+?)(?:\x07|\x1b\\)/)
-				if (bgMatch) {
-					savedBg = bgMatch[1]
-					gotBg = true
-				}
-			}
-			if (gotFg && gotBg) {
-				cleanup()
-				then()
-			}
-		}
-		const cleanup = () => {
-			process.stdin.removeListener("data", handler)
-			clearTimeout(timeout)
-			// Strip the OSC 10/11 responses from the buffer and push anything
-			// else (keystrokes, paste) back to stdin so pi sees it.
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
-			let leftover = buffer.replace(/\x1b\]10;.+?(?:\x07|\x1b\\)/, "")
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
-			leftover = leftover.replace(/\x1b\]11;.+?(?:\x07|\x1b\\)/, "")
-			if (leftover.length > 0) process.stdin.unshift(Buffer.from(leftover, "utf8"))
-		}
-		const timeout = setTimeout(() => {
-			cleanup()
-			then()
-		}, QUERY_TIMEOUT_MS)
-
-		process.stdin.on("data", handler)
-		process.stdout.write(QUERY_FG)
-		if (!gotBg) process.stdout.write(QUERY_BG)
 	}
 
 	const reactToThemeChange = (newName: string | undefined) => {
@@ -239,13 +194,12 @@ export default function terminalColorsExtension(pi: ExtensionAPI) {
 		// when the user later switches away from a theme that sets osc colors.
 		// No clearScreen here — cli.ts paints the initial background before pi-mono
 		// renders its first frame.
-		probeAndSave(() => {
-			const colors = getThemeColors(getActiveThemeName() ?? "")
-			if (colors?.bgHex) apply(colors.fgHex, colors.bgHex)
+		loadCachedColors()
+		const colors = getThemeColors(getActiveThemeName() ?? "")
+		if (colors?.bgHex) apply(colors.fgHex, colors.bgHex)
 
-			unsubscribeThemeChange?.()
-			unsubscribeThemeChange = onThemeChange(reactToThemeChange)
-		})
+		unsubscribeThemeChange?.()
+		unsubscribeThemeChange = onThemeChange(reactToThemeChange)
 	})
 
 	pi.on("session_shutdown", () => {

--- a/src/terminal-bg-probe.test.ts
+++ b/src/terminal-bg-probe.test.ts
@@ -1,5 +1,61 @@
-import { describe, expect, it } from "vitest"
-import { CUBE, estimateTerminalBackground, GRAY, hexToBgAnsi, rgbTo256, tintBackground } from "./terminal-bg-probe.js"
+import { EventEmitter } from "node:events"
+import { describe, expect, it, vi } from "vitest"
+import {
+	CUBE,
+	estimateTerminalBackground,
+	GRAY,
+	hexToBgAnsi,
+	probeTerminalColors,
+	QUERY_BG,
+	QUERY_FG,
+	rgbTo256,
+	tintBackground,
+} from "./terminal-bg-probe.js"
+
+describe("probeTerminalColors", () => {
+	it("removes OSC replies and preserves early user input exactly once", async () => {
+		const stdin = new EventEmitter() as EventEmitter & {
+			isRaw: boolean
+			pause: ReturnType<typeof vi.fn>
+			resume: ReturnType<typeof vi.fn>
+			setRawMode: ReturnType<typeof vi.fn>
+			unshift: ReturnType<typeof vi.fn>
+		}
+		stdin.isRaw = false
+		stdin.pause = vi.fn()
+		stdin.resume = vi.fn()
+		stdin.setRawMode = vi.fn()
+		stdin.unshift = vi.fn()
+
+		const writes: string[] = []
+		const stdout = {
+			write: vi.fn((chunk: string) => {
+				writes.push(chunk)
+				if (writes.length === 2) {
+					stdin.emit(
+						"data",
+						`${QUERY_FG.replace("?", "rgb:eeee/dddd/cccc")}/ferment\r${QUERY_BG.replace("?", "rgb:1111/2222/3333")}`,
+					)
+				}
+				return true
+			}),
+		}
+
+		const result = await probeTerminalColors(
+			stdin as unknown as NodeJS.ReadStream,
+			stdout as unknown as NodeJS.WriteStream,
+		)
+
+		expect(result).toEqual({
+			background: { r: 0x11, g: 0x22, b: 0x33 },
+			rawBackground: "rgb:1111/2222/3333",
+			rawForeground: "rgb:eeee/dddd/cccc",
+		})
+		expect(writes).toEqual([QUERY_FG, QUERY_BG])
+		expect(stdin.unshift).toHaveBeenCalledOnce()
+		expect(stdin.unshift).toHaveBeenCalledWith(Buffer.from("/ferment\r"))
+	})
+})
 
 describe("tintBackground", () => {
 	const dark = { r: 0x1a, g: 0x18, b: 0x18 }

--- a/src/terminal-bg-probe.ts
+++ b/src/terminal-bg-probe.ts
@@ -1,9 +1,11 @@
-// OSC 11 query: ask the terminal what its current background color is.
-// Response shape: \x1b]11;rgb:RRRR/GGGG/BBBB(\x07|\x1b\\) — channels are
+// OSC color queries: ask the terminal for its current foreground (OSC 10)
+// and background (OSC 11) colors.
+// Response shape: \x1b]<10|11>;rgb:RRRR/GGGG/BBBB(\x07|\x1b\\) — channels are
 // 1-4 hex digits each; we take the most-significant byte. Modern terminals
 // (iTerm2, Terminal.app, Alacritty, Kitty, WezTerm, GNOME Terminal) all
 // support this; we time out after 200ms for ones that don't.
 
+export const QUERY_FG = "\x1b]10;?\x07"
 export const QUERY_BG = "\x1b]11;?\x07"
 const QUERY_TIMEOUT_MS = 200
 // OSC 11 response is ~25 bytes. Cap the buffer well above that so a flood of
@@ -12,6 +14,12 @@ const QUERY_TIMEOUT_MS = 200
 const MAX_BUFFER_BYTES = 4096
 
 export type Rgb = { r: number; g: number; b: number }
+
+export type TerminalColorProbeResult = {
+	background: Rgb | undefined
+	rawBackground: string | undefined
+	rawForeground: string | undefined
+}
 
 // Module-level cache so other extensions (notably terminal-colors.ts) can
 // reuse the probe result instead of re-querying. `probed` separates "didn't
@@ -23,6 +31,7 @@ export type Rgb = { r: number; g: number; b: number }
 // 16-bit terminals send (`1A2B` → we'd write back `1A1A`).
 let cachedProbedBg: Rgb | undefined
 let cachedRawBgPayload: string | undefined
+let cachedRawFgPayload: string | undefined
 let probed = false
 
 export function getProbedBackground(): Rgb | undefined {
@@ -31,6 +40,10 @@ export function getProbedBackground(): Rgb | undefined {
 
 export function getRawBgPayload(): string | undefined {
 	return cachedRawBgPayload
+}
+
+export function getRawFgPayload(): string | undefined {
+	return cachedRawFgPayload
 }
 
 // Bail without running the probe in environments known to either swallow
@@ -56,26 +69,50 @@ export async function probeTerminalBackground(): Promise<Rgb | undefined> {
 
 	if (shouldSkipProbe()) return undefined
 
-	const wasRaw = process.stdin.isRaw
-	process.stdin.setRawMode?.(true)
-	process.stdin.resume()
+	const result = await probeTerminalColors(process.stdin, process.stdout)
+	cachedProbedBg = result.background
+	cachedRawBgPayload = result.rawBackground
+	cachedRawFgPayload = result.rawForeground
+	return cachedProbedBg
+}
 
-	return new Promise<Rgb | undefined>((resolveResult) => {
+/** Run the OSC 10/11 exchange against terminal streams without touching the module cache. */
+export function probeTerminalColors(
+	stdin: NodeJS.ReadStream,
+	stdout: NodeJS.WriteStream,
+): Promise<TerminalColorProbeResult> {
+	const wasRaw = stdin.isRaw
+	stdin.setRawMode?.(true)
+	stdin.resume()
+
+	return new Promise<TerminalColorProbeResult>((resolveResult) => {
 		let buffer = ""
+		let gotFg = false
+		let gotBg = false
+		let background: Rgb | undefined
+		let rawBackground: string | undefined
+		let rawForeground: string | undefined
 
-		// Anything that arrived during the probe window but isn't the OSC 11
-		// response (early keystrokes, focus events, mouse, paste fragments)
-		// gets pushed BACK into stdin so pi sees it when it takes over. Without
-		// this the user's first few bytes after launch silently vanish.
-		const finish = (result: Rgb | undefined, rawPayload: string | undefined, leftover: string) => {
+		// Anything that arrived during the probe window but isn't an OSC
+		// 10/11 response (early keystrokes, focus events, mouse, paste
+		// fragments) gets pushed BACK into stdin so pi sees it when it takes
+		// over. Without this the user's first few bytes after launch silently
+		// vanish. Both queries share one stdin listener so the probe window
+		// is a single interval, not two serial ones.
+		const finish = () => {
 			clearTimeout(timeout)
-			process.stdin.removeListener("data", handler)
-			cachedProbedBg = result
-			cachedRawBgPayload = rawPayload
-			if (leftover.length > 0) process.stdin.unshift(Buffer.from(leftover, "utf8"))
-			if (!wasRaw) process.stdin.setRawMode?.(false)
-			process.stdin.pause()
-			resolveResult(result)
+			stdin.removeListener("data", handler)
+			// Strip the OSC 10/11 responses from the buffer; push back anything
+			// else (keystrokes, paste) so pi sees it when it takes over.
+			let leftover = buffer
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
+			leftover = leftover.replace(/\x1b\]10;.+?(?:\x07|\x1b\\)/, "")
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
+			leftover = leftover.replace(/\x1b\]11;.+?(?:\x07|\x1b\\)/, "")
+			if (leftover.length > 0) stdin.unshift(Buffer.from(leftover, "utf8"))
+			if (!wasRaw) stdin.setRawMode?.(false)
+			stdin.pause()
+			resolveResult({ background, rawBackground, rawForeground })
 		}
 
 		const handler = (data: Buffer | string) => {
@@ -86,25 +123,37 @@ export async function probeTerminalBackground(): Promise<Rgb | undefined> {
 			if (buffer.length > MAX_BUFFER_BYTES) {
 				buffer = buffer.slice(buffer.length - MAX_BUFFER_BYTES)
 			}
-			// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
-			const re = /\x1b\]11;(rgb:([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+))(?:\x07|\x1b\\)/
-			const match = buffer.match(re)
-			if (match) {
-				// Per X11 spec, a 1-digit channel replicates to fill: "A" → "AA" = 170.
-				// padEnd then slice handles 2-4 digit channels correctly; special-case 1.
-				const toByte = (h: string) =>
-					h.length === 1 ? Number.parseInt(h + h, 16) : Number.parseInt(h.padEnd(4, "0").slice(0, 2), 16)
-				const idx = match.index ?? 0
-				const leftover = buffer.slice(0, idx) + buffer.slice(idx + match[0].length)
-				const rgb = { r: toByte(match[2]), g: toByte(match[3]), b: toByte(match[4]) }
-				finish(rgb, match[1], leftover)
+
+			if (!gotFg) {
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
+				const fgMatch = buffer.match(/\x1b\]10;(.+?)(?:\x07|\x1b\\)/)
+				if (fgMatch) {
+					rawForeground = fgMatch[1]
+					gotFg = true
+				}
 			}
+			if (!gotBg) {
+				// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC terminal escape sequence
+				const re = /\x1b\]11;(rgb:([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+))(?:\x07|\x1b\\)/
+				const match = buffer.match(re)
+				if (match) {
+					// Per X11 spec, a 1-digit channel replicates to fill: "A" → "AA" = 170.
+					// padEnd then slice handles 2-4 digit channels correctly; special-case 1.
+					const toByte = (h: string) =>
+						h.length === 1 ? Number.parseInt(h + h, 16) : Number.parseInt(h.padEnd(4, "0").slice(0, 2), 16)
+					background = { r: toByte(match[2]), g: toByte(match[3]), b: toByte(match[4]) }
+					rawBackground = match[1]
+					gotBg = true
+				}
+			}
+			if (gotFg && gotBg) finish()
 		}
 
-		const timeout = setTimeout(() => finish(undefined, undefined, buffer), QUERY_TIMEOUT_MS)
+		const timeout = setTimeout(() => finish(), QUERY_TIMEOUT_MS)
 
-		process.stdin.on("data", handler)
-		process.stdout.write(QUERY_BG)
+		stdin.on("data", handler)
+		stdout.write(QUERY_FG)
+		stdout.write(QUERY_BG)
 	})
 }
 

--- a/tests/e2e/tui/ferment-draft-proposal-persistence.test.ts
+++ b/tests/e2e/tui/ferment-draft-proposal-persistence.test.ts
@@ -98,7 +98,15 @@ test("draft with persisted proposal reopens plan review across session restart",
 			await waitForText(terminal, "Persistent Proposal", { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("draft listed in ferment picker")
 			terminal.submit("")
-			trace.step("selected the draft — resumeFerment runs")
+			trace.step("selected the draft from the list")
+
+			// Selecting a draft ferment opens a resume dialog (Continue / Delete /
+			// Back). Confirm "Continue" to trigger resumeFerment, which re-arms
+			// the plan review from the persisted sidecar.
+			await waitForText(terminal, "Continue", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("resume dialog visible")
+			terminal.submit("")
+			trace.step("confirmed Continue — resumeFerment runs")
 
 			// Stage 3: the persisted proposal re-arms the plan review dialog
 			// directly (no LLM scoping turn, no re-propose). The dialog renders

--- a/tests/e2e/tui/multi-model-command.test.ts
+++ b/tests/e2e/tui/multi-model-command.test.ts
@@ -50,11 +50,10 @@ test("/multi-model opens the main menu with the role summary and bottom-row entr
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			// One-shot "/multi-model\r" races startup; write + submit separately.
-			// Trailing space switches autocomplete to argument mode so Enter
-			// cannot trigger the slash-command autocomplete accept path.
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			// Write + submit separately so the command text is visible before
+			// Enter fires — a one-shot submit races startup and can be lost.
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /multi-model")
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -88,8 +87,8 @@ test("/multi-model reset to defaults persists roles and surfaces a notification"
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /multi-model")
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -120,8 +119,8 @@ test("/multi-model metadata editor saves tier/vision/description", async ({ term
 			responses: [],
 		},
 		async (fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /multi-model")
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -226,8 +225,8 @@ test("/multi-model builder role opens toggle-select with current assignment pre-
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /multi-model")
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -269,8 +268,8 @@ test("/multi-model Enter on first row of toggle-select confirms without scrollin
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -304,8 +303,8 @@ test("/multi-model toggle-select has no Done/Add custom rows and uses new bottom
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -344,8 +343,8 @@ test("/multi-model toggle-select cursor resets to row 0 on Escape + re-open", as
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -400,8 +399,8 @@ test("/multi-model Space toggles checkbox state in toggle-select", async ({ term
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -446,8 +445,8 @@ test("/multi-model toggle-select title count updates after Space toggle", async 
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -500,8 +499,8 @@ test("/multi-model main menu cursor resets to row 0 after configuring a role", a
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")
@@ -548,8 +547,8 @@ test("/multi-model orchestrator picker omits the Enter custom model... option", 
 			responses: [],
 		},
 		async (_fixture, trace) => {
-			terminal.write("/multi-model ")
-			await waitForText(terminal, "/multi-model ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("main menu open")

--- a/tests/e2e/tui/theme-selector.test.ts
+++ b/tests/e2e/tui/theme-selector.test.ts
@@ -22,12 +22,10 @@ test.use(TUI_TEST_CONFIG)
 
 test("theme selector opens and shows available themes", async ({ terminal }) => {
 	await runKimchiSession(terminal, { artifactName: "theme-selector-opens", responses: [] }, async (_fixture, trace) => {
-		// Write then submit separately — one-shot "/theme\r" races startup.
-		// Trailing space switches autocomplete to argument mode (no args → cleared),
-		// so Enter cannot trigger the slash-command autocomplete accept that doubles
-		// the text when the stored prefix is stale.
-		terminal.write("/theme ")
-		await waitForText(terminal, "/theme ", { timeoutMs: INPUT_TIMEOUT_MS })
+		// Write then submit separately so the command is visible before Enter
+		// fires — a one-shot submit races startup and can be lost.
+		terminal.write("/theme")
+		await waitForText(terminal, "/theme", { timeoutMs: INPUT_TIMEOUT_MS })
 		trace.step("typed /theme")
 		terminal.submit("")
 		await waitForText(terminal, "Theme", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -50,8 +48,8 @@ test("theme selector escape cancels and restores prompt", async ({ terminal }) =
 		terminal,
 		{ artifactName: "theme-selector-escape", responses: [] },
 		async (_fixture, trace) => {
-			terminal.write("/theme ")
-			await waitForText(terminal, "/theme ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/theme")
+			await waitForText(terminal, "/theme", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /theme")
 			terminal.submit("")
 			await waitForText(terminal, "Theme", { timeoutMs: INPUT_TIMEOUT_MS })
@@ -76,8 +74,8 @@ test("theme selector enter confirms selection and returns to prompt", async ({ t
 		terminal,
 		{ artifactName: "theme-selector-confirm", responses: [] },
 		async (_fixture, trace) => {
-			terminal.write("/theme ")
-			await waitForText(terminal, "/theme ", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/theme")
+			await waitForText(terminal, "/theme", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("typed /theme")
 			terminal.submit("")
 			await waitForText(terminal, "Theme", { timeoutMs: INPUT_TIMEOUT_MS })


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Fixes intermittent TUI failures caused by user input being delivered twice during application startup.

### Problem

The terminal-colors extension queried the terminal foreground color during `session_start`, after pi-mono had already taken ownership of stdin.

Both pi-mono and the color probe listened to stdin concurrently:

1. pi-mono received and processed the user’s command.
2. The color probe buffered the same bytes while waiting for the OSC response.
3. During cleanup, the probe called `stdin.unshift()` with its remaining buffer.
4. The already-processed command was delivered to pi-mono a second time.

For ferment commands, this could create duplicate ferments such as `Old Ferment` and `Old Ferment (1)`, consume extra fake-server responses, and eventually cause lifecycle-guard exhaustion or plan-review timing failures.

### Fix

The OSC 10 foreground-color query now runs together with the existing OSC 11 background-color query before pi-mono takes ownership of stdin.

The startup probe:

- queries foreground and background colors through one pre-TUI stdin listener;
- caches both original raw color values;
- removes OSC responses from its buffer;
- preserves any early user input exactly once.

The terminal-colors extension now reads the cached values during `session_start`. It no longer installs a live stdin listener or replays input after the interactive session starts.

The probe’s terminal I/O was also extracted behind an injectable stream interface so this behavior can be tested deterministically.

### Regression coverage

Added tests verifying that:

- OSC 10/11 responses are removed while unrelated user input is preserved exactly once;
- the terminal-colors extension does not issue another color query during `session_start`.

The previously failing TUI workflows now pass:

- `ferment-new-resets-continuation-policy`
- both `plan-review-dismissal` scenarios

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [X] This PR links to an open issue above
- [X] Tests pass locally (`pnpm run test`)
- [X] Lint passes (`pnpm run check`)
- [X] Documentation updated if behavior changed
