### PR TITLE
fix(ferment): deduplicate resume messages

### DIFF
--- a/src/extensions/ferment/commands.test.ts
+++ b/src/extensions/ferment/commands.test.ts
@@ -871,6 +871,57 @@ describe("registerFermentCommands", () => {
 		expect(getPendingPlanReview(target.id)).toBeDefined()
 	})
 
+	it("/ferment switch resumes a paused ferment across a manual phase boundary", async () => {
+		const h = createHarness()
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const draft = h.storage.create("Boundary Switch")
+		const scoped = applyAndPersist(draft.id, {
+			type: "scope",
+			goal: "Goal",
+			successCriteria: ["Works"],
+			constraints: [],
+			phases: [
+				{ name: "Done", goal: "Build", steps: [] },
+				{ name: "Next", goal: "Continue", steps: [] },
+			],
+		})
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		const firstPhaseId = scoped.ferment.phases[0].id
+		const activated = applyAndPersist(scoped.ferment.id, { type: "activate_phase", phaseId: firstPhaseId })
+		if (!activated.ok) throw new Error(activated.error.message)
+		const completed = applyAndPersist(activated.ferment.id, {
+			type: "complete_phase",
+			phaseId: firstPhaseId,
+			summary: "done",
+		})
+		if (!completed.ok) throw new Error(completed.error.message)
+		const paused = applyAndPersist(completed.ferment.id, { type: "pause" })
+		if (!paused.ok) throw new Error(paused.error.message)
+
+		const commands = new Map<string, RegisteredCommand>()
+		const pi = {
+			...h.pi,
+			registerCommand: (name: string, command: RegisteredCommand) => {
+				commands.set(name, command)
+			},
+		} as unknown as ExtensionAPI
+		registerFermentCommands(pi, h.runtime)
+
+		const fermentCommand = commands.get("ferment")
+		if (!fermentCommand) throw new Error("ferment command was not registered")
+		await fermentCommand.handler(`switch "${paused.ferment.name}"`, h.ctx)
+
+		expect(h.storage.get(paused.ferment.id)?.status).toBe("planned")
+		expect(h.pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_continuation_nudge",
+				content: [expect.objectContaining({ text: expect.stringContaining("activate_ferment_phase") })],
+				details: expect.objectContaining({ action: "wake_up", expectedAction: "activate_phase" }),
+			}),
+			{ triggerTurn: true },
+		)
+	})
+
 	it("completes /ferment nested static argument groups", () => {
 		const h = createHarness()
 

--- a/src/extensions/ferment/commands.ts
+++ b/src/extensions/ferment/commands.ts
@@ -864,7 +864,7 @@ export class FermentCommandController {
 				const previousActiveId = runtime.getActiveId()
 				if (previousActiveId && previousActiveId !== f.id) runtime.clearPendingPlanReview(previousActiveId)
 				sendBreadcrumb(pi, `Switched to "${f.name}" [${f.status}]${wtWarning}`, "ack", "ferment_ack")
-				resumeFerment(pi, f.id, ctx, runtime)
+				resumeFerment(pi, f.id, ctx, runtime, { allowManualPhaseBoundary: true })
 			} catch (err) {
 				ctx.ui.notify(err instanceof FermentError ? err.message : "Switch failed.")
 			}

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -16,6 +16,7 @@ import type { FermentRuntime } from "./runtime.js"
 import { createDefaultFermentRuntime } from "./runtime.js"
 import { clearActiveFermentId, getFermentLockPath, markScopingInteractive, writeFermentLock } from "./state.js"
 import { filterSentMessages } from "./test-helpers.js"
+import { createApplyAndPersist } from "./tool-helpers.js"
 import { FERMENT_TOOL_NAMES } from "./tool-names.js"
 import { profileForFerment } from "./tool-scope.js"
 
@@ -62,6 +63,74 @@ afterEach(() => {
 })
 
 describe("registerFermentEvents", () => {
+	it("continues across a manual phase boundary when the user explicitly resumes from the session banner", async () => {
+		vi.useFakeTimers()
+		const storageDir = mkdtempSync(join(tmpdir(), "ferment-events-manual-resume-"))
+		const storage = new FermentEventStore(storageDir)
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+		}
+		try {
+			vi.stubEnv("KIMCHI_FERMENT_LOCK_DIR", join(storageDir, "locks"))
+			const draft = storage.create("Manual Boundary Resume")
+			const applyAndPersist = createApplyAndPersist(runtime)
+			const scoped = applyAndPersist(draft.id, {
+				type: "scope",
+				title: "Manual Boundary Resume",
+				goal: "g",
+				successCriteria: ["c"],
+				constraints: [],
+				assumptions: "a",
+				phases: [
+					{ name: "P1", goal: "g1", steps: [] },
+					{ name: "P2", goal: "g2", steps: [{ description: "s2" }] },
+				],
+			})
+			if (!scoped.ok) throw new Error(scoped.error.message)
+			const firstPhaseId = scoped.ferment.phases[0].id
+			const activated = applyAndPersist(draft.id, { type: "activate_phase", phaseId: firstPhaseId })
+			if (!activated.ok) throw new Error(activated.error.message)
+			const completed = applyAndPersist(draft.id, {
+				type: "complete_phase",
+				phaseId: firstPhaseId,
+				summary: "done",
+			})
+			if (!completed.ok) throw new Error(completed.error.message)
+			const paused = applyAndPersist(draft.id, { type: "pause" })
+			if (!paused.ok) throw new Error(paused.error.message)
+
+			vi.stubEnv("KIMCHI_ACTIVE_FERMENT", draft.id)
+			const { handlers, pi } = createPi()
+			registerFermentEvents(pi, runtime)
+			const sessionStart = handlers.get("session_start")
+			if (!sessionStart) throw new Error("session_start handler was not registered")
+			const ctx = createContext({ ui: { select: vi.fn().mockResolvedValue("Resume") } })
+
+			await sessionStart({}, ctx)
+			await vi.runAllTimersAsync()
+
+			const actionableHidden = [
+				...filterSentMessages(vi.mocked(pi.sendMessage), "ferment_resume_nudge"),
+				...filterSentMessages(vi.mocked(pi.sendMessage), "ferment_continuation_nudge"),
+			]
+			expect(actionableHidden).toHaveLength(1)
+			expect(pi.sendMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					customType: "ferment_continuation_nudge",
+					content: expect.arrayContaining([
+						expect.objectContaining({ text: expect.stringContaining("activate_ferment_phase") }),
+					]),
+				}),
+				expect.objectContaining({ triggerTurn: true }),
+			)
+		} finally {
+			vi.useRealTimers()
+			runtime.setActive(undefined)
+			rmSync(storageDir, { recursive: true, force: true })
+		}
+	})
+
 	it("clears injected runtime state and active cache when env resume id is missing", async () => {
 		vi.stubEnv("KIMCHI_ACTIVE_FERMENT", "missing-ferment-id")
 		const storage = { get: vi.fn(() => undefined) } as unknown as FermentEventStore

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -390,7 +390,7 @@ export function registerFermentEvents(
 				const choice = await ctx.ui.select(banner, ["Resume", "Leave paused"])
 				runtime.markHumanInput()
 				if (choice === "Resume") {
-					deferExtensionAction(() => resumeFerment(pi, envId, ctx, runtime))
+					deferExtensionAction(() => resumeFerment(pi, envId, ctx, runtime, { allowManualPhaseBoundary: true }))
 				} else {
 					// User explicitly declined to resume — emit stalled telemetry.
 					pi.events.emit(FERMENT_EVENTS.STALLED, buildStalledPayload(ferment, runtime.now().getTime()))

--- a/src/extensions/ferment/resume.test.ts
+++ b/src/extensions/ferment/resume.test.ts
@@ -43,6 +43,14 @@ interface SendMessageCall {
 	content?: { text?: string }[]
 }
 
+/** Count messages across both actionable hidden custom types (the resume
+ *  contract: at most one per resume). */
+function actionableHidden(messages: SendMessageCall[]): SendMessageCall[] {
+	return messages.filter(
+		(m) => m.customType === "ferment_resume_nudge" || m.customType === "ferment_continuation_nudge",
+	)
+}
+
 function createHarness() {
 	const fermentsDir = mkdtempSync(join(tmpdir(), "ferment-resume-test-"))
 	const eventStorage = new FermentEventStore(fermentsDir)
@@ -152,7 +160,9 @@ describe("resumeFerment pending-proposal hydration", () => {
 		expect(pendingScope?.goal).toBe("A test goal")
 		expect(pendingScope?.proposeIterations).toBe(1)
 
-		// No LLM scoping nudge (ferment_resume_nudge) — that path was skipped.
+		// No actionable hidden continuation is sent while a plan review is
+		// pending — neither the resume nudge nor the continuation nudge.
+		expect(actionableHidden(h.sentMessages)).toHaveLength(0)
 		const resumeNudge = h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")
 		expect(resumeNudge).toBeUndefined()
 
@@ -178,6 +188,11 @@ describe("resumeFerment pending-proposal hydration", () => {
 		// The existing resume nudge fires (regression guard).
 		const resumeNudge = h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")
 		expect(resumeNudge).toBeDefined()
+
+		// Resume contract: exactly one actionable hidden message, and it is the
+		// resume nudge — no continuation nudge should be sent for a draft.
+		expect(actionableHidden(h.sentMessages)).toHaveLength(1)
+		expect(h.sentMessages.find((m) => m.customType === "ferment_continuation_nudge")).toBeUndefined()
 	})
 
 	it("confirming the plan deletes the persisted sidecar file", () => {
@@ -220,23 +235,83 @@ describe("resumeFerment pending-proposal hydration", () => {
 	})
 })
 
-describe("resumeFerment automated scope-nudge dedup", () => {
-	it("automated draft resume without a persisted proposal does not queue duplicate scoping nudges", () => {
-		const ferment = h.eventStorage.create("Automated Untouched Draft")
-		h.runtime.setContinuationPolicy("automated")
+describe("resumeFerment planned state", () => {
+	it("planned resume sends exactly one continuation nudge naming the activate_phase action", () => {
+		const ferment = h.eventStorage.create("Planned Resume")
 		h.runtime.setActive(ferment)
+
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const scoped = applyAndPersist(ferment.id, {
+			type: "scope",
+			title: "Planned Resume",
+			goal: "g",
+			successCriteria: ["c"],
+			constraints: [],
+			assumptions: "a",
+			phases: [{ name: "P1", goal: "g", steps: [{ description: "s1" }] }],
+		})
+		expect(scoped.ok).toBe(true)
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		// A freshly scoped ferment lands in "planned" with all phases planned.
+		expect(scoped.ferment.status).toBe("planned")
 
 		resumeFerment(h.pi, ferment.id, { hasUI: false } as ExtensionCommandContext, h.runtime)
 
-		const hiddenNudges = h.sentMessages
-			.filter((m) => m.customType === "ferment_resume_nudge" || m.customType === "ferment_continuation_nudge")
-			.map((m) => m.customType)
-		expect(hiddenNudges).toEqual(["ferment_resume_nudge"])
+		// Resume contract: exactly one actionable hidden message.
+		expect(actionableHidden(h.sentMessages)).toHaveLength(1)
+
+		// It is the scheduler's contextual continuation nudge (not the resume
+		// nudge) and it names the expected activate_phase action.
+		const continuation = h.sentMessages.find((m) => m.customType === "ferment_continuation_nudge")
+		expect(continuation).toBeDefined()
+		const text = continuation?.content?.map((c) => c.text ?? "").join("") ?? ""
+		expect(text).toContain("activate_ferment_phase")
+		expect(text).toContain(scoped.ferment.phases[0].id)
+
+		// No resume nudge is sent for a planned ferment.
+		expect(h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")).toBeUndefined()
+		expect(h.sentMessages.filter((m) => m.customType === "ferment_breadcrumb")).toHaveLength(1)
+		expect(h.pi.appendEntry).not.toHaveBeenCalledWith("ferment_breadcrumb", expect.anything())
+	})
+
+	it("continues a planned ferment whose final phase is complete", () => {
+		const ferment = h.eventStorage.create("Ready To Complete")
+		h.runtime.setActive(ferment)
+
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+		const scoped = applyAndPersist(ferment.id, {
+			type: "scope",
+			title: "Ready To Complete",
+			goal: "g",
+			successCriteria: ["c"],
+			constraints: [],
+			assumptions: "a",
+			phases: [{ name: "P1", goal: "g", steps: [] }],
+		})
+		if (!scoped.ok) throw new Error(scoped.error.message)
+		const phaseId = scoped.ferment.phases[0].id
+		const activated = applyAndPersist(ferment.id, { type: "activate_phase", phaseId })
+		if (!activated.ok) throw new Error(activated.error.message)
+		const phaseDone = applyAndPersist(ferment.id, {
+			type: "complete_phase",
+			phaseId,
+			summary: "done",
+		})
+		if (!phaseDone.ok) throw new Error(phaseDone.error.message)
+		expect(phaseDone.ferment.status).toBe("planned")
+
+		resumeFerment(h.pi, ferment.id, { hasUI: false } as ExtensionCommandContext, h.runtime)
+
+		expect(actionableHidden(h.sentMessages)).toHaveLength(1)
+		const continuation = h.sentMessages.find((message) => message.customType === "ferment_continuation_nudge")
+		const text = continuation?.content?.map((content) => content.text ?? "").join("") ?? ""
+		expect(text).toContain("complete_ferment")
+		expect(h.sentMessages.find((message) => message.customType === "ferment_resume_nudge")).toBeUndefined()
 	})
 })
 
-describe("resumeFerment paused-state nudge guard", () => {
-	it("paused ferment that resumes to running emits the resume nudge", () => {
+describe("resumeFerment running state", () => {
+	it("paused ferment that resumes to running sends one continuation nudge with the resume imperative and next action", () => {
 		const draft = h.eventStorage.create("Paused Then Running")
 		h.runtime.setActive(draft)
 
@@ -268,18 +343,31 @@ describe("resumeFerment paused-state nudge guard", () => {
 
 		resumeFerment(h.pi, draft.id, hasUIContext(), h.runtime)
 
-		// After resume, status should be running and the model gets the imperative nudge.
+		// After resume, status should be running.
 		const running = h.eventStorage.get(draft.id)
 		expect(running?.status).toBe("running")
 
-		const resumeNudge = h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")
-		expect(resumeNudge).toBeDefined()
-		const nudgeText = resumeNudge?.content?.map((c) => c.text ?? "").join("") ?? ""
+		// Resume contract: exactly one actionable hidden message.
+		expect(actionableHidden(h.sentMessages)).toHaveLength(1)
+
+		// It is the scheduler's contextual continuation nudge containing both
+		// the resume imperative and the next-action instructions.
+		const continuation = h.sentMessages.find((m) => m.customType === "ferment_continuation_nudge")
+		expect(continuation).toBeDefined()
+		const nudgeText = continuation?.content?.map((c) => c.text ?? "").join("") ?? ""
 		expect(nudgeText).toContain("RESUMING ferment")
 		expect(nudgeText).toContain("Pick up the work immediately")
-	})
+		expect(nudgeText).toContain("start_ferment_step")
 
-	it("paused ferment that remains paused does not emit the resume nudge", () => {
+		// No resume nudge is sent for a running ferment.
+		expect(h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")).toBeUndefined()
+		expect(h.sentMessages.filter((m) => m.customType === "ferment_breadcrumb")).toHaveLength(1)
+		expect(h.pi.appendEntry).not.toHaveBeenCalledWith("ferment_breadcrumb", expect.anything())
+	})
+})
+
+describe("resumeFerment still-paused state", () => {
+	it("a failed resume attempt sends the paused notice and no actionable hidden message", () => {
 		const draft = h.eventStorage.create("Stays Paused")
 		h.runtime.setActive(draft)
 
@@ -310,11 +398,6 @@ describe("resumeFerment paused-state nudge guard", () => {
 		// force it to fail with a non-ok outcome. Because resume.ts only
 		// reassigns `existing = out.ferment` when `out.ok`, leaving
 		// existing.status === "paused" exercises the ferment_paused_notice branch.
-		// We can't achieve this by mocking eventStorage.get alone: resume.ts
-		// reassigns `existing` from the applyAndPersist return value, and
-		// mutateWithEvents reads the underlying storage via this.storage.get
-		// (not this.get), so a spy on eventStorage.get would not intercept the
-		// mutate path.
 		vi.spyOn(h.eventStorage, "mutateWithEvents").mockImplementationOnce(() => {
 			return { ok: false, error: { code: "FERMENT_NOT_FOUND", message: "simulated resume failure" } }
 		})
@@ -328,9 +411,8 @@ describe("resumeFerment paused-state nudge guard", () => {
 
 		resumeFerment(h.pi, draft.id, hasUIContext(), h.runtime)
 
-		// No resume nudge should be sent to the model.
-		const resumeNudge = h.sentMessages.find((m) => m.customType === "ferment_resume_nudge")
-		expect(resumeNudge).toBeUndefined()
+		// Resume contract: no actionable hidden message is sent.
+		expect(actionableHidden(h.sentMessages)).toHaveLength(0)
 
 		// A user-facing paused notice should be sent instead.
 		const pausedNotice = h.sentMessages.find((m) => m.customType === "ferment_paused_notice")
@@ -342,6 +424,60 @@ describe("resumeFerment paused-state nudge guard", () => {
 			kind: "claimed",
 			reason: "exhausted",
 		})
+	})
+})
+
+describe("resumeFerment early-return states", () => {
+	it.each(["complete", "abandoned"] as const)("does not continue a %s ferment", (terminalStatus) => {
+		const draft = h.eventStorage.create(`${terminalStatus} Resume`)
+		const applyAndPersist = createApplyAndPersist(h.runtime)
+
+		if (terminalStatus === "abandoned") {
+			const abandoned = applyAndPersist(draft.id, { type: "abandon", reason: "done" })
+			expect(abandoned.ok).toBe(true)
+		} else {
+			const scoped = applyAndPersist(draft.id, {
+				type: "scope",
+				title: "Complete Resume",
+				goal: "g",
+				successCriteria: ["c"],
+				constraints: [],
+				assumptions: "a",
+				phases: [{ name: "P1", goal: "g", steps: [] }],
+			})
+			if (!scoped.ok) throw new Error(scoped.error.message)
+			const phaseId = scoped.ferment.phases[0].id
+			const activated = applyAndPersist(draft.id, { type: "activate_phase", phaseId })
+			if (!activated.ok) throw new Error(activated.error.message)
+			const completedPhase = applyAndPersist(draft.id, {
+				type: "complete_phase",
+				phaseId,
+				summary: "done",
+			})
+			if (!completedPhase.ok) throw new Error(completedPhase.error.message)
+			const completed = applyAndPersist(draft.id, { type: "complete_ferment", finalSummary: "done" })
+			expect(completed.ok).toBe(true)
+		}
+
+		resumeFerment(h.pi, draft.id, hasUIContext(), h.runtime)
+
+		expect(actionableHidden(h.sentMessages)).toHaveLength(0)
+		expect(h.sentMessages).toHaveLength(0)
+		expect(h.runtime.getActive()).toBeUndefined()
+	})
+
+	it("sends a warning without continuing when the worktree check blocks resume", () => {
+		const ferment = h.eventStorage.create("Blocked Worktree Resume")
+		vi.spyOn(h.eventStorage, "get").mockReturnValue({
+			...ferment,
+			worktree: { ...ferment.worktree, path: join(tmpdir(), "different-worktree") },
+		})
+
+		resumeFerment(h.pi, ferment.id, hasUIContext(), h.runtime)
+
+		expect(actionableHidden(h.sentMessages)).toHaveLength(0)
+		expect(h.sentMessages.find((message) => message.customType === "ferment_worktree_warning")).toBeDefined()
+		expect(h.sentMessages.find((message) => message.customType === "ferment_breadcrumb")).toBeUndefined()
 	})
 })
 

--- a/src/extensions/ferment/resume.ts
+++ b/src/extensions/ferment/resume.ts
@@ -153,14 +153,7 @@ export function resumeFerment(
 		}
 	}
 
-	const action = determineNextAction(existing)
-	const baseMsg = action ? formatActionNudgeLine(action) : ""
 	const breadcrumb = `Resumed ferment: "${existing.name}" [${existing.status}] ${runtime.getContinuationPolicy()} policy`
-
-	const imperative =
-		existing.status === "running"
-			? `RESUMING ferment "${existing.name}" — the previous session was interrupted. Pick up the work immediately. Do NOT explain or summarize — execute the next action below.\n\n${baseMsg}`
-			: baseMsg
 
 	safeSendMessage(
 		pi,
@@ -173,21 +166,7 @@ export function resumeFerment(
 		{ triggerTurn: false },
 	)
 
-	if (existing.status !== "paused") {
-		// Renew draft-scoping recovery only once resume has passed every
-		// blocking check and will actually schedule another model turn.
-		resetScopingStopNudgeCount(existing.id)
-		safeSendMessage(
-			pi,
-			{
-				customType: "ferment_resume_nudge",
-				content: [{ type: "text", text: imperative }],
-				display: false,
-				details: undefined,
-			},
-			{ triggerTurn: true },
-		)
-	} else {
+	if (existing.status === "paused") {
 		safeSendMessage(
 			pi,
 			{
@@ -206,9 +185,45 @@ export function resumeFerment(
 		return
 	}
 
-	// `resumeFerment` already sent a `ferment_resume_nudge` with triggerTurn for
-	// this ferment. Passing `skipNudge` prevents `scheduleFermentWakeUp` from
-	// queuing a duplicate `ferment_continuation_nudge` for the same scope action
-	// (only affects draft ferments where determineNextAction returns { kind: "scope" }).
-	scheduleFermentWakeUp(pi, runtime, { ...opts, fermentId: existing.id, tag: "Resume wake-up", skipNudge: true })
+	// Renew draft-scoping recovery only once resume has passed every
+	// blocking check and will actually schedule another model turn.
+	resetScopingStopNudgeCount(existing.id)
+
+	// Draft without pending review: send one ferment_resume_nudge directly and
+	// return. This preserves the existing draft-scoping behavior without
+	// depending on action-specific skipNudge logic in the scheduler.
+	if (existing.status === "draft") {
+		const action = determineNextAction(existing)
+		const baseMsg = action ? formatActionNudgeLine(action) : ""
+		safeSendMessage(
+			pi,
+			{
+				customType: "ferment_resume_nudge",
+				content: [{ type: "text", text: baseMsg }],
+				display: false,
+				details: undefined,
+			},
+			{ triggerTurn: true },
+		)
+		return
+	}
+
+	// Planned or running: route through the scheduler as the single
+	// hidden-message owner. The scheduler sends one action-specific
+	// ferment_continuation_nudge. For a resumed running ferment, pass the
+	// resume imperative as messagePrefix so the final hidden message contains
+	// both the resume context and the exact next-action instructions.
+	const messagePrefix =
+		existing.status === "running"
+			? `RESUMING ferment "${existing.name}" — the previous session was interrupted. Pick up the work immediately. Do NOT explain or summarize — execute the next action below.`
+			: undefined
+
+	scheduleFermentWakeUp(pi, runtime, {
+		...opts,
+		fermentId: existing.id,
+		tag: "Resume wake-up",
+		messagePrefix,
+		skipBreadcrumb: true,
+		treatCompleteFermentAsContinue: true,
+	})
 }

--- a/src/extensions/ferment/scheduler.test.ts
+++ b/src/extensions/ferment/scheduler.test.ts
@@ -5,8 +5,9 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { createDefaultFermentRuntime, type FermentRuntime } from "./runtime.js"
-import { scheduleNextFermentAction } from "./scheduler.js"
+import { scheduleFermentWakeUp, scheduleNextFermentAction } from "./scheduler.js"
 import { setActive } from "./state.js"
+import { createApplyAndPersist } from "./tool-helpers.js"
 
 function createPi(): ExtensionAPI {
 	return {
@@ -15,13 +16,13 @@ function createPi(): ExtensionAPI {
 	} as unknown as ExtensionAPI
 }
 
+const tmpDirs: string[] = []
+
 /**
  * Builds a runtime backed by a real FermentEventStore with a freshly created
  * draft ferment (no phases). `determineNextAction` resolves such a draft to a
  * `{ kind: "scope" }` action, which is the exact path that regresses.
  */
-const tmpDirs: string[] = []
-
 function makeRuntime(policy: "automated" | "manual"): {
 	runtime: FermentRuntime
 	draftId: string
@@ -38,6 +39,41 @@ function makeRuntime(policy: "automated" | "manual"): {
 		isAutomatedContinuationEnabled: () => policy === "automated",
 	}
 	return { runtime, draftId: draft.id }
+}
+
+/**
+ * Builds a runtime backed by a real FermentEventStore with a scoped ferment in
+ * the "planned" status (phases defined, none active). `determineNextAction`
+ * resolves such a ferment to an `activate_phase` action, exercising the
+ * contextual-nudge path used by `scheduleFermentWakeUp`.
+ */
+function makePlannedRuntime(policy: "automated" | "manual"): {
+	runtime: FermentRuntime
+	fermentId: string
+} {
+	const tmpDir = mkdtempSync(join(tmpdir(), "ferment-scheduler-test-"))
+	tmpDirs.push(tmpDir)
+	const storage = new FermentEventStore(tmpDir)
+	const draft = storage.create("Planned Nudge Ferment")
+	const runtime: FermentRuntime = {
+		...createDefaultFermentRuntime(),
+		getStorage: () => storage,
+		getActiveId: () => draft.id,
+		getContinuationPolicy: () => policy,
+		isAutomatedContinuationEnabled: () => policy === "automated",
+	}
+	const applyAndPersist = createApplyAndPersist(runtime)
+	const scoped = applyAndPersist(draft.id, {
+		type: "scope",
+		title: "Planned Nudge Ferment",
+		goal: "g",
+		successCriteria: ["c"],
+		constraints: [],
+		assumptions: "a",
+		phases: [{ name: "P1", goal: "g", steps: [{ description: "s1" }] }],
+	})
+	if (!scoped.ok) throw new Error(scoped.error.message)
+	return { runtime, fermentId: scoped.ferment.id }
 }
 
 afterEach(() => {
@@ -79,5 +115,57 @@ describe("scheduleNextFermentAction — scope nudge suppression", () => {
 		scheduleNextFermentAction(pi, draft, runtime)
 
 		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+})
+
+describe("scheduleFermentWakeUp — messagePrefix composition", () => {
+	it("prepends messagePrefix to the contextual scheduler message", () => {
+		const pi = createPi()
+		const { runtime, fermentId } = makePlannedRuntime("automated")
+
+		const prefix = 'RESUMING ferment "Planned" — pick up the work immediately.'
+		scheduleFermentWakeUp(pi, runtime, { fermentId, tag: "Resume wake-up", messagePrefix: prefix })
+
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				customType: "ferment_continuation_nudge",
+				display: false,
+			}),
+			expect.objectContaining({ triggerTurn: true }),
+		)
+
+		const call = vi.mocked(pi.sendMessage).mock.calls[0][0]
+		const raw = call.content
+		const text = typeof raw === "string" ? raw : (raw ?? []).map((p) => ("text" in p ? p.text : "")).join("")
+		// The prefix must appear before the contextual nudge body.
+		expect(text.startsWith(prefix)).toBe(true)
+		// The contextual nudge (activate_ferment_phase) must follow the prefix.
+		expect(text).toContain("activate_ferment_phase")
+	})
+
+	it("sends the contextual nudge unchanged when messagePrefix is omitted", () => {
+		const pi = createPi()
+		const { runtime, fermentId } = makePlannedRuntime("automated")
+
+		scheduleFermentWakeUp(pi, runtime, { fermentId, tag: "Wake-up" })
+
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const call = vi.mocked(pi.sendMessage).mock.calls[0][0]
+		const raw = call.content
+		const text = typeof raw === "string" ? raw : (raw ?? []).map((p) => ("text" in p ? p.text : "")).join("")
+		expect(text).toContain("activate_ferment_phase")
+	})
+
+	it("omits the scheduler breadcrumb when requested", () => {
+		const pi = createPi()
+		const { runtime, fermentId } = makePlannedRuntime("automated")
+
+		scheduleFermentWakeUp(pi, runtime, { fermentId, skipBreadcrumb: true })
+
+		expect(pi.appendEntry).not.toHaveBeenCalled()
+		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: "ferment_continuation_nudge" }), {
+			triggerTurn: true,
+		})
 	})
 })

--- a/src/extensions/ferment/scheduler.ts
+++ b/src/extensions/ferment/scheduler.ts
@@ -19,8 +19,10 @@ export interface ScheduleFermentWakeUpOptions {
 	allowManualPhaseBoundary?: boolean
 	deliverAs?: "followUp"
 	fermentId?: string
-	skipNudge?: boolean
+	messagePrefix?: string
+	skipBreadcrumb?: boolean
 	tag?: string
+	treatCompleteFermentAsContinue?: boolean
 }
 
 // ─── Contextual nudge builder ─────────────────────────────────────────────────
@@ -239,19 +241,22 @@ export function scheduleFermentWakeUp(
 
 	const decision = decideContinuation(ferment, runtime.getContinuationPolicy(), opts)
 	if (decision.type !== "continue") return
-	if (opts.skipNudge && decision.action.kind === "scope") return
 	if (shouldSuppressHiddenNudge(decision.action, runtime.getContinuationPolicy())) return
 
 	const tag = opts.tag ?? "Wake-up"
+	const baseNudge = buildContextualNudge(ferment, decision.action)
+	const prefix = opts.messagePrefix ? `${opts.messagePrefix}\n\n` : ""
 	tryPiAction(() => {
-		pi.appendEntry("ferment_breadcrumb", {
-			text: `${tag} [${decision.action.kind}]: "${ferment.name}" [${ferment.status}] · policy ${runtime.getContinuationPolicy()}`,
-		})
+		if (!opts.skipBreadcrumb) {
+			pi.appendEntry("ferment_breadcrumb", {
+				text: `${tag} [${decision.action.kind}]: "${ferment.name}" [${ferment.status}] · policy ${runtime.getContinuationPolicy()}`,
+			})
+		}
 		safeSendMessage(
 			pi,
 			{
 				customType: "ferment_continuation_nudge",
-				content: [{ type: "text", text: buildContextualNudge(ferment, decision.action) }],
+				content: [{ type: "text", text: `${prefix}${baseNudge}` }],
 				display: false,
 				details: { action: "wake_up", expectedAction: decision.action.kind },
 			},


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Resuming a planned or running Ferment could send two hidden messages to the agent:

1. A general “resume” message.
2. A second message describing the next Ferment action.

Both messages could start an agent turn, causing the same work to be triggered twice.

### How is it fixed?

Each Ferment state now has one clear resume path:

- Draft Ferments receive one general resume message.
- Planned and running Ferments receive one message with the exact next action.
- Pending reviews, paused Ferments, completed Ferments, and blocked worktrees do not start an unintended agent turn.
- Running Ferments still receive the context that the previous session was interrupted.

The obsolete skipNudge workaround was removed.

### Testing

Added and updated tests for:

- Draft, planned, running, paused, and completed Ferments.
- Pending plan reviews.
- Blocked worktrees.
- Manual phase boundaries.
- Resume messages containing the correct next action.

Focused tests and lint pass.

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [X] This PR links to an open issue above
- [X] Tests pass locally (`pnpm run test`)
- [X] Lint passes (`pnpm run check`)
- [X] Documentation updated if behavior changed
