### PR TITLE
feat(teleport): add v hotkey to open workspace in VSCode Remote-SSH

### DIFF
--- a/src/extensions/teleport/commands/remote-sessions.test.ts
+++ b/src/extensions/teleport/commands/remote-sessions.test.ts
@@ -1,5 +1,6 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { SANDBOX_HOME } from "../provisioning/constants.js"
 
 const {
 	authMock,
@@ -14,6 +15,9 @@ const {
 	runTerminalMock,
 	ensureIncludeDirectiveMock,
 	syncSshConfigMock,
+	isVsCodeAvailableMock,
+	launchVsCodeRemoteMock,
+	getSshAliasMock,
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	verifyApiKeyMock: vi.fn(),
@@ -27,6 +31,9 @@ const {
 	runTerminalMock: vi.fn(),
 	ensureIncludeDirectiveMock: vi.fn(),
 	syncSshConfigMock: vi.fn(),
+	isVsCodeAvailableMock: vi.fn(),
+	launchVsCodeRemoteMock: vi.fn(),
+	getSshAliasMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({
@@ -56,6 +63,11 @@ vi.mock("./terminal.js", () => ({ runTerminal: runTerminalMock }))
 vi.mock("../ssh-config/sync.js", () => ({
 	ensureIncludeDirective: ensureIncludeDirectiveMock,
 	syncSshConfig: syncSshConfigMock,
+}))
+vi.mock("../ssh-config/render.js", () => ({ getSshAlias: getSshAliasMock }))
+vi.mock("../vscode.js", () => ({
+	isVsCodeAvailable: isVsCodeAvailableMock,
+	launchVsCodeRemote: launchVsCodeRemoteMock,
 }))
 
 import type { Workspace } from "../../../sandbox/cloud/types.js"
@@ -180,6 +192,9 @@ beforeEach(() => {
 	runTerminalMock.mockReset().mockResolvedValue(undefined)
 	ensureIncludeDirectiveMock.mockReset().mockResolvedValue(undefined)
 	syncSshConfigMock.mockReset().mockResolvedValue(undefined)
+	isVsCodeAvailableMock.mockReset().mockReturnValue(true)
+	launchVsCodeRemoteMock.mockReset().mockReturnValue(undefined)
+	getSshAliasMock.mockReset().mockReturnValue(undefined)
 })
 
 describe("deriveStatus", () => {
@@ -366,6 +381,59 @@ describe("runRemoteSessions", () => {
 		ui.confirm.mockResolvedValue(true)
 		await runRemoteSessions("", ctx)
 		expect(deleteSessionMock).toHaveBeenCalledWith(expect.anything(), "s-1", undefined)
+		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("opens VSCode on action='open-vscode' for a provisioned workspace", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		getSshAliasMock.mockReturnValue("kimchi-alpha")
+		pickRemoteSessionsMock
+			.mockResolvedValueOnce({
+				action: "open-vscode",
+				node: workspaceNode({
+					row: { id: "w-1", name: "alpha", status: "active", sessionCount: 0, host: "host.example" },
+				}),
+			})
+			.mockResolvedValueOnce(undefined)
+		const { ctx } = makeCtx()
+		await runRemoteSessions("", ctx)
+		expect(getSshAliasMock).toHaveBeenCalledWith([expect.objectContaining({ id: "w-1" })], "w-1")
+		expect(isVsCodeAvailableMock).toHaveBeenCalled()
+		expect(launchVsCodeRemoteMock).toHaveBeenCalledWith("kimchi-alpha", `${SANDBOX_HOME}/`)
+		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("warns and does not launch VSCode for an unprovisioned workspace", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		pickRemoteSessionsMock
+			.mockResolvedValueOnce({
+				action: "open-vscode",
+				node: workspaceNode({ row: { id: "w-1", name: "alpha", status: "active", sessionCount: 0 } }),
+			})
+			.mockResolvedValueOnce(undefined)
+		const { ctx, ui } = makeCtx()
+		await runRemoteSessions("", ctx)
+		expect(launchVsCodeRemoteMock).not.toHaveBeenCalled()
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("not provisioned"), "warning")
+		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("warns and does not launch VSCode when 'code' is missing from PATH", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		getSshAliasMock.mockReturnValue("kimchi-alpha")
+		isVsCodeAvailableMock.mockReturnValue(false)
+		pickRemoteSessionsMock
+			.mockResolvedValueOnce({
+				action: "open-vscode",
+				node: workspaceNode({
+					row: { id: "w-1", name: "alpha", status: "active", sessionCount: 0, host: "host.example" },
+				}),
+			})
+			.mockResolvedValueOnce(undefined)
+		const { ctx, ui } = makeCtx()
+		await runRemoteSessions("", ctx)
+		expect(launchVsCodeRemoteMock).not.toHaveBeenCalled()
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Install VS Code or add it to PATH"), "warning")
 		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/extensions/teleport/commands/remote-sessions.test.ts
+++ b/src/extensions/teleport/commands/remote-sessions.test.ts
@@ -15,7 +15,7 @@ const {
 	runTerminalMock,
 	ensureIncludeDirectiveMock,
 	syncSshConfigMock,
-	isVsCodeAvailableMock,
+	resolveVsCodeCommandMock,
 	launchVsCodeRemoteMock,
 	getSshAliasMock,
 } = vi.hoisted(() => ({
@@ -31,7 +31,7 @@ const {
 	runTerminalMock: vi.fn(),
 	ensureIncludeDirectiveMock: vi.fn(),
 	syncSshConfigMock: vi.fn(),
-	isVsCodeAvailableMock: vi.fn(),
+	resolveVsCodeCommandMock: vi.fn(),
 	launchVsCodeRemoteMock: vi.fn(),
 	getSshAliasMock: vi.fn(),
 }))
@@ -66,7 +66,7 @@ vi.mock("../ssh-config/sync.js", () => ({
 }))
 vi.mock("../ssh-config/render.js", () => ({ getSshAlias: getSshAliasMock }))
 vi.mock("../vscode.js", () => ({
-	isVsCodeAvailable: isVsCodeAvailableMock,
+	resolveVsCodeCommand: resolveVsCodeCommandMock,
 	launchVsCodeRemote: launchVsCodeRemoteMock,
 }))
 
@@ -192,7 +192,7 @@ beforeEach(() => {
 	runTerminalMock.mockReset().mockResolvedValue(undefined)
 	ensureIncludeDirectiveMock.mockReset().mockResolvedValue(undefined)
 	syncSshConfigMock.mockReset().mockResolvedValue(undefined)
-	isVsCodeAvailableMock.mockReset().mockReturnValue(true)
+	resolveVsCodeCommandMock.mockReset().mockReturnValue("code")
 	launchVsCodeRemoteMock.mockReset().mockReturnValue(undefined)
 	getSshAliasMock.mockReset().mockReturnValue(undefined)
 })
@@ -384,7 +384,7 @@ describe("runRemoteSessions", () => {
 		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
 	})
 
-	it("opens VSCode on action='open-vscode' for a provisioned workspace", async () => {
+	it("opens VS Code on action='open-vscode' for a provisioned workspace", async () => {
 		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
 		getSshAliasMock.mockReturnValue("kimchi-alpha")
 		pickRemoteSessionsMock
@@ -398,8 +398,8 @@ describe("runRemoteSessions", () => {
 		const { ctx } = makeCtx()
 		await runRemoteSessions("", ctx)
 		expect(getSshAliasMock).toHaveBeenCalledWith([expect.objectContaining({ id: "w-1" })], "w-1")
-		expect(isVsCodeAvailableMock).toHaveBeenCalled()
-		expect(launchVsCodeRemoteMock).toHaveBeenCalledWith("kimchi-alpha", `${SANDBOX_HOME}/`)
+		expect(resolveVsCodeCommandMock).toHaveBeenCalled()
+		expect(launchVsCodeRemoteMock).toHaveBeenCalledWith("code", "kimchi-alpha", `${SANDBOX_HOME}/`)
 		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
 	})
 
@@ -418,10 +418,10 @@ describe("runRemoteSessions", () => {
 		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
 	})
 
-	it("warns and does not launch VSCode when 'code' is missing from PATH", async () => {
+	it("warns and does not launch VS Code when 'code' is missing from PATH", async () => {
 		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
 		getSshAliasMock.mockReturnValue("kimchi-alpha")
-		isVsCodeAvailableMock.mockReturnValue(false)
+		resolveVsCodeCommandMock.mockReturnValue(null)
 		pickRemoteSessionsMock
 			.mockResolvedValueOnce({
 				action: "open-vscode",

--- a/src/extensions/teleport/commands/remote-sessions.ts
+++ b/src/extensions/teleport/commands/remote-sessions.ts
@@ -14,7 +14,7 @@ import type { TeleportContext } from "../types.js"
 import type { RemoteWorkspaceNode } from "../ui/remote-sessions-panel.js"
 import { pickRemoteSessions } from "../ui/remote-sessions-panel.js"
 import type { CombinedStatus, SessionRow } from "../ui/sessions-table.js"
-import { isVsCodeAvailable, launchVsCodeRemote } from "../vscode.js"
+import { launchVsCodeRemote, resolveVsCodeCommand } from "../vscode.js"
 import { assignWorkspaceSlugs } from "../workspace-slugs.js"
 import { runAttachSession } from "./attach.js"
 import { info, refuse, status, warn } from "./errors.js"
@@ -95,12 +95,13 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 				warn(ctx, "This workspace is not provisioned yet — no SSH connection available.")
 				continue
 			}
-			if (!isVsCodeAvailable()) {
-				warn(ctx, "VSCode's 'code' command was not found on PATH. Install VS Code or add it to PATH.")
+			const command = resolveVsCodeCommand()
+			if (!command) {
+				warn(ctx, "VS Code's 'code' command was not found on PATH. Install VS Code or add it to PATH.")
 				continue
 			}
-			launchVsCodeRemote(alias, `${SANDBOX_HOME}/`)
-			info(ctx, "Opening VSCode…")
+			launchVsCodeRemote(command, alias, `${SANDBOX_HOME}/`)
+			info(ctx, "Opening VS Code…")
 			continue
 		}
 

--- a/src/extensions/teleport/commands/remote-sessions.ts
+++ b/src/extensions/teleport/commands/remote-sessions.ts
@@ -6,12 +6,15 @@ import { deleteWorkspace, listWorkspaces } from "../../../sandbox/cloud/workspac
 import { WorkerClient } from "../../../sandbox/worker/client.js"
 import { deleteSession, listSessions } from "../../../sandbox/worker/sessions.js"
 import type { Session } from "../../../sandbox/worker/types.js"
+import { SANDBOX_HOME } from "../provisioning/constants.js"
 import { isVisibleSession } from "../session-filter.js"
+import { getSshAlias } from "../ssh-config/render.js"
 import { ensureIncludeDirective, syncSshConfig } from "../ssh-config/sync.js"
 import type { TeleportContext } from "../types.js"
 import type { RemoteWorkspaceNode } from "../ui/remote-sessions-panel.js"
 import { pickRemoteSessions } from "../ui/remote-sessions-panel.js"
 import type { CombinedStatus, SessionRow } from "../ui/sessions-table.js"
+import { isVsCodeAvailable, launchVsCodeRemote } from "../vscode.js"
 import { assignWorkspaceSlugs } from "../workspace-slugs.js"
 import { runAttachSession } from "./attach.js"
 import { info, refuse, status, warn } from "./errors.js"
@@ -78,6 +81,26 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 			} catch (err) {
 				warn(ctx, `Could not rename workspace: ${err instanceof Error ? err.message : String(err)}`)
 			}
+			continue
+		}
+
+		if (result.action === "open-vscode") {
+			const row = result.node.row
+			if (!row.host) {
+				warn(ctx, "This workspace is not provisioned yet — no SSH connection available.")
+				continue
+			}
+			const alias = getSshAlias(workspaces, row.id)
+			if (!alias) {
+				warn(ctx, "This workspace is not provisioned yet — no SSH connection available.")
+				continue
+			}
+			if (!isVsCodeAvailable()) {
+				warn(ctx, "VSCode's 'code' command was not found on PATH. Install VS Code or add it to PATH.")
+				continue
+			}
+			launchVsCodeRemote(alias, `${SANDBOX_HOME}/`)
+			info(ctx, "Opening VSCode…")
 			continue
 		}
 

--- a/src/extensions/teleport/ssh-config/render.ts
+++ b/src/extensions/teleport/ssh-config/render.ts
@@ -35,13 +35,34 @@ export function renderSshConfig(workspaces: Workspace[], now: Date = new Date())
 	return `${header}\n\n${body}\n`
 }
 
+/**
+ * Filters to provisioned workspaces and assigns each a `kimchi-<slug>` alias.
+ * Both the SSH config renderer and callers like the VSCode launcher share
+ * this so the alias they construct is guaranteed to match the Host block
+ * written to the managed ssh_config file.
+ */
+function getProvisionedAliases(workspaces: Workspace[]): Map<string, string> {
+	const provisioned = workspaces.filter((w) => typeof w.host === "string" && w.host.length > 0)
+	return assignAliases(provisioned)
+}
+
 function renderBlocks(workspaces: Workspace[]): RenderedBlock[] {
 	const provisioned = workspaces.filter((w) => typeof w.host === "string" && w.host.length > 0)
-	const aliases = assignAliases(provisioned)
+	const aliases = getProvisionedAliases(workspaces)
 	return provisioned.map((ws) => ({
 		alias: aliases.get(ws.id) ?? "",
 		body: renderBlock(aliases.get(ws.id) ?? "", ws),
 	}))
+}
+
+/**
+ * Returns the SSH alias (`kimchi-<slug>`) for a provisioned workspace, or
+ * `undefined` when the workspace has no provisioned `host` (nothing to connect
+ * to yet). Uses {@link getProvisionedAliases} so the result always matches the
+ * Host block written to the managed ssh_config.
+ */
+export function getSshAlias(workspaces: Workspace[], workspaceId: string): string | undefined {
+	return getProvisionedAliases(workspaces).get(workspaceId)
 }
 
 function renderBlock(alias: string, ws: Workspace): string {

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -158,6 +158,19 @@ describe("RemoteSessionsPanel", () => {
 			expect(done).toHaveBeenCalledWith({ action: "delete-session", node: treeNodes[0]?.sessions[0] })
 		})
 
+		it("'v' on a workspace resolves action='open-vscode'", () => {
+			const { panel, done } = makePanel()
+			panel.handleInput("v")
+			expect(done).toHaveBeenCalledWith({ action: "open-vscode", node: treeNodes[0] })
+		})
+
+		it("'v' is a no-op on a session entry", () => {
+			const { panel, done } = makePanel()
+			panel.handleInput("j")
+			panel.handleInput("v")
+			expect(done).not.toHaveBeenCalled()
+		})
+
 		it("'r' on a workspace resolves action='rename-workspace'", () => {
 			const { panel, done } = makePanel()
 			panel.handleInput("r")

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -31,6 +31,7 @@ export interface RemoteWorkspaceNode {
 
 export type RemoteSessionsResult =
 	| { action: "open-terminal"; node: RemoteWorkspaceNode }
+	| { action: "open-vscode"; node: RemoteWorkspaceNode }
 	| { action: "delete-workspace"; node: RemoteWorkspaceNode }
 	| { action: "rename-workspace"; node: RemoteWorkspaceNode }
 	| { action: "open-session"; node: RemoteSessionNode }
@@ -169,6 +170,12 @@ export class RemoteSessionsPanel implements Component {
 			}
 			return
 		}
+		if (matchesKey(data, "v")) {
+			const entry = this.entries[this.selectedIndex]
+			if (entry?.kind !== "workspace") return
+			this.done({ action: "open-vscode", node: entry.node })
+			return
+		}
 		if (matchesKey(data, "r")) {
 			const entry = this.entries[this.selectedIndex]
 			if (entry?.kind !== "workspace") return
@@ -279,7 +286,7 @@ export class RemoteSessionsPanel implements Component {
 		}
 
 		lines.push(emptyRow())
-		const hint = "↑/↓ j/k: navigate  enter: open  d: delete  r: rename  esc: close"
+		const hint = "↑/↓ j/k: navigate  enter: open  v: vscode  d: delete  r: rename  esc: close"
 		lines.push(ansiRow(dim(`  ${hint}`), hint.length + 2))
 		lines.push(b(`╰${"─".repeat(innerW)}╯`))
 

--- a/src/extensions/teleport/vscode.test.ts
+++ b/src/extensions/teleport/vscode.test.ts
@@ -1,0 +1,84 @@
+import type { ChildProcess, SpawnOptions, SpawnSyncOptions, SpawnSyncReturns } from "node:child_process"
+import { EventEmitter } from "node:events"
+import { describe, expect, it, vi } from "vitest"
+import { isVsCodeAvailable, launchVsCodeRemote, type VsCodeInternals } from "./vscode.js"
+
+type SpawnSyncLike = NonNullable<VsCodeInternals["_spawnSync"]>
+type SpawnLike = NonNullable<VsCodeInternals["_spawn"]>
+
+/** Minimal fake spawnSync that records the call and returns a fixed status. */
+function makeSpawnSync(status: number | null = 0): {
+	fn: SpawnSyncLike
+	calls: { args: string[]; opts: SpawnSyncOptions }[]
+} {
+	const calls: { args: string[]; opts: SpawnSyncOptions }[] = []
+	const fn = ((_cmd: string, args: string[], opts: SpawnSyncOptions) => {
+		calls.push({ args, opts })
+		const result: SpawnSyncReturns<Buffer | string> = {
+			status,
+			signal: null,
+			stdout: "",
+			stderr: "",
+			pid: 0,
+			output: [],
+		}
+		return result
+	}) as unknown as SpawnSyncLike
+	return { fn, calls }
+}
+
+/** Minimal fake spawn returning a ChildProcess-like stub with unref(). */
+function makeSpawn(): { fn: SpawnLike; calls: { args: string[]; opts: SpawnOptions }[]; child: ChildProcess } {
+	const calls: { args: string[]; opts: SpawnOptions }[] = []
+	const child = Object.assign(new EventEmitter(), {
+		pid: 123,
+		stdout: null,
+		stderr: null,
+		stdin: null,
+		unref: vi.fn(),
+		kill: vi.fn(),
+	}) as unknown as ChildProcess
+	const fn = ((_cmd: string, args: string[], opts: SpawnOptions) => {
+		calls.push({ args, opts })
+		return child
+	}) as unknown as SpawnLike
+	return { fn, calls, child }
+}
+
+describe("isVsCodeAvailable", () => {
+	it("returns true when `code --version` exits 0", () => {
+		const { fn, calls } = makeSpawnSync(0)
+		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(true)
+		expect(calls[0]?.args).toEqual(["--version"])
+		expect(calls[0]?.opts.shell).toBe(true)
+		expect(calls[0]?.opts.stdio).toBe("ignore")
+	})
+
+	it("returns false when `code --version` exits non-zero", () => {
+		const { fn } = makeSpawnSync(127)
+		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(false)
+	})
+
+	it("returns false when spawnSync throws", () => {
+		const fn = (() => {
+			throw new Error("ENOENT")
+		}) as unknown as SpawnSyncLike
+		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(false)
+	})
+})
+
+describe("launchVsCodeRemote", () => {
+	it("spawns `code --remote ssh-remote+<alias> <remotePath>` detached", () => {
+		const { fn, calls } = makeSpawn()
+		launchVsCodeRemote("kimchi-alpha", "/home/sandbox/", { _spawn: fn })
+		expect(calls[0]?.args).toEqual(["--remote", "ssh-remote+kimchi-alpha", "/home/sandbox/"])
+	})
+
+	it("detaches the child and unrefs it so kimchi keeps running", () => {
+		const { fn, calls, child } = makeSpawn()
+		launchVsCodeRemote("kimchi-alpha", "/home/sandbox/", { _spawn: fn })
+		expect(calls[0]?.opts.detached).toBe(true)
+		expect(calls[0]?.opts.stdio).toBe("ignore")
+		expect(vi.mocked(child.unref)).toHaveBeenCalled()
+	})
+})

--- a/src/extensions/teleport/vscode.test.ts
+++ b/src/extensions/teleport/vscode.test.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess, SpawnOptions, SpawnSyncOptions, SpawnSyncReturns } from "node:child_process"
 import { EventEmitter } from "node:events"
 import { describe, expect, it, vi } from "vitest"
-import { isVsCodeAvailable, launchVsCodeRemote, type VsCodeInternals } from "./vscode.js"
+import { isVsCodeAvailable, launchVsCodeRemote, resolveVsCodeCommand, type VsCodeInternals } from "./vscode.js"
 
 type SpawnSyncLike = NonNullable<VsCodeInternals["_spawnSync"]>
 type SpawnLike = NonNullable<VsCodeInternals["_spawn"]>
@@ -9,11 +9,11 @@ type SpawnLike = NonNullable<VsCodeInternals["_spawn"]>
 /** Minimal fake spawnSync that records the call and returns a fixed status. */
 function makeSpawnSync(status: number | null = 0): {
 	fn: SpawnSyncLike
-	calls: { args: string[]; opts: SpawnSyncOptions }[]
+	calls: { cmd: string; args: string[]; opts: SpawnSyncOptions }[]
 } {
-	const calls: { args: string[]; opts: SpawnSyncOptions }[] = []
-	const fn = ((_cmd: string, args: string[], opts: SpawnSyncOptions) => {
-		calls.push({ args, opts })
+	const calls: { cmd: string; args: string[]; opts: SpawnSyncOptions }[] = []
+	const fn = ((cmd: string, args: string[], opts: SpawnSyncOptions) => {
+		calls.push({ cmd, args, opts })
 		const result: SpawnSyncReturns<Buffer | string> = {
 			status,
 			signal: null,
@@ -28,8 +28,12 @@ function makeSpawnSync(status: number | null = 0): {
 }
 
 /** Minimal fake spawn returning a ChildProcess-like stub with unref(). */
-function makeSpawn(): { fn: SpawnLike; calls: { args: string[]; opts: SpawnOptions }[]; child: ChildProcess } {
-	const calls: { args: string[]; opts: SpawnOptions }[] = []
+function makeSpawn(): {
+	fn: SpawnLike
+	calls: { cmd: string; args: string[]; opts: SpawnOptions }[]
+	child: ChildProcess
+} {
+	const calls: { cmd: string; args: string[]; opts: SpawnOptions }[] = []
 	const child = Object.assign(new EventEmitter(), {
 		pid: 123,
 		stdout: null,
@@ -38,28 +42,110 @@ function makeSpawn(): { fn: SpawnLike; calls: { args: string[]; opts: SpawnOptio
 		unref: vi.fn(),
 		kill: vi.fn(),
 	}) as unknown as ChildProcess
-	const fn = ((_cmd: string, args: string[], opts: SpawnOptions) => {
-		calls.push({ args, opts })
+	const fn = ((cmd: string, args: string[], opts: SpawnOptions) => {
+		calls.push({ cmd, args, opts })
 		return child
 	}) as unknown as SpawnLike
 	return { fn, calls, child }
 }
 
-describe("isVsCodeAvailable", () => {
-	it("returns true when `code --version` exits 0", () => {
+describe("resolveVsCodeCommand", () => {
+	it("returns 'code' when `code --version` exits 0", () => {
 		const { fn, calls } = makeSpawnSync(0)
-		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(true)
+		expect(resolveVsCodeCommand({ _spawnSync: fn })).toBe("code")
+		expect(calls[0]?.cmd).toBe("code")
 		expect(calls[0]?.args).toEqual(["--version"])
 		expect(calls[0]?.opts.shell).toBe(true)
 		expect(calls[0]?.opts.stdio).toBe("ignore")
 	})
 
-	it("returns false when `code --version` exits non-zero", () => {
+	it("falls back to 'code-insiders' when `code` exits non-zero", () => {
+		const { calls } = makeSpawnSync(0)
+		// First call (code) fails, second (code-insiders) succeeds.
+		let i = 0
+		const wrapped = ((cmd: string, args: string[], opts: SpawnSyncOptions) => {
+			const result: SpawnSyncReturns<Buffer | string> = {
+				status: i === 0 ? 127 : 0,
+				signal: null,
+				stdout: "",
+				stderr: "",
+				pid: 0,
+				output: [],
+			}
+			calls.push({ cmd, args, opts })
+			i++
+			return result
+		}) as unknown as SpawnSyncLike
+		expect(resolveVsCodeCommand({ _spawnSync: wrapped })).toBe("code-insiders")
+		expect(calls.map((c) => c.cmd)).toEqual(["code", "code-insiders"])
+	})
+
+	it("falls back to 'code-insiders' when `code` throws", () => {
+		const { calls } = makeSpawnSync(0)
+		let i = 0
+		const wrapped = ((cmd: string, args: string[], opts: SpawnSyncOptions) => {
+			calls.push({ cmd, args, opts })
+			if (i === 0) {
+				i++
+				throw new Error("ENOENT")
+			}
+			const result: SpawnSyncReturns<Buffer | string> = {
+				status: 0,
+				signal: null,
+				stdout: "",
+				stderr: "",
+				pid: 0,
+				output: [],
+			}
+			i++
+			return result
+		}) as unknown as SpawnSyncLike
+		expect(resolveVsCodeCommand({ _spawnSync: wrapped })).toBe("code-insiders")
+		expect(calls.map((c) => c.cmd)).toEqual(["code", "code-insiders"])
+	})
+
+	it("returns null when both `code` and `code-insiders` are missing", () => {
+		const { fn } = makeSpawnSync(127)
+		expect(resolveVsCodeCommand({ _spawnSync: fn })).toBeNull()
+	})
+
+	it("returns null when both `code` and `code-insiders` throw", () => {
+		const fn = (() => {
+			throw new Error("ENOENT")
+		}) as unknown as SpawnSyncLike
+		expect(resolveVsCodeCommand({ _spawnSync: fn })).toBeNull()
+	})
+})
+
+describe("isVsCodeAvailable", () => {
+	it("returns true when `code --version` exits 0", () => {
+		const { fn } = makeSpawnSync(0)
+		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(true)
+	})
+
+	it("returns true when `code` is missing but `code-insiders` exits 0", () => {
+		let i = 0
+		const fn = (() => {
+			const result: SpawnSyncReturns<Buffer | string> = {
+				status: i === 0 ? 127 : 0,
+				signal: null,
+				stdout: "",
+				stderr: "",
+				pid: 0,
+				output: [],
+			}
+			i++
+			return result
+		}) as unknown as SpawnSyncLike
+		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(true)
+	})
+
+	it("returns false when both `code` and `code-insiders` exit non-zero", () => {
 		const { fn } = makeSpawnSync(127)
 		expect(isVsCodeAvailable({ _spawnSync: fn })).toBe(false)
 	})
 
-	it("returns false when spawnSync throws", () => {
+	it("returns false when spawnSync throws for both candidates", () => {
 		const fn = (() => {
 			throw new Error("ENOENT")
 		}) as unknown as SpawnSyncLike
@@ -68,15 +154,23 @@ describe("isVsCodeAvailable", () => {
 })
 
 describe("launchVsCodeRemote", () => {
-	it("spawns `code --remote ssh-remote+<alias> <remotePath>` detached", () => {
+	it("spawns `<command> --remote ssh-remote+<alias> <remotePath>` detached", () => {
 		const { fn, calls } = makeSpawn()
-		launchVsCodeRemote("kimchi-alpha", "/home/sandbox/", { _spawn: fn })
+		launchVsCodeRemote("code", "kimchi-alpha", "/home/sandbox/", { _spawn: fn })
+		expect(calls[0]?.cmd).toBe("code")
 		expect(calls[0]?.args).toEqual(["--remote", "ssh-remote+kimchi-alpha", "/home/sandbox/"])
+	})
+
+	it("spawns `code-insiders` when that is the resolved command", () => {
+		const { fn, calls } = makeSpawn()
+		launchVsCodeRemote("code-insiders", "kimchi-beta", "/home/sandbox/", { _spawn: fn })
+		expect(calls[0]?.cmd).toBe("code-insiders")
+		expect(calls[0]?.args).toEqual(["--remote", "ssh-remote+kimchi-beta", "/home/sandbox/"])
 	})
 
 	it("detaches the child and unrefs it so kimchi keeps running", () => {
 		const { fn, calls, child } = makeSpawn()
-		launchVsCodeRemote("kimchi-alpha", "/home/sandbox/", { _spawn: fn })
+		launchVsCodeRemote("code", "kimchi-alpha", "/home/sandbox/", { _spawn: fn })
 		expect(calls[0]?.opts.detached).toBe(true)
 		expect(calls[0]?.opts.stdio).toBe("ignore")
 		expect(vi.mocked(child.unref)).toHaveBeenCalled()

--- a/src/extensions/teleport/vscode.ts
+++ b/src/extensions/teleport/vscode.ts
@@ -9,43 +9,62 @@ export interface VsCodeInternals {
 	_spawn?: typeof spawn
 }
 
-/** Command kimchi shells out to when launching / detecting VSCode. */
-const CODE_CMD = "code"
+/** Commands to probe, in priority order: stable first, then Insiders. */
+const CODE_COMMANDS = ["code", "code-insiders"]
 
-/** VSCode Remote-SSH scheme prefix. */
+/** VS Code Remote-SSH scheme prefix. */
 const REMOTE_SCHEME = "ssh-remote+"
 
 /**
- * Detects whether VSCode's `code` command is available on PATH.
+ * Resolves which `code` command is available on PATH.
  *
- * Uses `shell: true` so it resolves `code.cmd` on Windows and the `code`
- * shell-script shim on macOS/Linux. Best-effort: any failure (non-zero exit,
- * signal, thrown error) is treated as "not available".
+ * Probes `code` first, then falls back to `code-insiders` for users running
+ * the Insiders build. Uses `shell: true` so it resolves `code.cmd` on Windows
+ * and the `code` shell-script shim on macOS/Linux. Best-effort: any failure
+ * (non-zero exit, signal, thrown error) is treated as "not available".
  */
-export function isVsCodeAvailable(internals: VsCodeInternals = {}): boolean {
+export function resolveVsCodeCommand(internals: VsCodeInternals = {}): string | null {
 	const run = internals._spawnSync ?? spawnSync
 	const opts: SpawnSyncOptions = { shell: true, stdio: "ignore", timeout: 5_000 }
-	try {
-		const result = run(CODE_CMD, ["--version"], opts)
-		return result.status === 0
-	} catch {
-		return false
+	for (const cmd of CODE_COMMANDS) {
+		try {
+			const result = run(cmd, ["--version"], opts)
+			if (result.status === 0) return cmd
+		} catch {
+			// try next candidate
+		}
 	}
+	return null
 }
 
 /**
- * Launches VSCode connected to a remote SSH host, opening `remotePath` as the
+ * Detects whether a VS Code command (`code` or `code-insiders`) is available
+ * on PATH. Convenience wrapper around {@link resolveVsCodeCommand}.
+ */
+export function isVsCodeAvailable(internals: VsCodeInternals = {}): boolean {
+	return resolveVsCodeCommand(internals) !== null
+}
+
+/**
+ * Launches VS Code connected to a remote SSH host, opening `remotePath` as the
  * workspace folder. Fire-and-forget: the child is detached and unreffed so
  * it survives the parent and kimchi's TUI keeps running.
  *
  * Uses `shell: true` for the same cross-platform `code` resolution reasons as
- * {@link isVsCodeAvailable}.
+ * {@link resolveVsCodeCommand}.
+ *
+ * @param command The command to launch (from {@link resolveVsCodeCommand}).
  */
-export function launchVsCodeRemote(alias: string, remotePath: string, internals: VsCodeInternals = {}): void {
+export function launchVsCodeRemote(
+	command: string,
+	alias: string,
+	remotePath: string,
+	internals: VsCodeInternals = {},
+): void {
 	const run = internals._spawn ?? spawn
 	const target = `${REMOTE_SCHEME}${alias}`
 	const opts: SpawnOptions = { shell: true, detached: true, stdio: "ignore" }
-	const child = run(CODE_CMD, ["--remote", target, remotePath], opts)
-	// Detach so VSCode outlives kimchi — we neither wait for nor observe it.
+	const child = run(command, ["--remote", target, remotePath], opts)
+	// Detach so VS Code outlives kimchi — we neither wait for nor observe it.
 	child.unref()
 }

--- a/src/extensions/teleport/vscode.ts
+++ b/src/extensions/teleport/vscode.ts
@@ -1,0 +1,51 @@
+import { type SpawnOptions, type SpawnSyncOptions, spawn, spawnSync } from "node:child_process"
+
+/**
+ * Per-invocation hooks so tests can inject fake spawners without touching the
+ * real process table.
+ */
+export interface VsCodeInternals {
+	_spawnSync?: typeof spawnSync
+	_spawn?: typeof spawn
+}
+
+/** Command kimchi shells out to when launching / detecting VSCode. */
+const CODE_CMD = "code"
+
+/** VSCode Remote-SSH scheme prefix. */
+const REMOTE_SCHEME = "ssh-remote+"
+
+/**
+ * Detects whether VSCode's `code` command is available on PATH.
+ *
+ * Uses `shell: true` so it resolves `code.cmd` on Windows and the `code`
+ * shell-script shim on macOS/Linux. Best-effort: any failure (non-zero exit,
+ * signal, thrown error) is treated as "not available".
+ */
+export function isVsCodeAvailable(internals: VsCodeInternals = {}): boolean {
+	const run = internals._spawnSync ?? spawnSync
+	const opts: SpawnSyncOptions = { shell: true, stdio: "ignore", timeout: 5_000 }
+	try {
+		const result = run(CODE_CMD, ["--version"], opts)
+		return result.status === 0
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Launches VSCode connected to a remote SSH host, opening `remotePath` as the
+ * workspace folder. Fire-and-forget: the child is detached and unreffed so
+ * it survives the parent and kimchi's TUI keeps running.
+ *
+ * Uses `shell: true` for the same cross-platform `code` resolution reasons as
+ * {@link isVsCodeAvailable}.
+ */
+export function launchVsCodeRemote(alias: string, remotePath: string, internals: VsCodeInternals = {}): void {
+	const run = internals._spawn ?? spawn
+	const target = `${REMOTE_SCHEME}${alias}`
+	const opts: SpawnOptions = { shell: true, detached: true, stdio: "ignore" }
+	const child = run(CODE_CMD, ["--remote", target, remotePath], opts)
+	// Detach so VSCode outlives kimchi — we neither wait for nor observe it.
+	child.unref()
+}


### PR DESCRIPTION
## Summary

Adds a `v` hotkey to the `/remote-sessions` panel that launches VSCode Remote-SSH connected to the selected workspace's sandbox at `/home/sandbox/`.

- Pressing `v` on a **workspace** entry spawns `code --remote ssh-remote+<alias> /home/sandbox/` as a detached process
- `v` is a no-op on **session** entries (same as `r`)
- Guards on provisioning (no host → warning) and `code` availability (missing → warning with short install hint)
- SSH config is already synced before the panel renders, so no additional trigger needed

https://github.com/user-attachments/assets/66ace46b-9e41-472e-bb1b-64334bd25cc6

## Changes

- **`vscode.ts`** (new): `isVsCodeAvailable()` (cross-platform `code --version` check via `spawnSync` + `shell:true`) and `launchVsCodeRemote()` (detached `spawn` + `unref()`)
- **`render.ts`**: Exported `getSshAlias()`, shared with `renderBlocks` via `getProvisionedAliases()` so the alias always matches the SSH config
- **`remote-sessions-panel.ts`**: Added `{ action: "open-vscode" }` to result union, `v` keybinding, and `v: vscode` in the hint line
- **`remote-sessions.ts`**: `open-vscode` handler — host check → `getSshAlias` → `isVsCodeAvailable` → `launchVsCodeRemote` → info; re-shows picker

## Test plan

- [x] Unit tests: 449 pass (30 files) including 10 new tests
- [x] Typecheck: `tsc --noEmit` clean
- [x] Lint: biome check clean
- [x] Manual: run `/remote-sessions`, press `v` on a provisioned workspace → VSCode opens connected to sandbox
- [ ] Manual: press `v` on unprovisioned workspace → warning shown, no launch
- [x] Manual: shadow `code` with a failing stub → missing-code warning shown

Co-Authored-By: Kimchi <noreply@kimchi.dev>
