### PR TITLE
fix: Ctrl+C cascade state machine (clear → abort → exit)

### DIFF
--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,7 +1,7 @@
 import { Key, matchesKey } from "@earendil-works/pi-tui"
 import { describe, expect, it } from "vitest"
 import { isBareExitAlias } from "./exit-utils.js"
-import { findNextCompatibleModel } from "./ui.js"
+import { ctrlCCascadeDecision, findNextCompatibleModel } from "./ui.js"
 
 // Helper to create a minimal Model mock
 function makeModel(id: string, contextWindow: number, input: string[] = ["text", "image"]) {
@@ -41,6 +41,31 @@ describe("isBareExitAlias", () => {
 		expect(isBareExitAlias("exit now")).toBe(false)
 		expect(isBareExitAlias("please exit")).toBe(false)
 		expect(isBareExitAlias("quit")).toBe(false)
+	})
+})
+
+describe("ctrlCCascadeDecision", () => {
+	it("returns 'clear' when editor has text (regardless of streaming)", () => {
+		expect(ctrlCCascadeDecision(true, true)).toBe("clear")
+		expect(ctrlCCascadeDecision(true, false)).toBe("clear")
+	})
+
+	it("returns 'abort' when no text and agent is streaming", () => {
+		expect(ctrlCCascadeDecision(false, true)).toBe("abort")
+	})
+
+	it("returns 'exit' when no text and agent is idle", () => {
+		expect(ctrlCCascadeDecision(false, false)).toBe("exit")
+	})
+
+	it("cascade ordering: clear takes priority over abort", () => {
+		// Text + streaming → clear first, not abort
+		expect(ctrlCCascadeDecision(true, true)).toBe("clear")
+	})
+
+	it("cascade ordering: abort takes priority over exit", () => {
+		// No text + streaming → abort, not exit
+		expect(ctrlCCascadeDecision(false, true)).toBe("abort")
 	})
 })
 

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -114,18 +114,25 @@ let currentEditor: PromptEditor | undefined
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
 
+// Timestamp of the last Ctrl+C press. Updated on every press so the exit
+// stage measures its 500ms window from the most recent press (abort or
+// clear), not from upstream's lastSigintTime which is only updated when the
+// event reaches upstream's handleCtrlC.
+let lastCtrlCTime = 0
+const CTRL_C_EXIT_WINDOW_MS = 500
+
 /**
  * Pure decision function for the Ctrl+C cascade state machine.
  *
  * Given the current editor and agent state, returns what action to take:
  * - `"clear"` — clear text; let the event flow to upstream's app.clear handler.
  * - `"abort"` — abort the agent; consume the event so upstream doesn't fire.
- * - `"exit"` — let the event flow to upstream's handleCtrlC (exit timer / exit).
+ * - `"exit"` — handle exit in the extension layer (check lastCtrlCTime, shut down if within window).
  *
  * The cascade is:
  *   1. Text exists       → clear text (upstream handles it)
  *   2. No text, streaming → abort agent (consume event)
- *   3. No text, idle      → let upstream handle double-press-to-exit
+ *   3. No text, idle      → check exit timer, shut down if within 500ms of last press
  */
 export type CtrlCAction = "clear" | "abort" | "exit"
 export function ctrlCCascadeDecision(hasText: boolean, isStreaming: boolean): CtrlCAction {
@@ -405,39 +412,51 @@ export default function uiExtension(pi: ExtensionAPI) {
 				// We implement a cascade so Ctrl+C is a single-key workflow:
 				//
 				//   1. Text exists       → clear text (let upstream handle it)
-				//   2. No text, streaming → abort agent (consume so upstream exit timer doesn't fire)
-				//   3. No text, idle      → let upstream handle double-press-to-exit
+				//   2. No text, streaming → abort agent (consume so upstream doesn't fire)
+				//   3. No text, idle      → check own timer, shut down if within 500ms
 				//
-				// The exit-on-double-press timing (500ms) is handled by upstream's
-				// handleCtrlC via its own lastSigintTime variable.
+				// Exit timing is managed entirely in this extension via lastCtrlCTime.
+				// We do NOT rely on upstream's lastSigintTime because the abort stage
+				// consumes the event, preventing upstream from updating its timer.
+				// This avoids a timing gap where a rapid triple-press (clear → abort
+				// → exit) would measure the exit window from the clear press instead
+				// of the abort press.
 				if (matchesKey(data, Key.ctrl("c")) && !isKeyRelease(data)) {
+					const now = Date.now()
 					const hasText = (currentEditor?.getText().trim().length ?? 0) > 0
 					const streaming = currentCtx ? !currentCtx.isIdle() : false
 
 					switch (ctrlCCascadeDecision(hasText, streaming)) {
 						case "clear": {
 							// Stage 1: clear text. Let the event flow to upstream's app.clear
-							// handler (handleCtrlC), which calls clearEditor() and sets
-							// lastSigintTime. Show a hint so the user knows the next press
-							// will abort.
+							// handler (handleCtrlC), which calls clearEditor(). Show a hint
+							// so the user knows the next press will abort.
 							if (streaming) {
 								currentCtx?.ui.setStatus("__ctrl_c_hint", "Ctrl+C again to abort")
 							}
+							lastCtrlCTime = now
 							return undefined // upstream clears text
 						}
 						case "abort": {
 							// Stage 2: abort the agent. Consume the event so upstream's
-							// handleCtrlC doesn't also start its exit timer.
+							// handleCtrlC doesn't fire (would set its own exit timer).
 							currentCtx?.abort()
 							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
+							lastCtrlCTime = now
 							return { consume: true }
 						}
 						case "exit": {
-							// Stage 3: idle + no text. Let upstream handle the exit timer.
-							// Upstream's handleCtrlC checks lastSigintTime; if within 500ms
-							// of the previous press it exits, otherwise it sets the timer.
+							// Stage 3: idle + no text. Check our own timer. If within
+							// 500ms of the previous press (clear or abort), shut down.
+							// Otherwise just arm the timer. Consume the event in both
+							// cases so upstream's handleCtrlC doesn't set a competing
+							// lastSigintTime that could cause a later unintended exit.
 							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
-							return undefined
+							if (now - lastCtrlCTime < CTRL_C_EXIT_WINDOW_MS) {
+								currentCtx?.shutdown()
+							}
+							lastCtrlCTime = now
+							return { consume: true }
 						}
 					}
 				}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -114,6 +114,26 @@ let currentEditor: PromptEditor | undefined
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
 
+/**
+ * Pure decision function for the Ctrl+C cascade state machine.
+ *
+ * Given the current editor and agent state, returns what action to take:
+ * - `"clear"` — clear text; let the event flow to upstream's app.clear handler.
+ * - `"abort"` — abort the agent; consume the event so upstream doesn't fire.
+ * - `"exit"` — let the event flow to upstream's handleCtrlC (exit timer / exit).
+ *
+ * The cascade is:
+ *   1. Text exists       → clear text (upstream handles it)
+ *   2. No text, streaming → abort agent (consume event)
+ *   3. No text, idle      → let upstream handle double-press-to-exit
+ */
+export type CtrlCAction = "clear" | "abort" | "exit"
+export function ctrlCCascadeDecision(hasText: boolean, isStreaming: boolean): CtrlCAction {
+	if (hasText) return "clear"
+	if (isStreaming) return "abort"
+	return "exit"
+}
+
 const branchPoller = createBranchPoller({
 	refreshBranch: (cb) => refreshGitBranch(cb),
 })
@@ -380,14 +400,46 @@ export default function uiExtension(pi: ExtensionAPI) {
 		if (ctx.hasUI) {
 			unsubModelCycleInput = ctx.ui.onTerminalInput((data) => {
 				// In raw-mode terminals Ctrl+C arrives as \x03 rather than raising
-				// SIGINT.  The upstream TUI already maps Escape to abort, but does
-				// not handle Ctrl+C.  Bridge the gap so both keys cancel the active
-				// turn while the agent is working.
+				// SIGINT.  The upstream TUI maps Ctrl+C to app.clear (clear editor /
+				// double-press to exit) and Escape to app.interrupt (abort agent).
+				// We implement a cascade so Ctrl+C is a single-key workflow:
+				//
+				//   1. Text exists       → clear text (let upstream handle it)
+				//   2. No text, streaming → abort agent (consume so upstream exit timer doesn't fire)
+				//   3. No text, idle      → let upstream handle double-press-to-exit
+				//
+				// The exit-on-double-press timing (500ms) is handled by upstream's
+				// handleCtrlC via its own lastSigintTime variable.
 				if (matchesKey(data, Key.ctrl("c")) && !isKeyRelease(data)) {
-					if (currentCtx && !currentCtx.isIdle()) {
-						currentCtx.abort()
+					const hasText = (currentEditor?.getText().trim().length ?? 0) > 0
+					const streaming = currentCtx ? !currentCtx.isIdle() : false
+
+					switch (ctrlCCascadeDecision(hasText, streaming)) {
+						case "clear": {
+							// Stage 1: clear text. Let the event flow to upstream's app.clear
+							// handler (handleCtrlC), which calls clearEditor() and sets
+							// lastSigintTime. Show a hint so the user knows the next press
+							// will abort.
+							if (streaming) {
+								currentCtx?.ui.setStatus("__ctrl_c_hint", "Ctrl+C again to abort")
+							}
+							return undefined // upstream clears text
+						}
+						case "abort": {
+							// Stage 2: abort the agent. Consume the event so upstream's
+							// handleCtrlC doesn't also start its exit timer.
+							currentCtx?.abort()
+							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
+							return { consume: true }
+						}
+						case "exit": {
+							// Stage 3: idle + no text. Let upstream handle the exit timer.
+							// Upstream's handleCtrlC checks lastSigintTime; if within 500ms
+							// of the previous press it exits, otherwise it sets the timer.
+							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
+							return undefined
+						}
 					}
-					return undefined
 				}
 				if (matchesKey(data, "ctrl+p")) {
 					// Defer to a foreground UI that is forwarding raw terminal input
@@ -590,6 +642,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 	})
 	pi.on("turn_end", (_, ctx) => {
 		currentCtx = ctx
+		// Clear any lingering Ctrl+C hint — the agent is no longer streaming
+		// so the cascade's "press again to abort" guidance is stale.
+		if (ctx.hasUI) ctx.ui.setStatus("__ctrl_c_hint", undefined)
 		refresh("idle")
 		if (ctx.hasUI && turnStartMs > 0) {
 			clearTimeout(workedForTimer)

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -114,26 +114,12 @@ let currentEditor: PromptEditor | undefined
 let pasteImageHandler: (() => void) | undefined
 let currentSessionIndicatorText: string | null = null
 
-// Timestamp of the last Ctrl+C press. Updated on every press so the exit
-// stage measures its 500ms window from the most recent press (abort or
-// clear), not from upstream's lastSigintTime which is only updated when the
-// event reaches upstream's handleCtrlC.
+// Own timer for the exit stage — upstream's lastSigintTime isn't updated when
+// the abort stage consumes the event, so we can't rely on it.
 let lastCtrlCTime = 0
 const CTRL_C_EXIT_WINDOW_MS = 500
 
-/**
- * Pure decision function for the Ctrl+C cascade state machine.
- *
- * Given the current editor and agent state, returns what action to take:
- * - `"clear"` — clear text; let the event flow to upstream's app.clear handler.
- * - `"abort"` — abort the agent; consume the event so upstream doesn't fire.
- * - `"exit"` — handle exit in the extension layer (check lastCtrlCTime, shut down if within window).
- *
- * The cascade is:
- *   1. Text exists       → clear text (upstream handles it)
- *   2. No text, streaming → abort agent (consume event)
- *   3. No text, idle      → check exit timer, shut down if within 500ms of last press
- */
+/** Cascade: text → clear, streaming → abort, otherwise → exit. */
 export type CtrlCAction = "clear" | "abort" | "exit"
 export function ctrlCCascadeDecision(hasText: boolean, isStreaming: boolean): CtrlCAction {
 	if (hasText) return "clear"
@@ -406,21 +392,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 		if (unsubModelCycleInput) unsubModelCycleInput()
 		if (ctx.hasUI) {
 			unsubModelCycleInput = ctx.ui.onTerminalInput((data) => {
-				// In raw-mode terminals Ctrl+C arrives as \x03 rather than raising
-				// SIGINT.  The upstream TUI maps Ctrl+C to app.clear (clear editor /
-				// double-press to exit) and Escape to app.interrupt (abort agent).
-				// We implement a cascade so Ctrl+C is a single-key workflow:
-				//
-				//   1. Text exists       → clear text (let upstream handle it)
-				//   2. No text, streaming → abort agent (consume so upstream doesn't fire)
-				//   3. No text, idle      → check own timer, shut down if within 500ms
-				//
-				// Exit timing is managed entirely in this extension via lastCtrlCTime.
-				// We do NOT rely on upstream's lastSigintTime because the abort stage
-				// consumes the event, preventing upstream from updating its timer.
-				// This avoids a timing gap where a rapid triple-press (clear → abort
-				// → exit) would measure the exit window from the clear press instead
-				// of the abort press.
+				// Ctrl+C cascade: clear text → abort agent → exit app.
+				// The exit stage is handled here (not upstream) because the abort
+				// stage consumes the event, leaving upstream's lastSigintTime stale.
 				if (matchesKey(data, Key.ctrl("c")) && !isKeyRelease(data)) {
 					const now = Date.now()
 					const hasText = (currentEditor?.getText().trim().length ?? 0) > 0
@@ -428,29 +402,22 @@ export default function uiExtension(pi: ExtensionAPI) {
 
 					switch (ctrlCCascadeDecision(hasText, streaming)) {
 						case "clear": {
-							// Stage 1: clear text. Let the event flow to upstream's app.clear
-							// handler (handleCtrlC), which calls clearEditor(). Show a hint
-							// so the user knows the next press will abort.
+							// Let upstream clearEditor() via app.clear.
 							if (streaming) {
 								currentCtx?.ui.setStatus("__ctrl_c_hint", "Ctrl+C again to abort")
 							}
 							lastCtrlCTime = now
-							return undefined // upstream clears text
+							return undefined
 						}
 						case "abort": {
-							// Stage 2: abort the agent. Consume the event so upstream's
-							// handleCtrlC doesn't fire (would set its own exit timer).
+							// Consume so upstream's handleCtrlC doesn't fire.
 							currentCtx?.abort()
 							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
 							lastCtrlCTime = now
 							return { consume: true }
 						}
 						case "exit": {
-							// Stage 3: idle + no text. Check our own timer. If within
-							// 500ms of the previous press (clear or abort), shut down.
-							// Otherwise just arm the timer. Consume the event in both
-							// cases so upstream's handleCtrlC doesn't set a competing
-							// lastSigintTime that could cause a later unintended exit.
+							// Check own timer; consume so upstream doesn't set a competing lastSigintTime.
 							currentCtx?.ui.setStatus("__ctrl_c_hint", undefined)
 							if (now - lastCtrlCTime < CTRL_C_EXIT_WINDOW_MS) {
 								currentCtx?.shutdown()


### PR DESCRIPTION
## Problem

When the agent is working and the user navigates through previous messages with up/down arrows, pressing Ctrl+C to clean the input box also aborts the agent — requiring a "please continue" prompt afterward.

## Root cause

In `src/extensions/ui.ts`, the global `onTerminalInput` listener intercepted Ctrl+C (`\x03`) and called `currentCtx.abort()` when the agent was streaming, but returned plain `undefined` instead of `{ consume: true }`. Since `undefined` doesn't stop propagation in pi-tui's `handleInput`, the event flowed through to upstream's `app.clear` handler (`handleCtrlC()`) which cleared the editor text. So Ctrl+C **simultaneously** aborted the agent AND cleared text.

## Solution

Replaced the single-shot abort with a cascading state machine:

| State | Action | Event handling |
|-------|--------|----------------|
| Text exists | Clear text | Let event flow to upstream `app.clear` |
| No text, streaming | Abort agent | Consume event (`{ consume: true }`) |
| No text, idle | Exit timer | Check own 500ms timer, shut down if within window |

The exit timing is managed entirely in the extension layer via `lastCtrlCTime` (updated on every press), not upstream's `lastSigintTime`, to avoid a timing gap where the abort press consumes the event without updating upstream's timer.

A status hint "Ctrl+C again to abort" is shown after the first press clears text while the agent is streaming, and is cleared on `turn_end`.

The decision logic is extracted into a pure function `ctrlCCascadeDecision(hasText, isStreaming)` for testability. ESC behavior is unchanged (immediate abort, no text clearing).

## Test plan

- [x] Added unit tests for `ctrlCCascadeDecision` covering all state transitions
- [ ] Manual test: type text while agent streaming → Ctrl+C clears text → Ctrl+C again aborts → Ctrl+C again exits
- [ ] Manual test: idle + text → Ctrl+C clears → Ctrl+C exits (preserved behavior)
- [ ] Manual test: streaming + no text → Ctrl+C aborts → Ctrl+C exits

Closes #944