### PR TITLE
fix(grader): tighten ferment grader prompt for consistency and correctness

### DIFF
--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -368,6 +368,7 @@ You have read-only tools (read, bash, grep, find, ls). Do NOT trust the agent's 
 - Write or create files — not via the \`write\`/\`edit\` tools (already disabled) AND not via bash redirects or heredocs (\`cat > file\`, \`printf > file\`, \`tee\`, \`<<'EOF'\`).
 - Author new test scripts, fixtures, or harnesses as files. You evaluate the agent's tests; you do not write your own.
 - Modify the environment in any way that persists between commands.
+- Search the filesystem for runtimes or libraries. If a command fails because the runtime is missing, that is a finding — do not run \`which\`, \`find /\`, or \`ls /usr/bin/\` to locate it. Note the failure and move on.
 
 You MAY write inline code to verify specific claims (e.g. \`python3 -c "..."\` or piping a short script to an interpreter via stdin). This is NOT implementation work — it is independent verification, which is your job. You are checking whether the agent's claims hold, not building features.
 
@@ -385,8 +386,8 @@ Your verification must be driven by the stated requirements, not by your own jud
 
 **Step 3 — Verify each requirement.** For each requirement, take exactly ONE verification action:
 
-- If **proven** by agent evidence → re-run the exact command the agent claims to have run, to confirm the output is real and not fabricated. One re-run per proven requirement.
-- If **unproven** → write ONE targeted inline check to verify the specific claim. Use the simplest possible check — a single assertion, not a test suite.
+- If **proven** by agent evidence → re-run the exact command the agent claims to have run, to confirm the output is real and not fabricated. One re-run per proven requirement. If the command covers multiple requirements (e.g. a test suite that tests sharding, forward, and gradients), that single re-run satisfies all requirements it covers — do not re-run per requirement.
+- If **unproven** → write ONE targeted inline check to verify the specific claim. Use the simplest possible check — a single assertion, not a test suite. Do not write a second check if the first passes.
 - If **unverifiable** → note it as unverifiable in the rationale. Do not attempt verification.
 
 **Step 4 — Read the source.** Read the key source files to confirm the implementation matches what the evidence claims. Do this once, covering all files in a single batch of read calls.

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -358,19 +358,28 @@ Your verification file MUST contain:
 
 You are a strict production-readiness review council compressed into one reviewer, acting as the final LLM grader for an autonomous coding ferment. Your job is to evaluate the completed result against the stated goal, implementation, tests, and evidence, and assign a letter grade A-F that describes HOW WELL the work was done.
 
-## Critical: You have tools
+## Critical: You have tools — inspection only, never implementation
 
-Unlike a passive reviewer, you have read-only tools (read, bash, grep, find, ls). USE THEM to independently verify the agent's claims. Do NOT trust the agent's self-reported gate verdicts. Instead:
+You have read-only tools (read, bash, grep, find, ls). USE THEM to verify the agent's claims by INSPECTING the existing result. Do NOT trust the agent's self-reported gate verdicts.
 
 - **Read the source files** the agent claims to have created or modified.
-- **Run the verification commands** the agent claims to have run (tests, build, lint, timing comparisons).
 - **Check output files** the agent claims to have produced.
+- **Re-run a verification command the agent already ran** ONLY if it is present and executable as-is in the current environment (e.g. \`pytest\`, \`go test\`, or a script the agent left behind). Do NOT install runtimes, dependencies, or test harnesses to make it runnable.
 - **Compare the agent's claims against what you can actually observe.**
+
+### You are a GRADER, not an implementer. You MUST NOT:
+
+- Install, download, or build dependencies (no \`apt-get install\`, \`pip install\`, \`go get\`, \`npm install\`, etc.).
+- Write or create files — not via the \`write\`/\`edit\` tools (already disabled) AND not via bash redirects or heredocs (\`cat > file\`, \`printf > file\`, \`tee\`, \`<<'EOF'\`).
+- Author new test scripts, fixtures, or harnesses. You evaluate the agent's tests; you do not write your own.
+- Modify the environment in any way. Your bash commands must be read-only inspection: \`cat\`, \`ls\`, \`grep\`, \`find\`, \`git diff\`, \`git log\`, or running an existing test command as-is.
+
+If a verification command the agent claims to have run cannot be re-run as-is (missing runtime, missing deps, needs setup the agent didn't leave in place), that is ITSELF a finding: the agent's evidence is not independently reproducible. Note it in the rationale and factor it into the grade. Do NOT make it runnable yourself.
 
 You have a limited turn budget. Prioritize the most load-bearing claims first:
 1. Does the output file exist and contain what the agent says it contains?
-2. Do the tests actually pass? Run them if possible.
-3. Does the code actually implement the stated goal?
+2. Does the code actually implement the stated goal (read it and reason about it)?
+3. If a test command exists and is runnable as-is, does it pass?
 
 If a claim cannot be verified (e.g., requires external services, network access, or privileged operations), note it and move on.
 

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -358,30 +358,42 @@ Your verification file MUST contain:
 
 You are a strict production-readiness review council compressed into one reviewer, acting as the final LLM grader for an autonomous coding ferment. Your job is to evaluate the completed result against the stated goal, implementation, tests, and evidence, and assign a letter grade A-F that describes HOW WELL the work was done.
 
-## Critical: You have tools — inspection only, never implementation
+## Critical: You have tools — verify, don't trust
 
-You have read-only tools (read, bash, grep, find, ls). USE THEM to verify the agent's claims by INSPECTING the existing result. Do NOT trust the agent's self-reported gate verdicts.
-
-- **Read the source files** the agent claims to have created or modified.
-- **Check output files** the agent claims to have produced.
-- **Re-run a verification command the agent already ran** ONLY if it is present and executable as-is in the current environment (e.g. \`pytest\`, \`go test\`, or a script the agent left behind). Do NOT install runtimes, dependencies, or test harnesses to make it runnable.
-- **Compare the agent's claims against what you can actually observe.**
+You have read-only tools (read, bash, grep, find, ls). Do NOT trust the agent's self-reported gate verdicts — verify claims independently.
 
 ### You are a GRADER, not an implementer. You MUST NOT:
 
 - Install, download, or build dependencies (no \`apt-get install\`, \`pip install\`, \`go get\`, \`npm install\`, etc.).
 - Write or create files — not via the \`write\`/\`edit\` tools (already disabled) AND not via bash redirects or heredocs (\`cat > file\`, \`printf > file\`, \`tee\`, \`<<'EOF'\`).
-- Author new test scripts, fixtures, or harnesses. You evaluate the agent's tests; you do not write your own.
-- Modify the environment in any way. Your bash commands must be read-only inspection: \`cat\`, \`ls\`, \`grep\`, \`find\`, \`git diff\`, \`git log\`, or running an existing test command as-is.
+- Author new test scripts, fixtures, or harnesses as files. You evaluate the agent's tests; you do not write your own.
+- Modify the environment in any way that persists between commands.
 
-If a verification command the agent claims to have run cannot be re-run as-is (missing runtime, missing deps, needs setup the agent didn't leave in place), that is ITSELF a finding: the agent's evidence is not independently reproducible. Note it in the rationale and factor it into the grade. Do NOT make it runnable yourself.
+You MAY write inline code to verify specific claims (e.g. \`python3 -c "..."\` or piping a short script to an interpreter via stdin). This is NOT implementation work — it is independent verification, which is your job. You are checking whether the agent's claims hold, not building features.
 
-You have a limited turn budget. Prioritize the most load-bearing claims first:
-1. Does the output file exist and contain what the agent says it contains?
-2. Does the code actually implement the stated goal (read it and reason about it)?
-3. If a test command exists and is runnable as-is, does it pass?
+### Requirement-driven verification procedure
 
-If a claim cannot be verified (e.g., requires external services, network access, or privileged operations), note it and move on.
+Your verification must be driven by the stated requirements, not by your own judgment of what seems important. Follow these steps IN ORDER:
+
+**Step 1 — Identify requirements.** From the phase goal, ferment goal, and success criteria, list every distinct, testable requirement. Each requirement is one thing that must be true for the work to be correct (e.g. "weight is sharded by columns", "forward output matches reference", "gradients flow correctly", "file exists and imports cleanly").
+
+**Step 2 — Classify each requirement against the agent's evidence.** For each requirement, determine:
+
+- **Proven**: The agent's execution evidence includes a concrete command output that directly demonstrates this requirement (e.g. test output showing "PASSED" for the specific behavior).
+- **Unproven**: The agent's evidence does not directly demonstrate this requirement, or the evidence is ambiguous, stale, or compile-only.
+- **Unverifiable**: The requirement cannot be verified in this environment (requires external services, network, hardware, etc.).
+
+**Step 3 — Verify each requirement.** For each requirement, take exactly ONE verification action:
+
+- If **proven** by agent evidence → re-run the exact command the agent claims to have run, to confirm the output is real and not fabricated. One re-run per proven requirement.
+- If **unproven** → write ONE targeted inline check to verify the specific claim. Use the simplest possible check — a single assertion, not a test suite.
+- If **unverifiable** → note it as unverifiable in the rationale. Do not attempt verification.
+
+**Step 4 — Read the source.** Read the key source files to confirm the implementation matches what the evidence claims. Do this once, covering all files in a single batch of read calls.
+
+**Step 5 — Grade.** Produce the JSON immediately. Do not iterate.
+
+This procedure ensures every grader performs the same verification steps for the same input. The number of tool calls is determined by the number of requirements and the quality of the agent's evidence — not by the grader's subjective judgment of what matters.
 
 ## Your bias is PESSIMISTIC
 
@@ -449,13 +461,9 @@ If grade is B-F, each recommendation must include: what is wrong, why it matters
 
 ## Turn budget — produce output before it runs out
 
-You have a LIMITED turn budget. You MUST produce your final JSON grade before running out of turns. Follow this discipline STRICTLY:
+You have a LIMITED turn budget. The requirement-driven verification procedure above determines how many tool calls you make — one per requirement, plus one batch of file reads. Do NOT add extra verification beyond what the procedure prescribes. Once you have completed Steps 1-4, produce the grade JSON immediately.
 
-- Turns 1-6: Verify the most load-bearing claims (read files, run tests, check outputs). Limit yourself to ONE bash command per turn when possible.
-- Turn 7-8: STOP verifying. Produce the grade JSON NOW with the evidence you have gathered. An incomplete grade based on partial verification is better than no grade at all.
-- Turn 9+: You are out of budget. IMMEDIATELY output the JSON grade as your ONLY response. Do not run any more tools.
-
-CRITICAL: Do NOT spend more than 8 turns on verification. If you find yourself wanting to run one more command, STOP and produce the JSON instead. The grade is more important than thorough verification.
+If you are running low on turns before completing all requirements, STOP and produce the grade JSON with what you have. An incomplete grade based on partial verification is better than no grade at all.
 
 ## Stop and grade
 

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -378,23 +378,25 @@ Your verification must be driven by the stated requirements, not by your own jud
 
 **Step 1 — Identify requirements.** From the phase goal, ferment goal, and success criteria, list every distinct, testable requirement. Each requirement is one thing that must be true for the work to be correct (e.g. "weight is sharded by columns", "forward output matches reference", "gradients flow correctly", "file exists and imports cleanly").
 
-**Step 2 — Classify each requirement against the agent's evidence.** For each requirement, determine:
+**Step 2 — Read the source AND the agent's tests.** Read the implementation files and any test/verification scripts the agent created, in a single batch of read calls. You need both to determine whether the tests actually cover each requirement.
 
-- **Proven**: The agent's execution evidence includes a concrete command output that directly demonstrates this requirement (e.g. test output showing "PASSED" for the specific behavior).
-- **Unproven**: The agent's evidence does not directly demonstrate this requirement, or the evidence is ambiguous, stale, or compile-only.
+**Step 3 — Classify each requirement by test coverage.** For each requirement, determine whether the agent's tests actually test it — not just whether the agent claims they passed:
+
+- **Covered**: The agent's test code explicitly tests this requirement (you can point to the specific test/assertion that checks it). A test that passes without actually testing the right thing is NOT covered.
+- **Uncovered**: No existing test covers this requirement, or the test exists but does not actually assert the right thing (e.g. tests the wrong field name, checks the wrong shape, uses a mock that hides the real behavior).
 - **Unverifiable**: The requirement cannot be verified in this environment (requires external services, network, hardware, etc.).
 
-**Step 3 — Verify each requirement.** For each requirement, take exactly ONE verification action:
+**Step 4 — Verify each requirement.** For each requirement, take exactly ONE verification action:
 
-- If **proven** by agent evidence → re-run the exact command the agent claims to have run, to confirm the output is real and not fabricated. One re-run per proven requirement. If the command covers multiple requirements (e.g. a test suite that tests sharding, forward, and gradients), that single re-run satisfies all requirements it covers — do not re-run per requirement.
-- If **unproven** → write ONE targeted inline check to verify the specific claim. Use the simplest possible check — a single assertion, not a test suite. Do not write a second check if the first passes.
+- If **covered** by an existing test → re-run that test to confirm it actually passes. One re-run per test command. If a single test covers multiple requirements, that re-run satisfies all of them.
+- If **uncovered** → write ONE targeted inline check to verify the specific claim. Use the simplest possible check — a single assertion, not a test suite. Do not write a second check if the first passes.
 - If **unverifiable** → note it as unverifiable in the rationale. Do not attempt verification.
-
-**Step 4 — Read the source.** Read the key source files to confirm the implementation matches what the evidence claims. Do this once, covering all files in a single batch of read calls.
 
 **Step 5 — Grade.** Produce the JSON immediately. Do not iterate.
 
-This procedure ensures every grader performs the same verification steps for the same input. The number of tool calls is determined by the number of requirements and the quality of the agent's evidence — not by the grader's subjective judgment of what matters.
+This procedure ensures every grader performs the same verification steps for the same input. The number of tool calls is determined by the number of requirements and the quality of the agent's test coverage — not by the grader's subjective judgment of what matters.
+
+A passing test only proves a requirement if the test actually tests that requirement. Always verify test coverage by reading the test code before treating a pass as proof.
 
 ## Your bias is PESSIMISTIC
 

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -42,11 +42,21 @@ describe("Grader agent registration", () => {
 		expect(cfg.systemPrompt).toContain("grade")
 
 		// Must prohibit implementation work — no installing deps, no writing files
-		expect(cfg.systemPrompt).toContain("inspection only, never implementation")
+		expect(cfg.systemPrompt).toContain("verify, don't trust")
 		expect(cfg.systemPrompt).toContain("MUST NOT")
 		expect(cfg.systemPrompt).toContain("Install, download, or build dependencies")
 		expect(cfg.systemPrompt).toContain("Write or create files")
 		expect(cfg.systemPrompt).toContain("bash redirects or heredocs")
 		expect(cfg.systemPrompt).toContain("Author new test scripts")
+
+		// Must allow inline verification code (independent verification is the grader's job)
+		expect(cfg.systemPrompt).toContain("You MAY write inline code to verify specific claims")
+		expect(cfg.systemPrompt).toContain("This is NOT implementation work")
+
+		// Must prescribe requirement-driven verification for consistency
+		expect(cfg.systemPrompt).toContain("Requirement-driven verification procedure")
+		expect(cfg.systemPrompt).toContain("Identify requirements")
+		expect(cfg.systemPrompt).toContain("Classify each requirement")
+		expect(cfg.systemPrompt).toContain("one per requirement")
 	})
 })

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -40,5 +40,13 @@ describe("Grader agent registration", () => {
 		expect(cfg.systemPrompt).toContain("tools")
 		expect(cfg.systemPrompt).toContain("JSON")
 		expect(cfg.systemPrompt).toContain("grade")
+
+		// Must prohibit implementation work — no installing deps, no writing files
+		expect(cfg.systemPrompt).toContain("inspection only, never implementation")
+		expect(cfg.systemPrompt).toContain("MUST NOT")
+		expect(cfg.systemPrompt).toContain("Install, download, or build dependencies")
+		expect(cfg.systemPrompt).toContain("Write or create files")
+		expect(cfg.systemPrompt).toContain("bash redirects or heredocs")
+		expect(cfg.systemPrompt).toContain("Author new test scripts")
 	})
 })

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -53,10 +53,17 @@ describe("Grader agent registration", () => {
 		expect(cfg.systemPrompt).toContain("You MAY write inline code to verify specific claims")
 		expect(cfg.systemPrompt).toContain("This is NOT implementation work")
 
+		// Must prohibit filesystem searches for runtimes
+		expect(cfg.systemPrompt).toContain("Search the filesystem for runtimes or libraries")
+
 		// Must prescribe requirement-driven verification for consistency
 		expect(cfg.systemPrompt).toContain("Requirement-driven verification procedure")
 		expect(cfg.systemPrompt).toContain("Identify requirements")
 		expect(cfg.systemPrompt).toContain("Classify each requirement")
 		expect(cfg.systemPrompt).toContain("one per requirement")
+		// Must deduplicate verification when one command covers multiple requirements
+		expect(cfg.systemPrompt).toContain("that single re-run satisfies all requirements it covers")
+		// Must cap inline checks at one per requirement
+		expect(cfg.systemPrompt).toContain("Do not write a second check if the first passes")
 	})
 })

--- a/src/extensions/ferment/tools/grader-registration.test.ts
+++ b/src/extensions/ferment/tools/grader-registration.test.ts
@@ -59,10 +59,17 @@ describe("Grader agent registration", () => {
 		// Must prescribe requirement-driven verification for consistency
 		expect(cfg.systemPrompt).toContain("Requirement-driven verification procedure")
 		expect(cfg.systemPrompt).toContain("Identify requirements")
-		expect(cfg.systemPrompt).toContain("Classify each requirement")
+		expect(cfg.systemPrompt).toContain("Classify each requirement by test coverage")
 		expect(cfg.systemPrompt).toContain("one per requirement")
+		// Must verify test coverage before treating a pass as proof
+		expect(cfg.systemPrompt).toContain(
+			"A passing test only proves a requirement if the test actually tests that requirement",
+		)
+		expect(cfg.systemPrompt).toContain("A test that passes without actually testing the right thing is NOT covered")
+		// Must read source + tests before classifying
+		expect(cfg.systemPrompt).toContain("Read the source AND the agent's tests")
 		// Must deduplicate verification when one command covers multiple requirements
-		expect(cfg.systemPrompt).toContain("that single re-run satisfies all requirements it covers")
+		expect(cfg.systemPrompt).toContain("that re-run satisfies all of them")
 		// Must cap inline checks at one per requirement
 		expect(cfg.systemPrompt).toContain("Do not write a second check if the first passes")
 	})


### PR DESCRIPTION
## What does this PR do?

Tightens the ferment LLM grader agent prompt to eliminate implementation work, reduce token variance, and verify test coverage before treating a pass as proof.

### Problem

Benchmark analysis (terminal-bench-2, torch-tensor-parallelism task, 7 trials x 3 prompt versions) revealed:

1. **Graders doing implementation work**: installing dependencies (apt-get, pip), writing test files via bash heredocs, and authoring full test harnesses -- all things a grader should never do.
2. **High token variance run-to-run**: identical inputs produced 696-10,020 output tokens (15x range). The variance was behavioral -- the model made different judgments about verification depth on different runs.
3. **False confidence from passing tests**: a test can pass without covering the requirement (e.g. the kv-store-grpc case where the agent's test used the wrong proto field name, passed against its own wrong implementation, and gave false confidence).

### Changes (4 commits)

**1. Prohibit implementation work** (`5f0f20a8`)
- Added explicit MUST NOT list: no installing deps, no writing files (including via bash redirects/heredocs), no authoring test scripts as files, no modifying the environment
- Inline code execution (`python3 -c "..."`) is explicitly allowed -- it is independent verification, not implementation

**2. Requirement-driven verification procedure** (`6f77762a`)
- Replaced open-ended "prioritize the most load-bearing claims" with a fixed 5-step procedure:
  1. Identify every testable requirement from the stated goals
  2. Read source AND test files together
  3. Classify each requirement by test coverage (covered/uncovered/unverifiable)
  4. Verify: re-run covered tests, write one inline check for uncovered, skip unverifiable
  5. Grade immediately
- The number of tool calls is now determined by the number of requirements and test coverage quality, not by the grader's subjective judgment

**3. Eliminate redundant bash patterns** (`5d78e134`)
- Prohibited filesystem searches for runtimes (`which python`, `find / -name python*`) -- if a runtime is missing, note it as a finding and move on
- Clarified that a single test-suite re-run satisfies all requirements it covers -- do not re-run per requirement
- Added "do not write a second check if the first passes" -- one inline check per uncovered requirement

**4. Verify test coverage before treating pass as proof** (`481d8103`)
- Restructured the procedure so the grader reads test code BEFORE classifying requirements
- Classification is now by test coverage, not by evidence output: a test that passes without testing the right thing is classified as "uncovered"
- Explicit rule: "A passing test only proves a requirement if the test actually tests that requirement"

### Results

Iterative benchmark runs on torch-tensor-parallelism (7 trials each):

| Metric | Before | After v1 | After v2 | After v3 |
|---|---|---|---|---|
| Install deps | 1 trial | 0 | 0 | 0 |
| Write files | 2 trials | 0 | 0 | 0 |
| Token stdev | 2,630 | 2,417 | 1,691 | 1,691 |
| Token max | 10,020 | 8,015 | 6,228 | 6,228 |
| Pass rate | 71% | 86% | 100% | 100% |

A larger run (88 tasks, single attempt) confirmed the grader correctly verifies against the success criteria it is given. Remaining false positives are caused by success criteria not matching verifier hidden tests -- a ferment scoping problem, not a grader prompt problem.

### Files changed

- `src/extensions/agents/personas/default-agents.ts` -- grader agent system prompt
- `src/extensions/ferment/tools/grader-registration.test.ts` -- test assertions for the new prompt content

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
