### PR TITLE
feat(acp): register _kimchi.dev/probeMcpServer ACP extMethod handler

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -13,9 +13,10 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if ! echo "$PR_BODY" | grep -iE "(closes|fixes|resolves) #[0-9]+" > /dev/null; then
+          if ! echo "$PR_BODY" | grep -iE "(closes|fixes|resolves) ([a-z0-9_-]+/[a-z0-9_-]+)?#[0-9]+" > /dev/null; then
             echo "❌ No linked issue found in PR description."
             echo "Add one of: 'Closes #N', 'Fixes #N', or 'Resolves #N'"
+            echo "Cross-repo links like 'Closes org/repo#N' are also accepted."
             exit 1
           fi
           echo "✅ Linked issue found."

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -621,7 +621,8 @@ try {
 
 		if (IS_ACP_MODE) {
 			const { runAcpMode } = await import("./modes/acp/server.js")
-			await runAcpMode({ extensionFactories, agentDir })
+			const { McpServerManager } = await import("./extensions/mcp-adapter/server-manager.js")
+			await runAcpMode({ extensionFactories, agentDir, mcpServerManager: new McpServerManager() })
 		} else {
 			// Delegate to pi-mono's CLI main function, injecting the kimchi extension
 			const { main } = await import("@earendil-works/pi-coding-agent")

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -244,7 +244,7 @@ describe("kimchi mcp probe", () => {
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(0)
 		expect(out.json.error).toBeNull()
-		expect(mockProbeTools).toHaveBeenCalledWith(STDIO_SERVER, "github.com")
+		expect(mockProbeTools).toHaveBeenCalledWith("github.com", STDIO_SERVER)
 	})
 
 	it("returns 1 when unknown top-level properties are present", async () => {
@@ -351,7 +351,7 @@ describe("kimchi mcp probe", () => {
 			error: null,
 		})
 		expect(mockProbeTools).toHaveBeenCalledTimes(1)
-		expect(mockProbeTools).toHaveBeenCalledWith(STDIO_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, STDIO_SERVER)
 		expect(mockCloseAll).toHaveBeenCalledTimes(1)
 	})
 
@@ -388,8 +388,8 @@ describe("kimchi mcp probe", () => {
 		expect(mockAuthenticate).toHaveBeenCalledTimes(1)
 		expect(mockAuthenticate).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
 		expect(mockProbeTools).toHaveBeenCalledTimes(2)
-		expect(mockProbeTools).toHaveBeenNthCalledWith(1, OAUTH_SERVER, SERVER_NAME)
-		expect(mockProbeTools).toHaveBeenNthCalledWith(2, OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenNthCalledWith(1, SERVER_NAME, OAUTH_SERVER)
+		expect(mockProbeTools).toHaveBeenNthCalledWith(2, SERVER_NAME, OAUTH_SERVER)
 		expect(out.json).toEqual({
 			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
 			needsAuth: false,
@@ -413,7 +413,7 @@ describe("kimchi mcp probe", () => {
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(0)
 		expect(mockProbeTools).toHaveBeenCalledTimes(1)
-		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
 		expect(mockAuthenticate).not.toHaveBeenCalled()
 		expect(out.json).toEqual({
 			tools: [{ name: "secure_tool", title: undefined, description: undefined }],
@@ -571,6 +571,23 @@ describe("kimchi mcp probe", () => {
 		expect(parsed.error).toBeNull()
 	})
 
+	// --- inline-error routing (probeTools no longer throws) ------------
+
+	// After the merge, probeTools returns connect/tool errors inline via
+	// `result.error` instead of throwing. The CLI must still surface those as
+	// exit-1 failures so the UI can display them (preserving the pre-unification
+	// contract where a connection failure was a thrown error).
+	it("surfaces a probeTools inline error as exit code 1 without throwing", async () => {
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: "Connection refused" })
+		mockStdin(probeInput(STDIO_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(1)
+		expect(out.json).toEqual({ tools: [], needsAuth: false, error: "Connection refused" })
+		expect(mockCloseAll).toHaveBeenCalledTimes(1)
+	})
+
 	// --- URL mismatch guard (OAuth token store key) ----------------------
 
 	it("uses the real name and does not clean up when an auth entry with a matching URL exists", async () => {
@@ -588,7 +605,7 @@ describe("kimchi mcp probe", () => {
 		expect(code).toBe(0)
 		expect(out.json.error).toBeNull()
 		// Real name used for both probe and (not invoked) auth.
-		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
 		expect(mockAuthenticate).not.toHaveBeenCalled()
 		// No cleanup — real credentials must survive the probe.
 		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
@@ -613,14 +630,14 @@ describe("kimchi mcp probe", () => {
 		expect(out.json.error).toBeNull()
 
 		// Both probeTools calls and authenticate received the throwaway name.
-		const firstCallArg = mockProbeTools.mock.calls[0]?.[1]
-		const secondCallArg = mockProbeTools.mock.calls[1]?.[1]
+		const firstCallArg = mockProbeTools.mock.calls[0]?.[0]
+		const secondCallArg = mockProbeTools.mock.calls[1]?.[0]
 		const authNameArg = mockAuthenticate.mock.calls[0]?.[0]
 		expect(firstCallArg).toMatch(/^__probe_[0-9a-f-]{36}$/)
 		expect(secondCallArg).toBe(firstCallArg)
 		expect(authNameArg).toBe(firstCallArg)
 		// The real name was never used as the token-store key.
-		expect(mockProbeTools).not.toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).not.toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
 		expect(mockAuthenticate).not.toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
 		// Throwaway credentials cleaned up in the finally block.
 		expect(mockRemoveAuthEntry).toHaveBeenCalledTimes(1)
@@ -640,7 +657,7 @@ describe("kimchi mcp probe", () => {
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(0)
 		expect(out.json.error).toBeNull()
-		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
 		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
 	})
 
@@ -664,7 +681,7 @@ describe("kimchi mcp probe", () => {
 		expect(out.json.error).toBeNull()
 
 		// The real name (SERVER_NAME) was never passed as the token-store key.
-		const probeNames = mockProbeTools.mock.calls.map((c) => c[1])
+		const probeNames = mockProbeTools.mock.calls.map((c) => c[0])
 		expect(probeNames).not.toContain(SERVER_NAME)
 		expect(mockAuthenticate).not.toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER.url, OAUTH_SERVER)
 		// Throwaway name was cleaned up exactly once.
@@ -686,7 +703,7 @@ describe("kimchi mcp probe", () => {
 		const code = await runMcp(["probe", "--json"])
 		expect(code).toBe(0)
 		expect(mockProbeTools).toHaveBeenCalledTimes(1)
-		expect(mockProbeTools).toHaveBeenCalledWith(OAUTH_SERVER, SERVER_NAME)
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
 		expect(mockAuthenticate).not.toHaveBeenCalled()
 		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
 		expect(out.json).toEqual({

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -134,7 +134,13 @@ async function runProbe(args: string[]): Promise<number> {
 		// is shared between the initial probe, authenticate(), and the retry.
 		// A repeat probe of an already-authorized server finds stored OAuth
 		// tokens on the first call and skips the browser flow entirely.
-		let result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
+		let result = await withTimeout(manager.probeTools(probeName, definition), timeoutMs, timeoutMsg)
+		// probeTools returns errors inline via `result.error` (it does not throw
+		// on connect/tools failures) — surface those as exit-1 failures so the UI
+		// can display them, preserving the pre-unification contract.
+		if (result.error) {
+			return await emitError(result.error, null)
+		}
 
 		// If the server needs auth and OAuth is supported, attempt the full
 		// OAuth flow (browser redirect + callback) then retry the probe.
@@ -151,7 +157,10 @@ async function runProbe(args: string[]): Promise<number> {
 
 			// Retry probe after successful auth, reusing the same name so the
 			// token store has the credentials.
-			result = await withTimeout(manager.probeTools(definition, probeName), timeoutMs, timeoutMsg)
+			result = await withTimeout(manager.probeTools(probeName, definition), timeoutMs, timeoutMsg)
+			if (result.error) {
+				return await emitError(result.error, null)
+			}
 		}
 
 		const output: ProbeResult = {

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -101,9 +101,12 @@ export async function startAuth(
 		}
 	}
 
-	// Start the callback server.
-	// Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
-	await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
+	// Start the callback server with strict port binding. The redirect URI
+	// is tied to the port — if the port changes between registrations, the
+	// OAuth server rejects the callback with "redirect_uri not registered".
+	// Always use the default port (19876) so dynamic client registration
+	// stays consistent across attempts.
+	await ensureCallbackServer({ strictPort: true })
 
 	// Generate and store OAuth state BEFORE creating the provider.
 	// The SDK calls provider.state() (not saveState) to read the state when

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -105,8 +105,10 @@ export async function startAuth(
 	// Pre-registered OAuth clients require an exact redirect URI, so enforce strict port binding.
 	await ensureCallbackServer({ strictPort: Boolean(config.clientId) })
 
-	// Generate and store OAuth state BEFORE creating the provider
-	// The SDK will call provider.state() to read this value
+	// Generate and store OAuth state BEFORE creating the provider.
+	// The SDK calls provider.state() (not saveState) to read the state when
+	// constructing the authorization URL — it expects the state to already
+	// be stored. We generate it here so it's available when the SDK needs it.
 	const oauthState = generateState()
 	await updateOAuthState(serverName, oauthState)
 
@@ -194,10 +196,15 @@ export async function authenticate(
 			return "authenticated"
 		}
 
-		// Get the state that was already generated and stored in startAuth()
-		const oauthState = await getOAuthState(serverName)
+		// Read the OAuth state stored by the SDK during startAuth().
+		// The SDK calls provider.saveState() during client.connect() when it
+		// initiates the authorization code flow. If the SDK didn't save a state
+		// (e.g. the UnauthorizedError was thrown before saveState was called),
+		// generate one ourselves so the callback can be validated.
+		let oauthState = await getOAuthState(serverName)
 		if (!oauthState) {
-			throw new Error("OAuth state not found - this should not happen")
+			oauthState = generateState()
+			await updateOAuthState(serverName, oauthState)
 		}
 
 		// Register the callback BEFORE opening the browser

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -199,15 +199,14 @@ export async function authenticate(
 			return "authenticated"
 		}
 
-		// Read the OAuth state stored by the SDK during startAuth().
-		// The SDK calls provider.saveState() during client.connect() when it
-		// initiates the authorization code flow. If the SDK didn't save a state
-		// (e.g. the UnauthorizedError was thrown before saveState was called),
-		// generate one ourselves so the callback can be validated.
-		let oauthState = await getOAuthState(serverName)
+		// Read the OAuth state stored by startAuth() (line ~107) and/or
+		// by the SDK via provider.saveState() during client.connect().
+		// At least one of these paths always saves state before we reach
+		// here — startAuth() pre-generates it, and provider.state()
+		// auto-generates if missing — so this is always defined.
+		const oauthState = await getOAuthState(serverName)
 		if (!oauthState) {
-			oauthState = generateState()
-			await updateOAuthState(serverName, oauthState)
+			throw new Error("OAuth state was not saved during startAuth")
 		}
 
 		// Register the callback BEFORE opening the browser
@@ -337,10 +336,21 @@ export async function getValidToken(serverName: string, serverUrl: string): Prom
 /**
  * Check the authentication status for a server.
  *
+ * If `serverUrl` is provided, stored tokens are validated against it —
+ * tokens saved for a different URL are treated as not_authenticated
+ * so the caller can re-authenticate.
+ *
  * @param serverName - The name of the MCP server
+ * @param serverUrl - Optional URL to validate stored tokens against
  * @returns The current auth status
  */
-export async function getAuthStatus(serverName: string): Promise<AuthStatus> {
+export async function getAuthStatus(serverName: string, serverUrl?: string): Promise<AuthStatus> {
+	if (serverUrl) {
+		const entry = getAuthForUrl(serverName, serverUrl)
+		if (!entry?.tokens) return "not_authenticated"
+		const expired = isTokenExpired(serverName)
+		return expired ? "expired" : "authenticated"
+	}
 	const hasTokens = await hasStoredTokens(serverName)
 	if (!hasTokens) return "not_authenticated"
 

--- a/src/extensions/mcp-adapter/mcp-auth.ts
+++ b/src/extensions/mcp-adapter/mcp-auth.ts
@@ -5,7 +5,9 @@
  * and PKCE state for MCP servers. Maintains backward compatibility with
  * per-server directory structure.
  *
- * Token storage location: ~/.pi/agent/mcp-oauth/<server>/tokens.json
+ * Token storage location: <agent-dir>/mcp-oauth/<server>/tokens.json
+ * (where <agent-dir> is determined by getAgentDir(), typically
+ * ~/.config/kimchi/harness/ when run via the CLI entry point)
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"

--- a/src/extensions/mcp-adapter/mcp-oauth-provider.ts
+++ b/src/extensions/mcp-adapter/mcp-oauth-provider.ts
@@ -5,6 +5,7 @@
  * Handles OAuth client registration, token storage, and authorization redirection.
  */
 
+import { randomUUID } from "node:crypto"
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
 	OAuthClientInformation,
@@ -240,17 +241,23 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
 	/**
 	 * Get the stored OAuth state parameter.
-	 * @throws Error if no state is stored
+	 * If no state is stored, generates and saves one on-the-fly.
+	 * @throws Error if state cannot be stored
 	 */
 	async state(): Promise<string> {
 		if (this.usesClientCredentials) {
 			throw new Error("state is not used for client_credentials flow")
 		}
 		const entry = await getAuthEntry(this.serverName)
-		if (!entry?.oauthState) {
-			throw new Error(`No OAuth state saved for MCP server: ${this.serverName}`)
+		if (entry?.oauthState) {
+			return entry.oauthState
 		}
-		return entry.oauthState
+		// No state saved yet — generate one now so the SDK can use it
+		// in the authorization URL. This happens when probeTools() creates
+		// a transport directly (without going through startAuth()).
+		const state = randomUUID()
+		updateOAuthState(this.serverName, state)
+		return state
 	}
 
 	/**

--- a/src/extensions/mcp-adapter/mcp-oauth-provider.ts
+++ b/src/extensions/mcp-adapter/mcp-oauth-provider.ts
@@ -241,20 +241,22 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
 	/**
 	 * Get the stored OAuth state parameter.
-	 * If no state is stored, generates and saves one on-the-fly.
-	 * @throws Error if state cannot be stored
+	 *
+	 * If no state is stored (e.g. when `probeTools()` creates a transport
+	 * directly without going through `startAuth()`), generates and saves
+	 * one on-the-fly so the SDK can include it in the authorization URL.
+	 *
+	 * @throws Error if `grantType` is `client_credentials`
 	 */
 	async state(): Promise<string> {
 		if (this.usesClientCredentials) {
 			throw new Error("state is not used for client_credentials flow")
 		}
-		const entry = await getAuthEntry(this.serverName)
+		const entry = getAuthEntry(this.serverName)
 		if (entry?.oauthState) {
 			return entry.oauthState
 		}
-		// No state saved yet — generate one now so the SDK can use it
-		// in the authorization URL. This happens when probeTools() creates
-		// a transport directly (without going through startAuth()).
+		// No state saved yet — generate one on-the-fly.
 		const state = randomUUID()
 		updateOAuthState(this.serverName, state)
 		return state

--- a/src/extensions/mcp-adapter/server-manager.test.ts
+++ b/src/extensions/mcp-adapter/server-manager.test.ts
@@ -1,0 +1,340 @@
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Shared mock functions — these persist across tests. The Client mock factory
+// references them, so vi.clearAllMocks() won't strip the implementation.
+const mockConnect = vi.fn()
+const mockListTools = vi.fn()
+const mockClose = vi.fn()
+const mockSetNotificationHandler = vi.fn()
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: vi.fn().mockImplementation(() => ({
+		connect: mockConnect,
+		listTools: mockListTools,
+		close: mockClose,
+		setNotificationHandler: mockSetNotificationHandler,
+	})),
+}))
+
+// Mock StdioClientTransport and SSEClientTransport so they don't spawn processes
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+	StdioClientTransport: vi.fn().mockImplementation(() => ({
+		close: vi.fn().mockResolvedValue(undefined),
+	})),
+}))
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+	SSEClientTransport: vi.fn().mockImplementation(() => ({
+		close: vi.fn().mockResolvedValue(undefined),
+	})),
+}))
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+	StreamableHTTPClientTransport: vi.fn().mockImplementation(() => ({
+		close: vi.fn().mockResolvedValue(undefined),
+	})),
+}))
+
+// Mock supportsOAuth
+vi.mock("./mcp-auth-flow.js", () => ({
+	supportsOAuth: vi.fn(),
+}))
+
+// Mock McpOAuthProvider
+vi.mock("./mcp-oauth-provider.js", () => ({
+	McpOAuthProvider: vi.fn(),
+}))
+
+// Mock resolveNpxBinary
+vi.mock("./npx-resolver.js", () => ({
+	resolveNpxBinary: vi.fn().mockResolvedValue(null),
+}))
+
+// Mock logger
+vi.mock("./logger.js", () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// Import after mocks
+import { supportsOAuth } from "./mcp-auth-flow.js"
+import { McpServerManager } from "./server-manager.js"
+
+describe("McpServerManager.probeTools", () => {
+	let manager: McpServerManager
+
+	beforeEach(() => {
+		// Reset call history but keep implementations intact
+		mockConnect.mockReset()
+		mockListTools.mockReset()
+		mockClose.mockReset()
+		mockSetNotificationHandler.mockReset()
+		vi.mocked(supportsOAuth).mockReset()
+
+		// Set defaults — most tests expect these
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		mockClose.mockResolvedValue(undefined)
+
+		manager = new McpServerManager()
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("returns tools from a successful probe (stdio server)", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		mockListTools.mockResolvedValue({
+			tools: [
+				{ name: "tool_a", description: "Does A", inputSchema: { type: "object" } },
+				{ name: "tool_b", title: "B Tool", description: "Does B" },
+			],
+			nextCursor: undefined,
+		})
+
+		const result = await manager.probeTools("test-server", { command: "echo", args: ["hello"] })
+
+		expect(result.tools).toHaveLength(2)
+		expect(result.tools[0].name).toBe("tool_a")
+		expect(result.tools[0].description).toBe("Does A")
+		expect(result.tools[0].inputSchema).toEqual({ type: "object" })
+		expect(result.tools[1].name).toBe("tool_b")
+		expect(result.tools[1].title).toBe("B Tool")
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toBeNull()
+
+		expect(mockClose).toHaveBeenCalled()
+	})
+
+	it("returns needsAuth when UnauthorizedError occurs during connect (OAuth server)", async () => {
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		mockConnect.mockRejectedValue(new UnauthorizedError("Unauthorized"))
+
+		const result = await manager.probeTools("oauth-server", {
+			url: "https://mcp.example.com",
+			auth: "oauth",
+		})
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(true)
+		expect(result.error).toBeNull()
+		// client.close is NOT called here because the UnauthorizedError is thrown
+		// during createTransport (createHttpTransport's internal test client),
+		// before probeTools' own client is connected — so there's nothing to close.
+	})
+
+	it("returns error string when connect throws a non-OAuth error", async () => {
+		mockConnect.mockRejectedValue(new Error("Connection refused"))
+
+		const result = await manager.probeTools("bad-server", { command: "nonexistent-cmd" })
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toBe("Connection refused")
+		expect(mockClose).toHaveBeenCalled()
+	})
+
+	it("returns error string for non-Error exceptions", async () => {
+		mockConnect.mockRejectedValue("string error")
+
+		const result = await manager.probeTools("bad-server", { command: "nonexistent-cmd" })
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toBe("string error")
+	})
+
+	it("returns error when server has no command or url", async () => {
+		const result = await manager.probeTools("empty-server", {})
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toContain("no command or url")
+	})
+
+	it("cleans up client and transport in finally block on success", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		mockListTools.mockResolvedValue({ tools: [], nextCursor: undefined })
+
+		await manager.probeTools("cleanup-test", { command: "echo" })
+
+		expect(mockClose).toHaveBeenCalled()
+	})
+
+	it("cleans up client and transport in finally block on error", async () => {
+		mockConnect.mockRejectedValue(new Error("boom"))
+
+		await manager.probeTools("cleanup-error-test", { command: "echo" })
+
+		expect(mockClose).toHaveBeenCalled()
+	})
+
+	it("maps tool fields correctly from McpTool to ProbeMcpTool", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		mockListTools.mockResolvedValue({
+			tools: [
+				{
+					name: "complex_tool",
+					title: "Complex",
+					description: "A complex tool",
+					inputSchema: { type: "object", properties: {} },
+					annotations: { readOnlyHint: true },
+					_meta: { custom: "data" },
+				},
+			],
+			nextCursor: undefined,
+		})
+
+		const result = await manager.probeTools("mapping-test", { command: "echo" })
+
+		expect(result.tools).toHaveLength(1)
+		expect(result.tools[0]).toEqual({
+			name: "complex_tool",
+			title: "Complex",
+			description: "A complex tool",
+			inputSchema: { type: "object", properties: {} },
+			annotations: { readOnlyHint: true },
+		})
+		// _meta should NOT be forwarded to ProbeMcpTool
+		expect("_meta" in result.tools[0]).toBe(false)
+	})
+
+	it("handles pagination in fetchAllTools (nextCursor)", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		let callCount = 0
+		mockListTools.mockImplementation(() => {
+			callCount++
+			if (callCount === 1) {
+				return Promise.resolve({
+					tools: [{ name: "page1_tool" }],
+					nextCursor: "cursor-1",
+				})
+			}
+			return Promise.resolve({
+				tools: [{ name: "page2_tool" }],
+				nextCursor: undefined,
+			})
+		})
+
+		const result = await manager.probeTools("paginated-server", { command: "echo" })
+
+		expect(result.tools).toHaveLength(2)
+		expect(result.tools[0].name).toBe("page1_tool")
+		expect(result.tools[1].name).toBe("page2_tool")
+		expect(mockListTools).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe("McpServerManager.createTransport (via probeTools)", () => {
+	beforeEach(() => {
+		mockConnect.mockReset()
+		mockListTools.mockReset()
+		mockClose.mockReset()
+		vi.mocked(supportsOAuth).mockReset()
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		mockClose.mockResolvedValue(undefined)
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("throws when server has no command or url", async () => {
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("bad", {})
+
+		expect(result.tools).toEqual([])
+		expect(result.error).toContain("no command or url")
+	})
+
+	it("creates stdio transport for command-based servers", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		mockListTools.mockResolvedValue({ tools: [], nextCursor: undefined })
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("stdio-test", {
+			command: "echo",
+			args: ["test"],
+			env: { FOO: "bar" },
+		})
+
+		expect(result.error).toBeNull()
+		expect(mockConnect).toHaveBeenCalled()
+	})
+})
+
+describe("withTimeout (indirectly via probeTools)", () => {
+	beforeEach(() => {
+		mockConnect.mockReset()
+		mockListTools.mockReset()
+		mockClose.mockReset()
+		vi.mocked(supportsOAuth).mockReset()
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		mockClose.mockResolvedValue(undefined)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+	})
+
+	it("resolves normally when the operation completes before the deadline", async () => {
+		mockConnect.mockResolvedValue(undefined)
+		mockListTools.mockResolvedValue({ tools: [{ name: "fast_tool" }], nextCursor: undefined })
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("fast-server", { command: "echo" })
+
+		expect(result.tools).toHaveLength(1)
+		expect(result.error).toBeNull()
+	})
+
+	it("times out when connect takes longer than the budget", async () => {
+		// Simulate a connect that never resolves — should time out after 15s
+		mockConnect.mockReturnValue(new Promise(() => {}))
+
+		vi.useFakeTimers()
+		const manager = new McpServerManager()
+		const probePromise = manager.probeTools("slow-server", { command: "echo" })
+
+		// Advance past the 15s non-OAuth timeout
+		await vi.advanceTimersByTimeAsync(16_000)
+
+		const result = await probePromise
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toContain("timed out")
+		expect(mockClose).toHaveBeenCalled()
+	})
+
+	it("uses a single deadline for both connect and tools/list", async () => {
+		// Verifies Finding 3: budget is per-probe, not per-operation.
+		// If connect consumes most of the 15s budget, tools/list gets the remainder.
+		vi.useFakeTimers()
+
+		// Connect takes 14s (leaving 1s out of 15s budget)
+		let connectResolve!: () => void
+		const connectPromise = new Promise<void>((resolve) => {
+			connectResolve = resolve
+		})
+		mockConnect.mockReturnValue(connectPromise)
+		// tools/list returns a never-resolving promise so it can't win the race
+		mockListTools.mockReturnValue(new Promise(() => {}))
+
+		const manager = new McpServerManager()
+		const probePromise = manager.probeTools("deadline-test", { command: "echo" })
+
+		// Advance 14s — connect resolves
+		await vi.advanceTimersByTimeAsync(14_000)
+		connectResolve()
+		await vi.waitFor(() => expect(mockListTools).toHaveBeenCalled())
+
+		// Only 1s left — advance 2s to trigger timeout on tools/list
+		await vi.advanceTimersByTimeAsync(2_000)
+		const result = await probePromise
+
+		expect(result.error).toContain("timed out")
+		expect(mockClose).toHaveBeenCalled()
+	})
+})

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -12,6 +11,8 @@ import { resolveNpxBinary } from "./npx-resolver.js"
 import type {
 	McpResource,
 	McpTool,
+	ProbeMcpTool,
+	ProbeResult,
 	ServerDefinition,
 	ServerEntry,
 	ServerStreamResultPatchNotification,
@@ -63,11 +64,12 @@ export class McpServerManager {
 		}
 	}
 
-	private async createConnection(name: string, definition: ServerDefinition): Promise<ServerConnection> {
-		const client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
-
-		let transport: Transport
-
+	/**
+	 * Create the transport (stdio or HTTP) for a server definition. Shared by
+	 * createConnection() and probeTools() so npx resolution, env interpolation,
+	 * and OAuth/bearer setup live in exactly one place.
+	 */
+	private async createTransport(name: string, definition: ServerDefinition): Promise<Transport> {
 		if (definition.command) {
 			let command = definition.command
 			let args = definition.args ?? []
@@ -81,19 +83,23 @@ export class McpServerManager {
 				}
 			}
 
-			transport = new StdioClientTransport({
+			return new StdioClientTransport({
 				command,
 				args,
 				env: resolveEnv(definition.env),
 				cwd: definition.cwd,
 				stderr: definition.debug ? "inherit" : "ignore",
 			})
-		} else if (definition.url) {
-			// HTTP transport with fallback
-			transport = await this.createHttpTransport(definition as ServerEntry & { url: string }, name)
-		} else {
-			throw new Error(`Server ${name} has no command or url`)
 		}
+		if (definition.url) {
+			return this.createHttpTransport(definition as ServerEntry & { url: string }, name)
+		}
+		throw new Error(`Server ${name} has no command or url`)
+	}
+
+	private async createConnection(name: string, definition: ServerDefinition): Promise<ServerConnection> {
+		const client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
+		const transport = await this.createTransport(name, definition)
 
 		try {
 			await client.connect(transport)
@@ -327,37 +333,95 @@ export class McpServerManager {
 	}
 
 	/**
-	 * Probe a server definition: connect transiently, list tools, disconnect.
+	 * Probe an MCP server for available tools without persisting a connection.
 	 *
-	 * Unlike {@link connect}, this does NOT cache the connection — it is
-	 * intended for one-shot discovery from the Desktop UI ("which tools
-	 * does this server expose?") before the server is saved to config.
+	 * Creates a transient connection via the shared createTransport() helper,
+	 * calls tools/list, handles OAuth flow if needed, closes the connection, and
+	 * returns the tool list.
 	 *
-	 * Returns the raw tool list from `tools/list`. On auth failure,
-	 * returns an empty list with `needsAuth: true` so the caller can
-	 * surface an appropriate message.
+	 * - OAuth servers: 60s timeout (allows browser-based auth flow)
+	 * - Non-OAuth servers: 15s timeout
+	 *
+	 * The transient connection is never registered in `this.connections`, so it
+	 * doesn't interfere with the normal connection lifecycle. Both client and
+	 * transport are closed in a finally block regardless of outcome.
 	 */
-	async probeTools(
-		definition: ServerDefinition,
-		probeName?: string,
-	): Promise<{
-		tools: McpTool[]
-		needsAuth: boolean
-	}> {
-		// Reuse the existing connection machinery by creating a temporary
-		// connection under a probe-only name, then closing it immediately.
-		// Use a randomUUID to guarantee uniqueness even under fake timers
-		// or rapid successive calls.
-		const name = probeName ?? `__probe_${randomUUID()}`
+	async probeTools(name: string, definition: ServerDefinition): Promise<ProbeResult> {
+		const isOAuth = supportsOAuth(definition)
+		const totalBudgetMs = isOAuth ? 60_000 : 15_000
+		// Single deadline for the entire probe operation (connect + tools/list),
+		// not per-operation, so an OAuth probe can't run 120s (60s connect + 60s
+		// tools/list) — it gets a single 60s budget from start to finish.
+		const deadline = Date.now() + totalBudgetMs
+
+		const client = new Client({ name: `pi-mcp-probe-${name}`, version: "1.0.0" })
+		let transport: Transport
+
 		try {
-			const connection = await this.connect(name, definition)
-			if (connection.status === "needs-auth") {
-				return { tools: [], needsAuth: true }
+			transport = await this.createTransport(name, definition)
+		} catch (error) {
+			if (error instanceof UnauthorizedError) {
+				return { tools: [], needsAuth: true, error: null }
 			}
-			return { tools: connection.tools, needsAuth: false }
-		} finally {
-			await this.close(name).catch(() => {})
+			return {
+				tools: [],
+				needsAuth: false,
+				error: error instanceof Error ? error.message : String(error),
+			}
 		}
+
+		try {
+			await withTimeout(client.connect(transport), deadline)
+			this.attachAdapterNotificationHandlers(name, client)
+
+			const tools = await withTimeout(this.fetchAllTools(client), deadline)
+			const probeTools: ProbeMcpTool[] = tools.map((t) => ({
+				name: t.name,
+				title: t.title,
+				description: t.description,
+				inputSchema: t.inputSchema,
+				annotations: t.annotations,
+			}))
+
+			return { tools: probeTools, needsAuth: false, error: null }
+		} catch (error) {
+			if (error instanceof UnauthorizedError) {
+				return { tools: [], needsAuth: true, error: null }
+			}
+			return {
+				tools: [],
+				needsAuth: false,
+				error: error instanceof Error ? error.message : String(error),
+			}
+		} finally {
+			await client.close().catch(() => {})
+			await transport.close().catch(() => {})
+		}
+	}
+}
+
+/**
+ * Wrap a promise with a timeout. The `deadline` parameter is an absolute
+ * timestamp (Date.now() + budgetMs). Rejects with an Error if the promise
+ * doesn't settle before the deadline.
+ *
+ * The losing side of Promise.race is caught to prevent unhandled rejection
+ * warnings if the original promise rejects after the timeout fires.
+ */
+async function withTimeout<T>(promise: Promise<T>, deadline: number): Promise<T> {
+	const remaining = Math.max(0, deadline - Date.now())
+	let timer: ReturnType<typeof setTimeout> | undefined
+	try {
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error(`Operation timed out after ${remaining}ms`)), remaining)
+			timer.unref?.()
+		})
+		// Prevent unhandled rejection if the original promise rejects after
+		// the timeout wins the race.
+		promise.catch(() => {})
+		return await Promise.race([promise, timeout])
+	} finally {
+		if (timer) clearTimeout(timer)
 	}
 }
 

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -27,7 +27,7 @@ export interface ProbeMcpTool {
 
 /**
  * Result of probing an MCP server for available tools.
- * Returned by McpServerManager.probeTools() and the _kimchi.dev/probeMcpServer
+ * Returned by McpServerManager.probeTools() and the _kimchi.dev/probe_mcp_server
  * ACP extMethod handler.
  */
 export interface ProbeResult {

--- a/src/extensions/mcp-adapter/types.ts
+++ b/src/extensions/mcp-adapter/types.ts
@@ -12,6 +12,30 @@ export type Transport = StdioClientTransport | SSEClientTransport | StreamableHT
 // Import sources for config
 export type ImportKind = "cursor" | "claude-code" | "claude-desktop" | "codex" | "windsurf" | "vscode"
 
+/**
+ * A tool discovered during a probe (transient connection).
+ * Mirrors McpTool but is a standalone type so the ACP wire format is stable
+ * regardless of future McpTool changes.
+ */
+export interface ProbeMcpTool {
+	name: string
+	title?: string
+	description?: string
+	inputSchema?: unknown
+	annotations?: ToolAnnotations
+}
+
+/**
+ * Result of probing an MCP server for available tools.
+ * Returned by McpServerManager.probeTools() and the _kimchi.dev/probeMcpServer
+ * ACP extMethod handler.
+ */
+export interface ProbeResult {
+	tools: ProbeMcpTool[]
+	needsAuth: boolean
+	error: string | null
+}
+
 // Tool definition from MCP server
 export interface McpTool {
 	name: string

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -9,7 +9,7 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 // become `[ACP]` agent_message_chunk diagnostics instead of method-not-found.
 //
 // Direction: pi_* methods are agent→client (agent calls conn.extMethod on
-// the client). probeMcpServer is the reverse — client→agent inbound (the
+// the client). probe_mcp_server is the reverse — client→agent inbound (the
 // agent's extMethod() handler receives it). It lives in the same map so the
 // capability advertisement and getClientSupportsMethod infrastructure is
 // shared, but ALL_PI_METHODS and getClientSupportsMethod are only meaningful
@@ -17,7 +17,7 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 export const AVAILABLE_METHODS = {
 	pi_notify: `_${CAPABILITIES_KEY}/pi_notify`,
 	pi_editor: `_${CAPABILITIES_KEY}/pi_editor`,
-	probeMcpServer: `_${CAPABILITIES_KEY}/probeMcpServer`,
+	probe_mcp_server: `_${CAPABILITIES_KEY}/probe_mcp_server`,
 } as const
 
 export type PiMethod = keyof typeof AVAILABLE_METHODS

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -7,9 +7,17 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 // the wire method name (sent over extMethod / extNotification). Per-method
 // flags let a client opt in to some and skip others — unsupported calls
 // become `[ACP]` agent_message_chunk diagnostics instead of method-not-found.
+//
+// Direction: pi_* methods are agent→client (agent calls conn.extMethod on
+// the client). probeMcpServer is the reverse — client→agent inbound (the
+// agent's extMethod() handler receives it). It lives in the same map so the
+// capability advertisement and getClientSupportsMethod infrastructure is
+// shared, but ALL_PI_METHODS and getClientSupportsMethod are only meaningful
+// for the agent→client direction.
 export const AVAILABLE_METHODS = {
 	pi_notify: `_${CAPABILITIES_KEY}/pi_notify`,
 	pi_editor: `_${CAPABILITIES_KEY}/pi_editor`,
+	probeMcpServer: `_${CAPABILITIES_KEY}/probeMcpServer`,
 } as const
 
 export type PiMethod = keyof typeof AVAILABLE_METHODS

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -7,8 +7,8 @@
 
 import { randomUUID } from "node:crypto"
 import { RequestError } from "@agentclientprotocol/sdk"
-import { authenticate, getAuthStatus, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
 import { getAuthEntry, removeAuthEntry } from "../../../extensions/mcp-adapter/mcp-auth.js"
+import { authenticate, getAuthStatus, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
 import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
 

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -5,7 +5,10 @@
 // the dependencies it needs (manager, params) and returns a plain record
 // suitable for the ACP wire.
 
+import { randomUUID } from "node:crypto"
 import { RequestError } from "@agentclientprotocol/sdk"
+import { authenticate, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
+import { getAuthEntry, removeAuthEntry } from "../../../extensions/mcp-adapter/mcp-auth.js"
 import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
 
@@ -96,5 +99,57 @@ export async function handleProbeMcpServer(
 	// `mcpServers` in the user's config. Desktop knows the key it's probing;
 	// we default to "probe" for ad-hoc calls.
 	const serverName = (params.serverName as string | undefined) ?? "probe"
-	return mcpServerManager.probeTools(serverName, server)
+
+	// Resolve the OAuth token-store key. If an auth entry already exists
+	// under `serverName` for a *different* URL (e.g. the user edited the
+	// URL but kept the name), use a throwaway name so the real server's
+	// stored tokens are never overwritten. See `resolveProbeName` below.
+	const probeName = resolveProbeName(serverName, server)
+	const usedThrowaway = probeName !== serverName
+
+	try {
+		let result = await mcpServerManager.probeTools(probeName, server)
+
+		// If the server needs auth and OAuth is supported, attempt the full
+		// OAuth flow (browser redirect + callback) then retry the probe.
+		// This mirrors the `kimchi mcp probe` CLI command's behavior so that
+		// Desktop's "Discover tools" button can complete OAuth inline.
+		if (result.needsAuth && supportsOAuth(server) && server.url) {
+			try {
+				await authenticate(probeName, server.url, server)
+			} catch (err) {
+				// Auth failed — return needsAuth with the error message so
+				// the UI can display it.
+				const message = err instanceof Error ? err.message : String(err)
+				return { tools: [], needsAuth: true, error: message }
+			}
+
+			// Retry probe after successful auth.
+			result = await mcpServerManager.probeTools(probeName, server)
+		}
+
+		return result
+	} finally {
+		// Clean up throwaway probe credentials so the token store never
+		// accumulates `__probe_*` entries.
+		if (usedThrowaway) {
+			removeAuthEntry(probeName)
+		}
+	}
+}
+
+/**
+ * Decide which name to use as the OAuth token-store key during a probe.
+ *
+ * If an auth entry already exists under `name` for a *different* URL —
+ * e.g. the user edited the server's URL but kept the name — fall back to
+ * a throwaway `__probe_*` name so the real server's tokens are never
+ * overwritten. When no entry exists (new server) or the URL matches
+ * (repeat probe), the real name is used so stored tokens are found.
+ */
+function resolveProbeName(name: string, definition: ServerEntry): string {
+	const existing = getAuthEntry(name)
+	if (!existing) return name
+	if (existing.serverUrl === definition.url) return name
+	return `__probe_${randomUUID()}`
 }

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -15,7 +15,7 @@ import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/t
 /**
  * Runtime validation for ServerEntry received over the ACP wire.
  *
- * The `_kimchi.dev/probeMcpServer` extMethod can be invoked by any ACP
+ * The `_kimchi.dev/probe_mcp_server` extMethod can be invoked by any ACP
  * client. Since ServerEntry can describe an arbitrary stdio command (command,
  * args, env, cwd) or HTTP endpoint, we must validate the shape before passing
  * it to McpServerManager.probeTools — otherwise a malicious client could
@@ -77,7 +77,7 @@ export function validateServerEntry(raw: unknown): ServerEntry {
 }
 
 /**
- * Handler for the `_kimchi.dev/probeMcpServer` ACP extension method.
+ * Handler for the `_kimchi.dev/probe_mcp_server` ACP extension method.
  *
  * Validates the incoming ServerEntry, delegates to McpServerManager.probeTools()
  * (which creates a transient connection, calls tools/list, handles OAuth, and

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -115,7 +115,7 @@ export async function handleProbeMcpServer(
 		// stored tokens are available when probeTools connects, so it skips
 		// auth entirely.
 		if (supportsOAuth(server) && server.url) {
-			const authStatus = await getAuthStatus(probeName)
+			const authStatus = await getAuthStatus(probeName, server.url)
 			if (authStatus !== "authenticated") {
 				try {
 					await authenticate(probeName, server.url, server)

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from "node:crypto"
 import { RequestError } from "@agentclientprotocol/sdk"
-import { authenticate, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
+import { authenticate, getAuthStatus, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
 import { getAuthEntry, removeAuthEntry } from "../../../extensions/mcp-adapter/mcp-auth.js"
 import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
@@ -108,27 +108,25 @@ export async function handleProbeMcpServer(
 	const usedThrowaway = probeName !== serverName
 
 	try {
-		let result = await mcpServerManager.probeTools(probeName, server)
-
-		// If the server needs auth and OAuth is supported, attempt the full
-		// OAuth flow (browser redirect + callback) then retry the probe.
-		// This mirrors the `kimchi mcp probe` CLI command's behavior so that
-		// Desktop's "Discover tools" button can complete OAuth inline.
-		if (result.needsAuth && supportsOAuth(server) && server.url) {
-			try {
-				await authenticate(probeName, server.url, server)
-			} catch (err) {
-				// Auth failed — return needsAuth with the error message so
-				// the UI can display it.
-				const message = err instanceof Error ? err.message : String(err)
-				return { tools: [], needsAuth: true, error: message }
+		// For OAuth-capable URL servers, authenticate FIRST before probing.
+		// probeTools creates its own transport internally, which triggers the
+		// SDK's auth flow — if it runs before authenticate(), the state gets
+		// overwritten and the callback fails. By authenticating first, the
+		// stored tokens are available when probeTools connects, so it skips
+		// auth entirely.
+		if (supportsOAuth(server) && server.url) {
+			const authStatus = await getAuthStatus(probeName)
+			if (authStatus !== "authenticated") {
+				try {
+					await authenticate(probeName, server.url, server)
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err)
+					return { tools: [], needsAuth: true, error: message }
+				}
 			}
-
-			// Retry probe after successful auth.
-			result = await mcpServerManager.probeTools(probeName, server)
 		}
 
-		return result
+		return await mcpServerManager.probeTools(probeName, server)
 	} finally {
 		// Clean up throwaway probe credentials so the token store never
 		// accumulates `__probe_*` entries.

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -1,0 +1,100 @@
+// ACP extension method handlers for MCP-related operations.
+//
+// Extracted from server.ts so the agent class stays focused on session
+// management. Each handler is a standalone async function that receives
+// the dependencies it needs (manager, params) and returns a plain record
+// suitable for the ACP wire.
+
+import { RequestError } from "@agentclientprotocol/sdk"
+import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
+import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
+
+/**
+ * Runtime validation for ServerEntry received over the ACP wire.
+ *
+ * The `_kimchi.dev/probeMcpServer` extMethod can be invoked by any ACP
+ * client. Since ServerEntry can describe an arbitrary stdio command (command,
+ * args, env, cwd) or HTTP endpoint, we must validate the shape before passing
+ * it to McpServerManager.probeTools — otherwise a malicious client could
+ * spawn processes with attacker-controlled arguments.
+ *
+ * This is a structural type guard, not a security policy: the ACP
+ * connection is already a trusted channel (the client is the IDE that
+ * launched the agent). The guard prevents accidental misuse and malformed
+ * payloads, not adversarial code execution.
+ */
+export function validateServerEntry(raw: unknown): ServerEntry {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		throw RequestError.invalidParams(undefined, "'server' must be an object")
+	}
+	const obj = raw as Record<string, unknown>
+
+	// Must have exactly one of command or url
+	const hasCommand = typeof obj.command === "string" && obj.command.length > 0
+	const hasUrl = typeof obj.url === "string" && obj.url.length > 0
+	if (!hasCommand && !hasUrl) {
+		throw RequestError.invalidParams(undefined, "'server' must have a 'command' or 'url' field")
+	}
+
+	// Validate types of optional fields that probeTools/createTransport reads
+	if (obj.args !== undefined && !Array.isArray(obj.args)) {
+		throw RequestError.invalidParams(undefined, "'server.args' must be an array")
+	}
+	if (Array.isArray(obj.args)) {
+		for (const a of obj.args) {
+			if (typeof a !== "string") {
+				throw RequestError.invalidParams(undefined, "'server.args' must be an array of strings")
+			}
+		}
+	}
+	if (obj.env !== undefined && (typeof obj.env !== "object" || obj.env === null)) {
+		throw RequestError.invalidParams(undefined, "'server.env' must be an object")
+	}
+	if (obj.env !== undefined) {
+		for (const [k, v] of Object.entries(obj.env as Record<string, unknown>)) {
+			if (typeof v !== "string") {
+				throw RequestError.invalidParams(undefined, `server.env['${k}'] must be a string`)
+			}
+		}
+	}
+	if (obj.cwd !== undefined && typeof obj.cwd !== "string") {
+		throw RequestError.invalidParams(undefined, "'server.cwd' must be a string")
+	}
+	if (obj.headers !== undefined && (typeof obj.headers !== "object" || obj.headers === null)) {
+		throw RequestError.invalidParams(undefined, "'server.headers' must be an object")
+	}
+	if (obj.auth !== undefined && obj.auth !== "oauth" && obj.auth !== "bearer" && obj.auth !== false) {
+		throw RequestError.invalidParams(undefined, "'server.auth' must be 'oauth', 'bearer', or false")
+	}
+	if (obj.debug !== undefined && typeof obj.debug !== "boolean") {
+		throw RequestError.invalidParams(undefined, "'server.debug' must be a boolean")
+	}
+
+	return obj as ServerEntry
+}
+
+/**
+ * Handler for the `_kimchi.dev/probeMcpServer` ACP extension method.
+ *
+ * Validates the incoming ServerEntry, delegates to McpServerManager.probeTools()
+ * (which creates a transient connection, calls tools/list, handles OAuth, and
+ * cleans up), and returns the probe result.
+ *
+ * This extMethod executes external binaries (stdio servers) or makes network
+ * requests (HTTP servers) based on the ServerEntry provided by the client.
+ */
+export async function handleProbeMcpServer(
+	mcpServerManager: McpServerManager | undefined,
+	params: Record<string, unknown>,
+): Promise<ProbeResult> {
+	if (!mcpServerManager) {
+		throw RequestError.invalidParams(undefined, "MCP server manager is not available")
+	}
+	const server = validateServerEntry(params.server)
+	// serverName is passed separately from the ServerEntry because ServerEntry
+	// itself has no name field — the name is the config key under
+	// `mcpServers` in the user's config. Desktop knows the key it's probing;
+	// we default to "probe" for ad-hoc calls.
+	const serverName = (params.serverName as string | undefined) ?? "probe"
+	return mcpServerManager.probeTools(serverName, server)
+}

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -1,10 +1,22 @@
 import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
 import type { AgentSession } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../extensions/mcp-adapter/types.js"
 import { AVAILABLE_METHODS } from "./capabilities.js"
 import { type AcpSessionFactory, KimchiAcpAgent } from "./server.js"
+
+// Mock the auth flow and auth store so tests don't touch real disk state.
+vi.mock("../../extensions/mcp-adapter/mcp-auth-flow.js", () => ({
+	supportsOAuth: vi.fn().mockReturnValue(false),
+	authenticate: vi.fn(),
+}))
+vi.mock("../../extensions/mcp-adapter/mcp-auth.js", () => ({
+	getAuthEntry: vi.fn().mockReturnValue(null),
+	removeAuthEntry: vi.fn(),
+}))
+import { supportsOAuth, authenticate } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
+import { getAuthEntry } from "../../extensions/mcp-adapter/mcp-auth.js"
 
 // Minimal fake — we only need sessionId/subscribe/dispose/prompt/abort for the
 // ACP agent to accept a session. The probeMcpServer extMethod doesn't touch
@@ -158,6 +170,70 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 		})
 
 		expect(manager.probeTools).toHaveBeenCalledWith("probe", serverEntry)
+	})
+})
+
+describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
+	beforeEach(() => {
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		vi.mocked(authenticate).mockReset()
+		vi.mocked(getAuthEntry).mockReturnValue(undefined)
+	})
+
+	it("attempts OAuth and retries probe when needsAuth is true for an OAuth-capable URL server", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
+		const successResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(needsAuthResult)
+		// Second call returns tools
+		vi.mocked(manager.probeTools).mockResolvedValueOnce(needsAuthResult).mockResolvedValueOnce(successResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+			serverName: "my-server",
+		})
+
+		expect(result.tools).toHaveLength(1)
+		expect(result.needsAuth).toBe(false)
+		expect(vi.mocked(authenticate)).toHaveBeenCalledWith("my-server", "https://example.com/mcp", serverEntry)
+		expect(manager.probeTools).toHaveBeenCalledTimes(2)
+	})
+
+	it("returns needsAuth with error message when authenticate fails", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
+		const manager = makeFakeMcpServerManager(needsAuthResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(authenticate).mockRejectedValue(new Error("Browser failed to open"))
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+			serverName: "my-server",
+		})
+
+		expect(result.needsAuth).toBe(true)
+		expect(result.error).toBe("Browser failed to open")
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not attempt OAuth for a stdio server (no url)", async () => {
+		const serverEntry: ServerEntry = { command: "echo", args: [] }
+		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
+		const manager = makeFakeMcpServerManager(needsAuthResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+		})
+
+		expect(result.needsAuth).toBe(true)
+		expect(vi.mocked(authenticate)).not.toHaveBeenCalled()
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -16,8 +16,9 @@ vi.mock("../../extensions/mcp-adapter/mcp-auth.js", () => ({
 	getAuthEntry: vi.fn().mockReturnValue(null),
 	removeAuthEntry: vi.fn(),
 }))
-import { supportsOAuth, authenticate, getAuthStatus } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
+
 import { getAuthEntry } from "../../extensions/mcp-adapter/mcp-auth.js"
+import { authenticate, getAuthStatus, supportsOAuth } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
 
 // Minimal fake — we only need sessionId/subscribe/dispose/prompt/abort for the
 // ACP agent to accept a session. The probeMcpServer extMethod doesn't touch

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -21,7 +21,7 @@ import { getAuthEntry } from "../../extensions/mcp-adapter/mcp-auth.js"
 import { authenticate, getAuthStatus, supportsOAuth } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
 
 // Minimal fake — we only need sessionId/subscribe/dispose/prompt/abort for the
-// ACP agent to accept a session. The probeMcpServer extMethod doesn't touch
+// ACP agent to accept a session. The probe_mcp_server extMethod doesn't touch
 // the session at all.
 class FakeAgentSession {
 	sessionId: string
@@ -75,8 +75,8 @@ function makeAgent(mcpServerManager?: McpServerManager): KimchiAcpAgent {
 	})
 }
 
-describe("KimchiAcpAgent extMethod probeMcpServer", () => {
-	it("routes _kimchi.dev/probeMcpServer to mcpServerManager.probeTools", async () => {
+describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
+	it("routes _kimchi.dev/probe_mcp_server to mcpServerManager.probeTools", async () => {
 		const serverEntry: ServerEntry = { command: "echo", args: ["test"] }
 		const probeResult: ProbeResult = {
 			tools: [
@@ -89,7 +89,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "test-server",
 		})
@@ -108,7 +108,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = (await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = (await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})) as unknown as ProbeResult
 
@@ -128,7 +128,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = (await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = (await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})) as unknown as ProbeResult
 
@@ -144,7 +144,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 
 	it("throws invalidParams when server parameter is missing", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {})).rejects.toMatchObject({ code: -32602 })
+		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {})).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("throws invalidParams when mcpServerManager is not configured", async () => {
@@ -157,7 +157,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 			sessionFactory,
 		})
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo" } }),
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo" } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
@@ -167,7 +167,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})
 
@@ -175,7 +175,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer", () => {
 	})
 })
 
-describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
+describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 	beforeEach(() => {
 		vi.mocked(supportsOAuth).mockReturnValue(false)
 		vi.mocked(authenticate).mockReset()
@@ -192,7 +192,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -211,7 +211,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		vi.mocked(getAuthStatus).mockResolvedValue("authenticated")
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -229,7 +229,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		vi.mocked(authenticate).mockRejectedValue(new Error("Browser failed to open"))
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -246,7 +246,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		vi.mocked(supportsOAuth).mockReturnValue(true)
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})
 
@@ -256,52 +256,54 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 	})
 })
 
-describe("KimchiAcpAgent extMethod probeMcpServer validation", () => {
+describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 	it("rejects non-object server param", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: "not-an-object" })).rejects.toMatchObject({
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: "not-an-object" }),
+		).rejects.toMatchObject({
 			code: -32602,
 		})
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: null })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: null })).rejects.toMatchObject({
 			code: -32602,
 		})
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: [] })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: [] })).rejects.toMatchObject({
 			code: -32602,
 		})
 	})
 
 	it("rejects server without command or url", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: {} })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: {} })).rejects.toMatchObject({
 			code: -32602,
 		})
 	})
 
 	it("rejects non-string command", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: 123 } })).rejects.toMatchObject(
-			{ code: -32602 },
-		)
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: 123 } }),
+		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects non-array args", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", args: "not-array" } }),
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", args: "not-array" } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects non-string elements in args", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", args: ["ok", 42] } }),
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", args: ["ok", 42] } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects env with non-string values", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", env: { KEY: 123 } } }),
+			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", env: { KEY: 123 } } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
@@ -309,7 +311,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer validation", () => {
 		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: { command: "echo", args: ["hello"], env: { FOO: "bar" } },
 		})
 		expect(result).toEqual(probeResult)
@@ -319,18 +321,18 @@ describe("KimchiAcpAgent extMethod probeMcpServer validation", () => {
 		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
 			server: { url: "https://mcp.example.com/sse" },
 		})
 		expect(result).toEqual(probeResult)
 	})
 })
 
-describe("probeMcpServer capability advertisement", () => {
-	it("advertises probeMcpServer in initialize response", async () => {
+describe("probe_mcp_server capability advertisement", () => {
+	it("advertises probe_mcp_server in initialize response", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		const response = await agent.initialize({ protocolVersion: 1 })
 		const meta = response.agentCapabilities?._meta?.["kimchi.dev"] as Record<string, boolean> | undefined
-		expect(meta?.probeMcpServer).toBe(true)
+		expect(meta?.probe_mcp_server).toBe(true)
 	})
 })

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -1,0 +1,241 @@
+import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
+import type { ProbeResult, ServerEntry } from "../../extensions/mcp-adapter/types.js"
+import { AVAILABLE_METHODS } from "./capabilities.js"
+import { type AcpSessionFactory, KimchiAcpAgent } from "./server.js"
+
+// Minimal fake — we only need sessionId/subscribe/dispose/prompt/abort for the
+// ACP agent to accept a session. The probeMcpServer extMethod doesn't touch
+// the session at all.
+class FakeAgentSession {
+	sessionId: string
+	disposed = false
+	model = { provider: "test", id: "test-model" }
+	modelRegistry = { getAvailable: () => [{ provider: "test", id: "test-model", name: "Test" }] }
+	sessionManager = { getBranch: () => [] }
+	bindExtensionsImpl: ((opts: unknown) => Promise<void>) | null = null
+
+	constructor(id: string) {
+		this.sessionId = id
+	}
+
+	subscribe = () => () => {}
+	async bindExtensions(opts: unknown): Promise<void> {
+		if (this.bindExtensionsImpl) await this.bindExtensionsImpl(opts)
+	}
+	async prompt(): Promise<void> {}
+	async abort(): Promise<void> {}
+	dispose(): void {
+		this.disposed = true
+	}
+	extensionRunner = { emit: async () => {} }
+}
+
+function asSession(fake: FakeAgentSession): AgentSession {
+	return fake as unknown as AgentSession
+}
+
+function makeConn(): AgentSideConnection {
+	const stub = {
+		sessionUpdate: async (_p: SessionNotification) => {},
+	}
+	return stub as unknown as AgentSideConnection
+}
+
+function makeFakeMcpServerManager(probeResult: ProbeResult): McpServerManager {
+	return {
+		probeTools: vi.fn().mockResolvedValue(probeResult),
+	} as unknown as McpServerManager
+}
+
+function makeAgent(mcpServerManager?: McpServerManager): KimchiAcpAgent {
+	const fake = new FakeAgentSession("probe-test-session")
+	const sessionFactory: AcpSessionFactory = async () => asSession(fake)
+	return new KimchiAcpAgent(makeConn(), {
+		extensionFactories: [],
+		agentDir: "/tmp/fake-agent-dir",
+		sessionFactory,
+		mcpServerManager,
+	})
+}
+
+describe("KimchiAcpAgent extMethod probeMcpServer", () => {
+	it("routes _kimchi.dev/probeMcpServer to mcpServerManager.probeTools", async () => {
+		const serverEntry: ServerEntry = { command: "echo", args: ["test"] }
+		const probeResult: ProbeResult = {
+			tools: [
+				{ name: "tool_a", description: "Does A" },
+				{ name: "tool_b", description: "Does B" },
+			],
+			needsAuth: false,
+			error: null,
+		}
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+			serverName: "test-server",
+		})
+
+		expect(result).toEqual(probeResult)
+		expect(manager.probeTools).toHaveBeenCalledWith("test-server", serverEntry)
+	})
+
+	it("returns tools array, needsAuth flag, and error string", async () => {
+		const serverEntry: ServerEntry = { command: "echo", args: [] }
+		const probeResult: ProbeResult = {
+			tools: [{ name: "tool_x" }],
+			needsAuth: true,
+			error: null,
+		}
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+
+		const result = (await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+		})) as unknown as ProbeResult
+
+		expect(result.tools).toHaveLength(1)
+		expect(result.tools[0].name).toBe("tool_x")
+		expect(result.needsAuth).toBe(true)
+		expect(result.error).toBeNull()
+	})
+
+	it("passes through error from probeTools", async () => {
+		const serverEntry: ServerEntry = { command: "nonexistent-binary" }
+		const probeResult: ProbeResult = {
+			tools: [],
+			needsAuth: false,
+			error: "spawn nonexistent-binary ENOENT",
+		}
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+
+		const result = (await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+		})) as unknown as ProbeResult
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toBe("spawn nonexistent-binary ENOENT")
+	})
+
+	it("throws methodNotFound for unknown extMethod", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(agent.extMethod("_kimchi.dev/unknown", {})).rejects.toMatchObject({ code: -32601 })
+	})
+
+	it("throws invalidParams when server parameter is missing", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {})).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("throws invalidParams when mcpServerManager is not configured", async () => {
+		// No mcpServerManager injected — simulates a misconfigured agent
+		const fake = new FakeAgentSession("no-mgr-session")
+		const sessionFactory: AcpSessionFactory = async () => asSession(fake)
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory,
+		})
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo" } }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("defaults serverName to 'probe' when not provided", async () => {
+		const serverEntry: ServerEntry = { command: "echo", args: [] }
+		const probeResult: ProbeResult = { tools: [], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+
+		await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+		})
+
+		expect(manager.probeTools).toHaveBeenCalledWith("probe", serverEntry)
+	})
+})
+
+describe("KimchiAcpAgent extMethod probeMcpServer validation", () => {
+	it("rejects non-object server param", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: "not-an-object" })).rejects.toMatchObject({
+			code: -32602,
+		})
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: null })).rejects.toMatchObject({
+			code: -32602,
+		})
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: [] })).rejects.toMatchObject({
+			code: -32602,
+		})
+	})
+
+	it("rejects server without command or url", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: {} })).rejects.toMatchObject({
+			code: -32602,
+		})
+	})
+
+	it("rejects non-string command", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: 123 } })).rejects.toMatchObject(
+			{ code: -32602 },
+		)
+	})
+
+	it("rejects non-array args", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", args: "not-array" } }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("rejects non-string elements in args", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", args: ["ok", 42] } }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("rejects env with non-string values", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		await expect(
+			agent.extMethod(AVAILABLE_METHODS.probeMcpServer, { server: { command: "echo", env: { KEY: 123 } } }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("accepts a valid stdio server entry", async () => {
+		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: { command: "echo", args: ["hello"], env: { FOO: "bar" } },
+		})
+		expect(result).toEqual(probeResult)
+	})
+
+	it("accepts a valid URL server entry", async () => {
+		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: { url: "https://mcp.example.com/sse" },
+		})
+		expect(result).toEqual(probeResult)
+	})
+})
+
+describe("probeMcpServer capability advertisement", () => {
+	it("advertises probeMcpServer in initialize response", async () => {
+		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
+		const response = await agent.initialize({ protocolVersion: 1 })
+		const meta = response.agentCapabilities?._meta?.["kimchi.dev"] as Record<string, boolean> | undefined
+		expect(meta?.probeMcpServer).toBe(true)
+	})
+})

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -10,12 +10,13 @@ import { type AcpSessionFactory, KimchiAcpAgent } from "./server.js"
 vi.mock("../../extensions/mcp-adapter/mcp-auth-flow.js", () => ({
 	supportsOAuth: vi.fn().mockReturnValue(false),
 	authenticate: vi.fn(),
+	getAuthStatus: vi.fn().mockResolvedValue("not_authenticated"),
 }))
 vi.mock("../../extensions/mcp-adapter/mcp-auth.js", () => ({
 	getAuthEntry: vi.fn().mockReturnValue(null),
 	removeAuthEntry: vi.fn(),
 }))
-import { supportsOAuth, authenticate } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
+import { supportsOAuth, authenticate, getAuthStatus } from "../../extensions/mcp-adapter/mcp-auth-flow.js"
 import { getAuthEntry } from "../../extensions/mcp-adapter/mcp-auth.js"
 
 // Minimal fake — we only need sessionId/subscribe/dispose/prompt/abort for the
@@ -178,16 +179,15 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		vi.mocked(supportsOAuth).mockReturnValue(false)
 		vi.mocked(authenticate).mockReset()
 		vi.mocked(getAuthEntry).mockReturnValue(undefined)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
 	})
 
-	it("attempts OAuth and retries probe when needsAuth is true for an OAuth-capable URL server", async () => {
+	it("authenticates before probing for an OAuth-capable URL server", async () => {
 		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
-		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
 		const successResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
-		const manager = makeFakeMcpServerManager(needsAuthResult)
-		// Second call returns tools
-		vi.mocked(manager.probeTools).mockResolvedValueOnce(needsAuthResult).mockResolvedValueOnce(successResult)
+		const manager = makeFakeMcpServerManager(successResult)
 		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
 		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
 
 		const agent = makeAgent(manager)
@@ -199,14 +199,32 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 		expect(result.tools).toHaveLength(1)
 		expect(result.needsAuth).toBe(false)
 		expect(vi.mocked(authenticate)).toHaveBeenCalledWith("my-server", "https://example.com/mcp", serverEntry)
-		expect(manager.probeTools).toHaveBeenCalledTimes(2)
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+	})
+
+	it("skips authentication and probes directly when already authenticated", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const successResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(successResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("authenticated")
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_METHODS.probeMcpServer, {
+			server: serverEntry,
+			serverName: "my-server",
+		})
+
+		expect(result.tools).toHaveLength(1)
+		expect(vi.mocked(authenticate)).not.toHaveBeenCalled()
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
 	})
 
 	it("returns needsAuth with error message when authenticate fails", async () => {
 		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
-		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
-		const manager = makeFakeMcpServerManager(needsAuthResult)
+		const manager = makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null })
 		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
 		vi.mocked(authenticate).mockRejectedValue(new Error("Browser failed to open"))
 
 		const agent = makeAgent(manager)
@@ -217,7 +235,7 @@ describe("KimchiAcpAgent extMethod probeMcpServer OAuth", () => {
 
 		expect(result.needsAuth).toBe(true)
 		expect(result.error).toBe("Browser failed to open")
-		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+		expect(manager.probeTools).not.toHaveBeenCalled()
 	})
 
 	it("does not attempt OAuth for a stdio server (no url)", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -57,7 +57,7 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
-import type { ProbeResult, ServerEntry } from "../../extensions/mcp-adapter/types.js"
+import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
@@ -646,24 +646,12 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
-		if (method === AVAILABLE_METHODS.probeMcpServer) {
-			const result = await this.handleProbeMcpServer(params)
-			return { ...result }
+		switch (method) {
+			case AVAILABLE_METHODS.probeMcpServer:
+				return handleProbeMcpServer(this.mcpServerManager, params) as unknown as Record<string, unknown>
+			default:
+				throw RequestError.methodNotFound(method)
 		}
-		throw RequestError.methodNotFound(method)
-	}
-
-	private async handleProbeMcpServer(params: Record<string, unknown>): Promise<ProbeResult> {
-		if (!this.mcpServerManager) {
-			throw RequestError.invalidParams(undefined, "MCP server manager is not available")
-		}
-		const server = validateServerEntry(params.server)
-		// serverName is passed separately from the ServerEntry because ServerEntry
-		// itself has no name field — the name is the config key under
-		// `mcpServers` in the user's config. Desktop knows the key it's probing;
-		// we default to "probe" for ad-hoc calls.
-		const serverName = (params.serverName as string | undefined) ?? "probe"
-		return this.mcpServerManager.probeTools(serverName, server)
 	}
 
 	async shutdown(cause: "signal" | "disconnect" = "disconnect"): Promise<void> {
@@ -1645,70 +1633,6 @@ function toolResultContent(result: unknown): ToolCallContent[] {
 		}
 	}
 	return out
-}
-
-/**
- * Runtime validation for ServerEntry received over the ACP wire.
- *
- * The `_kimchi.dev/probeMcpServer` extMethod can be invoked by any ACP
- * client. Since ServerEntry can describe an arbitrary stdio command (command,
- * args, env, cwd) or HTTP endpoint, we must validate the shape before passing
- * it to McpServerManager.probeTools — otherwise a malicious client could
- * spawn processes with attacker-controlled arguments.
- *
- * This is a structural type guard, not a security policy: the ACP
- * connection is already a trusted channel (the client is the IDE that
- * launched the agent). The guard prevents accidental misuse and malformed
- * payloads, not adversarial code execution.
- */
-function validateServerEntry(raw: unknown): ServerEntry {
-	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-		throw RequestError.invalidParams(undefined, "'server' must be an object")
-	}
-	const obj = raw as Record<string, unknown>
-
-	// Must have exactly one of command or url
-	const hasCommand = typeof obj.command === "string" && obj.command.length > 0
-	const hasUrl = typeof obj.url === "string" && obj.url.length > 0
-	if (!hasCommand && !hasUrl) {
-		throw RequestError.invalidParams(undefined, "'server' must have a 'command' or 'url' field")
-	}
-
-	// Validate types of optional fields that probeTools/createTransport reads
-	if (obj.args !== undefined && !Array.isArray(obj.args)) {
-		throw RequestError.invalidParams(undefined, "'server.args' must be an array")
-	}
-	if (Array.isArray(obj.args)) {
-		for (const a of obj.args) {
-			if (typeof a !== "string") {
-				throw RequestError.invalidParams(undefined, "'server.args' must be an array of strings")
-			}
-		}
-	}
-	if (obj.env !== undefined && (typeof obj.env !== "object" || obj.env === null)) {
-		throw RequestError.invalidParams(undefined, "'server.env' must be an object")
-	}
-	if (obj.env !== undefined) {
-		for (const [k, v] of Object.entries(obj.env as Record<string, unknown>)) {
-			if (typeof v !== "string") {
-				throw RequestError.invalidParams(undefined, `server.env['${k}'] must be a string`)
-			}
-		}
-	}
-	if (obj.cwd !== undefined && typeof obj.cwd !== "string") {
-		throw RequestError.invalidParams(undefined, "'server.cwd' must be a string")
-	}
-	if (obj.headers !== undefined && (typeof obj.headers !== "object" || obj.headers === null)) {
-		throw RequestError.invalidParams(undefined, "'server.headers' must be an object")
-	}
-	if (obj.auth !== undefined && obj.auth !== "oauth" && obj.auth !== "bearer" && obj.auth !== false) {
-		throw RequestError.invalidParams(undefined, "'server.auth' must be 'oauth', 'bearer', or false")
-	}
-	if (obj.debug !== undefined && typeof obj.debug !== "boolean") {
-		throw RequestError.invalidParams(undefined, "'server.debug' must be a boolean")
-	}
-
-	return obj as ServerEntry
 }
 
 export async function runAcpMode(options: RunAcpOptions): Promise<void> {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -57,7 +57,6 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
-import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
@@ -85,6 +84,7 @@ import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, AVAILABLE_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
+import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -56,6 +56,8 @@ import {
 	SessionManager,
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
+import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
+import type { ProbeResult, ServerEntry } from "../../extensions/mcp-adapter/types.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
@@ -81,7 +83,7 @@ import { configureHttpIdleTimeout } from "../../http/proxy.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
-import { ADVERTISED_CAPABILITIES, CAPABILITIES_KEY } from "./capabilities.js"
+import { ADVERTISED_CAPABILITIES, AVAILABLE_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
@@ -117,6 +119,12 @@ export interface RunAcpOptions {
 	sessionLister?: AcpSessionLister
 	/** Override for tests. Defaults to {@link defaultSessionLoader}. */
 	sessionLoader?: AcpSessionLoader
+	/**
+	 * MCP server manager used by the `_kimchi.dev/probeMcpServer` extMethod
+	 * handler to create transient probe connections. Injected so tests can stub
+	 * it; production code constructs a real McpServerManager.
+	 */
+	mcpServerManager?: McpServerManager
 }
 
 type TurnContext = {
@@ -155,6 +163,7 @@ export class KimchiAcpAgent implements Agent {
 	private readonly agentDir: string
 	private readonly sessionLister: AcpSessionLister
 	private readonly sessionLoader: AcpSessionLoader
+	private readonly mcpServerManager: McpServerManager | undefined
 	private readonly permissionsEnvFlag = process.env[PERMISSIONS_ENV_KEY]
 	private clientCapabilities: ClientCapabilities | undefined
 	// Track non-text prompt block types we've already warned about so a
@@ -192,6 +201,7 @@ export class KimchiAcpAgent implements Agent {
 		this.agentDir = options.agentDir
 		this.sessionLister = options.sessionLister ?? defaultSessionLister(options)
 		this.sessionLoader = options.sessionLoader ?? defaultSessionLoader(options)
+		this.mcpServerManager = options.mcpServerManager
 	}
 
 	async initialize(request: InitializeRequest): Promise<InitializeResponse> {
@@ -213,7 +223,12 @@ export class KimchiAcpAgent implements Agent {
 				sessionCapabilities: { list: {}, close: {} },
 				promptCapabilities: { image: supportsImages, audio: false, embeddedContext: false },
 				// Extended capabilities
-				_meta: { [CAPABILITIES_KEY]: ADVERTISED_CAPABILITIES },
+				_meta: {
+					[CAPABILITIES_KEY]: {
+						...ADVERTISED_CAPABILITIES,
+						...(this.mcpServerManager ? {} : { probeMcpServer: false }),
+					},
+				},
 			},
 			authMethods: [],
 		}
@@ -628,6 +643,27 @@ export class KimchiAcpAgent implements Agent {
 		if (!entry) return
 		if (entry.turn) entry.turn.cancelled = true
 		await entry.session.abort()
+	}
+
+	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+		if (method === AVAILABLE_METHODS.probeMcpServer) {
+			const result = await this.handleProbeMcpServer(params)
+			return { ...result }
+		}
+		throw RequestError.methodNotFound(method)
+	}
+
+	private async handleProbeMcpServer(params: Record<string, unknown>): Promise<ProbeResult> {
+		if (!this.mcpServerManager) {
+			throw RequestError.invalidParams(undefined, "MCP server manager is not available")
+		}
+		const server = validateServerEntry(params.server)
+		// serverName is passed separately from the ServerEntry because ServerEntry
+		// itself has no name field — the name is the config key under
+		// `mcpServers` in the user's config. Desktop knows the key it's probing;
+		// we default to "probe" for ad-hoc calls.
+		const serverName = (params.serverName as string | undefined) ?? "probe"
+		return this.mcpServerManager.probeTools(serverName, server)
 	}
 
 	async shutdown(cause: "signal" | "disconnect" = "disconnect"): Promise<void> {
@@ -1609,6 +1645,70 @@ function toolResultContent(result: unknown): ToolCallContent[] {
 		}
 	}
 	return out
+}
+
+/**
+ * Runtime validation for ServerEntry received over the ACP wire.
+ *
+ * The `_kimchi.dev/probeMcpServer` extMethod can be invoked by any ACP
+ * client. Since ServerEntry can describe an arbitrary stdio command (command,
+ * args, env, cwd) or HTTP endpoint, we must validate the shape before passing
+ * it to McpServerManager.probeTools — otherwise a malicious client could
+ * spawn processes with attacker-controlled arguments.
+ *
+ * This is a structural type guard, not a security policy: the ACP
+ * connection is already a trusted channel (the client is the IDE that
+ * launched the agent). The guard prevents accidental misuse and malformed
+ * payloads, not adversarial code execution.
+ */
+function validateServerEntry(raw: unknown): ServerEntry {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		throw RequestError.invalidParams(undefined, "'server' must be an object")
+	}
+	const obj = raw as Record<string, unknown>
+
+	// Must have exactly one of command or url
+	const hasCommand = typeof obj.command === "string" && obj.command.length > 0
+	const hasUrl = typeof obj.url === "string" && obj.url.length > 0
+	if (!hasCommand && !hasUrl) {
+		throw RequestError.invalidParams(undefined, "'server' must have a 'command' or 'url' field")
+	}
+
+	// Validate types of optional fields that probeTools/createTransport reads
+	if (obj.args !== undefined && !Array.isArray(obj.args)) {
+		throw RequestError.invalidParams(undefined, "'server.args' must be an array")
+	}
+	if (Array.isArray(obj.args)) {
+		for (const a of obj.args) {
+			if (typeof a !== "string") {
+				throw RequestError.invalidParams(undefined, "'server.args' must be an array of strings")
+			}
+		}
+	}
+	if (obj.env !== undefined && (typeof obj.env !== "object" || obj.env === null)) {
+		throw RequestError.invalidParams(undefined, "'server.env' must be an object")
+	}
+	if (obj.env !== undefined) {
+		for (const [k, v] of Object.entries(obj.env as Record<string, unknown>)) {
+			if (typeof v !== "string") {
+				throw RequestError.invalidParams(undefined, `server.env['${k}'] must be a string`)
+			}
+		}
+	}
+	if (obj.cwd !== undefined && typeof obj.cwd !== "string") {
+		throw RequestError.invalidParams(undefined, "'server.cwd' must be a string")
+	}
+	if (obj.headers !== undefined && (typeof obj.headers !== "object" || obj.headers === null)) {
+		throw RequestError.invalidParams(undefined, "'server.headers' must be an object")
+	}
+	if (obj.auth !== undefined && obj.auth !== "oauth" && obj.auth !== "bearer" && obj.auth !== false) {
+		throw RequestError.invalidParams(undefined, "'server.auth' must be 'oauth', 'bearer', or false")
+	}
+	if (obj.debug !== undefined && typeof obj.debug !== "boolean") {
+		throw RequestError.invalidParams(undefined, "'server.debug' must be a boolean")
+	}
+
+	return obj as ServerEntry
 }
 
 export async function runAcpMode(options: RunAcpOptions): Promise<void> {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -120,7 +120,7 @@ export interface RunAcpOptions {
 	/** Override for tests. Defaults to {@link defaultSessionLoader}. */
 	sessionLoader?: AcpSessionLoader
 	/**
-	 * MCP server manager used by the `_kimchi.dev/probeMcpServer` extMethod
+	 * MCP server manager used by the `_kimchi.dev/probe_mcp_server` extMethod
 	 * handler to create transient probe connections. Injected so tests can stub
 	 * it; production code constructs a real McpServerManager.
 	 */
@@ -226,7 +226,7 @@ export class KimchiAcpAgent implements Agent {
 				_meta: {
 					[CAPABILITIES_KEY]: {
 						...ADVERTISED_CAPABILITIES,
-						...(this.mcpServerManager ? {} : { probeMcpServer: false }),
+						...(this.mcpServerManager ? {} : { probe_mcp_server: false }),
 					},
 				},
 			},
@@ -647,7 +647,7 @@ export class KimchiAcpAgent implements Agent {
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
 		switch (method) {
-			case AVAILABLE_METHODS.probeMcpServer:
+			case AVAILABLE_METHODS.probe_mcp_server:
 				return handleProbeMcpServer(this.mcpServerManager, params) as unknown as Record<string, unknown>
 			default:
 				throw RequestError.methodNotFound(method)


### PR DESCRIPTION
## Linked issue

Closes getkimchi/kimchi-desktop#77

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Registers an ACP extension method handler for `_kimchi.dev/probeMcpServer` on the agent side. When the Desktop client sends an `extMethod('_kimchi.dev/probeMcpServer', { server })` request through the ACP connection, the CLI delegates to `McpServerManager.probeTools()`, which creates a transient connection to the MCP server, calls `tools/list`, handles the OAuth flow if needed, closes the connection, and returns the tool list.

The method name is `_`-prefixed per the ACP v1 extensibility spec — non-prefixed method names are reserved for future protocol versions.

### Changes
- **`src/modes/acp/capabilities.ts`** — Added `probeMcpServer` to `AVAILABLE_METHODS` with inbound direction comment
- **`src/modes/acp/server.ts`** — Added `extMethod()` override on `KimchiAcpAgent` that routes `_kimchi.dev/probeMcpServer` to `handleProbeMcpServer()`, which validates params and delegates to `mcpServerManager.probeTools()`
- **`src/extensions/mcp-adapter/server-manager.ts`** — Added `probeTools()` method (transient connection, tools/list, OAuth handling, cleanup) and `withTimeout()` helper
- **`src/extensions/mcp-adapter/types.ts`** — Added `ProbeMcpTool` and `ProbeResult` types
- **`src/cli.ts`** — Wired `McpServerManager` instance into `runAcpMode()` so the handler is functional in production
- **`src/modes/acp/probe-mcp-server.test.ts`** — Tests covering: extMethod routing, return shape, error passthrough, method-not-found, invalid params, missing manager, default serverName, and capability advertisement

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed