### PR TITLE
fix(todos): deliver early nudge as steer instead of follow-up

### DIFF
--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -392,6 +392,18 @@ describe("early todo nudge", () => {
 		expect(harness.sendMessage).toHaveBeenCalledTimes(1)
 	})
 
+	it("delivers the nudge as a steer, never a follow-up", async () => {
+		const harness = createTodosHarness()
+		const ctx = createContext("session", [])
+		await harness.fire("session_start", { reason: "new" }, ctx)
+
+		for (let i = 0; i < 10; i++) {
+			await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+		}
+
+		expect(vi.mocked(harness.sendMessage).mock.calls[0]?.[1]).toEqual({ deliverAs: "steer" })
+	})
+
 	it("does not fire when the model creates a todo list before the threshold", async () => {
 		const harness = createTodosHarness()
 		const ctx = createContext("session", [])

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -167,7 +167,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 			const count = getWorkToolCalls(sessionId)
 			if (count >= TODO_EARLY_NUDGE_THRESHOLD) {
 				markTodoNudgeFired(sessionId)
-				pi.sendMessage(hiddenTodoMessage(TODO_EARLY_NUDGE_MESSAGE), { deliverAs: "followUp" })
+				pi.sendMessage(hiddenTodoMessage(TODO_EARLY_NUDGE_MESSAGE), { deliverAs: "steer" })
 			}
 		}
 


### PR DESCRIPTION
## Summary

The early todo nudge was sent with `deliverAs: "followUp"`, which drains
only once the agent would otherwise stop — forcing an extra assistant
message on top of the final answer. In headless `-p` sessions this
replaces the result the caller expects with chit-chat about todos.

Switch to `deliverAs: "steer"`, which drains at the end of the current
tool round. The model sees the suggestion before composing its final
answer and can act on it in the same turn — which is what the nudge text
already asks for ("pair the create_todos call with your next work tool
call in the same turn"). The nudge still reaches the model; only the
forced-reply side effect is gone.

## Changes

- `src/extensions/todos/index.ts` — change `deliverAs: "followUp"` → `"steer"`
- `src/extensions/todos/index.test.ts` — regression test asserting the delivery mode is `{ deliverAs: "steer" }`

## Type of change

- [x] Bug fix