### PR TITLE
fix: session name prompt

### DIFF
--- a/src/extensions/session-name.test.ts
+++ b/src/extensions/session-name.test.ts
@@ -79,19 +79,19 @@ const createMockCtx = (entries: unknown[]) => {
 }
 
 describe("deterministicFallback", () => {
-	it("should return input as-is when <= 35 chars", () => {
+	it("should return input as-is when <= 50 chars", () => {
 		expect(deterministicFallback("short-name")).toBe("short-name")
-		expect(deterministicFallback("a".repeat(35))).toBe("a".repeat(35))
+		expect(deterministicFallback("a".repeat(50))).toBe("a".repeat(50))
 	})
 
-	it("should truncate at last space before 35 chars", () => {
+	it("should truncate at last space before 50 chars", () => {
 		const longName = "this is a very long session name that should be truncated"
-		expect(deterministicFallback(longName)).toBe("this is a very long session name")
+		expect(deterministicFallback(longName)).toBe("this is a very long session name that should be")
 	})
 
-	it("should handle no spaces by truncating at 35", () => {
-		const noSpaces = "a".repeat(50)
-		expect(deterministicFallback(noSpaces)).toBe("a".repeat(35))
+	it("should handle no spaces by truncating at 50", () => {
+		const noSpaces = "a".repeat(70)
+		expect(deterministicFallback(noSpaces)).toBe("a".repeat(50))
 	})
 
 	it("should trim whitespace", () => {
@@ -228,7 +228,7 @@ describe("suggestSessionName", () => {
 			},
 		])
 		const result = await suggestSessionName(ctx as never, undefined, true)
-		expect(result).toBe("this is a very long session name")
+		expect(result).toBe("this is a very long session name that should be")
 	})
 
 	it("should use provided hint instead of extracting from context", async () => {

--- a/src/extensions/session-name.ts
+++ b/src/extensions/session-name.ts
@@ -17,10 +17,11 @@ import { loadConfig, RETRY_DEFAULTS } from "../config.js"
 import { fetchWithRetry } from "../utils/http.js"
 
 export const SESSION_NAME_MODEL = "deepseek-v4-flash"
-const SESSION_NAME_SYSTEM_PROMPT =
-	"You are a title generator. Respond with ONLY a short title. 1-5 words, no quotes, no explanation, no markdown."
-const HINT_MAX_LEN = 500
 const SESSION_NAME_TIMEOUT_MS = 10_000
+
+const SESSION_NAME_MAX_LEN = 50
+const SESSION_NAME_SYSTEM_PROMPT = `You are a title generator. Respond ONLY with a short, descriptive title (3-6 words, max ${SESSION_NAME_MAX_LEN} chars, easy to scan). No quotes, no explanation, no markdown.`
+const HINT_MAX_LEN = 500
 
 function getSessionNameMaxRetries(cwd: string): number {
 	try {
@@ -93,10 +94,10 @@ function extractEarlyUserText(entries: SessionEntries): string | null {
 }
 
 /**
- * Deterministic title: truncate name at 35 chars at last space.
+ * Deterministic title: truncate name at SESSION_NAME_MAX_LEN chars at last space.
  */
 export function deterministicFallback(input: string): string {
-	const max = 35
+	const max = SESSION_NAME_MAX_LEN
 	const normalized = input.trim().replace(/\s+/g, " ")
 	if (normalized.length <= max) return normalized
 	const truncated = normalized.slice(0, max)
@@ -143,9 +144,12 @@ export async function suggestSessionName(ctx: ExtensionContext, hint?: string, q
 					model: SESSION_NAME_MODEL,
 					messages: [
 						{ role: "system", content: SESSION_NAME_SYSTEM_PROMPT },
-						{ role: "user", content: `Short title for this conversation:\n\n${capHint(resolvedHint)}` },
+						{
+							role: "user",
+							content: `Generate a concise, descriptive title for this conversation:\n\n${capHint(resolvedHint)}`,
+						},
 					],
-					max_tokens: 32,
+					max_tokens: 40,
 					temperature: 0,
 				}),
 			},


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Previously, the session name generated was way too short and ambiguous. A lot of these times conversations may revolve around similar topics, but the session names were too short to identify that. Updated the prompt so that it does it better.

Previous:
<img width="638" height="406" alt="image" src="https://github.com/user-attachments/assets/5798791c-d7dd-4225-9bfc-324071e8d315" />

Fixed:
<img width="626" height="252" alt="image" src="https://github.com/user-attachments/assets/da97f68c-bd68-452c-a293-aaf175527075" />

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
