### PR TITLE
feat: allow trivial fixes without spinning up a subagent, harden delegation guard

### DIFF
--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -559,3 +559,42 @@ describe("Build phase directive (complex-chunk tier routing)", () => {
 		expect(result).not.toMatch(/standard-tier Builder by default.*retry/s)
 	})
 })
+
+describe("Trivial fix and triage exceptions", () => {
+	const registry = new ModelRegistry(ALL_KNOWN_METADATA)
+
+	it("includes trivial fix exception in build phase", () => {
+		const result = resolveAsString({
+			currentModelId: "kimi-k2.6",
+			registry,
+			roles: DEFAULT_MODEL_ROLES,
+		})
+		expect(result).toContain("#### Build phase")
+		expect(result).toContain("Trivial fix exception")
+		expect(result).toContain("trivial fix directly")
+		expect(result).toMatch(/2-3 tool calls.*delegate a Fixer agent/s)
+	})
+
+	it("includes trivial fix exception for review NEEDS_FIXES", () => {
+		const result = resolveAsString({
+			currentModelId: "kimi-k2.6",
+			registry,
+			roles: DEFAULT_MODEL_ROLES,
+		})
+		expect(result).toContain("Trivial fix exception")
+		expect(result).toMatch(/NEEDS_FIXES.*delegate a fix agent by default/s)
+		expect(result).toMatch(/single obvious issue.*1-2 edits/s)
+	})
+
+	it("allows small triage after subagent abort instead of forcing immediate follow-up", () => {
+		const result = resolveAsString({
+			currentModelId: "kimi-k2.6",
+			registry,
+			roles: DEFAULT_MODEL_ROLES,
+		})
+		expect(result).toContain("Post-abort triage")
+		expect(result).toMatch(/at most 2-3 tool calls/s)
+		expect(result).toMatch(/obvious one-line fix/s)
+		expect(result).toMatch(/more than trivial.*follow-up Agent/s)
+	})
+})

--- a/src/extensions/orchestration/orchestration-instructions.test.ts
+++ b/src/extensions/orchestration/orchestration-instructions.test.ts
@@ -572,7 +572,7 @@ describe("Trivial fix and triage exceptions", () => {
 		expect(result).toContain("#### Build phase")
 		expect(result).toContain("Trivial fix exception")
 		expect(result).toContain("trivial fix directly")
-		expect(result).toMatch(/2-3 tool calls.*delegate a Fixer agent/s)
+		expect(result).toMatch(/2-3 edit\/write calls.*delegate a Fixer/s)
 	})
 
 	it("includes trivial fix exception for review NEEDS_FIXES", () => {
@@ -593,7 +593,7 @@ describe("Trivial fix and triage exceptions", () => {
 			roles: DEFAULT_MODEL_ROLES,
 		})
 		expect(result).toContain("Post-abort triage")
-		expect(result).toMatch(/at most 2-3 tool calls/s)
+		expect(result).toMatch(/at most 2-3 edit\/write calls/s)
 		expect(result).toMatch(/obvious one-line fix/s)
 		expect(result).toMatch(/more than trivial.*follow-up Agent/s)
 	})

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -128,7 +128,7 @@ The review agent runs tests, checks lint, and verifies the implementation matche
 
 **If the review agent times out or produces no output:** Retry ONCE with the same or a different standard-tier Reviewer. If the retry also fails, skip review and report to the user that review could not be completed. Do NOT attempt a third reviewer.
 
-**Handling review results:** After the review agent completes, read ONLY the review file — do NOT re-read source files yourself. If the verdict is APPROVED, the review phase is done — produce the final summary and stop. If the verdict is NEEDS_FIXES, delegate a fix agent: pass it the review file path and the spec file path.
+**Handling review results:** After the review agent completes, read ONLY the review file — do NOT re-read source files yourself. If the verdict is APPROVED, the review phase is done — produce the final summary and stop. If the verdict is NEEDS_FIXES, delegate a fix agent by default: pass it the review file path and the spec file path. **Trivial fix exception:** if the reviewer identifies a single obvious issue that you can fix in 1-2 edits (e.g. a typo, missing import, or simple test expectation), you may apply it directly instead of spawning a Fixer. If the fix grows beyond that scope, stop and delegate.
 
 **Fix agent contract:** Instruct the fix agent to: (1) read the review findings file, (2) apply all fixes, (3) run the full test suite (with race/thread-safety detection if applicable) and lint, (4) write a verification report to the Documents directory (e.g. \`.kimchi/docs/verification.md\`) containing:
 - **Test output**: pass/fail count, any failures
@@ -152,7 +152,7 @@ function buildAgentDelegation(delegatePlanning: boolean): string {
 
 	return `### Agent delegation
 
-**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort anti-pattern**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work — this is the most common violation. Spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains.
+**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort triage**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work. You may, however, perform a small amount of triage (at most 2-3 tool calls) to understand the failure, verify state, or apply an obvious one-line fix. If the remaining work is more than trivial, spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains.
 
 - Write Agent prompts that are fully self-contained. Agents start with fresh context by default — include necessary instructions directly, or point them to a Markdown file containing larger context.
 ${planBullet}
@@ -309,6 +309,9 @@ function buildBuildPhaseDirectives(ctx: PhaseDirectiveContext): string {
 	lines.push("- DO NOT build code yourself. Delegate one Agent call per chunk from the plan.")
 	lines.push(
 		`- DO delegate each chunk to Agent(type: "Builder", model: ${models}). Simple chunks use a standard-tier Builder; complex chunks (concurrency, state machines, algorithms) require a heavy-tier Builder. Retries may escalate to a heavier tier when the first choice fails.`,
+	)
+	lines.push(
+		"- **Trivial fix exception:** After a subagent returns, you may apply a trivial fix directly (a single edit affecting at most one or two files, such as a typo, missing import, or test mock mismatch) instead of spawning another subagent. If the fix is not immediately obvious within 2-3 tool calls, stop and delegate a Fixer agent.",
 	)
 	lines.push("- DO pass the spec file path, the chunk's `complexity`, and set `thinking` per **Thinking levels**.")
 	lines.push(

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -152,7 +152,7 @@ function buildAgentDelegation(delegatePlanning: boolean): string {
 
 	return `### Agent delegation
 
-**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort triage**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work. You may, however, perform a small amount of triage (at most 2-3 tool calls) to understand the failure, verify state, or apply an obvious one-line fix. If the remaining work is more than trivial, spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains.
+**Orchestrator discipline**: Between delegation calls, you may do at most 5 tool calls (e.g. reading the spec file, setting the phase, checking a subagent result). If you find yourself doing reads, edits, bash calls, or writes on implementation files, STOP — you are doing a subagent's job. Delegate it instead. **Post-abort triage**: When a subagent aborts (budget or turns), do NOT manually complete its remaining work. You may do a small amount of triage (at most 2-3 edit/write calls; reads and bash checks don't count) to understand the failure, verify state, or apply an obvious one-line fix. If the remaining work is more than trivial, spawn a follow-up Agent scoped to the unfinished portion. List what the aborted agent completed and what remains.
 
 - Write Agent prompts that are fully self-contained. Agents start with fresh context by default — include necessary instructions directly, or point them to a Markdown file containing larger context.
 ${planBullet}
@@ -311,7 +311,7 @@ function buildBuildPhaseDirectives(ctx: PhaseDirectiveContext): string {
 		`- DO delegate each chunk to Agent(type: "Builder", model: ${models}). Simple chunks use a standard-tier Builder; complex chunks (concurrency, state machines, algorithms) require a heavy-tier Builder. Retries may escalate to a heavier tier when the first choice fails.`,
 	)
 	lines.push(
-		"- **Trivial fix exception:** After a subagent returns, you may apply a trivial fix directly (a single edit affecting at most one or two files, such as a typo, missing import, or test mock mismatch) instead of spawning another subagent. If the fix is not immediately obvious within 2-3 tool calls, stop and delegate a Fixer agent.",
+		"- **Trivial fix exception:** After a subagent returns, you may apply a trivial fix directly (one edit touching 1-2 files, e.g. a typo or missing import) instead of spawning another subagent. If the fix is not obvious within 2-3 edit/write calls, delegate a Fixer.",
 	)
 	lines.push("- DO pass the spec file path, the chunk's `complexity`, and set `thinking` per **Thinking levels**.")
 	lines.push(

--- a/src/extensions/review-write-guard.integration.test.ts
+++ b/src/extensions/review-write-guard.integration.test.ts
@@ -16,12 +16,15 @@ vi.mock("./tags.js", () => ({
 
 type BlockResult = { block: true; reason: string }
 
+interface ToolEventPayload {
+	toolName?: string
+	result?: unknown
+	details?: unknown
+}
+
 interface MockExtensionAPI {
-	handlers: Record<string, Array<(event: { toolName?: string; result?: unknown }, ctx: ExtensionContext) => unknown>>
-	on: (
-		event: string,
-		handler: (event: { toolName?: string; result?: unknown }, ctx: ExtensionContext) => unknown,
-	) => void
+	handlers: Record<string, Array<(event: ToolEventPayload, ctx: ExtensionContext) => unknown>>
+	on: (event: string, handler: (event: ToolEventPayload, ctx: ExtensionContext) => unknown) => void
 	sendMessage: ReturnType<typeof vi.fn>
 	_blockResult?: BlockResult
 }
@@ -38,12 +41,7 @@ function createMockPI(): MockExtensionAPI {
 	}
 }
 
-function emit(
-	pi: MockExtensionAPI,
-	event: string,
-	payload: { toolName?: string; result?: unknown } = {},
-	ctx = createContext(),
-) {
+function emit(pi: MockExtensionAPI, event: string, payload: ToolEventPayload = {}, ctx = createContext()) {
 	const handlers = pi.handlers[event] ?? []
 	for (const h of handlers) {
 		const result = h(payload, ctx) as BlockResult | undefined
@@ -199,6 +197,87 @@ describe("reviewWriteGuardExtension wiring", () => {
 		emit(pi, "tool_call", { toolName: "edit" }, createContext({ sessionManager: { getSessionId: () => "session-b" } }))
 
 		// Only session A should have triggered a steer.
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("extracts agentOutcome from tool_result details and applies triage thresholds", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseBlockThreshold: 5,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		mockPhase = "build"
+
+		emit(pi, "tool_result", {
+			toolName: "Agent",
+			result: undefined,
+			details: {
+				status: "aborted",
+				outcome: "failed",
+				subagentType: "Builder",
+				agentOutcome: { status: "aborted", outcome: "failed", subagentType: "Builder" },
+			},
+		})
+
+		// First 3 edits are allowed under triage threshold of 4.
+		emit(pi, "tool_call", { toolName: "edit" })
+		emit(pi, "tool_call", { toolName: "edit" })
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+
+		// 4th edit triggers steer (not block).
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: STEER_MESSAGE_TYPE }), {
+			deliverAs: "steer",
+		})
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("disarms guard when agentOutcome is unknown", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		mockPhase = "build"
+
+		emit(pi, "tool_result", {
+			toolName: "Agent",
+			result: undefined,
+			details: {
+				status: "weird",
+				outcome: "unknown",
+				agentOutcome: { status: "weird", outcome: "unknown" },
+			},
+		})
+
+		for (let i = 0; i < 10; i++) {
+			emit(pi, "tool_call", { toolName: "edit" })
+		}
+
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+	})
+
+	it("uses normal thresholds when agentOutcome indicates success", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		mockPhase = "build"
+
+		emit(pi, "tool_result", {
+			toolName: "Agent",
+			result: undefined,
+			details: {
+				status: "completed",
+				outcome: "completed",
+				agentOutcome: { status: "completed", outcome: "completed", subagentType: "Builder" },
+			},
+		})
+
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+		emit(pi, "tool_call", { toolName: "edit" })
 		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/review-write-guard.integration.test.ts
+++ b/src/extensions/review-write-guard.integration.test.ts
@@ -294,6 +294,29 @@ describe("reviewWriteGuardExtension wiring", () => {
 		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
 	})
 
+	it("does not reset guard state when the orchestrator spawns another Agent", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		mockPhase = "build"
+
+		// First subagent returns and arms the guard.
+		emit(pi, "tool_result", { toolName: "Agent" })
+
+		// One edit counts toward the threshold.
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+
+		// Spawning another Agent must NOT reset the guard.
+		emit(pi, "tool_call", { toolName: "Agent" })
+
+		// The second edit should still trigger the steer from the first subagent return.
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: STEER_MESSAGE_TYPE }), {
+			deliverAs: "steer",
+		})
+	})
+
 	it("evicts the session guard from the map on session_shutdown", () => {
 		const pi = createMockPI()
 		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })

--- a/src/extensions/review-write-guard.integration.test.ts
+++ b/src/extensions/review-write-guard.integration.test.ts
@@ -237,9 +237,14 @@ describe("reviewWriteGuardExtension wiring", () => {
 		expect(pi._blockResult).toBeUndefined()
 	})
 
-	it("disarms guard when agentOutcome is unknown", () => {
+	it("uses triage thresholds when agentOutcome is unknown", () => {
 		const pi = createMockPI()
-		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		reviewWriteGuardExtension(pi as unknown as PI, {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseBlockThreshold: 5,
+			buildPhaseTriageBlockThreshold: 8,
+		})
 		mockPhase = "build"
 
 		emit(pi, "tool_result", {
@@ -252,11 +257,19 @@ describe("reviewWriteGuardExtension wiring", () => {
 			},
 		})
 
-		for (let i = 0; i < 10; i++) {
-			emit(pi, "tool_call", { toolName: "edit" })
-		}
-
+		// 3 edits under the triage threshold of 4 should not trigger a steer.
+		emit(pi, "tool_call", { toolName: "edit" })
+		emit(pi, "tool_call", { toolName: "edit" })
+		emit(pi, "tool_call", { toolName: "edit" })
 		expect(pi.sendMessage).not.toHaveBeenCalled()
+		expect(pi._blockResult).toBeUndefined()
+
+		// 4th edit crosses the triage steer threshold.
+		emit(pi, "tool_call", { toolName: "edit" })
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: STEER_MESSAGE_TYPE }), {
+			deliverAs: "steer",
+		})
 		expect(pi._blockResult).toBeUndefined()
 	})
 
@@ -279,5 +292,33 @@ describe("reviewWriteGuardExtension wiring", () => {
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 		emit(pi, "tool_call", { toolName: "edit" })
 		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	it("evicts the session guard from the map on session_shutdown", () => {
+		const pi = createMockPI()
+		reviewWriteGuardExtension(pi as unknown as PI, { buildPhaseThreshold: 2 })
+		mockPhase = "build"
+
+		const ctx = createContext({ sessionManager: { getSessionId: () => "session-evict" } })
+
+		// Populate the guardMap by recording a subagent return.
+		emit(pi, "tool_result", { toolName: "Agent" }, ctx)
+
+		// First edit would normally pass under the steer threshold of 2.
+		emit(pi, "tool_call", { toolName: "edit" }, ctx)
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+
+		// Fire session_shutdown for the same session — guard should be evicted.
+		emit(pi, "session_shutdown", {}, ctx)
+
+		// A fresh subagent return + edit on the same session should behave like a
+		// new guard (subagentReturnedInBuild is true again, no leftover state).
+		// If the old guard had been reused, the second edit below would still be
+		// allowed (count reset by recordSubagentReturn), but the eviction proves
+		// the old instance is gone — assert by re-checking sessionStart behavior.
+		emit(pi, "session_start", {}, ctx)
+		mockPhase = "review"
+		emit(pi, "tool_call", { toolName: "edit" }, ctx)
+		expect(pi._blockResult).toMatchObject({ block: true, reason: expect.stringContaining("BLOCKED") })
 	})
 })

--- a/src/extensions/review-write-guard.test.ts
+++ b/src/extensions/review-write-guard.test.ts
@@ -187,6 +187,25 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		expect(guard.getState().subagentReturnedInBuild).toBe(false)
 	})
 
+	it("resets build-phase state when a subagent returns outside build phase", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
+		guard.recordSubagentReturn({ status: "completed", outcome: "completed" })
+		expect(guard.getState().subagentReturnedInBuild).toBe(true)
+		expect(guard.getState().lastSubagentSuccessful).toBe(true)
+
+		// Subagent returns while the session is in plan phase.
+		mockPhase = "plan"
+		guard.recordSubagentReturn({ status: "completed", outcome: "completed" })
+		expect(guard.getState().subagentReturnedInBuild).toBe(false)
+		expect(guard.getState().lastSubagentSuccessful).toBe(false)
+
+		// Returning to build should not inherit the earlier build-phase state.
+		mockPhase = "build"
+		expect(guard.checkToolCall("edit")).toBeUndefined()
+		expect(guard.checkToolCall("edit")).toBeUndefined()
+	})
+
 	it("uses default threshold of 2", () => {
 		mockPhase = "build"
 		const guard = new OrchestratorWriteGuard(createContext())

--- a/src/extensions/review-write-guard.test.ts
+++ b/src/extensions/review-write-guard.test.ts
@@ -65,6 +65,66 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		expect(result).toEqual({ steer: expect.stringContaining("Delegation guard") })
 	})
 
+	it("uses higher triage thresholds after an aborted subagent return", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		guard.recordSubagentReturn({ status: "aborted", outcome: "failed" })
+		for (let i = 0; i < 3; i++) guard.checkToolCall("edit")
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("uses higher triage thresholds after a stopped subagent return", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		guard.recordSubagentReturn({ status: "stopped", outcome: "failed" })
+		for (let i = 0; i < 3; i++) guard.checkToolCall("edit")
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("uses higher triage thresholds after an error outcome", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		guard.recordSubagentReturn({ status: "completed", outcome: "error" })
+		for (let i = 0; i < 3; i++) guard.checkToolCall("edit")
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("uses normal thresholds after a successful subagent return with explicit details", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
+		guard.recordSubagentReturn({ status: "completed", outcome: "completed", subagentType: "Builder" })
+		expect(guard.checkToolCall("edit")).toBeUndefined()
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("disarms after an ambiguous outcome", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
+		guard.recordSubagentReturn({ status: "in_progress", outcome: "unknown" })
+		for (let i = 0; i < 10; i++) guard.checkToolCall("edit")
+		expect(guard.getState().subagentReturnedInBuild).toBe(false)
+	})
+
+	it("disarms after an unknown subagent outcome", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
+		guard.recordSubagentReturn({ status: "weird", outcome: "unknown" })
+		for (let i = 0; i < 10; i++) guard.checkToolCall("edit")
+		expect(guard.getState().subagentReturnedInBuild).toBe(false)
+	})
+
 	it("steers only once then allows edits until block threshold", () => {
 		mockPhase = "build"
 		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2, buildPhaseBlockThreshold: 5 })

--- a/src/extensions/review-write-guard.test.ts
+++ b/src/extensions/review-write-guard.test.ts
@@ -32,12 +32,11 @@ describe("OrchestratorWriteGuard — review phase", () => {
 		expect(guard.checkToolCall("grep")).toBeUndefined()
 	})
 
-	it("resets when Agent is called", () => {
+	it("does not treat Agent tool calls as a reset signal on the guard", () => {
 		const guard = new OrchestratorWriteGuard(createContext())
-		guard.checkToolCall("Agent")
-		mockPhase = "review"
-		const result = guard.checkToolCall("edit")
-		expect(result).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
+		// The extension short-circuits Agent calls in tool_call; the guard never
+		// receives them. Verifying that calling it directly with "Agent" is a no-op.
+		expect(guard.checkToolCall("Agent")).toBeUndefined()
 	})
 
 	it("blocks every edit attempt, not just the first", () => {
@@ -109,12 +108,47 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
 	})
 
-	it("disarms after a non-terminal but valid subagent outcome", () => {
+	it("uses triage thresholds after a non-terminal but valid subagent outcome", () => {
 		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
 		guard.recordSubagentReturn({ status: "queued", outcome: "completed" })
-		for (let i = 0; i < 10; i++) guard.checkToolCall("edit")
-		expect(guard.getState().subagentReturnedInBuild).toBe(false)
+		expect(guard.getState().subagentReturnedInBuild).toBe(true)
+		expect(guard.getState().lastSubagentSuccessful).toBe(false)
+		// 3 edits under the triage threshold of 4 should not trigger a steer.
+		for (let i = 0; i < 3; i++) guard.checkToolCall("edit")
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("treats status:steered, outcome:completed as a successful subagent return", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		guard.recordSubagentReturn({ status: "steered", outcome: "completed" })
+		expect(guard.getState().subagentReturnedInBuild).toBe(true)
+		expect(guard.getState().lastSubagentSuccessful).toBe(true)
+		// Normal thresholds: 1st edit allowed, 2nd triggers steer.
+		expect(guard.checkToolCall("edit")).toBeUndefined()
+		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
+	})
+
+	it("uses triage thresholds for an unknown subagent outcome", () => {
+		mockPhase = "build"
+		const guard = new OrchestratorWriteGuard(createContext(), {
+			buildPhaseThreshold: 2,
+			buildPhaseTriageThreshold: 4,
+			buildPhaseTriageBlockThreshold: 8,
+		})
+		// Cast to never so we can pass arbitrary values that aren't valid AgentOutcomeSummary fields.
+		guard.recordSubagentReturn({ status: "weird" as never, outcome: "mystery" as never })
+		expect(guard.getState().subagentReturnedInBuild).toBe(true)
+		expect(guard.getState().lastSubagentSuccessful).toBe(false)
 	})
 
 	it("steers only once then allows edits until block threshold", () => {
@@ -144,16 +178,6 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		for (let i = 0; i < 5; i++) guard.checkToolCall("edit")
 		expect(guard.checkToolCall("edit")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
 		expect(guard.checkToolCall("write")).toEqual({ block: true, reason: expect.stringContaining("BLOCKED") })
-	})
-
-	it("resets when a new Agent is spawned", () => {
-		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
-		guard.recordSubagentReturn()
-		guard.checkToolCall("edit")
-		guard.checkToolCall("Agent")
-		expect(guard.getState().subagentReturnedInBuild).toBe(false)
-		expect(guard.getState().buildWriteCount).toBe(0)
 	})
 
 	it("does not track subagent returns outside build phase", () => {
@@ -199,5 +223,51 @@ describe("OrchestratorWriteGuard — other phases", () => {
 		mockPhase = "plan"
 		guard.checkToolCall("edit")
 		expect(guard.getState().subagentReturnedInBuild).toBe(false)
+	})
+})
+
+describe("OrchestratorWriteGuard — threshold order assertions", () => {
+	it("throws when block threshold is not greater than steer threshold", () => {
+		expect(
+			() =>
+				new OrchestratorWriteGuard(createContext(), {
+					buildPhaseThreshold: 5,
+					buildPhaseBlockThreshold: 5,
+				}),
+		).toThrow(/buildPhaseBlockThreshold/)
+	})
+
+	it("throws when triage block threshold is not greater than triage steer threshold", () => {
+		expect(
+			() =>
+				new OrchestratorWriteGuard(createContext(), {
+					buildPhaseTriageThreshold: 8,
+					buildPhaseTriageBlockThreshold: 8,
+				}),
+		).toThrow(/buildPhaseTriageBlockThreshold/)
+	})
+
+	it("throws when triage threshold is not greater than normal threshold", () => {
+		expect(
+			() =>
+				new OrchestratorWriteGuard(createContext(), {
+					buildPhaseThreshold: 4,
+					buildPhaseTriageThreshold: 4,
+				}),
+		).toThrow(/buildPhaseTriageThreshold/)
+	})
+
+	it("throws when triage block threshold is not greater than normal block threshold", () => {
+		expect(
+			() =>
+				new OrchestratorWriteGuard(createContext(), {
+					buildPhaseBlockThreshold: 8,
+					buildPhaseTriageBlockThreshold: 8,
+				}),
+		).toThrow(/buildPhaseTriageBlockThreshold/)
+	})
+
+	it("accepts default threshold ordering", () => {
+		expect(() => new OrchestratorWriteGuard(createContext())).not.toThrow()
 	})
 })

--- a/src/extensions/review-write-guard.test.ts
+++ b/src/extensions/review-write-guard.test.ts
@@ -89,14 +89,14 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
 	})
 
-	it("uses higher triage thresholds after an error outcome", () => {
+	it("uses higher triage thresholds after a status error outcome", () => {
 		mockPhase = "build"
 		const guard = new OrchestratorWriteGuard(createContext(), {
 			buildPhaseThreshold: 2,
 			buildPhaseTriageThreshold: 4,
 			buildPhaseTriageBlockThreshold: 8,
 		})
-		guard.recordSubagentReturn({ status: "completed", outcome: "error" })
+		guard.recordSubagentReturn({ status: "error", outcome: "failed" })
 		for (let i = 0; i < 3; i++) guard.checkToolCall("edit")
 		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
 	})
@@ -109,18 +109,10 @@ describe("OrchestratorWriteGuard — build phase", () => {
 		expect(guard.checkToolCall("edit")).toEqual({ steer: expect.stringContaining("Delegation guard") })
 	})
 
-	it("disarms after an ambiguous outcome", () => {
+	it("disarms after a non-terminal but valid subagent outcome", () => {
 		mockPhase = "build"
 		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
-		guard.recordSubagentReturn({ status: "in_progress", outcome: "unknown" })
-		for (let i = 0; i < 10; i++) guard.checkToolCall("edit")
-		expect(guard.getState().subagentReturnedInBuild).toBe(false)
-	})
-
-	it("disarms after an unknown subagent outcome", () => {
-		mockPhase = "build"
-		const guard = new OrchestratorWriteGuard(createContext(), { buildPhaseThreshold: 2 })
-		guard.recordSubagentReturn({ status: "weird", outcome: "unknown" })
+		guard.recordSubagentReturn({ status: "queued", outcome: "completed" })
 		for (let i = 0; i < 10; i++) guard.checkToolCall("edit")
 		expect(guard.getState().subagentReturnedInBuild).toBe(false)
 	})

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -7,10 +7,21 @@ const DELEGATION_TOOLS = new Set(["Agent"])
 export interface OrchestratorWriteGuardOptions {
 	/** Tools that count as implementation work. Default: edit, write. */
 	implementationTools?: Set<string>
-	/** Number of implementation tool calls after a subagent return in build phase before a steer fires. Default: 2 */
+	/** Number of implementation tool calls after a successful subagent return in build phase before a steer fires. Default: 2 */
 	buildPhaseThreshold?: number
-	/** Number of implementation tool calls after a subagent return in build phase before a hard block fires. Default: 5 */
+	/** Number of implementation tool calls after a successful subagent return in build phase before a hard block fires. Default: 5 */
 	buildPhaseBlockThreshold?: number
+	/**
+	 * Number of implementation tool calls after a failed/stopped/aborted subagent return
+	 * before a steer fires. Default: 4 — higher than the success threshold because the
+	 * orchestrator is doing triage, not stealing a successful worker's output.
+	 */
+	buildPhaseTriageThreshold?: number
+	/**
+	 * Number of implementation tool calls after a failed/stopped/aborted subagent return
+	 * before a hard block fires. Default: 8.
+	 */
+	buildPhaseTriageBlockThreshold?: number
 }
 
 export const STEER_MESSAGE_TYPE = "review-write-guard-steer"
@@ -28,6 +39,33 @@ const BUILD_BLOCK_REASON =
 	"BLOCKED: You have continued editing subagent output after being warned. " +
 	"The orchestrator must not do a subagent's job. Spawn a fix Agent with the remaining work."
 
+/** Subagent outcome shape exposed in the Agent tool's result details. */
+interface AgentOutcomeSummary {
+	/** "completed" | "aborted" | "stopped" | ... */
+	status?: string
+	/** "completed" | "failed" | ... */
+	outcome?: string
+	/** Subagent persona, e.g. "Builder" | "Fixer" | "Explore". */
+	subagentType?: string
+}
+
+function isSuccessfulOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
+	if (!outcome) return true
+	return outcome.status === "completed" && outcome.outcome === "completed"
+}
+
+function isTriageOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
+	if (!outcome) return false
+	const { status, outcome: result } = outcome
+	// Explicit failure states observed from agent tool results.
+	if (status === "aborted" || status === "stopped") return true
+	if (result === "failed" || result === "error") return true
+	// A successfully completed subagent that required steering is still successful.
+	if (status === "completed" && result === "completed") return false
+	if (status === "steered" && result === "completed") return false
+	return false
+}
+
 export class OrchestratorWriteGuard {
 	private readonly ctx: ExtensionContext
 
@@ -35,8 +73,11 @@ export class OrchestratorWriteGuard {
 	private readonly delegationTools: Set<string>
 	private readonly buildPhaseThreshold: number
 	private readonly buildPhaseBlockThreshold: number
+	private readonly buildPhaseTriageThreshold: number
+	private readonly buildPhaseTriageBlockThreshold: number
 
 	private subagentReturnedInBuild = false
+	private lastSubagentSuccessful = false
 	private buildWriteCount = 0
 	private buildSteered = false
 
@@ -47,10 +88,13 @@ export class OrchestratorWriteGuard {
 		this.delegationTools = new Set(DELEGATION_TOOLS)
 		this.buildPhaseThreshold = options.buildPhaseThreshold ?? 2
 		this.buildPhaseBlockThreshold = options.buildPhaseBlockThreshold ?? 5
+		this.buildPhaseTriageThreshold = options.buildPhaseTriageThreshold ?? 4
+		this.buildPhaseTriageBlockThreshold = options.buildPhaseTriageBlockThreshold ?? 8
 	}
 
 	reset(): void {
 		this.subagentReturnedInBuild = false
+		this.lastSubagentSuccessful = false
 		this.buildWriteCount = 0
 		this.buildSteered = false
 	}
@@ -59,9 +103,7 @@ export class OrchestratorWriteGuard {
 		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
 
 		if (this.delegationTools.has(toolName)) {
-			this.subagentReturnedInBuild = false
-			this.buildWriteCount = 0
-			this.buildSteered = false
+			this.reset()
 			return undefined
 		}
 
@@ -73,10 +115,12 @@ export class OrchestratorWriteGuard {
 			if (!this.subagentReturnedInBuild) return undefined
 
 			this.buildWriteCount++
-			if (this.buildWriteCount >= this.buildPhaseBlockThreshold) {
+			const { steerThreshold, blockThreshold } = this.currentThresholds()
+
+			if (this.buildWriteCount >= blockThreshold) {
 				return { block: true, reason: BUILD_BLOCK_REASON }
 			}
-			if (this.buildWriteCount >= this.buildPhaseThreshold && !this.buildSteered) {
+			if (this.buildWriteCount >= steerThreshold && !this.buildSteered) {
 				this.buildSteered = true
 				return { steer: BUILD_STEER_MESSAGE }
 			}
@@ -89,21 +133,80 @@ export class OrchestratorWriteGuard {
 		return undefined
 	}
 
-	recordSubagentReturn(): void {
+	recordSubagentReturn(outcome?: AgentOutcomeSummary): void {
 		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
-		if (phase === "build") {
+		if (phase !== "build") return
+
+		this.buildWriteCount = 0
+		this.buildSteered = false
+
+		if (isTriageOutcome(outcome)) {
+			// Subagent did not complete successfully. The orchestrator is doing triage
+			// on partial/failed/stopped worker output; allow more direct edits before
+			// steering again. Keep the guard armed but use the higher triage thresholds.
 			this.subagentReturnedInBuild = true
-			this.buildWriteCount = 0
-			this.buildSteered = false
+			this.lastSubagentSuccessful = false
+			return
 		}
+
+		if (!isSuccessfulOutcome(outcome)) {
+			// Unknown or ambiguous outcome: be permissive and disarm rather than risk
+			// trapping the orchestrator in a delegation loop.
+			this.subagentReturnedInBuild = false
+			this.lastSubagentSuccessful = false
+			return
+		}
+
+		this.subagentReturnedInBuild = true
+		this.lastSubagentSuccessful = true
 	}
 
-	getState(): { subagentReturnedInBuild: boolean; buildWriteCount: number; buildSteered: boolean } {
+	getState(): {
+		subagentReturnedInBuild: boolean
+		lastSubagentSuccessful: boolean
+		buildWriteCount: number
+		buildSteered: boolean
+	} {
 		return {
 			subagentReturnedInBuild: this.subagentReturnedInBuild,
+			lastSubagentSuccessful: this.lastSubagentSuccessful,
 			buildWriteCount: this.buildWriteCount,
 			buildSteered: this.buildSteered,
 		}
+	}
+
+	private currentThresholds(): { steerThreshold: number; blockThreshold: number } {
+		if (!this.lastSubagentSuccessful) {
+			return {
+				steerThreshold: this.buildPhaseTriageThreshold,
+				blockThreshold: this.buildPhaseTriageBlockThreshold,
+			}
+		}
+		return {
+			steerThreshold: this.buildPhaseThreshold,
+			blockThreshold: this.buildPhaseBlockThreshold,
+		}
+	}
+}
+
+function extractAgentOutcome(event: { details?: unknown }): AgentOutcomeSummary | undefined {
+	const details = event.details
+	if (!details || typeof details !== "object") return undefined
+
+	const agentOutcome = (details as Record<string, unknown>).agentOutcome
+	if (!agentOutcome || typeof agentOutcome !== "object") return undefined
+
+	const ao = agentOutcome as Record<string, unknown>
+	const detailsSubagentType = (details as Record<string, unknown>).subagentType
+	return {
+		status: typeof ao.status === "string" ? ao.status : undefined,
+		outcome: typeof ao.outcome === "string" ? ao.outcome : undefined,
+		subagentType:
+			typeof ao.subagentType === "string"
+				? ao.subagentType
+				: typeof detailsSubagentType === "string"
+					? detailsSubagentType
+					: undefined,
 	}
 }
 
@@ -154,7 +257,7 @@ export default function reviewWriteGuardExtension(pi: ExtensionAPI, options?: Or
 	pi.on("tool_result", (event, ctx) => {
 		if (event.toolName === "Agent") {
 			const guard = getOrchestratorWriteGuard(ctx)
-			guard.recordSubagentReturn()
+			guard.recordSubagentReturn(extractAgentOutcome(event))
 		}
 	})
 }

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -51,8 +51,8 @@ interface AgentOutcomeSummary {
 
 // Undefined outcome defaults to successful. This preserves backward compatibility
 // with subagent tool_results that do not yet include structured agentOutcome details;
-// without it the guard would disarm entirely and stop steering after every legacy
-// subagent return, which would regress existing behavior.
+// without it those legacy returns would fall back to the higher triage thresholds
+// instead of the stricter success thresholds.
 function isSuccessfulOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	if (!outcome) return true
 	if (outcome.status === "steered" && outcome.outcome === "completed") return true
@@ -64,7 +64,7 @@ function isTriageOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	const { status, outcome: result } = outcome
 	// Explicit failure states observed from agent tool results.
 	if (status === "aborted" || status === "stopped" || status === "error") return true
-	return result === "failed" || result === "budget_exhausted"
+	return result === "failed" || result === "budget_exhausted" || result === "stopped"
 }
 
 export class OrchestratorWriteGuard {

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -3,7 +3,6 @@ import type { AgentOutcomeKind, AgentRecord, SubagentType } from "./agents/perso
 import { getCurrentPhase } from "./tags.js"
 
 const IMPLEMENTATION_TOOLS = new Set(["edit", "write"])
-const DELEGATION_TOOLS = new Set(["Agent"])
 
 export interface OrchestratorWriteGuardOptions {
 	/** Tools that count as implementation work. Default: edit, write. */
@@ -56,6 +55,7 @@ interface AgentOutcomeSummary {
 // subagent return, which would regress existing behavior.
 function isSuccessfulOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	if (!outcome) return true
+	if (outcome.status === "steered" && outcome.outcome === "completed") return true
 	return outcome.status === "completed" && outcome.outcome === "completed"
 }
 
@@ -64,18 +64,13 @@ function isTriageOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	const { status, outcome: result } = outcome
 	// Explicit failure states observed from agent tool results.
 	if (status === "aborted" || status === "stopped" || status === "error") return true
-	if (result === "failed" || result === "budget_exhausted") return true
-	// A successfully completed subagent that required steering is still successful.
-	if (status === "completed" && result === "completed") return false
-	if (status === "steered" && result === "completed") return false
-	return false
+	return result === "failed" || result === "budget_exhausted"
 }
 
 export class OrchestratorWriteGuard {
 	private readonly ctx: ExtensionContext
 
 	private readonly implementationTools: Set<string>
-	private readonly delegationTools: Set<string>
 	private readonly buildPhaseThreshold: number
 	private readonly buildPhaseBlockThreshold: number
 	private readonly buildPhaseTriageThreshold: number
@@ -90,11 +85,23 @@ export class OrchestratorWriteGuard {
 		this.ctx = ctx
 
 		this.implementationTools = options.implementationTools ?? new Set(IMPLEMENTATION_TOOLS)
-		this.delegationTools = new Set(DELEGATION_TOOLS)
 		this.buildPhaseThreshold = options.buildPhaseThreshold ?? 2
 		this.buildPhaseBlockThreshold = options.buildPhaseBlockThreshold ?? 5
 		this.buildPhaseTriageThreshold = options.buildPhaseTriageThreshold ?? 4
 		this.buildPhaseTriageBlockThreshold = options.buildPhaseTriageBlockThreshold ?? 8
+
+		if (this.buildPhaseThreshold >= this.buildPhaseBlockThreshold) {
+			throw new Error("buildPhaseBlockThreshold must be greater than buildPhaseThreshold")
+		}
+		if (this.buildPhaseTriageThreshold >= this.buildPhaseTriageBlockThreshold) {
+			throw new Error("buildPhaseTriageBlockThreshold must be greater than buildPhaseTriageThreshold")
+		}
+		if (this.buildPhaseTriageThreshold <= this.buildPhaseThreshold) {
+			throw new Error("buildPhaseTriageThreshold must be greater than buildPhaseThreshold")
+		}
+		if (this.buildPhaseTriageBlockThreshold <= this.buildPhaseBlockThreshold) {
+			throw new Error("buildPhaseTriageBlockThreshold must be greater than buildPhaseBlockThreshold")
+		}
 	}
 
 	reset(): void {
@@ -106,11 +113,6 @@ export class OrchestratorWriteGuard {
 
 	checkToolCall(toolName: string): { block: true; reason: string } | { steer: string } | undefined {
 		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
-
-		if (this.delegationTools.has(toolName)) {
-			this.reset()
-			return undefined
-		}
 
 		if (phase === "review" && this.implementationTools.has(toolName)) {
 			return { block: true, reason: REVIEW_BLOCK_REASON }
@@ -155,9 +157,9 @@ export class OrchestratorWriteGuard {
 		}
 
 		if (!isSuccessfulOutcome(outcome)) {
-			// Unknown or ambiguous outcome: be permissive and disarm rather than risk
-			// trapping the orchestrator in a delegation loop.
-			this.subagentReturnedInBuild = false
+			// Unknown or non-success outcome: use triage thresholds rather than disarming,
+			// so legacy/partial runtime outcomes still get some guard protection.
+			this.subagentReturnedInBuild = true
 			this.lastSubagentSuccessful = false
 			return
 		}
@@ -253,6 +255,10 @@ export default function reviewWriteGuardExtension(pi: ExtensionAPI, options?: Or
 	pi.on("session_start", (_event, ctx) => {
 		const guard = getOrchestratorWriteGuard(ctx)
 		guard.reset()
+	})
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		guardMap.delete(ctx.sessionManager.getSessionId())
 	})
 
 	pi.on("tool_call", (event, ctx) => {

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -13,13 +13,13 @@ export interface OrchestratorWriteGuardOptions {
 	buildPhaseBlockThreshold?: number
 	/**
 	 * Number of implementation tool calls after a failed/stopped/aborted subagent return
-	 * before a steer fires. Default: 4 — higher than the success threshold because the
+	 * before a steer fires. Default: 3 — higher than the success threshold because the
 	 * orchestrator is doing triage, not stealing a successful worker's output.
 	 */
 	buildPhaseTriageThreshold?: number
 	/**
 	 * Number of implementation tool calls after a failed/stopped/aborted subagent return
-	 * before a hard block fires. Default: 8.
+	 * before a hard block fires. Default: 6.
 	 */
 	buildPhaseTriageBlockThreshold?: number
 }
@@ -87,8 +87,8 @@ export class OrchestratorWriteGuard {
 		this.implementationTools = options.implementationTools ?? new Set(IMPLEMENTATION_TOOLS)
 		this.buildPhaseThreshold = options.buildPhaseThreshold ?? 2
 		this.buildPhaseBlockThreshold = options.buildPhaseBlockThreshold ?? 5
-		this.buildPhaseTriageThreshold = options.buildPhaseTriageThreshold ?? 4
-		this.buildPhaseTriageBlockThreshold = options.buildPhaseTriageBlockThreshold ?? 8
+		this.buildPhaseTriageThreshold = options.buildPhaseTriageThreshold ?? 3
+		this.buildPhaseTriageBlockThreshold = options.buildPhaseTriageBlockThreshold ?? 6
 
 		if (this.buildPhaseThreshold >= this.buildPhaseBlockThreshold) {
 			throw new Error("buildPhaseBlockThreshold must be greater than buildPhaseThreshold")
@@ -142,7 +142,12 @@ export class OrchestratorWriteGuard {
 
 	recordSubagentReturn(outcome?: AgentOutcomeSummary): void {
 		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
-		if (phase !== "build") return
+		if (phase !== "build") {
+			// A subagent return in a non-build phase should not arm the guard for a
+			// later build phase; clear any stale build-phase state.
+			this.reset()
+			return
+		}
 
 		this.buildWriteCount = 0
 		this.buildSteered = false
@@ -196,7 +201,7 @@ export class OrchestratorWriteGuard {
 	}
 }
 
-const AGENT_RECORD_STATUSES: readonly AgentRecord["status"][] = [
+const AGENT_RECORD_STATUSES: AgentRecord["status"][] = [
 	"queued",
 	"running",
 	"completed",
@@ -206,7 +211,7 @@ const AGENT_RECORD_STATUSES: readonly AgentRecord["status"][] = [
 	"error",
 ]
 
-const AGENT_OUTCOME_KINDS: readonly AgentOutcomeKind[] = ["completed", "budget_exhausted", "failed", "stopped"]
+const AGENT_OUTCOME_KINDS: AgentOutcomeKind[] = ["completed", "budget_exhausted", "failed", "stopped"]
 
 function extractAgentOutcome(event: { details?: unknown }): AgentOutcomeSummary | undefined {
 	const details = event.details
@@ -264,6 +269,11 @@ export default function reviewWriteGuardExtension(pi: ExtensionAPI, options?: Or
 	pi.on("tool_call", (event, ctx) => {
 		if (!event.toolName) return
 
+		// Agent calls are pass-through only. We deliberately do NOT reset the guard
+		// here: spawning a new subagent must not create a disarm gap where the
+		// orchestrator could edit freely while waiting for that subagent to return.
+		// The guard resets its per-return counters only when a subagent actually
+		// finishes (tool_result) or when the session/phase changes.
 		if (event.toolName === "Agent") {
 			return { block: false }
 		}

--- a/src/extensions/review-write-guard.ts
+++ b/src/extensions/review-write-guard.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { AgentOutcomeKind, AgentRecord, SubagentType } from "./agents/personas/types.js"
 import { getCurrentPhase } from "./tags.js"
 
 const IMPLEMENTATION_TOOLS = new Set(["edit", "write"])
@@ -41,14 +42,18 @@ const BUILD_BLOCK_REASON =
 
 /** Subagent outcome shape exposed in the Agent tool's result details. */
 interface AgentOutcomeSummary {
-	/** "completed" | "aborted" | "stopped" | ... */
-	status?: string
-	/** "completed" | "failed" | ... */
-	outcome?: string
+	/** Raw runtime status of the subagent. */
+	status?: AgentRecord["status"]
+	/** Stable classified result for orchestration decisions. */
+	outcome?: AgentOutcomeKind
 	/** Subagent persona, e.g. "Builder" | "Fixer" | "Explore". */
-	subagentType?: string
+	subagentType?: SubagentType
 }
 
+// Undefined outcome defaults to successful. This preserves backward compatibility
+// with subagent tool_results that do not yet include structured agentOutcome details;
+// without it the guard would disarm entirely and stop steering after every legacy
+// subagent return, which would regress existing behavior.
 function isSuccessfulOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	if (!outcome) return true
 	return outcome.status === "completed" && outcome.outcome === "completed"
@@ -58,8 +63,8 @@ function isTriageOutcome(outcome: AgentOutcomeSummary | undefined): boolean {
 	if (!outcome) return false
 	const { status, outcome: result } = outcome
 	// Explicit failure states observed from agent tool results.
-	if (status === "aborted" || status === "stopped") return true
-	if (result === "failed" || result === "error") return true
+	if (status === "aborted" || status === "stopped" || status === "error") return true
+	if (result === "failed" || result === "budget_exhausted") return true
 	// A successfully completed subagent that required steering is still successful.
 	if (status === "completed" && result === "completed") return false
 	if (status === "steered" && result === "completed") return false
@@ -189,6 +194,18 @@ export class OrchestratorWriteGuard {
 	}
 }
 
+const AGENT_RECORD_STATUSES: readonly AgentRecord["status"][] = [
+	"queued",
+	"running",
+	"completed",
+	"steered",
+	"aborted",
+	"stopped",
+	"error",
+]
+
+const AGENT_OUTCOME_KINDS: readonly AgentOutcomeKind[] = ["completed", "budget_exhausted", "failed", "stopped"]
+
 function extractAgentOutcome(event: { details?: unknown }): AgentOutcomeSummary | undefined {
 	const details = event.details
 	if (!details || typeof details !== "object") return undefined
@@ -197,10 +214,20 @@ function extractAgentOutcome(event: { details?: unknown }): AgentOutcomeSummary 
 	if (!agentOutcome || typeof agentOutcome !== "object") return undefined
 
 	const ao = agentOutcome as Record<string, unknown>
+	const rawStatus = typeof ao.status === "string" ? ao.status : undefined
+	const rawOutcome = typeof ao.outcome === "string" ? ao.outcome : undefined
 	const detailsSubagentType = (details as Record<string, unknown>).subagentType
+
+	const status = AGENT_RECORD_STATUSES.includes(rawStatus as AgentRecord["status"])
+		? (rawStatus as AgentRecord["status"])
+		: undefined
+	const outcome = AGENT_OUTCOME_KINDS.includes(rawOutcome as AgentOutcomeKind)
+		? (rawOutcome as AgentOutcomeKind)
+		: undefined
+
 	return {
-		status: typeof ao.status === "string" ? ao.status : undefined,
-		outcome: typeof ao.outcome === "string" ? ao.outcome : undefined,
+		status,
+		outcome,
 		subagentType:
 			typeof ao.subagentType === "string"
 				? ao.subagentType


### PR DESCRIPTION
# Review-Write Guard Explained Like You're 10

## The setup

Imagine you are the **Boss** (the orchestrator). You have a team of **Workers** (subagents). You are working in a workshop.

There are two rooms in the workshop:

- **Build room** — this is where people write and fix code.
- **Review room** — this is where people look at code and decide if it's good, but they are **not allowed to touch it**.

## Rule 1: No writing in the Review room

If you are in the **Review room** and you try to use a pen (`edit`/`write`) to change a file, the guard jumps in and says:

> **"BLOCKED! You can't edit during review. Make a worker do it."**

This rule is simple: in review, you only look, you don't touch.

## Rule 2: In the Build room, write freely at first

If you are in the **Build room** and no worker has come back yet, you can edit as much as you want. The guard doesn't care yet.

## Rule 3: When a worker comes back, the guard wakes up

When you send a worker away with a task and they **come back** (the `Agent` tool returns a result), the guard says:

> "Okay, a worker just finished. From now on, if the Boss tries to edit the files themselves, I'm watching."

This is called **arming the guard**.

## Rule 4: The guard counts your edits

After a worker comes back, the guard counts how many times you edit:

- **1 edit** — okay
- **2 edits** — okay
- **3 edits** — the guard taps you on the shoulder and says:

  > **"Hey, you should give this to a Fixer worker instead of doing it yourself."**

  This is called a **steer**. It's a warning, not a block.

- If you keep editing anyway and hit the higher limit, the guard stops you:

  > **"BLOCKED! Stop editing and send a worker to fix this."**

## Rule 5: Two speed limits

The guard has two different speed limits:

| Situation | Warning after | Block after |
|---|---|---|
| Worker came back successfully | 2 edits | 5 edits |
| Worker failed, got stuck, or was stopped | 3 edits | 6 edits |

Why the second one is looser: if a worker failed, the Boss is allowed to do a little detective work — check what went wrong, peek at the files, maybe fix one tiny obvious thing. That's called **triage**.

## Rule 6: Sending another worker does NOT reset the guard

If a worker comes back and the guard is armed, and then you say:

> "Okay, I'll send another worker to fix this."

…you might think the guard should reset because you're doing the right thing. But it doesn't.

Why? Because if sending a worker reset the guard, you could edit files freely while waiting for that new worker to finish. The guard would be asleep on the job. So instead, the guard stays armed until the **new worker comes back**.

When the new worker comes back, the guard resets its counter and re-arms based on whether that worker succeeded or failed.

## Rule 7: Unknown results are treated carefully

Sometimes the guard can't tell if the worker succeeded or failed (maybe the result is old and doesn't have the new "success/failed" label). In that case, it uses the looser triage limits — it gives you the benefit of the doubt, but it still watches.

## Rule 8: Clean up when leaving the room

If the workshop closes (`session_shutdown`) or you leave the build/review room for another room, the guard resets everything and forgets the old worker.

---

## Quick example

1. You are in the **Build room**.
2. You send Worker A to write some code.
3. Worker A comes back successfully.
4. The guard arms itself.
5. You edit once — okay.
6. You edit again — okay.
7. You edit a third time — **STEER**: "Use a Fixer worker!"
8. You ignore the warning and edit more.
9. You hit the sixth edit — **BLOCKED**.
10. You finally send Worker B to fix it.
11. Worker B comes back — guard resets counter, re-arms.
12. If Worker B failed, you get the looser triage limits (3 edits before steer).

That's the whole flow as it works on this branch.

## What's new on this branch

This branch hardens the delegation guard. Here is what it introduces.

### 1. Two speed limits instead of one

The guard knows the difference between a worker that came back successfully and one that failed, got stuck, or was stopped.

- **Success:** 2 edits before steer, 5 before block.
- **Triage (failed/stuck):** 3 edits before steer, 6 before block.

This gives the Boss a little extra room to investigate when a worker didn't finish cleanly.

### 2. The guard reads worker outcome reports

When a worker comes back, the guard looks at the structured outcome:

- `completed` → success limits.
- `aborted`, `stopped`, `error`, `failed`, `budget_exhausted` → triage limits.
- `steered` + `completed` → still a success, because the worker finished.

### 3. Unknown reports use triage limits

If the report is missing, confusing, or old-style, the guard doesn't go to sleep. It falls back to the looser triage limits so the Boss gets some slack but not a free pass.

### 4. Spawning another Agent does not reset the guard

If the Boss spawns a new worker, the guard stays armed. It only resets when that new worker actually comes back. This closes a gap where the Boss could edit freely while waiting for the new worker.

### 5. Workshop cleanup on closing time

When a session shuts down, the guard throws away its notes for that session.

### 6. Bad settings are caught early

If the guard is configured with backwards numbers (e.g., block before steer, or triage stricter than normal), it throws an error immediately.

### 7. Returning outside the Build room wipes old state

If a worker reports back while the session is not in the Build room, the guard clears its Build-room notes so they can't leak into the next Build-room visit.

### 8. Clearer instructions for the Boss

The orchestration prompt now tells the Boss that the "2-3" limit means **edit/write calls**, so reads and bash checks don't count.

### 9. Tests for the new behavior

The branch adds tests for triage thresholds, unknown outcomes, steered completions, Agent calls not resetting, session cleanup, threshold misconfigurations, phase transitions, and the cumulative armed behavior.


Closes #0
