### PR TITLE
feat: add `kimchi mcp probe --json` subcommand with OAuth support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,9 +153,15 @@ function getSubcommand(args: string[]): string {
 	if (args.includes("--help") || args.includes("-h")) return "help"
 	const sub = args[0]
 	if (!sub || sub.startsWith("-")) return "harness"
+	// Telemetry allowlist: names reported as the `subcommand` label in the
+	// app_started event (getSubcommand's only consumer, below). This is NOT a
+	// dispatch table — dispatch happens independently in dispatchSubcommand()
+	// via the command registry. The list intentionally includes labels that are
+	// not registry commands (logout, doctor, skills, telemetry) so those
+	// invocations report their own label instead of the generic "harness"; `mcp`
+	// appears here for the same telemetry-accuracy reason even though it is also
+	// a registered command.
 	if (["setup", "config", "login", "logout", "doctor", "skills", "telemetry", "mcp"].includes(sub)) return sub
-	// "mcp" is handled here so it doesn't enter the harness mode; the actual
-	// subcommand logic is dispatched via the command registry in dispatchSubcommand.
 	return "harness"
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,7 +154,8 @@ function getSubcommand(args: string[]): string {
 	const sub = args[0]
 	if (!sub || sub.startsWith("-")) return "harness"
 	if (["setup", "config", "login", "logout", "doctor", "skills", "telemetry", "mcp"].includes(sub)) return sub
-	// "mcp" is also handled by dispatchSubcommand via the command registry,
+	// "mcp" is handled here so it doesn't enter the harness mode; the actual
+	// subcommand logic is dispatched via the command registry in dispatchSubcommand.
 	return "harness"
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,7 +153,8 @@ function getSubcommand(args: string[]): string {
 	if (args.includes("--help") || args.includes("-h")) return "help"
 	const sub = args[0]
 	if (!sub || sub.startsWith("-")) return "harness"
-	if (["setup", "config", "login", "logout", "doctor", "skills", "telemetry"].includes(sub)) return sub
+	if (["setup", "config", "login", "logout", "doctor", "skills", "telemetry", "mcp"].includes(sub)) return sub
+	// "mcp" is also handled by dispatchSubcommand via the command registry,
 	return "harness"
 }
 

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -28,6 +28,18 @@ vi.mock("../extensions/mcp-adapter/mcp-auth-flow.js", () => ({
 	authenticate: mockAuthenticate,
 }))
 
+// Mock the auth storage module — we control getAuthEntry / removeAuthEntry so
+// the URL-mismatch guard can be exercised without touching the filesystem.
+const { mockGetAuthEntry, mockRemoveAuthEntry } = vi.hoisted(() => ({
+	mockGetAuthEntry: vi.fn(),
+	mockRemoveAuthEntry: vi.fn(),
+}))
+
+vi.mock("../extensions/mcp-adapter/mcp-auth.js", () => ({
+	getAuthEntry: mockGetAuthEntry,
+	removeAuthEntry: mockRemoveAuthEntry,
+}))
+
 import { runMcp } from "./mcp.js"
 
 // ---------------------------------------------------------------------------
@@ -113,6 +125,10 @@ describe("kimchi mcp probe", () => {
 		mockSupportsOAuth.mockReturnValue(false)
 		// Default: no pending auth
 		mockAuthenticate.mockResolvedValue("authenticated")
+		// Default: no stored auth entry (new server). Individual tests override
+		// this to simulate an existing entry with a same/different URL.
+		mockGetAuthEntry.mockReturnValue(undefined)
+		mockRemoveAuthEntry.mockReturnValue(undefined)
 	})
 
 	afterEach(() => {
@@ -553,5 +569,130 @@ describe("kimchi mcp probe", () => {
 		expect(parsed.tools[4999].description).toBe(bigTools[4999].description)
 		expect(parsed.needsAuth).toBe(false)
 		expect(parsed.error).toBeNull()
+	})
+
+	// --- URL mismatch guard (OAuth token store key) ----------------------
+
+	it("uses the real name and does not clean up when an auth entry with a matching URL exists", async () => {
+		// Existing entry stored for the same URL → repeat probe of an authorized
+		// server. The guard should reuse the real name so stored tokens are found
+		// and OAuth is skipped.
+		mockGetAuthEntry.mockReturnValue({ serverUrl: OAUTH_SERVER.url, tokens: { accessToken: "tok" } })
+		mockSupportsOAuth.mockReturnValue(true)
+		mockProbeTools.mockResolvedValue({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+		// Real name used for both probe and (not invoked) auth.
+		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockAuthenticate).not.toHaveBeenCalled()
+		// No cleanup — real credentials must survive the probe.
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
+
+	it("uses a throwaway name and cleans it up when an auth entry with a different URL exists", async () => {
+		// The user edited the server's URL but kept the name. A stored entry
+		// exists under the real name for a DIFFERENT URL — probing with the real
+		// name would overwrite the real server's tokens.
+		mockGetAuthEntry.mockReturnValue({ serverUrl: "https://old.example.com/mcp", tokens: { accessToken: "tok" } })
+		mockSupportsOAuth.mockReturnValue(true)
+		// First probe needs auth; after auth, retry returns tools.
+		mockProbeTools
+			.mockResolvedValueOnce({ tools: [], needsAuth: true })
+			.mockResolvedValueOnce({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+
+		// Both probeTools calls and authenticate received the throwaway name.
+		const firstCallArg = mockProbeTools.mock.calls[0]?.[1]
+		const secondCallArg = mockProbeTools.mock.calls[1]?.[1]
+		const authNameArg = mockAuthenticate.mock.calls[0]?.[0]
+		expect(firstCallArg).toMatch(/^__probe_[0-9a-f-]{36}$/)
+		expect(secondCallArg).toBe(firstCallArg)
+		expect(authNameArg).toBe(firstCallArg)
+		// The real name was never used as the token-store key.
+		expect(mockProbeTools).not.toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockAuthenticate).not.toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
+		// Throwaway credentials cleaned up in the finally block.
+		expect(mockRemoveAuthEntry).toHaveBeenCalledTimes(1)
+		expect(mockRemoveAuthEntry).toHaveBeenCalledWith(firstCallArg)
+	})
+
+	it("uses the real name and does not clean up when no auth entry exists (new server)", async () => {
+		// No stored entry → new server. The guard should use the real name so the
+		// first probe persists tokens under it and a repeat probe finds them.
+		mockGetAuthEntry.mockReturnValue(undefined)
+		mockSupportsOAuth.mockReturnValue(true)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
+
+	it("does not overwrite the real server's tokens when probing an edited URL (entry for a different URL)", async () => {
+		// Scenario: editing a server's URL and probing it must NOT overwrite the
+		// real server's stored tokens. A throwaway name isolates the probe's
+		// credentials, and removeAuthEntry wipes them afterwards.
+		const realUrl = "https://old.example.com/mcp"
+		mockGetAuthEntry.mockReturnValue({ serverUrl: realUrl, tokens: { accessToken: "real-tok" } })
+		mockSupportsOAuth.mockReturnValue(true)
+		// Probe needs auth, OAuth succeeds, retry returns tools.
+		mockProbeTools
+			.mockResolvedValueOnce({ tools: [], needsAuth: true })
+			.mockResolvedValueOnce({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+
+		// The real name (SERVER_NAME) was never passed as the token-store key.
+		const probeNames = mockProbeTools.mock.calls.map((c) => c[1])
+		expect(probeNames).not.toContain(SERVER_NAME)
+		expect(mockAuthenticate).not.toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
+		// Throwaway name was cleaned up exactly once.
+		expect(mockRemoveAuthEntry).toHaveBeenCalledTimes(1)
+		expect(mockRemoveAuthEntry.mock.calls[0]?.[0]).not.toBe(SERVER_NAME)
+	})
+
+	it("reuses the real name and skips OAuth on a repeat probe of an unchanged authorized server", async () => {
+		// A repeat probe of an unchanged, authorized server: the stored entry's
+		// URL matches, so the real name is used and the first probe finds the
+		// stored tokens — authenticate() is never called.
+		mockGetAuthEntry.mockReturnValue({ serverUrl: OAUTH_SERVER.url, tokens: { accessToken: "tok" } })
+		mockSupportsOAuth.mockReturnValue(true)
+		mockProbeTools.mockResolvedValue({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(mockProbeTools).toHaveBeenCalledTimes(1)
+		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockAuthenticate).not.toHaveBeenCalled()
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+		expect(out.json).toEqual({
+			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
+			needsAuth: false,
+			error: null,
+		})
 	})
 })

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -103,11 +103,11 @@ describe("kimchi mcp probe", () => {
 		expect(stderrSpy).toHaveBeenCalled()
 	})
 
-	it("returns 1 when --json flag is missing", async () => {
-		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+	it("returns 1 and emits JSON error on stdout when --json flag is missing", async () => {
+		const out = captureStdout()
 		const code = await runMcp(["probe"])
 		expect(code).toBe(1)
-		expect(stderrSpy.mock.calls.flat().join("")).toContain("--json")
+		expect(out.json.error).toContain("--json")
 	})
 
 	it("returns 1 when server config has neither command nor url", async () => {

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -231,7 +231,7 @@ describe("kimchi mcp probe", () => {
 
 	// --- OAuth flow: auth fails, returns needsAuth: true ------------------
 
-	it("returns needsAuth: true when OAuth flow fails", async () => {
+	it("returns needsAuth: true with error message when OAuth flow fails", async () => {
 		mockSupportsOAuth.mockReturnValue(true)
 		mockAuthenticate.mockRejectedValue(new Error("user denied"))
 
@@ -245,12 +245,27 @@ describe("kimchi mcp probe", () => {
 		expect(code).toBe(0)
 		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
 		expect(mockProbeTools).toHaveBeenCalledTimes(1)
-		expect(out.json).toEqual({ tools: [], needsAuth: true, error: null })
+		expect(out.json).toEqual({ tools: [], needsAuth: true, error: "user denied" })
+	})
+
+	it("returns needsAuth: true with real error when OAuth fails with port-in-use message", async () => {
+		mockSupportsOAuth.mockReturnValue(true)
+		const oauthError = "port 19876 is held by another process"
+		mockAuthenticate.mockRejectedValue(new Error(oauthError))
+		mockProbeTools.mockResolvedValueOnce({ tools: [], needsAuth: true })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.needsAuth).toBe(true)
+		expect(out.json.error).toContain(oauthError)
 	})
 
 	// --- OAuth flow: auth times out, returns needsAuth: true --------------
 
-	it("returns needsAuth: true when OAuth flow times out", async () => {
+	it("returns needsAuth: true with timeout message when OAuth flow times out", async () => {
 		vi.useFakeTimers()
 		try {
 			mockSupportsOAuth.mockReturnValue(true)
@@ -267,7 +282,30 @@ describe("kimchi mcp probe", () => {
 			const code = await probePromise
 
 			expect(code).toBe(0)
-			expect(out.json).toEqual({ tools: [], needsAuth: true, error: null })
+			expect(out.json).toEqual({ tools: [], needsAuth: true, error: "OAuth flow timed out" })
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("returns exit code 1 when non-OAuth server times out", async () => {
+		vi.useFakeTimers()
+		try {
+			mockSupportsOAuth.mockReturnValue(false)
+			// probeTools never resolves — simulates server hanging
+			mockProbeTools.mockReturnValue(new Promise(() => {}))
+
+			mockStdin(probeInput(STDIO_SERVER))
+			const out = captureStdout()
+
+			const probePromise = runMcp(["probe", "--json"])
+			// Advance past the 15s non-OAuth timeout
+			await vi.advanceTimersByTimeAsync(15_000)
+			const code = await probePromise
+
+			expect(code).toBe(1)
+			expect(out.json.needsAuth).toBe(false)
+			expect(out.json.error).toContain("timed out")
 		} finally {
 			vi.useRealTimers()
 		}

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -312,36 +312,31 @@ describe("kimchi mcp probe", () => {
 	// --- stdout flush ------------------------------------------------------
 
 	it("awaits the stdout write callback before resolving (large payload >64KB is not truncated)", async () => {
-		// A payload larger than the ~64KB pipe buffer: backpressure could cause
-		// process.exit() to fire before the write drains if emitResult didn't
-		// wait for the write callback. Here we verify the promise only resolves
-		// after the callback fires and that the full payload is captured.
-		const bigDescription = "x".repeat(80_000)
-		mockProbeTools.mockResolvedValue({
-			tools: [{ name: "big_tool", description: bigDescription }],
-			needsAuth: false,
-		})
-
-		let writeCallbackCalled = false
-		vi.spyOn(process.stdout, "write").mockImplementation(
-			(
-				_chunk: string | Uint8Array,
-				encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
-				cb?: (err?: Error | null) => void,
-			) => {
-				process.nextTick(() => {
-					writeCallbackCalled = true
-					const callback = typeof encodingOrCb === "function" ? encodingOrCb : cb
-					callback?.(null)
-				})
-				return true
-			},
-		)
+		// Generate a payload well above the ~64KB pipe buffer: 5000 tool objects
+		// with long names. If emitResult didn't await the write callback, a
+		// subsequent process.exit() could truncate the output mid-stream.
+		const bigTools = Array.from({ length: 5000 }, (_, i) => ({
+			name: `tool_${String(i).padStart(6, "0")}_${"x".repeat(30)}`,
+			description: "y".repeat(30),
+		}))
+		mockProbeTools.mockResolvedValue({ tools: bigTools, needsAuth: false })
 
 		mockStdin(probeInput(STDIO_SERVER))
+		const out = captureStdout()
 		const code = await runMcp(["probe", "--json"])
 
 		expect(code).toBe(0)
-		expect(writeCallbackCalled).toBe(true)
+		// Parse the captured stdout and verify the full payload survived.
+		const parsed = out.json as {
+			tools: Array<{ name: string; description: string }>
+			needsAuth: boolean
+			error: string | null
+		}
+		expect(parsed.tools).toHaveLength(5000)
+		expect(parsed.tools[0].name).toBe(bigTools[0].name)
+		expect(parsed.tools[4999].name).toBe(bigTools[4999].name)
+		expect(parsed.tools[4999].description).toBe(bigTools[4999].description)
+		expect(parsed.needsAuth).toBe(false)
+		expect(parsed.error).toBeNull()
 	})
 })

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -64,9 +64,18 @@ function captureStdout(): { data: string; json: Record<string, unknown> } {
 	}
 }
 
+const SERVER_NAME = "my-server"
 const STDIO_SERVER = { command: "node", args: ["server.js"] }
 const URL_SERVER = { url: "https://example.com/mcp" }
 const OAUTH_SERVER = { url: "https://example.com/mcp", auth: "oauth" as const }
+
+/** Wrap a server entry in the { name, server } stdin contract. */
+function probeInput(
+	server: typeof STDIO_SERVER | typeof URL_SERVER | typeof OAUTH_SERVER | Record<string, unknown>,
+	name = SERVER_NAME,
+): string {
+	return JSON.stringify({ name, server })
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -102,7 +111,13 @@ describe("kimchi mcp probe", () => {
 	})
 
 	it("returns 1 when server config has neither command nor url", async () => {
-		mockStdin(JSON.stringify({}))
+		mockStdin(probeInput({}))
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+	})
+
+	it("returns 1 when input is missing the 'name' field", async () => {
+		mockStdin(JSON.stringify({ server: STDIO_SERVER }))
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(1)
 	})
@@ -117,7 +132,7 @@ describe("kimchi mcp probe", () => {
 			],
 			needsAuth: false,
 		})
-		mockStdin(JSON.stringify(STDIO_SERVER))
+		mockStdin(probeInput(STDIO_SERVER))
 		const out = captureStdout()
 
 		const code = await runMcp(["probe", "--json"])
@@ -131,6 +146,7 @@ describe("kimchi mcp probe", () => {
 			error: null,
 		})
 		expect(mockProbeTools).toHaveBeenCalledTimes(1)
+		expect(mockProbeTools).toHaveBeenCalledWith(STDIO_SERVER, SERVER_NAME)
 		expect(mockCloseAll).toHaveBeenCalledTimes(1)
 	})
 
@@ -139,7 +155,7 @@ describe("kimchi mcp probe", () => {
 	it("returns needsAuth: true when server needs auth but OAuth is not supported", async () => {
 		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: true })
 		mockSupportsOAuth.mockReturnValue(false)
-		mockStdin(JSON.stringify(URL_SERVER))
+		mockStdin(probeInput(URL_SERVER))
 		const out = captureStdout()
 
 		const code = await runMcp(["probe", "--json"])
@@ -159,18 +175,41 @@ describe("kimchi mcp probe", () => {
 			.mockResolvedValueOnce({ tools: [], needsAuth: true })
 			.mockResolvedValueOnce({ tools: [{ name: "secure_tool" }], needsAuth: false })
 
-		mockStdin(JSON.stringify(OAUTH_SERVER))
+		mockStdin(probeInput(OAUTH_SERVER))
 		const out = captureStdout()
 
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(0)
 		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
-		expect(mockAuthenticate).toHaveBeenCalledWith(
-			expect.stringMatching(/^__probe_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/),
-			OAUTH_SERVER.url,
-			OAUTH_SERVER,
-		)
+		expect(mockAuthenticate).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
 		expect(mockProbeTools).toHaveBeenCalledTimes(2)
+		expect(mockProbeTools).toHaveBeenNthCalledWith(1, OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenNthCalledWith(2, OAUTH_SERVER, SERVER_NAME)
+		expect(out.json).toEqual({
+			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
+			needsAuth: false,
+			error: null,
+		})
+	})
+
+	// --- repeat probe: tokens already exist, OAuth is skipped -------------
+
+	it("skips OAuth when the first probe returns tools (tokens already exist)", async () => {
+		mockSupportsOAuth.mockReturnValue(true)
+		// First probe returns tools directly — stored tokens were found.
+		mockProbeTools.mockResolvedValue({
+			tools: [{ name: "secure_tool" }],
+			needsAuth: false,
+		})
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(mockProbeTools).toHaveBeenCalledTimes(1)
+		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockAuthenticate).not.toHaveBeenCalled()
 		expect(out.json).toEqual({
 			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
 			needsAuth: false,
@@ -187,7 +226,7 @@ describe("kimchi mcp probe", () => {
 		// Auth fails immediately — no retry probe should happen.
 		mockProbeTools.mockResolvedValueOnce({ tools: [], needsAuth: true })
 
-		mockStdin(JSON.stringify(OAUTH_SERVER))
+		mockStdin(probeInput(OAUTH_SERVER))
 		const out = captureStdout()
 
 		const code = await runMcp(["probe", "--json"])
@@ -207,7 +246,7 @@ describe("kimchi mcp probe", () => {
 			mockAuthenticate.mockReturnValue(new Promise(() => {}))
 			mockProbeTools.mockResolvedValueOnce({ tools: [], needsAuth: true })
 
-			mockStdin(JSON.stringify(OAUTH_SERVER))
+			mockStdin(probeInput(OAUTH_SERVER))
 			const out = captureStdout()
 
 			const probePromise = runMcp(["probe", "--json"])
@@ -226,7 +265,7 @@ describe("kimchi mcp probe", () => {
 
 	it("returns exit code 1 with error JSON when probe throws", async () => {
 		mockProbeTools.mockRejectedValue(new Error("connection refused"))
-		mockStdin(JSON.stringify(STDIO_SERVER))
+		mockStdin(probeInput(STDIO_SERVER))
 		const out = captureStdout()
 
 		const code = await runMcp(["probe", "--json"])
@@ -252,7 +291,7 @@ describe("kimchi mcp probe", () => {
 
 	it("always calls closeAll in the finally block", async () => {
 		mockProbeTools.mockRejectedValue(new Error("boom"))
-		mockStdin(JSON.stringify(STDIO_SERVER))
+		mockStdin(probeInput(STDIO_SERVER))
 
 		await runMcp(["probe", "--json"])
 		expect(mockCloseAll).toHaveBeenCalledTimes(1)

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -47,6 +47,19 @@ function mockStdin(data: string): void {
 	})
 }
 
+/** Emit stdin data but never emit 'end' — simulates a parent that opens the
+ * pipe without closing it, so readStdin would hang without the timeout. */
+function mockStdinOpen(data: string): void {
+	const stdin = process.stdin as unknown as {
+		setEncoding: (enc: string) => void
+		emit: (event: string, ...args: unknown[]) => boolean
+	}
+	process.nextTick(() => {
+		stdin.emit("data", data)
+		// Intentionally do NOT emit 'end'.
+	})
+}
+
 /** Read and parse the JSON written to stdout. */
 function captureStdout(): { data: string; json: Record<string, unknown> } {
 	const writes: string[] = []
@@ -132,6 +145,55 @@ describe("kimchi mcp probe", () => {
 		mockStdin(JSON.stringify({ server: STDIO_SERVER }))
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(1)
+	})
+
+	// --- readStdin guards: TTY, timeout, size cap --------------------------
+
+	it("returns 1 when stdin is a TTY", async () => {
+		// Simulate an interactive launch with no piped input.
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: true,
+			configurable: true,
+			writable: true,
+		})
+		const out = captureStdout()
+		try {
+			const code = await runMcp(["probe", "--json"])
+			expect(code).toBe(1)
+			expect(out.json.error).toContain("No input on stdin")
+		} finally {
+			// Restore the non-TTY default so subsequent tests see no piped TTY.
+			;(process.stdin as { isTTY?: boolean }).isTTY = undefined
+		}
+	})
+
+	it("returns 1 when stdin input times out", async () => {
+		vi.useFakeTimers()
+		try {
+			// Emit data but never 'end' — readStdin would hang without the timeout.
+			mockStdinOpen(probeInput(STDIO_SERVER))
+			const out = captureStdout()
+
+			const probePromise = runMcp(["probe", "--json"])
+			await vi.advanceTimersByTimeAsync(5000)
+			const code = await probePromise
+
+			expect(code).toBe(1)
+			expect(out.json.error).toContain("Timed out after 5000ms")
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	it("returns 1 when stdin input exceeds 1MB", async () => {
+		// Build a payload larger than 1MB. The first chunk alone crosses the cap.
+		const big = JSON.stringify({ name: SERVER_NAME, server: STDIO_SERVER, padding: "x".repeat(1_050_000) })
+		mockStdinOpen(big)
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("stdin input exceeded 1MB")
 	})
 
 	// --- successful stdio probe -------------------------------------------

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -135,16 +135,131 @@ describe("kimchi mcp probe", () => {
 		expect(out.json.error).toContain("--json")
 	})
 
-	it("returns 1 when server config has neither command nor url", async () => {
+	// --- TypeBox schema validation ------------------------------------------
+
+	it("returns 1 when server config has neither command nor url (semantic check remains)", async () => {
 		mockStdin(probeInput({}))
+		const out = captureStdout()
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(1)
+		expect(out.json.error).toContain("Server config must have either 'command' or 'url'")
 	})
 
-	it("returns 1 when input is missing the 'name' field", async () => {
-		mockStdin(JSON.stringify({ server: STDIO_SERVER }))
+	it("returns 1 with JSON error when server is missing", async () => {
+		mockStdin(JSON.stringify({ name: SERVER_NAME }))
+		const out = captureStdout()
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+		expect(out.json.error).toContain("server")
+	})
+
+	it("returns 1 with JSON error when server is null", async () => {
+		mockStdin(JSON.stringify({ name: SERVER_NAME, server: null }))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+		expect(out.json.error).toContain("object")
+	})
+
+	it("returns 1 with JSON error when server is wrong type (string)", async () => {
+		mockStdin(JSON.stringify({ name: SERVER_NAME, server: "not-an-object" }))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+		expect(out.json.error).toContain("object")
+	})
+
+	it("returns 1 with JSON error when name is missing", async () => {
+		mockStdin(JSON.stringify({ server: STDIO_SERVER }))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+		expect(out.json.error).toContain("name")
+	})
+
+	it("returns 1 with JSON error when name is empty", async () => {
+		mockStdin(probeInput(STDIO_SERVER, ""))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("returns 1 when name contains path separator /", async () => {
+		mockStdin(probeInput(STDIO_SERVER, "foo/bar"))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("returns 1 when name contains path separator backslash", async () => {
+		mockStdin(probeInput(STDIO_SERVER, "foo\\bar"))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("returns 1 when name is .. (path traversal)", async () => {
+		mockStdin(probeInput(STDIO_SERVER, ".."))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("returns 1 when name contains consecutive dots (foo..bar)", async () => {
+		mockStdin(probeInput(STDIO_SERVER, "foo..bar"))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("accepts name with single dots (github.com)", async () => {
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false })
+		mockStdin(probeInput(STDIO_SERVER, "github.com"))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+		expect(mockProbeTools).toHaveBeenCalledWith(STDIO_SERVER, "github.com")
+	})
+
+	it("returns 1 when unknown top-level properties are present", async () => {
+		mockStdin(JSON.stringify({ name: SERVER_NAME, server: STDIO_SERVER, extra: true }))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Invalid probe input")
+	})
+
+	it("accepts server with additionalProperties (full ServerEntry shape)", async () => {
+		const fullServer = { command: "npx", args: ["-y", "server.js"], env: { FOO: "bar" }, cwd: "/tmp", debug: true }
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false })
+		mockStdin(probeInput(fullServer))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+	})
+
+	it("returns exit code 1 with JSON error for all validation failures", async () => {
+		// Verify error envelope shape for a validation failure
+		mockStdin(JSON.stringify({ name: SERVER_NAME, server: null }))
+		const out = captureStdout()
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json).toEqual({
+			tools: [],
+			needsAuth: false,
+			error: expect.stringContaining("Invalid probe input"),
+		})
 	})
 
 	// --- readStdin guards: TTY, timeout, size cap --------------------------

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -50,10 +50,22 @@ function mockStdin(data: string): void {
 /** Read and parse the JSON written to stdout. */
 function captureStdout(): { data: string; json: Record<string, unknown> } {
 	const writes: string[] = []
-	vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
-		writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString())
-		return true
-	})
+	vi.spyOn(process.stdout, "write").mockImplementation(
+		// process.stdout.write is overloaded: (chunk, cb?) or (chunk, encoding?, cb?).
+		// Accept both shapes so the mock satisfies the union type.
+		(
+			chunk: string | Uint8Array,
+			encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+			cb?: (err?: Error | null) => void,
+		) => {
+			writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString())
+			const callback = typeof encodingOrCb === "function" ? encodingOrCb : cb
+			// Node's write callback is asynchronous — defer it so the emitResult
+			// promise that awaits it resolves on the next tick, mirroring real I/O.
+			if (callback) process.nextTick(() => callback(null))
+			return true
+		},
+	)
 	return {
 		get data() {
 			return writes.join("")
@@ -295,5 +307,41 @@ describe("kimchi mcp probe", () => {
 
 		await runMcp(["probe", "--json"])
 		expect(mockCloseAll).toHaveBeenCalledTimes(1)
+	})
+
+	// --- stdout flush ------------------------------------------------------
+
+	it("awaits the stdout write callback before resolving (large payload >64KB is not truncated)", async () => {
+		// A payload larger than the ~64KB pipe buffer: backpressure could cause
+		// process.exit() to fire before the write drains if emitResult didn't
+		// wait for the write callback. Here we verify the promise only resolves
+		// after the callback fires and that the full payload is captured.
+		const bigDescription = "x".repeat(80_000)
+		mockProbeTools.mockResolvedValue({
+			tools: [{ name: "big_tool", description: bigDescription }],
+			needsAuth: false,
+		})
+
+		let writeCallbackCalled = false
+		vi.spyOn(process.stdout, "write").mockImplementation(
+			(
+				_chunk: string | Uint8Array,
+				encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+				cb?: (err?: Error | null) => void,
+			) => {
+				process.nextTick(() => {
+					writeCallbackCalled = true
+					const callback = typeof encodingOrCb === "function" ? encodingOrCb : cb
+					callback?.(null)
+				})
+				return true
+			},
+		)
+
+		mockStdin(probeInput(STDIO_SERVER))
+		const code = await runMcp(["probe", "--json"])
+
+		expect(code).toBe(0)
+		expect(writeCallbackCalled).toBe(true)
 	})
 })

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that consume them
+// ---------------------------------------------------------------------------
+
+// Mock McpServerManager so we never spawn real subprocesses or HTTP connections.
+const { mockProbeTools, mockCloseAll } = vi.hoisted(() => ({
+	mockProbeTools: vi.fn(),
+	mockCloseAll: vi.fn(),
+}))
+
+vi.mock("../extensions/mcp-adapter/server-manager.js", () => ({
+	McpServerManager: class MockMcpServerManager {
+		probeTools = mockProbeTools
+		closeAll = mockCloseAll
+	},
+}))
+
+// Mock the auth flow module — we control supportsOAuth and authenticate.
+const { mockSupportsOAuth, mockAuthenticate } = vi.hoisted(() => ({
+	mockSupportsOAuth: vi.fn(),
+	mockAuthenticate: vi.fn(),
+}))
+
+vi.mock("../extensions/mcp-adapter/mcp-auth-flow.js", () => ({
+	supportsOAuth: mockSupportsOAuth,
+	authenticate: mockAuthenticate,
+}))
+
+import { runMcp } from "./mcp.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Feed stdin data to process.stdin and emit 'end'. */
+function mockStdin(data: string): void {
+	const stdin = process.stdin as unknown as {
+		setEncoding: (enc: string) => void
+		emit: (event: string, ...args: unknown[]) => boolean
+	}
+	// Buffer the data, then emit 'data' and 'end' on next tick.
+	process.nextTick(() => {
+		stdin.emit("data", data)
+		stdin.emit("end")
+	})
+}
+
+/** Read and parse the JSON written to stdout. */
+function captureStdout(): { data: string; json: Record<string, unknown> } {
+	const writes: string[] = []
+	vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+		writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString())
+		return true
+	})
+	return {
+		get data() {
+			return writes.join("")
+		},
+		get json() {
+			return JSON.parse(writes.join(""))
+		},
+	}
+}
+
+const STDIO_SERVER = { command: "node", args: ["server.js"] }
+const URL_SERVER = { url: "https://example.com/mcp" }
+const OAUTH_SERVER = { url: "https://example.com/mcp", auth: "oauth" as const }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("kimchi mcp probe", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockCloseAll.mockResolvedValue(undefined)
+		mockSupportsOAuth.mockReturnValue(false)
+		// Default: no pending auth
+		mockAuthenticate.mockResolvedValue("authenticated")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	// --- argument parsing -------------------------------------------------
+
+	it("returns 1 and prints error for unknown subcommand", async () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+		const code = await runMcp(["bogus"])
+		expect(code).toBe(1)
+		expect(stderrSpy).toHaveBeenCalled()
+	})
+
+	it("returns 1 when --json flag is missing", async () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+		const code = await runMcp(["probe"])
+		expect(code).toBe(1)
+		expect(stderrSpy.mock.calls.flat().join("")).toContain("--json")
+	})
+
+	it("returns 1 when server config has neither command nor url", async () => {
+		mockStdin(JSON.stringify({}))
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+	})
+
+	// --- successful stdio probe -------------------------------------------
+
+	it("connects, lists tools, and prints JSON for a stdio server", async () => {
+		mockProbeTools.mockResolvedValue({
+			tools: [
+				{ name: "tool_a", title: "Tool A", description: "Does A" },
+				{ name: "tool_b", description: "Does B" },
+			],
+			needsAuth: false,
+		})
+		mockStdin(JSON.stringify(STDIO_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json).toEqual({
+			tools: [
+				{ name: "tool_a", title: "Tool A", description: "Does A" },
+				{ name: "tool_b", title: undefined, description: "Does B" },
+			],
+			needsAuth: false,
+			error: null,
+		})
+		expect(mockProbeTools).toHaveBeenCalledTimes(1)
+		expect(mockCloseAll).toHaveBeenCalledTimes(1)
+	})
+
+	// --- needsAuth without OAuth (returns needsAuth: true) ----------------
+
+	it("returns needsAuth: true when server needs auth but OAuth is not supported", async () => {
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: true })
+		mockSupportsOAuth.mockReturnValue(false)
+		mockStdin(JSON.stringify(URL_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json).toEqual({ tools: [], needsAuth: true, error: null })
+		expect(mockAuthenticate).not.toHaveBeenCalled()
+	})
+
+	// --- OAuth flow: auth succeeds, retries probe --------------------------
+
+	it("attempts OAuth flow and retries probe when needsAuth + OAuth supported", async () => {
+		mockSupportsOAuth.mockReturnValue(true)
+		mockAuthenticate.mockResolvedValue("authenticated")
+
+		// First probe returns needsAuth, second probe (after auth) returns tools
+		mockProbeTools
+			.mockResolvedValueOnce({ tools: [], needsAuth: true })
+			.mockResolvedValueOnce({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(JSON.stringify(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
+		expect(mockAuthenticate).toHaveBeenCalledWith(
+			expect.stringMatching(/^__probe_\d+$/),
+			OAUTH_SERVER.url,
+			OAUTH_SERVER,
+		)
+		expect(mockProbeTools).toHaveBeenCalledTimes(2)
+		expect(out.json).toEqual({
+			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
+			needsAuth: false,
+			error: null,
+		})
+	})
+
+	// --- OAuth flow: auth fails, returns needsAuth: true ------------------
+
+	it("returns needsAuth: true when OAuth flow fails", async () => {
+		mockSupportsOAuth.mockReturnValue(true)
+		mockAuthenticate.mockRejectedValue(new Error("user denied"))
+
+		// Auth fails immediately — no retry probe should happen.
+		mockProbeTools.mockResolvedValueOnce({ tools: [], needsAuth: true })
+
+		mockStdin(JSON.stringify(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
+		expect(mockProbeTools).toHaveBeenCalledTimes(1)
+		expect(out.json).toEqual({ tools: [], needsAuth: true, error: null })
+	})
+
+	// --- OAuth flow: auth times out, returns needsAuth: true --------------
+
+	it("returns needsAuth: true when OAuth flow times out", async () => {
+		vi.useFakeTimers()
+		try {
+			mockSupportsOAuth.mockReturnValue(true)
+			// authenticate never resolves — simulates user walking away
+			mockAuthenticate.mockReturnValue(new Promise(() => {}))
+			mockProbeTools.mockResolvedValueOnce({ tools: [], needsAuth: true })
+
+			mockStdin(JSON.stringify(OAUTH_SERVER))
+			const out = captureStdout()
+
+			const probePromise = runMcp(["probe", "--json"])
+			// Advance past the 60s OAuth timeout
+			await vi.advanceTimersByTimeAsync(60_000)
+			const code = await probePromise
+
+			expect(code).toBe(0)
+			expect(out.json).toEqual({ tools: [], needsAuth: true, error: null })
+		} finally {
+			vi.useRealTimers()
+		}
+	})
+
+	// --- error handling ---------------------------------------------------
+
+	it("returns exit code 1 with error JSON when probe throws", async () => {
+		mockProbeTools.mockRejectedValue(new Error("connection refused"))
+		mockStdin(JSON.stringify(STDIO_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json).toEqual({
+			tools: [],
+			needsAuth: false,
+			error: "connection refused",
+		})
+		expect(mockCloseAll).toHaveBeenCalledTimes(1)
+	})
+
+	it("returns exit code 1 when stdin is not valid JSON", async () => {
+		mockStdin("not json {{{")
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json.error).toContain("Failed to parse JSON")
+	})
+
+	// --- cleanup ----------------------------------------------------------
+
+	it("always calls closeAll in the finally block", async () => {
+		mockProbeTools.mockRejectedValue(new Error("boom"))
+		mockStdin(JSON.stringify(STDIO_SERVER))
+
+		await runMcp(["probe", "--json"])
+		expect(mockCloseAll).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -166,7 +166,7 @@ describe("kimchi mcp probe", () => {
 		expect(code).toBe(0)
 		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
 		expect(mockAuthenticate).toHaveBeenCalledWith(
-			expect.stringMatching(/^__probe_\d+$/),
+			expect.stringMatching(/^__probe_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/),
 			OAUTH_SERVER.url,
 			OAUTH_SERVER,
 		)

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -48,7 +48,7 @@ async function runProbe(args: string[]): Promise<number> {
 	const json = args.includes("--json")
 
 	if (!json) {
-		return emitError("--json flag is required", null)
+		return await emitError("--json flag is required", null)
 	}
 
 	// Read server config from stdin
@@ -56,7 +56,7 @@ async function runProbe(args: string[]): Promise<number> {
 	try {
 		input = await readStdin()
 	} catch (err) {
-		return emitError("Failed to read stdin", err)
+		return await emitError("Failed to read stdin", err)
 	}
 
 	let name: string
@@ -66,15 +66,15 @@ async function runProbe(args: string[]): Promise<number> {
 		name = parsed.name
 		definition = parsed.server
 	} catch (err) {
-		return emitError("Failed to parse JSON from stdin", err)
+		return await emitError("Failed to parse JSON from stdin", err)
 	}
 
 	if (!name) {
-		return emitError("Input must include a 'name' field", null)
+		return await emitError("Input must include a 'name' field", null)
 	}
 
 	if (!definition.command && !definition.url) {
-		return emitError("Server config must have either 'command' or 'url'", null)
+		return await emitError("Server config must have either 'command' or 'url'", null)
 	}
 
 	// Non-OAuth servers: 15 second timeout.
@@ -100,7 +100,7 @@ async function runProbe(args: string[]): Promise<number> {
 				await withTimeout(authenticate(name, definition.url, definition), timeoutMs, "OAuth flow timed out")
 			} catch {
 				// Auth failed or timed out — return needsAuth: true, no retry.
-				return emitResult({ tools: [], needsAuth: true, error: null })
+				return await emitResult({ tools: [], needsAuth: true, error: null })
 			}
 
 			// Retry probe after successful auth, reusing the same name so the
@@ -117,9 +117,9 @@ async function runProbe(args: string[]): Promise<number> {
 			needsAuth: result.needsAuth,
 			error: null,
 		}
-		return emitResult(output)
+		return await emitResult(output)
 	} catch (err) {
-		return emitError(err instanceof Error ? err.message : String(err), null)
+		return await emitError(err instanceof Error ? err.message : String(err), null)
 	} finally {
 		await manager.closeAll().catch(() => {})
 	}
@@ -165,12 +165,19 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
 	})
 }
 
-function emitResult(result: ProbeResult): number {
-	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
-	return result.error === null ? 0 : 1
+function emitResult(result: ProbeResult): Promise<number> {
+	return new Promise<number>((resolve, reject) => {
+		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`, (err) => {
+			if (err) {
+				reject(err)
+			} else {
+				resolve(result.error === null ? 0 : 1)
+			}
+		})
+	})
 }
 
-function emitError(message: string, err: unknown): number {
+function emitError(message: string, err: unknown): Promise<number> {
 	return emitResult({
 		tools: [],
 		needsAuth: false,

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -98,9 +98,12 @@ async function runProbe(args: string[]): Promise<number> {
 		if (result.needsAuth && isOAuthCapable && definition.url) {
 			try {
 				await withTimeout(authenticate(name, definition.url, definition), timeoutMs, "OAuth flow timed out")
-			} catch {
-				// Auth failed or timed out — return needsAuth: true, no retry.
-				return await emitResult({ tools: [], needsAuth: true, error: null })
+			} catch (err) {
+				// Auth failed or timed out — return needsAuth: true with the real
+				// error message so the UI can display it. Exit 0 because the probe
+				// ran successfully; the user just needs to authorize.
+				const message = err instanceof Error ? err.message : String(err)
+				return await emitResult({ tools: [], needsAuth: true, error: message }, 0)
 			}
 
 			// Retry probe after successful auth, reusing the same name so the
@@ -117,7 +120,7 @@ async function runProbe(args: string[]): Promise<number> {
 			needsAuth: result.needsAuth,
 			error: null,
 		}
-		return await emitResult(output)
+		return await emitResult(output, 0)
 	} catch (err) {
 		return await emitError(err instanceof Error ? err.message : String(err), null)
 	} finally {
@@ -165,22 +168,25 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
 	})
 }
 
-function emitResult(result: ProbeResult): Promise<number> {
+function emitResult(result: ProbeResult, exitCode: number): Promise<number> {
 	return new Promise<number>((resolve, reject) => {
 		process.stdout.write(`${JSON.stringify(result, null, 2)}\n`, (err) => {
 			if (err) {
 				reject(err)
 			} else {
-				resolve(result.error === null ? 0 : 1)
+				resolve(exitCode)
 			}
 		})
 	})
 }
 
 function emitError(message: string, err: unknown): Promise<number> {
-	return emitResult({
-		tools: [],
-		needsAuth: false,
-		error: message + (err instanceof Error ? `: ${err.message}` : ""),
-	})
+	return emitResult(
+		{
+			tools: [],
+			needsAuth: false,
+			error: message + (err instanceof Error ? `: ${err.message}` : ""),
+		},
+		1,
+	)
 }

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -19,6 +19,9 @@
  * Output: { "tools": [{ "name": "..." }], "needsAuth": false }
  * Exit:   0 on success (including needs-auth), 1 on error
  */
+
+import { Type } from "typebox"
+import { Value } from "typebox/value"
 import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
 import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
 import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
@@ -30,6 +33,27 @@ interface ProbeResult {
 	needsAuth: boolean
 	error: string | null
 }
+
+/**
+ * TypeBox schema for the probe stdin input.
+ *
+ * Validates the `{ name, server }` wrapper structurally:
+ * - `name` must be a non-empty string with no path separators (`/`, `\`)
+ *   or consecutive dots (`..`) — prevents path-traversal attacks.
+ * - `server` accepts the full `ServerEntry` shape with `additionalProperties: true`
+ *   since it is a rich config object.
+ * - Top-level rejects unknown properties (`additionalProperties: false`).
+ */
+const ProbeInputSchema = Type.Object(
+	{
+		name: Type.String({
+			minLength: 1,
+			pattern: "^(?!.*\\.\\.)[^/\\\\]+$",
+		}),
+		server: Type.Object({}, { additionalProperties: true }),
+	},
+	{ additionalProperties: false },
+)
 
 export async function runMcp(args: string[]): Promise<number | undefined> {
 	const subcommand = args[0]
@@ -59,19 +83,24 @@ async function runProbe(args: string[]): Promise<number> {
 		return await emitError("Failed to read stdin", err)
 	}
 
-	let name: string
-	let definition: ServerEntry
+	let parsed: unknown
 	try {
-		const parsed = JSON.parse(input) as { name: string; server: ServerEntry }
-		name = parsed.name
-		definition = parsed.server
+		parsed = JSON.parse(input)
 	} catch (err) {
 		return await emitError("Failed to parse JSON from stdin", err)
 	}
 
-	if (!name) {
-		return await emitError("Input must include a 'name' field", null)
+	if (!Value.Check(ProbeInputSchema, parsed)) {
+		const errors = Value.Errors(ProbeInputSchema, parsed)
+		const first = errors[0]
+		const fieldPath =
+			first.instancePath || `/${(first.params as { requiredProperties?: string[] })?.requiredProperties?.[0] ?? ""}`
+		return await emitError(`Invalid probe input: ${fieldPath} ${first.message}`, null)
 	}
+
+	const validated = parsed as { name: string; server: ServerEntry }
+	const name = validated.name
+	const definition = validated.server
 
 	if (!definition.command && !definition.url) {
 		return await emitError("Server config must have either 'command' or 'url'", null)

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,19 +1,24 @@
 /**
  * `kimchi mcp probe` — transient MCP server tool discovery.
  *
- * Reads a {@link ServerEntry} JSON from stdin, connects to the server
- * using a throwaway {@link McpServerManager} connection, calls
- * `tools/list`, prints the result as JSON to stdout, and exits.
+ * Reads a `{ name: string, server: ServerEntry }` JSON from stdin,
+ * connects to the server using a throwaway {@link McpServerManager}
+ * connection, calls `tools/list`, prints the result as JSON to stdout,
+ * and exits.
+ *
+ * The `name` field is passed to both `probeTools` calls and to
+ * `authenticate` so that a repeat probe of an already-authorized
+ * server finds stored OAuth tokens and skips the browser flow.
  *
  * Used by Kimchi Desktop's MCP server configuration UI to populate a
  * multiselect dropdown of available tools when the user picks
  * "Expose selected tools".
  *
  * Usage:  kimchi mcp probe --json < server-config.json
+ * Input:  { "name": "my-server", "server": { "command": "..." } }
  * Output: { "tools": [{ "name": "..." }], "needsAuth": false }
  * Exit:   0 on success (including needs-auth), 1 on error
  */
-import { randomUUID } from "node:crypto"
 import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
 import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
 import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
@@ -55,11 +60,18 @@ async function runProbe(args: string[]): Promise<number> {
 		return emitError("Failed to read stdin", err)
 	}
 
+	let name: string
 	let definition: ServerEntry
 	try {
-		definition = JSON.parse(input) as ServerEntry
+		const parsed = JSON.parse(input) as { name: string; server: ServerEntry }
+		name = parsed.name
+		definition = parsed.server
 	} catch (err) {
 		return emitError("Failed to parse JSON from stdin", err)
+	}
+
+	if (!name) {
+		return emitError("Input must include a 'name' field", null)
 	}
 
 	if (!definition.command && !definition.url) {
@@ -76,24 +88,25 @@ async function runProbe(args: string[]): Promise<number> {
 
 	const manager = new McpServerManager()
 	try {
-		let result = await withTimeout(manager.probeTools(definition), timeoutMs, timeoutMsg)
+		// Pass the real server name so the token store (keyed by server name)
+		// is shared between the initial probe, authenticate(), and the retry.
+		// A repeat probe of an already-authorized server will find stored
+		// OAuth tokens on the first call and skip the browser flow entirely.
+		let result = await withTimeout(manager.probeTools(definition, name), timeoutMs, timeoutMsg)
 
 		// If the server needs auth and OAuth is supported, attempt the full
 		// OAuth flow (browser redirect + callback) then retry the probe.
-		// Use a stable probe name so the OAuth token store (keyed by server
-		// name) is shared between authenticate() and the retry probe.
 		if (result.needsAuth && isOAuthCapable && definition.url) {
-			const probeName = `__probe_${randomUUID()}`
 			try {
-				await withTimeout(authenticate(probeName, definition.url, definition), timeoutMs, "OAuth flow timed out")
+				await withTimeout(authenticate(name, definition.url, definition), timeoutMs, "OAuth flow timed out")
 			} catch {
 				// Auth failed or timed out — return needsAuth: true, no retry.
 				return emitResult({ tools: [], needsAuth: true, error: null })
 			}
 
-			// Retry probe after successful auth, reusing the same probe name
-			// so the token store has the credentials.
-			result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
+			// Retry probe after successful auth, reusing the same name so the
+			// token store has the credentials.
+			result = await withTimeout(manager.probeTools(definition, name), timeoutMs, timeoutMsg)
 		}
 
 		const output: ProbeResult = {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -48,8 +48,7 @@ async function runProbe(args: string[]): Promise<number> {
 	const json = args.includes("--json")
 
 	if (!json) {
-		process.stderr.write("Error: --json flag is required\n")
-		return 1
+		return emitError("--json flag is required", null)
 	}
 
 	// Read server config from stdin

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,145 @@
+/**
+ * `kimchi mcp probe` — transient MCP server tool discovery.
+ *
+ * Reads a {@link ServerEntry} JSON from stdin, connects to the server
+ * using a throwaway {@link McpServerManager} connection, calls
+ * `tools/list`, prints the result as JSON to stdout, and exits.
+ *
+ * Used by Kimchi Desktop's MCP server configuration UI to populate a
+ * multiselect dropdown of available tools when the user picks
+ * "Expose selected tools".
+ *
+ * Usage:  kimchi mcp probe --json < server-config.json
+ * Output: { "tools": [{ "name": "..." }], "needsAuth": false }
+ * Exit:   0 on success (including needs-auth), 1 on error
+ */
+import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
+import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
+import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
+
+type ProbeTool = Pick<McpTool, "name" | "title" | "description">
+
+interface ProbeResult {
+	tools: ProbeTool[]
+	needsAuth: boolean
+	error: string | null
+}
+
+export async function runMcp(args: string[]): Promise<number | undefined> {
+	const subcommand = args[0]
+
+	if (subcommand === "probe") {
+		return runProbe(args.slice(1))
+	}
+
+	// Future: `kimchi mcp list`, `kimchi mcp status`, etc.
+	process.stderr.write(`Unknown mcp subcommand: ${subcommand ?? "(none)"}\n`)
+	process.stderr.write("Usage: kimchi mcp probe --json < server-config.json\n")
+	return 1
+}
+
+async function runProbe(args: string[]): Promise<number> {
+	const json = args.includes("--json")
+
+	if (!json) {
+		process.stderr.write("Error: --json flag is required\n")
+		return 1
+	}
+
+	// Read server config from stdin
+	let input: string
+	try {
+		input = await readStdin()
+	} catch (err) {
+		return emitError("Failed to read stdin", err)
+	}
+
+	let definition: ServerEntry
+	try {
+		definition = JSON.parse(input) as ServerEntry
+	} catch (err) {
+		return emitError("Failed to parse JSON from stdin", err)
+	}
+
+	if (!definition.command && !definition.url) {
+		return emitError("Server config must have either 'command' or 'url'", null)
+	}
+
+	// Non-OAuth servers: 15 second timeout.
+	// OAuth-capable servers that need auth: 60 second timeout (browser redirect + callback).
+	const isOAuthCapable = supportsOAuth(definition)
+	const timeoutMs = isOAuthCapable ? 60_000 : 15_000
+	const timeoutMsg = isOAuthCapable
+		? "Probe timed out after 60 seconds (including OAuth flow)"
+		: "Probe timed out after 15 seconds"
+
+	const manager = new McpServerManager()
+	try {
+		let result = await withTimeout(manager.probeTools(definition), timeoutMs, timeoutMsg)
+
+		// If the server needs auth and OAuth is supported, attempt the full
+		// OAuth flow (browser redirect + callback) then retry the probe.
+		if (result.needsAuth && isOAuthCapable && definition.url) {
+			const probeName = `__probe_${Date.now()}`
+			try {
+				await withTimeout(authenticate(probeName, definition.url, definition), timeoutMs, "OAuth flow timed out")
+			} catch {
+				// Auth failed or timed out — return needsAuth: true, no retry.
+				return emitResult({ tools: [], needsAuth: true, error: null })
+			}
+
+			// Retry probe after successful auth.
+			result = await withTimeout(manager.probeTools(definition), timeoutMs, timeoutMsg)
+		}
+
+		const output: ProbeResult = {
+			tools: result.tools.map((t) => ({
+				name: t.name,
+				title: t.title,
+				description: t.description,
+			})),
+			needsAuth: result.needsAuth,
+			error: null,
+		}
+		return emitResult(output)
+	} catch (err) {
+		return emitError(err instanceof Error ? err.message : String(err), null)
+	} finally {
+		await manager.closeAll().catch(() => {})
+	}
+}
+
+function readStdin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let data = ""
+		process.stdin.setEncoding("utf8")
+		process.stdin.on("data", (chunk) => {
+			data += chunk
+		})
+		process.stdin.on("end", () => resolve(data))
+		process.stdin.on("error", reject)
+	})
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined
+	const timerPromise = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), ms)
+	})
+	return Promise.race([promise, timerPromise]).finally(() => {
+		if (timer) clearTimeout(timer)
+	})
+}
+
+function emitResult(result: ProbeResult): number {
+	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+	return result.error === null ? 0 : 1
+}
+
+function emitError(message: string, err: unknown): number {
+	return emitResult({
+		tools: [],
+		needsAuth: false,
+		error: message + (err instanceof Error ? `: ${err.message}` : ""),
+	})
+}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -129,10 +129,26 @@ async function runProbe(args: string[]): Promise<number> {
 }
 
 function readStdin(): Promise<string> {
+	const STDIN_TIMEOUT_MS = 5000
+	const STDIN_MAX_BYTES = 1024 * 1024 // 1 MB
+
 	return new Promise((resolve, reject) => {
+		// If stdin is a TTY, there is no piped input — reject immediately so the
+		// process never blocks waiting for data that will never arrive.
+		if (process.stdin.isTTY) {
+			reject(new Error("No input on stdin — pipe a server config in"))
+			return
+		}
+
 		let data = ""
+		let timer: ReturnType<typeof setTimeout> | undefined
+
 		const onData = (chunk: string) => {
 			data += chunk
+			if (Buffer.byteLength(data, "utf8") > STDIN_MAX_BYTES) {
+				cleanup()
+				reject(new Error("stdin input exceeded 1MB"))
+			}
 		}
 		const onEnd = () => {
 			cleanup()
@@ -143,10 +159,18 @@ function readStdin(): Promise<string> {
 			reject(err)
 		}
 		const cleanup = () => {
+			if (timer) clearTimeout(timer)
 			process.stdin.off("data", onData)
 			process.stdin.off("end", onEnd)
 			process.stdin.off("error", onError)
 		}
+
+		// Guard against a parent that opens the pipe but never closes it — the
+		// timeout rejects so the probe cannot hang forever.
+		timer = setTimeout(() => {
+			cleanup()
+			reject(new Error("Timed out after 5000ms waiting for stdin"))
+		}, STDIN_TIMEOUT_MS)
 
 		process.stdin.setEncoding("utf8")
 		process.stdin.on("data", onData)

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -6,9 +6,14 @@
  * connection, calls `tools/list`, prints the result as JSON to stdout,
  * and exits.
  *
- * The `name` field is passed to both `probeTools` calls and to
- * `authenticate` so that a repeat probe of an already-authorized
- * server finds stored OAuth tokens and skips the browser flow.
+ * The `name` field selects the OAuth token-store key. Before any OAuth
+ * write, the probe checks whether an auth entry already exists under that
+ * name for a *different* URL (e.g. the user edited the URL but kept the
+ * name). If so, it probes under a throwaway `__probe_<uuid>` name and
+ * cleans it up afterwards so the real server's stored tokens are never
+ * overwritten. If no entry exists or the URL matches, the real name is used
+ * so a repeat probe of an already-authorized server finds stored OAuth
+ * tokens and skips the browser flow.
  *
  * Used by Kimchi Desktop's MCP server configuration UI to populate a
  * multiselect dropdown of available tools when the user picks
@@ -20,8 +25,10 @@
  * Exit:   0 on success (including needs-auth), 1 on error
  */
 
+import { randomUUID } from "node:crypto"
 import { Type } from "typebox"
 import { Value } from "typebox/value"
+import { getAuthEntry, removeAuthEntry } from "../extensions/mcp-adapter/mcp-auth.js"
 import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
 import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
 import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
@@ -114,19 +121,26 @@ async function runProbe(args: string[]): Promise<number> {
 		? "Probe timed out after 60 seconds (including OAuth flow)"
 		: "Probe timed out after 15 seconds"
 
+	// Guard against URL mismatch in the OAuth token store. The token store is
+	// keyed by server name, so probing a server whose URL was edited (but whose
+	// name stayed the same) would otherwise overwrite the real server's stored
+	// credentials. See {@link resolveProbeName} for the decision rules.
+	const probeName = resolveProbeName(name, definition)
+	const usedThrowaway = probeName !== name
+
 	const manager = new McpServerManager()
 	try {
-		// Pass the real server name so the token store (keyed by server name)
+		// Use `probeName` (the real name or a throwaway) so the token-store key
 		// is shared between the initial probe, authenticate(), and the retry.
-		// A repeat probe of an already-authorized server will find stored
-		// OAuth tokens on the first call and skip the browser flow entirely.
-		let result = await withTimeout(manager.probeTools(definition, name), timeoutMs, timeoutMsg)
+		// A repeat probe of an already-authorized server finds stored OAuth
+		// tokens on the first call and skips the browser flow entirely.
+		let result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
 
 		// If the server needs auth and OAuth is supported, attempt the full
 		// OAuth flow (browser redirect + callback) then retry the probe.
 		if (result.needsAuth && isOAuthCapable && definition.url) {
 			try {
-				await withTimeout(authenticate(name, definition.url, definition), timeoutMs, "OAuth flow timed out")
+				await withTimeout(authenticate(probeName, definition.url, definition), timeoutMs, "OAuth flow timed out")
 			} catch (err) {
 				// Auth failed or timed out — return needsAuth: true with the real
 				// error message so the UI can display it. Exit 0 because the probe
@@ -137,7 +151,7 @@ async function runProbe(args: string[]): Promise<number> {
 
 			// Retry probe after successful auth, reusing the same name so the
 			// token store has the credentials.
-			result = await withTimeout(manager.probeTools(definition, name), timeoutMs, timeoutMsg)
+			result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
 		}
 
 		const output: ProbeResult = {
@@ -154,7 +168,40 @@ async function runProbe(args: string[]): Promise<number> {
 		return await emitError(err instanceof Error ? err.message : String(err), null)
 	} finally {
 		await manager.closeAll().catch(() => {})
+		// Clean up throwaway probe credentials so the token store never
+		// accumulates `__probe_*` entries. Never called for the real name —
+		// real credentials must survive the probe.
+		if (usedThrowaway) {
+			removeAuthEntry(probeName)
+		}
 	}
+}
+
+/**
+ * Decide which name to use as the OAuth token-store key during a probe.
+ *
+ * The token store is keyed by server name. If an auth entry already exists
+ * under `name` for a *different* URL — e.g. the user edited the server's URL
+ * but kept the name — probing with the real name would overwrite the real
+ * server's stored credentials. To avoid that, fall back to a throwaway
+ * `__probe_<uuid>` name whenever the stored URL does not match the probe's
+ * URL; the caller cleans it up with {@link removeAuthEntry} in its `finally`.
+ *
+ * When no entry exists (new server) or the URL matches (repeat probe of an
+ * authorized server), the real name is used so that stored tokens are found
+ * and OAuth is skipped on repeat probes.
+ */
+function resolveProbeName(name: string, definition: ServerEntry): string {
+	const existing = getAuthEntry(name)
+	// No stored entry: new server — use the real name so the first probe
+	// persists tokens under it and a repeat probe finds them.
+	if (!existing) return name
+	// URL matches: repeat probe of an authorized server — reuse the name so
+	// stored tokens are found and the browser flow is skipped.
+	if (existing.serverUrl === definition.url) return name
+	// Entry exists for a different URL — isolate the probe's credentials under
+	// a throwaway name so the real server's tokens are never overwritten.
+	return `__probe_${randomUUID()}`
 }
 
 function readStdin(): Promise<string> {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -13,6 +13,7 @@
  * Output: { "tools": [{ "name": "..." }], "needsAuth": false }
  * Exit:   0 on success (including needs-auth), 1 on error
  */
+import { randomUUID } from "node:crypto"
 import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
 import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
 import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
@@ -79,8 +80,10 @@ async function runProbe(args: string[]): Promise<number> {
 
 		// If the server needs auth and OAuth is supported, attempt the full
 		// OAuth flow (browser redirect + callback) then retry the probe.
+		// Use a stable probe name so the OAuth token store (keyed by server
+		// name) is shared between authenticate() and the retry probe.
 		if (result.needsAuth && isOAuthCapable && definition.url) {
-			const probeName = `__probe_${Date.now()}`
+			const probeName = `__probe_${randomUUID()}`
 			try {
 				await withTimeout(authenticate(probeName, definition.url, definition), timeoutMs, "OAuth flow timed out")
 			} catch {
@@ -88,8 +91,9 @@ async function runProbe(args: string[]): Promise<number> {
 				return emitResult({ tools: [], needsAuth: true, error: null })
 			}
 
-			// Retry probe after successful auth.
-			result = await withTimeout(manager.probeTools(definition), timeoutMs, timeoutMsg)
+			// Retry probe after successful auth, reusing the same probe name
+			// so the token store has the credentials.
+			result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
 		}
 
 		const output: ProbeResult = {
@@ -112,12 +116,27 @@ async function runProbe(args: string[]): Promise<number> {
 function readStdin(): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let data = ""
-		process.stdin.setEncoding("utf8")
-		process.stdin.on("data", (chunk) => {
+		const onData = (chunk: string) => {
 			data += chunk
-		})
-		process.stdin.on("end", () => resolve(data))
-		process.stdin.on("error", reject)
+		}
+		const onEnd = () => {
+			cleanup()
+			resolve(data)
+		}
+		const onError = (err: Error) => {
+			cleanup()
+			reject(err)
+		}
+		const cleanup = () => {
+			process.stdin.off("data", onData)
+			process.stdin.off("end", onEnd)
+			process.stdin.off("error", onError)
+		}
+
+		process.stdin.setEncoding("utf8")
+		process.stdin.on("data", onData)
+		process.stdin.on("end", onEnd)
+		process.stdin.on("error", onError)
 	})
 }
 
@@ -126,6 +145,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
 	const timerPromise = new Promise<never>((_, reject) => {
 		timer = setTimeout(() => reject(new Error(message)), ms)
 	})
+	// Attach a no-op catch to the original promise so that if it rejects
+	// after the timer wins the race, the rejection is not unhandled.
+	promise.catch(() => {})
 	return Promise.race([promise, timerPromise]).finally(() => {
 		if (timer) clearTimeout(timer)
 	})

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -10,6 +10,7 @@ import { runConfig } from "./config.js"
 import { runCursor } from "./cursor.js"
 import { runGsd2 } from "./gsd2.js"
 import { runLogin } from "./login.js"
+import { runMcp } from "./mcp.js"
 import { runOpenClaw } from "./openclaw.js"
 import { runOpenCode } from "./opencode.js"
 import { runResources } from "./resources.js"
@@ -30,6 +31,7 @@ export const COMMANDS: CommandDefinition[] = [
 	{ name: "update", summary: "Check for and install Kimchi/package updates", run: runUpdate },
 	{ name: "config", summary: "Inspect or change kimchi config (e.g. telemetry)", run: runConfig },
 	{ name: "resources", summary: "Enable or disable Kimchi hooks, tools, extensions, and plugins", run: runResources },
+	{ name: "mcp", summary: "MCP server utilities (probe, ...)", run: runMcp },
 	{ name: "version", summary: "Print the kimchi version", run: runVersion },
 ]
 

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -324,6 +324,35 @@ export class McpServerManager {
 		if (connection.inFlight > 0) return false
 		return Date.now() - connection.lastUsedAt > timeoutMs
 	}
+
+	/**
+	 * Probe a server definition: connect transiently, list tools, disconnect.
+	 *
+	 * Unlike {@link connect}, this does NOT cache the connection — it is
+	 * intended for one-shot discovery from the Desktop UI ("which tools
+	 * does this server expose?") before the server is saved to config.
+	 *
+	 * Returns the raw tool list from `tools/list`. On auth failure,
+	 * returns an empty list with `needsAuth: true` so the caller can
+	 * surface an appropriate message.
+	 */
+	async probeTools(definition: ServerDefinition): Promise<{
+		tools: McpTool[]
+		needsAuth: boolean
+	}> {
+		// Reuse the existing connection machinery by creating a temporary
+		// connection under a probe-only name, then closing it immediately.
+		const probeName = `__probe_${Date.now()}`
+		try {
+			const connection = await this.connect(probeName, definition)
+			if (connection.status === "needs-auth") {
+				return { tools: [], needsAuth: true }
+			}
+			return { tools: connection.tools, needsAuth: false }
+		} finally {
+			await this.close(probeName).catch(() => {})
+		}
+	}
 }
 
 /**

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -336,21 +337,26 @@ export class McpServerManager {
 	 * returns an empty list with `needsAuth: true` so the caller can
 	 * surface an appropriate message.
 	 */
-	async probeTools(definition: ServerDefinition): Promise<{
+	async probeTools(
+		definition: ServerDefinition,
+		probeName?: string,
+	): Promise<{
 		tools: McpTool[]
 		needsAuth: boolean
 	}> {
 		// Reuse the existing connection machinery by creating a temporary
 		// connection under a probe-only name, then closing it immediately.
-		const probeName = `__probe_${Date.now()}`
+		// Use a randomUUID to guarantee uniqueness even under fake timers
+		// or rapid successive calls.
+		const name = probeName ?? `__probe_${randomUUID()}`
 		try {
-			const connection = await this.connect(probeName, definition)
+			const connection = await this.connect(name, definition)
 			if (connection.status === "needs-auth") {
 				return { tools: [], needsAuth: true }
 			}
 			return { tools: connection.tools, needsAuth: false }
 		} finally {
-			await this.close(probeName).catch(() => {})
+			await this.close(name).catch(() => {})
 		}
 	}
 }


### PR DESCRIPTION
## Linked issue

Resolves #935

## What does this PR do?

Adds `kimchi mcp probe --json` — a CLI subcommand that reads a `ServerEntry` JSON from stdin, connects transiently to an MCP server, calls `tools/list`, and prints the result as JSON to stdout. Used by Kimchi Desktop's MCP server configuration UI to populate a multiselect dropdown of available tools.

Handles both stdio (command + args, with npx resolution) and URL (StreamableHTTP with SSE fallback) transports. If the server requires OAuth, attempts the full OAuth flow (browser redirect + callback), then retries the probe. OAuth flow is bounded by a 60-second timeout; non-OAuth servers use 15 seconds. On auth failure/timeout, returns `{ tools: [], needsAuth: true, error: null }` with exit code 0.

### Files changed

- **`src/commands/mcp.ts`** — New `runMcp` command handler with `probe` subcommand, OAuth flow, timeouts, and cleanup
- **`src/commands/mcp.test.ts`** — 11 unit tests (argument parsing, stdio probe, OAuth success/failure/timeout, error handling, cleanup)
- **`src/commands/registry.ts`** — Registers the `mcp` command
- **`src/cli.ts`** — Adds `mcp` to the subcommand dispatch list
- **`src/extensions/mcp-adapter/server-manager.ts`** — Adds `probeTools()` method for transient, non-cached tool discovery

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed