### PR TITLE
fix(ferment): use continuation policy instead of oneshot flag for error/shutdown decisions

### DIFF
--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -1167,6 +1167,7 @@ describe("turn_end error recovery in one-shot mode", () => {
 			...createDefaultFermentRuntime(),
 			getStorage: () => storage,
 		}
+		runtime.setContinuationPolicy("manual")
 		const active = storage.get(ferment.id)
 		if (!active) throw new Error("ferment not found after setup")
 		runtime.setActive(active)
@@ -1239,6 +1240,72 @@ describe("turn_end error recovery in one-shot mode", () => {
 
 		expect(pi.sendMessage).not.toHaveBeenCalled()
 		expect(storage.get(ferment.id)?.status).toBe("running")
+	})
+})
+
+describe("TUI /ferment one-shot without ferment-oneshot flag", () => {
+	it("auto-continues on turn_end error when continuation policy is automated (fix)", async () => {
+		// /ferment one-shot via the TUI slash command sets the continuation
+		// policy to "automated" via createFerment, but does NOT set the
+		// pi flag "ferment-oneshot" (that flag is only set by the CLI
+		// --ferment-oneshot argument). Previously the turn_end error handler
+		// read pi.getFlag("ferment-oneshot") to decide whether to pause or
+		// auto-continue — so a TUI one-shot session got paused on any
+		// connection error. The fix uses runtime.isAutomatedContinuationEnabled()
+		// instead, which is the actual source of truth.
+		const { storage, ferment } = setupScopedRunningFerment("ferment-tui-oneshot-error-", "TUI One-shot Error Ferment")
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			getStorage: () => storage,
+			isAutomatedContinuationEnabled: () => true,
+		}
+		const active = storage.get(ferment.id)
+		if (!active) throw new Error("ferment not found after setup")
+		runtime.setActive(active)
+
+		const { handlers, pi } = createPi()
+		// Simulate TUI /ferment one-shot: the flag is NOT set.
+		// createFerment already set the policy to "automated".
+		;(pi.getFlag as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+		registerFermentEvents(pi, runtime)
+		const turnEnd = handlers.get("turn_end")
+		if (!turnEnd) throw new Error("turn_end handler was not registered")
+		const notify = vi.fn()
+		const ctx = { ui: { notify } }
+
+		await turnEnd(
+			{
+				message: {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "Connection error: socket closed",
+					content: [],
+				},
+			},
+			ctx,
+		)
+
+		// After fix: the ferment stays running and a continuation nudge is injected.
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("running")
+		expect(notify).not.toHaveBeenCalledWith(expect.stringContaining("was paused"))
+		expect(pi.sendMessage).toHaveBeenCalled()
+	})
+
+	it("abandons on session_shutdown when continuation policy is automated (fix)", async () => {
+		// Same root cause area: session_shutdown previously read
+		// pi.getFlag("ferment-oneshot") to decide pause vs abandon. Without
+		// the flag (TUI one-shot), it paused — leaving a stuck ferment.
+		// The fix uses runtime.isAutomatedContinuationEnabled() instead.
+		const { storage, ferment, handlers } = setupAutomatedGuardFixture("TUI Shutdown Ferment")
+		const shutdown = handlers.get("session_shutdown")
+		if (!shutdown) throw new Error("session_shutdown handler was not registered")
+
+		await shutdown({}, {})
+
+		// After fix: abandoned because the continuation policy is automated.
+		const stored = storage.get(ferment.id)
+		expect(stored?.status).toBe("abandoned")
 	})
 })
 

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -5,7 +5,6 @@ import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { getMultiModelEnabled } from "../multi-model.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
-import { isStaleCtxError } from "../stale-ctx.js"
 import { maybeTriggerFermentCompaction, maybeTriggerMidTurnFermentCompaction } from "./auto-compaction.js"
 import { formatDuration } from "./colors.js"
 import { extractContextualOptions, extractTrailingQuestion } from "./contextual-options.js"
@@ -34,7 +33,7 @@ import { editPhaseProposal } from "./phase-editor.js"
 import { promptEditor, promptSelect } from "./prompt-ui.js"
 import { loadFermentSilently, resumeFerment } from "./resume.js"
 import { defaultFermentRuntime, type FermentRuntime } from "./runtime.js"
-import { safeSendMessage, tryPiAction } from "./safe-send.js"
+import { safeSendMessage } from "./safe-send.js"
 import { scheduleFermentWakeUp, scheduleNextFermentAction } from "./scheduler.js"
 import { confirmPendingScope } from "./scoping-confirmation.js"
 import { buildStalledPayload } from "./stalled-payload.js"
@@ -50,40 +49,6 @@ import { createApplyAndPersist } from "./tool-helpers.js"
 import { applyFermentRuntimeToolProfile, hasPendingPlanReview, setActiveFermentAndApplyProfile } from "./tool-scope.js"
 
 type AssistantContentPart = { type: string; text?: string; name?: string }
-
-// Telemetry wrapper: reads pi.getFlag(name), appends a ferment_breadcrumb with the
-// result/throw for /export visibility. Returns undefined on throw.
-function readFlag(pi: ExtensionAPI, name: string, location: string, fermentId: string | undefined): unknown {
-	let value: unknown = null
-	let errorMessage: string | null = null
-	try {
-		value = pi.getFlag?.(name) ?? null
-	} catch (err) {
-		errorMessage = err instanceof Error ? err.message : String(err)
-	}
-	const threw = errorMessage !== null
-	const staleCtx = threw && isStaleCtxError(errorMessage)
-	const payload = {
-		telemetry: "ferment_flag_read",
-		flag: name,
-		location,
-		fermentId: fermentId ?? null,
-		getFlagPresent: typeof pi.getFlag === "function",
-		value,
-		threw,
-		staleCtx,
-		error: errorMessage,
-	}
-	// Mirror the scheduler/nudge pattern: appendEntry on a ferment_breadcrumb
-	// so it is rendered in the /export HTML session transcript.
-	tryPiAction(() => {
-		pi.appendEntry("ferment_breadcrumb", {
-			text: `flag-read ${name} [${location}] ferment=${fermentId ?? "none"} threw=${threw} staleCtx=${staleCtx} value=${JSON.stringify(value)}${threw ? ` error=${JSON.stringify(errorMessage)}` : ""}`,
-			telemetry: payload,
-		})
-	})
-	return threw ? undefined : value
-}
 
 function isAssistantContentPart(value: unknown): value is AssistantContentPart {
 	return typeof value === "object" && value !== null && "type" in value && typeof value.type === "string"
@@ -425,8 +390,11 @@ export function registerFermentEvents(
 		if (!f) return
 		if (f.status === "running" || f.status === "planned") {
 			try {
-				const isOneShot = readFlag(pi, "ferment-oneshot", "session_shutdown", f.id) === true
-				applyAndPersist(f.id, { type: isOneShot ? "abandon" : "pause" })
+				// The continuation policy is the source of truth — the ferment-oneshot
+				// flag is only set by the CLI --ferment-oneshot argument, not by the TUI
+				// /ferment one-shot slash command.
+				const isAutomated = runtime.isAutomatedContinuationEnabled()
+				applyAndPersist(f.id, { type: isAutomated ? "abandon" : "pause" })
 			} catch {
 				// If persistence fails during shutdown, we can't fix it here.
 				// The startup scanner will recover the stale state on next launch.
@@ -556,14 +524,17 @@ export function registerFermentEvents(
 
 		// Connection / provider / gateway failure: the model's turn ended with
 		// stopReason "error" after retries were exhausted (or the error was
-		// non-retryable). In interactive mode, pause the ferment so its state
-		// stays valid and surface a clear message to the user. In one-shot mode,
-		// keep the ferment running and inject a continuation nudge so the
+		// non-retryable). Under manual policy, pause the ferment so its state
+		// stays valid and surface a clear message to the user. Under automated
+		// policy, keep the ferment running and inject a continuation nudge so the
 		// orchestrator retries on the next turn — there is no user to resume.
 		if (stopReason === "error") {
-			const isOneShot = readFlag(pi, "ferment-oneshot", "turn_end_error", activeId) === true
+			// The continuation policy is the source of truth — the ferment-oneshot
+			// flag is only set by the CLI --ferment-oneshot argument, not by the TUI
+			// /ferment one-shot slash command.
+			const isAutomated = runtime.isAutomatedContinuationEnabled()
 
-			if (!isOneShot) {
+			if (!isAutomated) {
 				const errorMessage = getMessageStringField(event.message, "errorMessage")
 				const errorFerment = runtime.getActive()
 				if (errorFerment && (errorFerment.status === "running" || errorFerment.status === "planned")) {
@@ -589,12 +560,12 @@ export function registerFermentEvents(
 				resetScopingExploreTurns(activeId)
 			}
 
-			// One-shot error recovery: schedule a continuation turn directly via
+			// Automated error recovery: schedule a continuation turn directly via
 			// the scheduler. This is a transport/provider failure, not a model-chosen
 			// bare stop. Error recovery deliberately clears the lifecycle-stop retry
 			// budget above, then schedules the next action independently. This gives
 			// the unchanged obligation a fresh two-retry budget after transport recovers.
-			if (isOneShot) {
+			if (isAutomated) {
 				const errorFerment = runtime.getActive()
 				// One-shot error recovery fires only when the ferment is still live —
 				// paused/complete/abandoned ferments must not be auto-continued.


### PR DESCRIPTION
Fixes #955

## Problem

When running `/ferment one-shot` via the TUI slash command, the agent would unexpectedly stop between steps and tell the user to run `/ferment resume`. This happened on transient transport errors (timeouts, socket closures) that should have been auto-recovered.

## Root Cause

The `turn_end` error handler and `session_shutdown` handler in `src/extensions/ferment/events.ts` used `pi.getFlag("ferment-oneshot")` to decide whether to pause (interactive) or auto-continue/abandon (one-shot). This flag is **only set by the CLI `--ferment-oneshot` argument** — the TUI `/ferment one-shot` slash command never sets it. So `pi.getFlag("ferment-oneshot")` returned `undefined` for TUI one-shot sessions, causing them to be treated as interactive and **paused** on any connection error.

A session export confirmed this: two stoppages caused by `"The operation timed out."` and `"The socket connection was closed unexpectedly"` — both classified as `transport_failure, retryable: true`, but the ferment was paused instead of auto-continued.

## Fix

Use `runtime.isAutomatedContinuationEnabled()` (which checks the continuation policy — the actual source of truth set by `createFerment`) instead of `pi.getFlag("ferment-oneshot")` in both the `turn_end` error handler and `session_shutdown` handler. The continuation policy is correctly set to `"automated"` by `createFerment` → `continuationPolicyForNewFerment(hasUI, isOneShot)` for both CLI and TUI one-shot paths.

Also removes the now-unused `readFlag` telemetry wrapper and its import.

## Testing

- [x] Added regression tests proving TUI one-shot sessions auto-continue on errors (ferment stays `running`, nudge injected) instead of pausing
- [x] Added regression test proving TUI one-shot sessions are abandoned (not paused) on session shutdown under automated policy
- [x] Updated existing test to explicitly set `"manual"` policy (was relying on the flag returning `undefined`)
- [x] All 270 tests across 9 ferment test files pass

- [x] Bug fix (non-breaking change)
