### PR TITLE
fix: stop retries for exhausted budgets

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -496,7 +496,8 @@ try {
 
 		installGlobalFetchInstrumentation({
 			userAgent: `kimchi/${getVersion()}`,
-			onModelCompletionSettled: (originalFetch) => refreshBillingStatusFromConfig({ fetch: originalFetch }),
+			onModelCompletionSettled: (originalFetch) =>
+				refreshBillingStatusFromConfig({ fetch: originalFetch, mode: "automatic" }),
 		})
 
 		const interactiveStartupContext = {

--- a/src/extensions/billing/command.ts
+++ b/src/extensions/billing/command.ts
@@ -81,7 +81,7 @@ function formatProviderLimit(limitType: string, budgetLimitUsd: string): string 
 
 async function handleBudgetCommand(ctx: ExtensionCommandContext): Promise<void> {
 	if (!ctx.hasUI) return
-	await refreshBillingStatusFromConfig()
+	await refreshBillingStatusFromConfig({ mode: "forced" })
 	const budget = getBillingStatus()?.budget
 	if (!budget) {
 		ctx.ui.notify("Budget information is currently unavailable.", "warning")

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -845,6 +845,10 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 	it("throttles automatic refreshes inside the TTL to one snapshot", async () => {
 		configureWithKey()
 		const calls: string[] = []
+		const configLoader = vi.fn(() => ({
+			apiKey: "api-key",
+			llmEndpoint: "https://llm.kimchi.dev/openai/v1",
+		}))
 		const fetchImpl = ((input: RequestInfo | URL) => {
 			calls.push(String(input))
 			return Promise.resolve(
@@ -852,13 +856,15 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 			)
 		}) as typeof fetch
 
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: configLoader, mode: "automatic" })
 		const firstSnapshot = getBillingStatus()
 
-		// Advance less than the TTL — second automatic refresh must be skipped.
+		// Advance less than the TTL — second automatic refresh must be skipped
+		// before performing another synchronous config read.
 		vi.advanceTimersByTime(AUTOMATIC_REFRESH_MIN_INTERVAL_MS - 1_000)
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: configLoader, mode: "automatic" })
 
+		expect(configLoader).toHaveBeenCalledOnce()
 		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(1)
 		expect(getBillingStatus()).toBe(firstSnapshot)
 	})
@@ -914,6 +920,55 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 
 		await refreshBillingStatusFromConfig({ fetch: fetchImpl })
 		expect(getBillingStatus()).toMatchObject({ remainingCredits: 5 })
+	})
+
+	it("does not bump the throttle timestamp when credentials invalidate the in-flight refresh", async () => {
+		// Stable credentials across both calls so the second refresh's
+		// configureBillingCreditsApi is a no-op — otherwise a credential flip
+		// would reset lastRefreshAt=0 and mask the stale-timestamp bug.
+		const configWith = (apiKey: string) => () => ({
+			apiKey,
+			llmEndpoint: "https://llm.kimchi.dev/openai/v1",
+		})
+		// Seed with the old key so the mid-flight credential change is real.
+		configureBillingCreditsApi({ apiKey: "old-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+
+		let resolveResponse!: (response: Response) => void
+		const pendingResponse = new Promise<Response>((resolve) => {
+			resolveResponse = resolve
+		})
+		const fetchImpl = ((_input: RequestInfo | URL) => pendingResponse) as typeof fetch
+
+		const refresh = refreshBillingStatusFromConfig({
+			fetch: fetchImpl,
+			mode: "automatic",
+			loadConfig: configWith("old-key"),
+		})
+		// Credential change mid-flight invalidates the coalesced refresh and
+		// resets the throttle (lastRefreshAt = 0).
+		configureBillingCreditsApi({ apiKey: "new-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+		resolveResponse(
+			new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+		)
+
+		await expect(refresh).resolves.toBeUndefined()
+
+		// A subsequent automatic refresh must NOT be throttled by the stale
+		// resolution — the credential reset must stand.
+		const calls: string[] = []
+		const nextFetch = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return Promise.resolve(
+				new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+			)
+		}) as typeof fetch
+		await refreshBillingStatusFromConfig({
+			fetch: nextFetch,
+			mode: "automatic",
+			loadConfig: configWith("new-key"),
+		})
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(1)
 	})
 })
 

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -905,6 +905,25 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
 	})
 
+	it("does not throttle an automatic refresh after a forced refresh", async () => {
+		configureWithKey()
+		const calls: string[] = []
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return Promise.resolve(
+				new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+			)
+		}) as typeof fetch
+
+		// A forced refresh (startup, login) must not set the automatic TTL —
+		// otherwise the first post-completion automatic refresh is throttled.
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "forced" })
+		vi.advanceTimersByTime(1_000)
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
+	})
+
 	it("does not retry a failed automatic billing refresh", async () => {
 		configureWithKey()
 		const fetchImpl = ((_input: RequestInfo | URL) =>

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -805,6 +805,14 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
 	}
 
+	/** Mock loadConfig that returns the same credentials configureWithKey sets,
+	 * so refreshBillingStatusFromConfig doesn't overwrite them via the real
+	 * loadConfig() (which returns empty in CI where no config file exists). */
+	const mockLoadConfig = () => ({
+		apiKey: "api-key",
+		llmEndpoint: "https://llm.kimchi.dev/openai/v1",
+	})
+
 	function fetchImplReturning(remaining: string) {
 		return ((_input: RequestInfo | URL) =>
 			Promise.resolve(
@@ -831,9 +839,9 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 			)
 		}) as typeof fetch
 
-		const first = refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		const first = refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 		// Start a second refresh before the first's fetch microtask runs.
-		const second = refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		const second = refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 
 		await expect(first).resolves.toMatchObject({ remainingCredits: 5 })
 		await expect(second).resolves.toMatchObject({ remainingCredits: 5 })
@@ -879,10 +887,10 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 			)
 		}) as typeof fetch
 
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 
 		vi.advanceTimersByTime(1_000)
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "forced" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "forced" })
 
 		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
 	})
@@ -897,10 +905,10 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 			)
 		}) as typeof fetch
 
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 
 		vi.advanceTimersByTime(AUTOMATIC_REFRESH_MIN_INTERVAL_MS)
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 
 		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
 	})
@@ -917,9 +925,9 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 
 		// A forced refresh (startup, login) must not set the automatic TTL —
 		// otherwise the first post-completion automatic refresh is throttled.
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "forced" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "forced" })
 		vi.advanceTimersByTime(1_000)
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" })
 
 		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
 	})
@@ -929,7 +937,9 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 		const fetchImpl = ((_input: RequestInfo | URL) =>
 			Promise.resolve(new Response("nope", { status: 500 }))) as typeof fetch
 
-		await expect(refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })).resolves.toBeUndefined()
+		await expect(
+			refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig, mode: "automatic" }),
+		).resolves.toBeUndefined()
 		expect(getBillingStatus()).toBeUndefined()
 	})
 
@@ -937,7 +947,7 @@ describe("refreshBillingStatusFromConfig coordinator", () => {
 		configureWithKey()
 		const fetchImpl = fetchImplReturning("5")
 
-		await refreshBillingStatusFromConfig({ fetch: fetchImpl })
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, loadConfig: mockLoadConfig })
 		expect(getBillingStatus()).toMatchObject({ remainingCredits: 5 })
 	})
 

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
+	AUTOMATIC_REFRESH_MIN_INTERVAL_MS,
 	BILLING_EXHAUSTED_MESSAGE,
 	COMMUNITY_TIER_HEADER_NOTICE,
 	budgetEndpointFromLlmEndpoint,
@@ -786,6 +787,133 @@ describe("billing status", () => {
 		} finally {
 			unsubscribe()
 		}
+	})
+})
+
+describe("refreshBillingStatusFromConfig coordinator", () => {
+	beforeEach(() => {
+		configureBillingCreditsApi({})
+		setBillingStatusForTest(undefined)
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	function configureWithKey() {
+		configureBillingCreditsApi({ apiKey: "api-key", llmEndpoint: "https://llm.kimchi.dev/openai/v1" })
+	}
+
+	function fetchImplReturning(remaining: string) {
+		return ((_input: RequestInfo | URL) =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({ serverless: true, tier: "coder", is_paid_tier: true, billing_status: "ok", remaining }),
+					{ status: 200 },
+				),
+			)) as typeof fetch
+	}
+
+	it("coalesces concurrent automatic refreshes into one request pair", async () => {
+		configureWithKey()
+		const calls: string[] = []
+		// Yield once per fetch so the response settles on a microtask, letting a
+		// second refresh call arrive while the first is still in flight.
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return new Promise<Response>((resolve) =>
+				queueMicrotask(() =>
+					resolve(
+						new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+					),
+				),
+			)
+		}) as typeof fetch
+
+		const first = refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		// Start a second refresh before the first's fetch microtask runs.
+		const second = refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		await expect(first).resolves.toMatchObject({ remainingCredits: 5 })
+		await expect(second).resolves.toMatchObject({ remainingCredits: 5 })
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(1)
+		expect(calls.filter((url) => url.endsWith("/budget"))).toHaveLength(1)
+	})
+
+	it("throttles automatic refreshes inside the TTL to one snapshot", async () => {
+		configureWithKey()
+		const calls: string[] = []
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return Promise.resolve(
+				new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+			)
+		}) as typeof fetch
+
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+		const firstSnapshot = getBillingStatus()
+
+		// Advance less than the TTL — second automatic refresh must be skipped.
+		vi.advanceTimersByTime(AUTOMATIC_REFRESH_MIN_INTERVAL_MS - 1_000)
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(1)
+		expect(getBillingStatus()).toBe(firstSnapshot)
+	})
+
+	it("allows a forced refresh to bypass the TTL", async () => {
+		configureWithKey()
+		const calls: string[] = []
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return Promise.resolve(
+				new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+			)
+		}) as typeof fetch
+
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		vi.advanceTimersByTime(1_000)
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "forced" })
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
+	})
+
+	it("runs an automatic refresh again after the TTL elapses", async () => {
+		configureWithKey()
+		const calls: string[] = []
+		const fetchImpl = ((input: RequestInfo | URL) => {
+			calls.push(String(input))
+			return Promise.resolve(
+				new Response(JSON.stringify({ serverless: true, is_paid_tier: true, remaining: "5" }), { status: 200 }),
+			)
+		}) as typeof fetch
+
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		vi.advanceTimersByTime(AUTOMATIC_REFRESH_MIN_INTERVAL_MS)
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })
+
+		expect(calls.filter((url) => url.endsWith("/credits"))).toHaveLength(2)
+	})
+
+	it("does not retry a failed automatic billing refresh", async () => {
+		configureWithKey()
+		const fetchImpl = ((_input: RequestInfo | URL) =>
+			Promise.resolve(new Response("nope", { status: 500 }))) as typeof fetch
+
+		await expect(refreshBillingStatusFromConfig({ fetch: fetchImpl, mode: "automatic" })).resolves.toBeUndefined()
+		expect(getBillingStatus()).toBeUndefined()
+	})
+
+	it("defaults to forced mode (manual command / login semantics)", async () => {
+		configureWithKey()
+		const fetchImpl = fetchImplReturning("5")
+
+		await refreshBillingStatusFromConfig({ fetch: fetchImpl })
+		expect(getBillingStatus()).toMatchObject({ remainingCredits: 5 })
 	})
 })
 

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -64,6 +64,8 @@ interface RefreshBillingStatusOptions {
 	jsonTimeoutMs?: number
 	loadConfig?: typeof loadConfig
 	requestTimeoutMs?: number
+	/** "automatic" = coalesced + throttled (completion hook); "forced" = bypasses TTL (manual command, login). Defaults to "forced". */
+	mode?: BillingRefreshMode
 }
 
 export const LOW_CREDITS_THRESHOLD_USD = 5
@@ -125,6 +127,11 @@ export function configureBillingCreditsApi(options: { apiKey?: string; llmEndpoi
 		latestBillingRefreshId++
 		latestBudgetRefreshId++
 		clearBillingStatus()
+		// Invalidate the coalesced in-flight refresh and reset the throttle —
+		// a credential change makes any pending fetch stale and should allow
+		// the next completion to trigger a fresh automatic refresh.
+		inFlightRefresh = undefined
+		lastRefreshAt = 0
 	}
 }
 
@@ -222,15 +229,57 @@ export async function refreshBillingSnapshot(
 	return currentBillingStatus
 }
 
+export type BillingRefreshMode = "automatic" | "forced"
+
+/** Minimum interval between automatic billing refreshes (completion hook). */
+export const AUTOMATIC_REFRESH_MIN_INTERVAL_MS = 30_000
+
+/** One shared in-flight refresh promise per process — coalesces concurrent callers. */
+let inFlightRefresh: Promise<BillingStatus | undefined> | undefined
+
+/** Timestamp of the last completed refresh (automatic or forced). */
+let lastRefreshAt = 0
+
 export async function refreshBillingStatusFromConfig(
 	options: RefreshBillingStatusOptions = {},
 ): Promise<BillingStatus | undefined> {
+	const mode: BillingRefreshMode = options.mode ?? "forced"
+
+	// Always sync credentials from config before checking coalescing state.
+	// Forced callers (login, API-key change) must update the billing API
+	// configuration even when an automatic refresh is already running —
+	// configureBillingCreditsApi invalidates any stale in-flight fetch via
+	// generation bump when credentials actually change.
 	try {
 		const config = (options.loadConfig ?? loadConfig)()
 		configureBillingCreditsApi({ apiKey: config.apiKey, llmEndpoint: config.llmEndpoint })
-		return await refreshBillingSnapshot(options)
 	} catch {
 		return undefined
+	}
+
+	// Coalesce: if a refresh is already in flight, share it regardless of mode.
+	if (inFlightRefresh) return inFlightRefresh
+
+	// Automatic mode: skip if we refreshed recently.
+	if (mode === "automatic" && Date.now() - lastRefreshAt < AUTOMATIC_REFRESH_MIN_INTERVAL_MS) {
+		return currentBillingStatus
+	}
+
+	const promise = (async () => {
+		try {
+			return await refreshBillingSnapshot(options)
+		} catch {
+			return undefined
+		}
+	})()
+
+	inFlightRefresh = promise
+	try {
+		const result = await promise
+		lastRefreshAt = Date.now()
+		return result
+	} finally {
+		if (inFlightRefresh === promise) inFlightRefresh = undefined
 	}
 }
 

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -280,11 +280,13 @@ export async function refreshBillingStatusFromConfig(
 	inFlightRefresh = promise
 	try {
 		const result = await promise
-		// Only bump the throttle timestamp when this promise is still the
-		// active in-flight refresh. If configureBillingCreditsApi invalidated
-		// it (credential change during login/logout/API-key rotation), the
-		// stale resolution must not extend the automatic refresh cooldown.
-		if (inFlightRefresh === promise) lastRefreshAt = Date.now()
+		// Only bump the throttle timestamp for automatic refreshes that are
+		// still the active in-flight refresh. Forced refreshes (login, manual
+		// command) must not extend the automatic cooldown — otherwise the
+		// first post-completion automatic refresh would be throttled by the
+		// startup forced refresh. The identity guard also skips stale
+		// resolutions invalidated by configureBillingCreditsApi.
+		if (mode === "automatic" && inFlightRefresh === promise) lastRefreshAt = Date.now()
 		return result
 	} finally {
 		if (inFlightRefresh === promise) inFlightRefresh = undefined

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -62,7 +62,7 @@ interface BillingApiConfig {
 interface RefreshBillingStatusOptions {
 	fetch?: typeof fetch
 	jsonTimeoutMs?: number
-	loadConfig?: typeof loadConfig
+	loadConfig?: () => Pick<ReturnType<typeof loadConfig>, "apiKey" | "llmEndpoint">
 	requestTimeoutMs?: number
 	/** "automatic" = coalesced + throttled (completion hook); "forced" = bypasses TTL (manual command, login). Defaults to "forced". */
 	mode?: BillingRefreshMode
@@ -245,6 +245,13 @@ export async function refreshBillingStatusFromConfig(
 ): Promise<BillingStatus | undefined> {
 	const mode: BillingRefreshMode = options.mode ?? "forced"
 
+	// Automatic mode: skip before loading config if we refreshed recently.
+	// If a forced refresh is already running, share it so callers still receive
+	// the newest snapshot without repeating synchronous config reads.
+	if (mode === "automatic" && Date.now() - lastRefreshAt < AUTOMATIC_REFRESH_MIN_INTERVAL_MS) {
+		return inFlightRefresh ?? currentBillingStatus
+	}
+
 	// Always sync credentials from config before checking coalescing state.
 	// Forced callers (login, API-key change) must update the billing API
 	// configuration even when an automatic refresh is already running —
@@ -253,22 +260,19 @@ export async function refreshBillingStatusFromConfig(
 	try {
 		const config = (options.loadConfig ?? loadConfig)()
 		configureBillingCreditsApi({ apiKey: config.apiKey, llmEndpoint: config.llmEndpoint })
-	} catch {
+	} catch (error) {
+		console.warn("[billing] failed to load config for billing refresh:", error)
 		return undefined
 	}
 
 	// Coalesce: if a refresh is already in flight, share it regardless of mode.
 	if (inFlightRefresh) return inFlightRefresh
 
-	// Automatic mode: skip if we refreshed recently.
-	if (mode === "automatic" && Date.now() - lastRefreshAt < AUTOMATIC_REFRESH_MIN_INTERVAL_MS) {
-		return currentBillingStatus
-	}
-
 	const promise = (async () => {
 		try {
 			return await refreshBillingSnapshot(options)
-		} catch {
+		} catch (error) {
+			console.warn("[billing] billing refresh failed:", error)
 			return undefined
 		}
 	})()
@@ -276,7 +280,11 @@ export async function refreshBillingStatusFromConfig(
 	inFlightRefresh = promise
 	try {
 		const result = await promise
-		lastRefreshAt = Date.now()
+		// Only bump the throttle timestamp when this promise is still the
+		// active in-flight refresh. If configureBillingCreditsApi invalidated
+		// it (credential change during login/logout/API-key rotation), the
+		// stale resolution must not extend the automatic refresh cooldown.
+		if (inFlightRefresh === promise) lastRefreshAt = Date.now()
 		return result
 	} finally {
 		if (inFlightRefresh === promise) inFlightRefresh = undefined

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -272,7 +272,7 @@ async function configureKimchiToken(
 	}
 	if (providerModels.length > 0) {
 		options.persistConfig?.()
-		void refreshBillingStatusFromConfig()
+		void refreshBillingStatusFromConfig({ mode: "forced" })
 		const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
 		await host.setModel?.(selectedModel)
 		host.addFeedback?.(formatKimchiLoginSuccessMessage(selectedModel.id))

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -21,7 +21,7 @@ export default function loginExtension(pi: ExtensionAPI): void {
 		const configKey = loadConfig().apiKey
 		if (configKey) {
 			setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
-			void refreshBillingStatusFromConfig()
+			void refreshBillingStatusFromConfig({ mode: "forced" })
 		}
 
 		const patchedAuthStorage = authStorage as typeof authStorage & { [KIMCHI_LOGOUT_PATCHED]?: boolean }
@@ -32,7 +32,7 @@ export default function loginExtension(pi: ExtensionAPI): void {
 			originalLogout(provider)
 			if (provider === KIMCHI_PROVIDER_ID) {
 				clearApiKey()
-				void refreshBillingStatusFromConfig()
+				void refreshBillingStatusFromConfig({ mode: "forced" })
 			}
 		}
 		patchedAuthStorage[KIMCHI_LOGOUT_PATCHED] = true
@@ -58,7 +58,7 @@ export default function loginExtension(pi: ExtensionAPI): void {
 			}
 			writeApiKey(key)
 			await updateModelsConfig(modelsJsonPath, key)
-			void refreshBillingStatusFromConfig()
+			void refreshBillingStatusFromConfig({ mode: "forced" })
 			return { access: key, refresh: "", expires: Number.MAX_SAFE_INTEGER }
 		},
 		refreshToken: (credentials: { access: string; refresh: string; expires: number }) => Promise.resolve(credentials),

--- a/src/http/instrument-fetch.test.ts
+++ b/src/http/instrument-fetch.test.ts
@@ -74,6 +74,22 @@ describe("installGlobalFetchInstrumentation", () => {
 		expect(hook).toHaveBeenCalledTimes(1)
 	})
 
+	it("does not fire the billing hook for a failed completion (e.g. 429 budget exhausted)", async () => {
+		const hook = vi.fn(async () => {})
+		install(hook)
+		baseResponse = () => new Response("budget exhausted", { status: 429 })
+		await (await fetch("https://llm.test/openai/v1/chat/completions")).text()
+		expect(hook).not.toHaveBeenCalled()
+	})
+
+	it("does not fire the billing hook for a 503 completion", async () => {
+		const hook = vi.fn(async () => {})
+		install(hook)
+		baseResponse = () => new Response("Service Unavailable", { status: 503 })
+		await (await fetch("https://llm.test/openai/v1/chat/completions")).text()
+		expect(hook).not.toHaveBeenCalled()
+	})
+
 	it("attaches the billing hook to an already-installed fetch (entry.ts installs early, cli.ts attaches late)", async () => {
 		install() // early install without hook, as entry.ts does
 		const hook = vi.fn(async () => {})

--- a/src/http/instrument-fetch.ts
+++ b/src/http/instrument-fetch.ts
@@ -74,7 +74,7 @@ export function installGlobalFetchInstrumentation(options: GlobalFetchInstrument
 		}
 		const response = await idleFetch(input, { ...init, headers })
 		const hook = onModelCompletionSettled
-		return hook && isModelCompletionFetch(input)
+		return hook && response.ok && isModelCompletionFetch(input)
 			? withBillingRefreshAfterResponseSettles(response, () => hook(originalFetch))
 			: response
 	}

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -174,6 +174,47 @@ describe("classifyLLMGatewayError", () => {
 
 	it.each([
 		{
+			name: "budget exhausted",
+			message: "budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "api key budget exhausted",
+			message: "api key budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "organization budget exhausted",
+			message: "organization budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "team budget exhausted",
+			message: "team budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "429 budget exhausted (classified before the generic 429 rule)",
+			message: "429 budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "status code 429 budget exhausted",
+			message: "status code 429: budget exhausted",
+			reason: "budget_exhausted",
+			httpStatusCode: 429,
+		},
+		{
+			name: "billing budget exhausted",
+			message: "429 billing budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
+			name: "billing error with API key budget exhausted",
+			message: "billing error: API key budget exhausted",
+			reason: "budget_exhausted",
+		},
+		{
 			name: "empty tools array",
 			message:
 				"Value error, tools must not be an empty array. Either provide at least one tool or omit the field entirely.",

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -1,4 +1,5 @@
 export type LLMGatewayErrorReason =
+	| "budget_exhausted"
 	| "rate_limit"
 	| "transport_failure"
 	| "stream_interrupted"
@@ -15,6 +16,7 @@ const LLM_GATEWAY_REASON_POLICIES: Record<
 	LLMGatewayErrorReason,
 	{ readonly retryable: boolean; readonly isInfrastructure: boolean; readonly exitCode: number }
 > = {
+	budget_exhausted: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
 	rate_limit: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
 	transport_failure: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
 	stream_interrupted: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
@@ -73,6 +75,7 @@ const CONTEXT_WINDOW_RE =
 const NON_GATEWAY_PROVIDER_VERDICT_RE =
 	/unauthorized|authentication[_\s]?(?:error|failed)|invalid api key|\b401\b|\b403\b|permission denied|account.{0,40}\b(?:terminated|suspended|deactivated|disabled)\b|quota|billing|insufficient_quota|out of budget|usage limit/i
 
+const BUDGET_EXHAUSTED_RE = /budget\s+exhausted/i
 const RATE_LIMIT_TEXT_RE = /rate.?limit|too many requests/i
 const STREAM_INTERRUPTED_RE =
 	/stream ended without finish_reason|stream ended before message_stop|ended without finish/i
@@ -119,6 +122,9 @@ export function classifyLLMGatewayError(rawMessage: string): LLMGatewayError | u
 
 	if (INVALID_REQUEST_PAYLOAD_RE.test(rawMessage)) return createError("invalid_request_payload", rawMessage, status)
 	if (CONTEXT_WINDOW_RE.test(rawMessage)) return createError("context_window_exceeded", rawMessage, status)
+	// Budget exhaustion is a terminal Kimchi verdict even when the gateway
+	// describes it using provider-verdict words such as "billing".
+	if (BUDGET_EXHAUSTED_RE.test(rawMessage)) return createError("budget_exhausted", rawMessage, status)
 	if (NON_GATEWAY_PROVIDER_VERDICT_RE.test(rawMessage)) return undefined
 	if (BAD_REQUEST_TEXT_RE.test(rawMessage) || status === 400) return createError("bad_request", rawMessage, status)
 

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -48,6 +48,57 @@ describe("upstream retry patch", () => {
 		expect(wrapped?.({ stopReason: "error", errorMessage: "500 internal server error" })).toBe(true)
 		expect(wrapped?.({ stopReason: "error", errorMessage: "invalid request" })).toBe(false)
 	})
+
+	// Critical regression: Pi's original classifier retries any message
+	// containing 429, but Kimchi must override that when the same 429 is a
+	// budget-exhausted verdict — otherwise exhausted budgets burn the full
+	// retry storm plus billing refreshes on every attempt.
+	it("does not retry a 429 budget-exhausted error even when the original classifier would retry it", () => {
+		const original = vi.fn((message: { stopReason?: string; errorMessage?: string }) =>
+			/429/.test(message.errorMessage ?? ""),
+		)
+		const sessionClass = { prototype: { _isRetryableError: original } }
+
+		installInfrastructureRetryPatch(sessionClass)
+		// biome-ignore lint/style/noNonNullAssertion: installInfrastructureRetryPatch always wraps the classifier above
+		const wrapped = sessionClass.prototype._isRetryableError!
+
+		expect(original).not.toHaveBeenCalled()
+		expect(wrapped({ stopReason: "error", errorMessage: "429 budget exhausted" })).toBe(false)
+		// The original classifier must never even be consulted once Kimchi
+		// produces an explicit non-retryable verdict.
+		expect(original).not.toHaveBeenCalled()
+	})
+
+	it("does not let billing wording hide a terminal budget-exhausted 429 from Kimchi", () => {
+		const original = vi.fn(() => true)
+		const sessionClass = { prototype: { _isRetryableError: original } }
+
+		installInfrastructureRetryPatch(sessionClass)
+		// biome-ignore lint/style/noNonNullAssertion: installInfrastructureRetryPatch always wraps the classifier above
+		const wrapped = sessionClass.prototype._isRetryableError!
+
+		expect(wrapped({ stopReason: "error", errorMessage: "429 billing budget exhausted" })).toBe(false)
+		expect(original).not.toHaveBeenCalled()
+	})
+
+	it("keeps ordinary 429 rate-limit errors retryable", () => {
+		// Pi's original classifier recognizes ordinary rate limits; Kimchi must
+		// not suppress them. A 429 that Kimchi classifies as rate_limit stays
+		// retryable, and a 429 Kimchi leaves unclassified still retries when the
+		// original classifier says so.
+		const original = vi.fn((message: { stopReason?: string; errorMessage?: string }) =>
+			/queue full/.test(message.errorMessage ?? ""),
+		)
+		const sessionClass = { prototype: { _isRetryableError: original } }
+
+		installInfrastructureRetryPatch(sessionClass)
+		// biome-ignore lint/style/noNonNullAssertion: installInfrastructureRetryPatch always wraps the classifier above
+		const wrapped = sessionClass.prototype._isRetryableError!
+
+		expect(wrapped({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
+		expect(wrapped({ stopReason: "error", errorMessage: "429 model queue full" })).toBe(true)
+	})
 })
 
 describe("isInfrastructureErrorRetryable", () => {

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -49,6 +49,16 @@ describe("upstream retry patch", () => {
 		expect(wrapped?.({ stopReason: "error", errorMessage: "invalid request" })).toBe(false)
 	})
 
+	it("does not retry non-error messages that contain retryable error wording", () => {
+		const original = vi.fn((_message: { stopReason?: string; errorMessage?: string }) => false)
+		const sessionClass = { prototype: { _isRetryableError: original } }
+
+		installInfrastructureRetryPatch(sessionClass)
+		const wrapped = sessionClass.prototype._isRetryableError
+
+		expect(wrapped?.({ stopReason: "stop", errorMessage: "503 Service Unavailable" })).toBe(false)
+	})
+
 	// Critical regression: Pi's original classifier retries any message
 	// containing 429, but Kimchi must override that when the same 429 is a
 	// budget-exhausted verdict — otherwise exhausted budgets burn the full
@@ -71,7 +81,7 @@ describe("upstream retry patch", () => {
 	})
 
 	it("does not let billing wording hide a terminal budget-exhausted 429 from Kimchi", () => {
-		const original = vi.fn(() => true)
+		const original = vi.fn((_message: { stopReason?: string; errorMessage?: string }) => true)
 		const sessionClass = { prototype: { _isRetryableError: original } }
 
 		installInfrastructureRetryPatch(sessionClass)

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -92,11 +92,19 @@ export function installInfrastructureRetryPatch(
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		const infrastructure = isInfrastructureErrorRetryable(message)
-		if (!(original.call(this, message) || infrastructure)) return false
+		const classification = message.errorMessage ? classifyLLMGatewayError(message.errorMessage) : undefined
+
+		// Kimchi's explicit non-retryable verdicts take precedence over Pi's
+		// generic 429 retry — e.g. "budget exhausted" arrives as a 429 but must
+		// not be retried, so it short-circuits before the original classifier
+		// can force a retry storm.
+		if (classification && !classification.retryable) return false
+
+		const kimchiRetryable = classification?.retryable === true
+		if (!(original.call(this, message) || kimchiRetryable)) return false
 		// Only infrastructure-classified errors are blocked by the breaker;
 		// ordinary upstream-retryable verdicts pass through uncounted.
-		if (!infrastructure) return true
+		if (!kimchiRetryable) return true
 		return !isInfrastructureBreakerTripped()
 	}
 	proto._kimchiInfrastructureRetryPatch = true

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -92,7 +92,9 @@ export function installInfrastructureRetryPatch(
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		const classification = message.errorMessage ? classifyLLMGatewayError(message.errorMessage) : undefined
+		if (message.stopReason !== "error" || !message.errorMessage) return false
+
+		const classification = classifyLLMGatewayError(message.errorMessage)
 
 		// Kimchi's explicit non-retryable verdicts take precedence over Pi's
 		// generic 429 retry — e.g. "budget exhausted" arrives as a 429 but must


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Fixes request amplification when the AI Optimizer rejects a model completion with HTTP `429` because an API key, team, or organization budget is exhausted.

Previously, Pi treated every `429` as a transient rate limit and retried it. Each failed completion could also trigger billing-status requests, multiplying traffic through the AI Optimizer ingress and contributing to `NginxHighUnsuccessfulResponseCodeCount`.

This PR:

- Classifies `budget exhausted` as a terminal, non-retryable error.
- Gives Kimchi’s terminal classification precedence over Pi’s generic `429` retry behavior.
- Keeps genuine rate-limit `429` responses retryable.
- Does not trigger billing refreshes after unsuccessful completion responses.
- Coalesces concurrent automatic billing refreshes.
- Throttles automatic refreshes to one snapshot per 30 seconds.
- Allows explicit refreshes from `/budget`, login, logout, and credential changes to bypass the throttle.
- Invalidates stale refresh state when credentials or endpoints change.

This substantially reduces traffic generated by an exhausted-budget request: Kimchi now makes one completion attempt and does not automatically issue billing requests for its failed response.

## Testing

Focused regression suites passed:

- LLM gateway error classification
- Upstream retry override
- Fetch instrumentation
- Billing refresh coordination
- Billing command
- Login flows

In total, 148 focused tests passed.

Additional validation:

- `pnpm run lint` passed.
- `git diff --check` passed.
- Repository-wide type checking is currently blocked by an unrelated unresolved import in `src/extensions/bash-background/process-registry.ts`.

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [X] This PR links to an open issue above
- [X] Tests pass locally (`pnpm run test`)
- [X] Lint passes (`pnpm run check`)
- [X] Documentation updated if behavior changed
