### PR TITLE
feat: switch to new workspace APIs

### DIFF
--- a/src/extensions/teleport/provisioning/git-provision.test.ts
+++ b/src/extensions/teleport/provisioning/git-provision.test.ts
@@ -31,7 +31,7 @@ describe("provisionGitIdentity", () => {
 
 		await provisionGitIdentity(client, { name: "Alice", email: "a@example.com" })
 
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/gitidentity`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/gitidentity`)
 		expect(JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)).toEqual({
 			user: { name: "Alice", email: "a@example.com" },
 		})
@@ -43,15 +43,15 @@ describe("provisionGitCredential", () => {
 		const seen: Array<{ url: string; method: string }> = []
 		const mockFetch = vi.fn().mockImplementation((url: string, init: RequestInit) => {
 			seen.push({ url, method: init.method ?? "GET" })
-			if (url.endsWith("/secrets")) return Promise.resolve(new Response(null, { status: 204 }))
+			if (url.endsWith("/api/secrets")) return Promise.resolve(new Response(null, { status: 204 }))
 			return Promise.resolve(jsonResponse({ host: "github.com", user: "oauth2", secretRef: "git-token-github_com" }))
 		})
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
 		await provisionGitCredential(client, { gitHost: "github.com", gitToken: "ghp_x" })
 
-		expect(seen[0]).toEqual({ url: `${BASE}/secrets`, method: "PUT" })
-		expect(seen[1]).toEqual({ url: `${BASE}/gitidentity/github.com`, method: "POST" })
+		expect(seen[0]).toEqual({ url: `${BASE}/api/secrets`, method: "PUT" })
+		expect(seen[1]).toEqual({ url: `${BASE}/api/gitidentity/github.com`, method: "POST" })
 
 		const secretBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
 		expect(secretBody.name).toBe("git-token-github_com")

--- a/src/extensions/terminal-compat/startup-warning.test.ts
+++ b/src/extensions/terminal-compat/startup-warning.test.ts
@@ -193,8 +193,10 @@ describe("emitTerminalCompatWarning", () => {
 
 	it("does not show warning in JetBrains terminals", async () => {
 		const originalTermEmulator = process.env.TERMINAL_EMULATOR
+		const originalTmux = process.env.TMUX
 		try {
 			process.env.TERMINAL_EMULATOR = "JetBrains-JediTerm"
+			delete process.env.TMUX
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
 
 			const warnings: string[] = []
@@ -211,6 +213,11 @@ describe("emitTerminalCompatWarning", () => {
 				process.env.TERMINAL_EMULATOR = originalTermEmulator
 			} else {
 				delete process.env.TERMINAL_EMULATOR
+			}
+			if (originalTmux !== undefined) {
+				process.env.TMUX = originalTmux
+			} else {
+				delete process.env.TMUX
 			}
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
 		}

--- a/src/sandbox/cloud/readiness.test.ts
+++ b/src/sandbox/cloud/readiness.test.ts
@@ -37,7 +37,7 @@ describe("waitForWorkspaceReady", () => {
 		await expect(promise).resolves.toBeUndefined()
 
 		expect(fetchMock).toHaveBeenCalledTimes(1)
-		expect(fetchMock).toHaveBeenCalledWith("https://h.example.com/startupcompletedz", {
+		expect(fetchMock).toHaveBeenCalledWith("https://h.example.com/api/startupcompletedz", {
 			method: "GET",
 			headers: { Authorization: "Bearer tok-1" },
 			signal: expect.any(AbortSignal),

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -43,7 +43,7 @@ async function probeReadyOnce(opts: {
 	let timer: ReturnType<typeof setTimeout> | undefined
 	try {
 		const baseUrl = deriveBaseUrl(opts.wsUrl)
-		const url = `${baseUrl}/startupcompletedz`
+		const url = `${baseUrl}/api/startupcompletedz`
 
 		const ctrl = new AbortController()
 		timer = setTimeout(() => ctrl.abort(), opts.probeTimeoutMs)

--- a/src/sandbox/worker/client.test.ts
+++ b/src/sandbox/worker/client.test.ts
@@ -51,11 +51,11 @@ describe("WorkerClient", () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
 		const client = new WorkerClient(creds({ connectToken: "tok-abc" }), { fetch: mockFetch })
 
-		const result = await client.get<{ ok: boolean }>("/status")
+		const result = await client.get<{ ok: boolean }>("/api/status")
 
 		expect(result).toEqual({ ok: true })
 		expect(mockFetch).toHaveBeenCalledTimes(1)
-		expect(mockFetch.mock.calls[0][0]).toBe("https://ws-1.remote.kimchi.dev/status")
+		expect(mockFetch.mock.calls[0][0]).toBe("https://ws-1.remote.kimchi.dev/api/status")
 		expect(mockFetch.mock.calls[0][1]).toMatchObject({
 			method: "GET",
 			headers: expect.objectContaining({
@@ -69,7 +69,7 @@ describe("WorkerClient", () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ created: true }, 201))
 		const client = new WorkerClient(creds({ connectToken: "tok-xyz" }), { fetch: mockFetch })
 
-		const result = await client.post<{ created: boolean }>("/session/foo", { agentMode: "PTY" })
+		const result = await client.post<{ created: boolean }>("/api/session/foo", { agentMode: "PTY" })
 
 		expect(result).toEqual({ created: true })
 		const [, init] = mockFetch.mock.calls[0]
@@ -87,7 +87,7 @@ describe("WorkerClient", () => {
 		const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
 		const client = new WorkerClient(creds(), { fetch: mockFetch })
 
-		await expect(client.del("/session/foo")).resolves.toBeUndefined()
+		await expect(client.del("/api/session/foo")).resolves.toBeUndefined()
 		expect(mockFetch.mock.calls[0][1]).toMatchObject({
 			method: "DELETE",
 			headers: expect.objectContaining({ Authorization: "Bearer jwt-tok" }),
@@ -97,15 +97,15 @@ describe("WorkerClient", () => {
 	it("prefixes paths missing a leading slash", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse({}))
 		const client = new WorkerClient(creds(), { fetch: mockFetch })
-		await client.get("status")
-		expect(mockFetch.mock.calls[0][0]).toBe("https://ws-1.remote.kimchi.dev/status")
+		await client.get("api/status")
+		expect(mockFetch.mock.calls[0][0]).toBe("https://ws-1.remote.kimchi.dev/api/status")
 	})
 
 	it("throws WorkerError with status + parsed JSON body on 4xx", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ message: "session not found" }, 404))
 		const client = new WorkerClient(creds(), { fetch: mockFetch })
 
-		await expect(client.get("/session/missing")).rejects.toMatchObject({
+		await expect(client.get("/api/session/missing")).rejects.toMatchObject({
 			name: "WorkerError",
 			status: 404,
 			body: { message: "session not found" },
@@ -121,7 +121,7 @@ describe("WorkerClient", () => {
 		)
 		const client = new WorkerClient(creds(), { fetch: mockFetch })
 
-		await expect(client.get("/status")).rejects.toMatchObject({
+		await expect(client.get("/api/status")).rejects.toMatchObject({
 			name: "WorkerError",
 			status: 500,
 			body: "kaboom",
@@ -140,7 +140,7 @@ describe("WorkerClient", () => {
 		})
 		const client = new WorkerClient(creds(), { fetch: mockFetch })
 
-		await expect(client.get("/status", ctrl.signal)).rejects.toThrow()
+		await expect(client.get("/api/status", ctrl.signal)).rejects.toThrow()
 	})
 
 	it("times out via timeoutMs (signal becomes aborted)", async () => {
@@ -151,6 +151,6 @@ describe("WorkerClient", () => {
 		})
 		const client = new WorkerClient(creds(), { fetch: mockFetch, timeoutMs: 5 })
 
-		await expect(client.get("/status")).rejects.toThrow()
+		await expect(client.get("/api/status")).rejects.toThrow()
 	})
 })

--- a/src/sandbox/worker/git-identity.test.ts
+++ b/src/sandbox/worker/git-identity.test.ts
@@ -21,13 +21,13 @@ function jsonResponse(body: unknown, status = 200): Response {
 const IDENTITY: GitIdentity = { host: "github.com", user: "oauth2", secretRef: "git-token-github-com" }
 
 describe("setGitGlobalConfig", () => {
-	it("PUTs /gitidentity with the user name/email", async () => {
+	it("PUTs /api/gitidentity with the user name/email", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
 		await setGitGlobalConfig(client, { name: "Alice", email: "a@example.com" })
 
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/gitidentity`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/gitidentity`)
 		const init = mockFetch.mock.calls[0][1] as RequestInit
 		expect(init.method).toBe("PUT")
 		expect(JSON.parse(init.body as string)).toEqual({ user: { name: "Alice", email: "a@example.com" } })
@@ -64,7 +64,7 @@ describe("upsertGitIdentity", () => {
 
 		expect(result).toEqual(IDENTITY)
 		expect(mockFetch).toHaveBeenCalledTimes(1)
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/gitidentity/github.com`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/gitidentity/github.com`)
 		expect((mockFetch.mock.calls[0][1] as RequestInit).method).toBe("POST")
 	})
 
@@ -84,7 +84,7 @@ describe("upsertGitIdentity", () => {
 		expect(mockFetch).toHaveBeenCalledTimes(2)
 		expect((mockFetch.mock.calls[0][1] as RequestInit).method).toBe("POST")
 		expect((mockFetch.mock.calls[1][1] as RequestInit).method).toBe("PUT")
-		expect(mockFetch.mock.calls[1][0]).toBe(`${BASE}/gitidentity/github.com`)
+		expect(mockFetch.mock.calls[1][0]).toBe(`${BASE}/api/gitidentity/github.com`)
 	})
 
 	it("rethrows non-409 errors without retrying", async () => {

--- a/src/sandbox/worker/git-identity.ts
+++ b/src/sandbox/worker/git-identity.ts
@@ -3,7 +3,7 @@ import { type CreateGitIdentityRequest, type GitIdentity, type UpdateGitIdentity
 
 /**
  * Set the global git user name/email on the sandbox via
- * `PUT /gitidentity` (worker runs `git config --global user.name/user.email`).
+ * `PUT /api/gitidentity` (worker runs `git config --global user.name/user.email`).
  * No-op if both are empty.
  */
 export async function setGitGlobalConfig(
@@ -15,15 +15,15 @@ export async function setGitGlobalConfig(
 	const user: { name?: string; email?: string } = {}
 	if (cfg.name) user.name = cfg.name
 	if (cfg.email) user.email = cfg.email
-	await client.putVoid("/gitidentity", { user }, signal)
+	await client.putVoid("/api/gitidentity", { user }, signal)
 }
 
 export async function listGitIdentities(client: WorkerClient, signal?: AbortSignal): Promise<GitIdentity[]> {
-	return client.get<GitIdentity[]>("/gitidentity", signal)
+	return client.get<GitIdentity[]>("/api/gitidentity", signal)
 }
 
 export async function getGitIdentity(client: WorkerClient, host: string, signal?: AbortSignal): Promise<GitIdentity> {
-	return client.get<GitIdentity>(`/gitidentity/${encodeURIComponent(host)}`, signal)
+	return client.get<GitIdentity>(`/api/gitidentity/${encodeURIComponent(host)}`, signal)
 }
 
 export async function createGitIdentity(
@@ -32,7 +32,7 @@ export async function createGitIdentity(
 	req: CreateGitIdentityRequest,
 	signal?: AbortSignal,
 ): Promise<GitIdentity> {
-	return client.post<GitIdentity>(`/gitidentity/${encodeURIComponent(host)}`, req, signal)
+	return client.post<GitIdentity>(`/api/gitidentity/${encodeURIComponent(host)}`, req, signal)
 }
 
 export async function updateGitIdentity(
@@ -41,11 +41,11 @@ export async function updateGitIdentity(
 	req: UpdateGitIdentityRequest,
 	signal?: AbortSignal,
 ): Promise<GitIdentity> {
-	return client.put<GitIdentity>(`/gitidentity/${encodeURIComponent(host)}`, req, signal)
+	return client.put<GitIdentity>(`/api/gitidentity/${encodeURIComponent(host)}`, req, signal)
 }
 
 export async function deleteGitIdentity(client: WorkerClient, host: string, signal?: AbortSignal): Promise<void> {
-	await client.del(`/gitidentity/${encodeURIComponent(host)}`, signal)
+	await client.del(`/api/gitidentity/${encodeURIComponent(host)}`, signal)
 }
 
 /**

--- a/src/sandbox/worker/secrets.test.ts
+++ b/src/sandbox/worker/secrets.test.ts
@@ -14,13 +14,13 @@ const CREDS: WorkspaceCredentials = {
 const BASE = "https://ws-1.remote.kimchi.dev"
 
 describe("putSecret", () => {
-	it("PUTs /secrets with a base64-encoded value", async () => {
+	it("PUTs /api/secrets with a base64-encoded value", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
 		await putSecret(client, { name: "git-token-github-com", value: "ghp_secret" })
 
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/secrets`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/secrets`)
 		const init = mockFetch.mock.calls[0][1] as RequestInit
 		expect(init.method).toBe("PUT")
 		const body = JSON.parse(init.body as string)
@@ -49,13 +49,13 @@ describe("putSecret", () => {
 })
 
 describe("deleteSecret", () => {
-	it("DELETEs /secrets/{name} URL-encoded", async () => {
+	it("DELETEs /api/secrets/{name} URL-encoded", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
 		await deleteSecret(client, "git-token-github-com")
 
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/secrets/git-token-github-com`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/secrets/git-token-github-com`)
 		expect(mockFetch.mock.calls[0][1]).toMatchObject({ method: "DELETE" })
 	})
 })

--- a/src/sandbox/worker/secrets.ts
+++ b/src/sandbox/worker/secrets.ts
@@ -13,7 +13,7 @@ export interface PutSecretOptions {
  */
 export async function putSecret(client: WorkerClient, opts: PutSecretOptions, signal?: AbortSignal): Promise<void> {
 	await client.putVoid(
-		"/secrets",
+		"/api/secrets",
 		{
 			name: opts.name,
 			value: Buffer.from(opts.value, "utf-8").toString("base64"),
@@ -24,5 +24,5 @@ export async function putSecret(client: WorkerClient, opts: PutSecretOptions, si
 }
 
 export async function deleteSecret(client: WorkerClient, name: string, signal?: AbortSignal): Promise<void> {
-	await client.del(`/secrets/${encodeURIComponent(name)}`, signal)
+	await client.del(`/api/secrets/${encodeURIComponent(name)}`, signal)
 }

--- a/src/sandbox/worker/sessions.test.ts
+++ b/src/sandbox/worker/sessions.test.ts
@@ -56,7 +56,7 @@ describe("listSessions", () => {
 		expect(result.map((s) => s.name).sort()).toEqual(["alpha", "beta"])
 		const alpha = result.find((s) => s.name === "alpha")
 		expect(alpha).toMatchObject({ name: "alpha", agentMode: "PTY", alive: true })
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/session?clientType=${HARNESS_CLIENT_TYPE}`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/session?clientType=${HARNESS_CLIENT_TYPE}`)
 	})
 
 	it("returns an empty array when the worker has no sessions", async () => {
@@ -81,7 +81,7 @@ describe("listSessions", () => {
 })
 
 describe("getSession", () => {
-	it("hits /session/{name} and embeds the name", async () => {
+	it("hits /api/session/{name} and embeds the name", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(sessionFixture()))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
@@ -89,14 +89,14 @@ describe("getSession", () => {
 
 		expect(result.name).toBe("foo")
 		expect(result.agentMode).toBe("PTY")
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/session/foo`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/session/foo`)
 	})
 
 	it("URL-encodes the session name", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(jsonResponse(sessionFixture()))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 		await getSession(client, "a b/c")
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/session/a%20b%2Fc`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/session/a%20b%2Fc`)
 	})
 
 	it("surfaces 404 as WorkerError with status preserved", async () => {
@@ -125,7 +125,7 @@ describe("createSession", () => {
 		const result = await createSession(client, "foo", req)
 
 		expect(result.name).toBe("foo")
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/session/foo`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/session/foo`)
 		const init = mockFetch.mock.calls[0][1] as RequestInit
 		expect(init.method).toBe("POST")
 		expect(init.body).toBeInstanceOf(FormData)
@@ -192,7 +192,7 @@ describe("createSession large-repo regression", () => {
 	beforeEach(async () => {
 		serverDelayMs = 0
 		server = createServer((req, res) => {
-			if (req.method === "POST" && req.url?.startsWith("/session/")) {
+			if (req.method === "POST" && req.url?.startsWith("/api/session/")) {
 				req.on("data", () => {})
 				req.on("end", () => {
 					setTimeout(() => {
@@ -243,13 +243,13 @@ describe("createSession large-repo regression", () => {
 })
 
 describe("deleteSession", () => {
-	it("DELETEs /session/{name}", async () => {
+	it("DELETEs /api/session/{name}", async () => {
 		const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
 		const client = new WorkerClient(CREDS, { fetch: mockFetch })
 
 		await deleteSession(client, "foo")
 
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/session/foo`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/session/foo`)
 		expect(mockFetch.mock.calls[0][1]).toMatchObject({ method: "DELETE" })
 	})
 

--- a/src/sandbox/worker/sessions.ts
+++ b/src/sandbox/worker/sessions.ts
@@ -4,12 +4,12 @@ import type { CreateSessionRequest, Session } from "./types.js"
 
 export async function listSessions(client: WorkerClient, signal?: AbortSignal): Promise<Session[]> {
 	const params = new URLSearchParams({ clientType: HARNESS_CLIENT_TYPE })
-	const map = await client.get<Record<string, Omit<Session, "name">>>(`/session?${params.toString()}`, signal)
+	const map = await client.get<Record<string, Omit<Session, "name">>>(`/api/session?${params.toString()}`, signal)
 	return Object.entries(map).map(([name, s]) => ({ ...s, name }))
 }
 
 export async function getSession(client: WorkerClient, name: string, signal?: AbortSignal): Promise<Session> {
-	const s = await client.get<Omit<Session, "name">>(`/session/${encodeURIComponent(name)}`, signal)
+	const s = await client.get<Omit<Session, "name">>(`/api/session/${encodeURIComponent(name)}`, signal)
 	return { ...s, name }
 }
 
@@ -20,7 +20,7 @@ export async function createSession(
 	opts: { sessionFile?: string; signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<Session> {
 	const s = await client.postMultipart<Omit<Session, "name">>(
-		`/session/${encodeURIComponent(name)}`,
+		`/api/session/${encodeURIComponent(name)}`,
 		{ request: req, sessionFile: opts.sessionFile },
 		opts.signal,
 		opts.timeoutMs,
@@ -29,5 +29,5 @@ export async function createSession(
 }
 
 export async function deleteSession(client: WorkerClient, name: string, signal?: AbortSignal): Promise<void> {
-	await client.del(`/session/${encodeURIComponent(name)}`, signal)
+	await client.del(`/api/session/${encodeURIComponent(name)}`, signal)
 }

--- a/src/sandbox/worker/status.test.ts
+++ b/src/sandbox/worker/status.test.ts
@@ -42,7 +42,7 @@ describe("getStatus", () => {
 		const result = await getStatus(client)
 
 		expect(result).toEqual(fixture)
-		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/status`)
+		expect(mockFetch.mock.calls[0][0]).toBe(`${BASE}/api/status`)
 		expect(mockFetch.mock.calls[0][1]).toMatchObject({
 			method: "GET",
 			headers: expect.objectContaining({ Authorization: "Bearer jwt-tok" }),

--- a/src/sandbox/worker/status.ts
+++ b/src/sandbox/worker/status.ts
@@ -2,5 +2,5 @@ import type { WorkerClient } from "./client.js"
 import type { SandboxStatus } from "./types.js"
 
 export async function getStatus(client: WorkerClient, signal?: AbortSignal): Promise<SandboxStatus> {
-	return client.get<SandboxStatus>("/status", signal)
+	return client.get<SandboxStatus>("/api/status", signal)
 }

--- a/src/sandbox/worker/types.ts
+++ b/src/sandbox/worker/types.ts
@@ -23,7 +23,7 @@ export interface SessionDetails {
 }
 
 /**
- * Shape of the `request` part of the multipart `POST /session/{name}` body.
+ * Shape of the `request` part of the multipart `POST /api/session/{name}` body.
  * The endpoint also accepts an optional `sessionFile` (session.jsonl) binary
  * part to seed/resume the new session.
  */


### PR DESCRIPTION
The workspace API endpoints have been moved to under the `/api` path.

## Linked issue

Closes #0