### PR TITLE
fix(tui-e2e): stabilize flaky TUI E2E tests and clear skip list

### DIFF
--- a/tests/e2e/tui/skip-list.js
+++ b/tests/e2e/tui/skip-list.js
@@ -1,35 +1,4 @@
 // Quarantined TUI e2e tests: excluded from default runs (still run when named explicitly).
 // Add `{ test, reason }` (`test` = file name without `.test.ts`); remove once fixed.
 /** @type {{ test: string; reason: string }[]} */
-export const SKIPPED_TUI_TESTS = [
-	{
-		test: "ferment-phase-review",
-		reason:
-			"test.fail for a known focus bug is flaky under parallel full-suite runs; passes in isolation but times out when run with other tests",
-	},
-	{
-		test: "plan-to-ferment-promo",
-		reason:
-			"test.fail for a known dropdown/buffer bug is flaky under parallel full-suite runs; passes in isolation but fails with assertion errors when run with other tests",
-	},
-	{
-		test: "ask-user-form",
-		reason:
-			"ferment plan-review dialog timing is flaky under parallel full-suite runs; passes in isolation but tool calls execute before the review dialog appears when run with other tests",
-	},
-	{
-		test: "ferment-progress-overlay",
-		reason:
-			"overlay rendering timing is flaky under parallel full-suite runs; passes in isolation but times out waiting for human: header when run with other tests",
-	},
-	{
-		test: "todo-overlay",
-		reason:
-			"todo overlay reconciliation test is flaky under parallel full-suite runs; passes in isolation but times out waiting for the widget to hide when run with other tests. Pre-existing on master.",
-	},
-	{
-		test: "billing-warnings",
-		reason:
-			"caller budget footer test times out waiting for monthly date range text; fails on multiple branches including fix/close-stale-action-config and feat/acp-probe-mcp-server. Pre-existing date-rollover flakiness.",
-	},
-]
+export const SKIPPED_TUI_TESTS = []

--- a/tests/e2e/tui/todo-overlay.test.ts
+++ b/tests/e2e/tui/todo-overlay.test.ts
@@ -1,6 +1,6 @@
 import { test } from "@microsoft/tui-test"
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
-import { INPUT_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { INPUT_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -83,7 +83,7 @@ test("completed todos stop pinning the overlay", async ({ terminal }) => {
 	)
 })
 
-test("todo overlay reconciles stale active todos after non-todo work", async ({ terminal }) => {
+test("todo overlay stays visible after non-todo work and hides when clear_todos is called", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
 		{
@@ -119,7 +119,11 @@ test("todo overlay reconciles stale active todos after non-todo work", async ({ 
 						},
 					],
 				},
+				// Turn 3: terminal turn (no tool calls) — the reconciliation
+				// follow-up mechanism was removed (commit 3c7b939b). The
+				// overlay stays visible; the user must prompt again to clear.
 				{ stream: ["Work finished."] },
+				// Turn 4: user prompts to clear → model calls clear_todos.
 				{
 					toolCalls: [
 						{
@@ -137,8 +141,18 @@ test("todo overlay reconciles stale active todos after non-todo work", async ({ 
 			await waitForText(terminal, "2/3 done · 1 active", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
 			trace.step("active todo overlay visible")
 
+			// After the terminal turn ("Work finished."), the overlay stays
+			// visible — the old reconciliation follow-up was removed.
+			await waitForText(terminal, "Work finished.", { timeoutMs: STREAM_TIMEOUT_MS, full: false })
+			trace.step("terminal turn rendered — overlay stays visible")
+
+			// User explicitly prompts to clear todos → model calls clear_todos
+			// → overlay hides.
+			terminal.submit("clear the todos")
+			trace.step("submitted 'clear the todos'")
+
 			await waitForWidgetToHide(terminal)
-			trace.step("reconciliation follow-up cleared overlay")
+			trace.step("clear_todos executed — overlay hidden")
 		},
 	)
 })
@@ -154,7 +168,7 @@ test("todo overlay reconciles stale active todos after non-todo work", async ({ 
 async function waitForWidgetToHide(terminal: Terminal): Promise<void> {
 	const startedAt = Date.now()
 	let view = viewText(terminal)
-	while (Date.now() - startedAt < INPUT_TIMEOUT_MS) {
+	while (Date.now() - startedAt < STREAM_TIMEOUT_MS) {
 		if (!view.includes("Todos · Global") && !view.includes("done · 0 active")) return
 		await new Promise((resolve) => setTimeout(resolve, 100))
 		view = viewText(terminal)


### PR DESCRIPTION
## Summary

6 TUI E2E tests were quarantined in `skip-list.js` due to flakiness under parallel full-suite runs. This PR unskips all of them after identifying root causes and verifying stability.

## Investigation

Ran the 6 quarantined tests multiple times — in isolation, grouped, and in the full parallel suite — to distinguish genuine flakiness from resolved issues:

| Test | Isolated | Grouped (3×) | Full suite (2×) | Result |
|------|----------|-------------|-----------------|--------|
| ferment-phase-review | ✅ | ✅ | ✅ | No longer flaky — unskipped |
| plan-to-ferment-promo | ✅ | ✅ | ✅ | No longer flaky — unskipped |
| ask-user-form | ✅ | ✅ | ✅ | No longer flaky — unskipped |
| ferment-progress-overlay | ✅ | ✅ | ✅ | No longer flaky — unskipped |
| billing-warnings | ✅ | ✅ | ✅ | No longer flaky — unskipped |
| todo-overlay | ❌ | ❌ | ❌ | Consistent failure — **fixed** |

## Root cause: todo-overlay reconciliation test

The `todo-overlay` reconciliation test was a **consistent failure, not flaky**. It failed every run, in isolation and in parallel.

Commit `3c7b939b` ("fix(todos): replace active nudges with passive staleness") **removed the automatic reconciliation follow-up mechanism** that injected a follow-up message after non-todo work to prompt the model to clear its todos. The unit tests were updated to confirm this change (`expect(harness.sendMessage).not.toHaveBeenCalled()`), but the E2E test was never updated.

The test expected the overlay to auto-hide after a terminal turn. With reconciliation removed, the overlay stays visible until the user explicitly prompts to clear.

## Changes

- **`tests/e2e/tui/todo-overlay.test.ts`**: Updated the reconciliation test to reflect the new behavior — the overlay stays visible after non-todo work and hides only when `clear_todos` is called via an explicit user prompt. Increased `waitForWidgetToHide` timeout from 5s to 15s for the additional LLM round-trip.
- **`tests/e2e/tui/skip-list.js`**: Cleared all quarantined entries.

## Verification

- `todo-overlay` passed 5/5 in isolation after the fix
- Full suite (75 tests, 0 skips) passed 3 consecutive runs with exit code 0 using the CI command: `KIMCHI_PROXY_HELPER=$(pwd)/bin/proxy-helper pnpm run test:e2e:tui`

## Checklist

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update