### PR TITLE
feat(acp): set_session_title extMethod, filter session list from subagent sessions

### DIFF
--- a/src/modes/acp/acp-ui-context.test.ts
+++ b/src/modes/acp/acp-ui-context.test.ts
@@ -512,22 +512,23 @@ describe("createAcpUIContext — input via elicitation", () => {
 		})
 	})
 
-	it("emits an agent_message_chunk warning when the client supports neither elicitation nor notifications", async () => {
-		const { conn, unstable_createElicitation, send } = makeConn()
+	it("falls back to notify when the client supports no elicitation and no _kimchi.dev methods", async () => {
+		const { conn, extNotification, unstable_createElicitation, send } = makeConn({
+			extNotification: vi.fn(async () => {}),
+		})
 		const real = createAcpUIContext(conn, "sess-1", undefined, send)
 		await expect(real.input("Workspace name", "type a name")).resolves.toBeUndefined()
 		expect(unstable_createElicitation).not.toHaveBeenCalled()
-		expect(send).toHaveBeenCalledTimes(1)
-		const params = send.mock.calls[0][0]
+		expect(extNotification).toHaveBeenCalledTimes(1)
+		const [method, params] = extNotification.mock.calls[0]
+		expect(method).toBe("_kimchi.dev/pi_notify")
 		expect(params).toEqual({
+			id: expect.any(String),
+			type: "extension_ui_request",
+			method: "notify",
 			sessionId: "sess-1",
-			update: {
-				content: {
-					text: '[ACP] input: Extension requested free-text input "Workspace name" but the client supports neither form elicitation nor notifications. The call was dropped.',
-					type: "text",
-				},
-				sessionUpdate: "agent_message_chunk",
-			},
+			message: 'Input requested: "Workspace name" (not supported by this client)',
+			notifyType: "warning",
 		})
 	})
 })

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -251,8 +251,6 @@ export function createAcpUIContext(
 		async input(title, placeholder, opts) {
 			if (!supportsElicitation) {
 				// No permission-equivalent for free text — notify and resolve undefined.
-				// pi_notify is a best-effort notification; we dispatch it without
-				// checking client capabilities.
 				ui.notify(`Input requested: "${title}" (not supported by this client)`, "warning")
 				return undefined
 			}

--- a/src/modes/acp/acp-ui-context.ts
+++ b/src/modes/acp/acp-ui-context.ts
@@ -26,10 +26,11 @@ import type {
 } from "@agentclientprotocol/sdk"
 import type { ExtensionUIContext, Theme as ThemeType } from "@earendil-works/pi-coding-agent"
 import {
-	AVAILABLE_METHODS,
+	type AcpExtMethod,
+	AVAILABLE_EXT_METHODS,
+	AVAILABLE_EXT_NOTIFICATIONS,
 	getClientSupportsElicitation,
 	getClientSupportsMethod,
-	type PiMethod,
 } from "./capabilities.js"
 import { requestWithAbort } from "./utils.js"
 
@@ -58,7 +59,7 @@ export function createAcpUIContext(
 	send: (params: SessionNotification) => void,
 ): ExtensionUIContext {
 	const supportsElicitation = getClientSupportsElicitation(clientCapabilities)
-	const supportsMethod = (method: PiMethod) => getClientSupportsMethod(clientCapabilities, method)
+	const supportsMethod = (method: AcpExtMethod) => getClientSupportsMethod(clientCapabilities, method)
 
 	async function requestDialog<T extends DialogResponse>(
 		acpMethod: "pi_editor",
@@ -67,7 +68,7 @@ export function createAcpUIContext(
 	): Promise<T | "aborted"> {
 		try {
 			return await requestWithAbort(
-				conn.extMethod(AVAILABLE_METHODS[acpMethod], {
+				conn.extMethod(AVAILABLE_EXT_METHODS[acpMethod], {
 					type: REQUEST_TYPE,
 					id: randomUUID(),
 					sessionId,
@@ -76,7 +77,7 @@ export function createAcpUIContext(
 				signal,
 			)
 		} catch (err) {
-			logError(AVAILABLE_METHODS[acpMethod], err)
+			logError(AVAILABLE_EXT_METHODS[acpMethod], err)
 			return { cancelled: true } as T
 		}
 	}
@@ -86,7 +87,7 @@ export function createAcpUIContext(
 			method: "notify" | "setStatus" | "setWidget" | "set_editor_text"
 		},
 	): void {
-		const acpMethod = AVAILABLE_METHODS.pi_notify
+		const acpMethod = AVAILABLE_EXT_NOTIFICATIONS.pi_notify
 		conn
 			.extNotification(acpMethod, {
 				type: REQUEST_TYPE,
@@ -249,15 +250,10 @@ export function createAcpUIContext(
 
 		async input(title, placeholder, opts) {
 			if (!supportsElicitation) {
-				if (supportsMethod("pi_notify")) {
-					// No permission-equivalent for free text — notify and resolve undefined.
-					ui.notify(`Input requested: "${title}" (not supported by this client)`, "warning")
-				} else {
-					warnUnsupportedMethod(
-						"input",
-						`Extension requested free-text input "${title}" but the client supports neither form elicitation nor notifications. The call was dropped.`,
-					)
-				}
+				// No permission-equivalent for free text — notify and resolve undefined.
+				// pi_notify is a best-effort notification; we dispatch it without
+				// checking client capabilities.
+				ui.notify(`Input requested: "${title}" (not supported by this client)`, "warning")
 				return undefined
 			}
 

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -2,37 +2,39 @@ import type { ClientCapabilities } from "@agentclientprotocol/sdk"
 
 export const CAPABILITIES_KEY = "kimchi.dev"
 
-// One entry per extension UI method. The key is the capability flag name
-// (advertised via `_meta["kimchi.dev"][<key>] === true`) and the value is
-// the wire method name (sent over extMethod / extNotification). Per-method
-// flags let a client opt in to some and skip others — unsupported calls
-// become `[ACP]` agent_message_chunk diagnostics instead of method-not-found.
+// Wire method names for kimchi.dev extension methods. The key is the local
+// identifier; the value is the method string sent over extMethod /
+// extNotification.
 //
-// Direction: pi_* methods are agent→client (agent calls conn.extMethod on
-// the client). probe_mcp_server is the reverse — client→agent inbound (the
-// agent's extMethod() handler receives it). It lives in the same map so the
-// capability advertisement and getClientSupportsMethod infrastructure is
-// shared, but ALL_PI_METHODS and getClientSupportsMethod are only meaningful
-// for the agent→client direction.
-export const AVAILABLE_METHODS = {
-	pi_notify: `_${CAPABILITIES_KEY}/pi_notify`,
+// Direction:
+// - pi_* methods are agent→client (the agent calls conn.extMethod on the client).
+// - probe_mcp_server and set_session_title are client→agent inbound (the
+//   agent's extMethod() handler receives them).
+//
+// Capability advertising: every entry here is exposed in
+// `_meta["kimchi.dev"][<key>] === true` so clients can discover the methods
+// the agent supports.
+export const AVAILABLE_EXT_METHODS = {
 	pi_editor: `_${CAPABILITIES_KEY}/pi_editor`,
 	probe_mcp_server: `_${CAPABILITIES_KEY}/probe_mcp_server`,
+	set_session_title: `_${CAPABILITIES_KEY}/set_session_title`,
 } as const
 
-export type PiMethod = keyof typeof AVAILABLE_METHODS
+export const AVAILABLE_EXT_NOTIFICATIONS = {
+	pi_notify: `_${CAPABILITIES_KEY}/pi_notify`,
+} as const
 
-export const ADVERTISED_CAPABILITIES: Record<PiMethod, boolean> = Object.keys(AVAILABLE_METHODS).reduce(
+export type AcpExtMethod = keyof typeof AVAILABLE_EXT_METHODS
+
+export const ADVERTISED_CAPABILITIES: Record<AcpExtMethod, boolean> = Object.keys(AVAILABLE_EXT_METHODS).reduce(
 	(acc, method) => {
-		acc[method as PiMethod] = true
+		acc[method as AcpExtMethod] = true
 		return acc
 	},
-	{} as Record<PiMethod, boolean>,
+	{} as Record<AcpExtMethod, boolean>,
 )
 
-export const ALL_PI_METHODS: readonly PiMethod[] = Object.keys(AVAILABLE_METHODS) as PiMethod[]
-
-export function getClientSupportsMethod(capabilities: ClientCapabilities | undefined, method: PiMethod): boolean {
+export function getClientSupportsMethod(capabilities: ClientCapabilities | undefined, method: AcpExtMethod): boolean {
 	const flags = capabilities?._meta?.[CAPABILITIES_KEY] as Record<string, boolean> | undefined
 	return flags?.[method] === true
 }

--- a/src/modes/acp/ext-methods/mcp.test.ts
+++ b/src/modes/acp/ext-methods/mcp.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
+import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
+import { handleProbeMcpServer, validateServerEntry } from "./mcp.js"
+
+const mockGetAuthEntry = vi.fn()
+const mockRemoveAuthEntry = vi.fn()
+const mockAuthenticate = vi.fn()
+const mockGetAuthStatus = vi.fn()
+const mockSupportsOAuth = vi.fn()
+const mockProbeTools = vi.fn()
+
+vi.mock("../../../extensions/mcp-adapter/mcp-auth.js", () => ({
+	getAuthEntry: (...args: unknown[]) => mockGetAuthEntry(...args),
+	removeAuthEntry: (...args: unknown[]) => mockRemoveAuthEntry(...args),
+}))
+
+vi.mock("../../../extensions/mcp-adapter/mcp-auth-flow.js", () => ({
+	authenticate: (...args: unknown[]) => mockAuthenticate(...args),
+	getAuthStatus: (...args: unknown[]) => mockGetAuthStatus(...args),
+	supportsOAuth: (...args: unknown[]) => mockSupportsOAuth(...args),
+}))
+
+function makeManager(overrides: Partial<McpServerManager> = {}): McpServerManager {
+	return {
+		probeTools: mockProbeTools,
+		...overrides,
+	} as unknown as McpServerManager
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockSupportsOAuth.mockReturnValue(false)
+})
+
+describe("validateServerEntry", () => {
+	it("accepts a minimal stdio server entry", () => {
+		const entry = validateServerEntry({ command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem"] })
+		expect(entry).toEqual({
+			command: "npx",
+			args: ["-y", "@modelcontextprotocol/server-filesystem"],
+		})
+	})
+
+	it("accepts a minimal URL server entry", () => {
+		const entry = validateServerEntry({ url: "https://mcp.example.com/sse" })
+		expect(entry).toEqual({ url: "https://mcp.example.com/sse" })
+	})
+
+	it("accepts all optional stdio fields", () => {
+		const raw = {
+			command: "node",
+			args: ["server.js"],
+			env: { FOO: "bar" },
+			cwd: "/project",
+			auth: false,
+			debug: true,
+		} as const
+		expect(validateServerEntry(raw)).toEqual(raw)
+	})
+
+	it("accepts all optional URL fields", () => {
+		const raw = {
+			url: "https://mcp.example.com",
+			headers: { Authorization: "Bearer token" },
+			auth: "bearer" as const,
+			debug: false,
+		}
+		expect(validateServerEntry(raw)).toEqual(raw)
+	})
+
+	it("throws invalidParams when server is not an object", () => {
+		for (const server of [null, undefined, "string", 123, []]) {
+			expect(() => validateServerEntry(server)).toThrow(
+				expect.objectContaining({ code: -32602, message: expect.stringContaining("'server' must be an object") }),
+			)
+		}
+	})
+
+	it("throws invalidParams when server has neither command nor url", () => {
+		expect(() => validateServerEntry({})).toThrow(
+			expect.objectContaining({
+				code: -32602,
+				message: expect.stringContaining("must have a 'command' or 'url' field"),
+			}),
+		)
+	})
+
+	it("throws invalidParams when command is empty", () => {
+		expect(() => validateServerEntry({ command: "" })).toThrow(expect.objectContaining({ code: -32602 }))
+	})
+
+	it("throws invalidParams when url is empty", () => {
+		expect(() => validateServerEntry({ url: "" })).toThrow(expect.objectContaining({ code: -32602 }))
+	})
+
+	it("throws invalidParams when args is not an array", () => {
+		expect(() => validateServerEntry({ command: "node", args: "server.js" })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.args' must be an array") }),
+		)
+	})
+
+	it("throws invalidParams when args contains a non-string", () => {
+		expect(() => validateServerEntry({ command: "node", args: ["server.js", 123] })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.args' must be an array of strings") }),
+		)
+	})
+
+	it("throws invalidParams when env is not an object", () => {
+		expect(() => validateServerEntry({ command: "node", env: "FOO=bar" })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.env' must be an object") }),
+		)
+	})
+
+	it("throws invalidParams when env value is not a string", () => {
+		expect(() => validateServerEntry({ command: "node", env: { FOO: 123 } })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("server.env['FOO'] must be a string") }),
+		)
+	})
+
+	it("throws invalidParams when cwd is not a string", () => {
+		expect(() => validateServerEntry({ command: "node", cwd: 123 })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.cwd' must be a string") }),
+		)
+	})
+
+	it("throws invalidParams when headers is not an object", () => {
+		expect(() => validateServerEntry({ url: "https://example.com", headers: "Auth" })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.headers' must be an object") }),
+		)
+	})
+
+	it("throws invalidParams when auth is not a recognized value", () => {
+		expect(() => validateServerEntry({ url: "https://example.com", auth: "basic" })).toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining("'server.auth' must be 'oauth', 'bearer', or false"),
+			}),
+		)
+	})
+
+	it("throws invalidParams when debug is not a boolean", () => {
+		expect(() => validateServerEntry({ command: "node", debug: "yes" })).toThrow(
+			expect.objectContaining({ message: expect.stringContaining("'server.debug' must be a boolean") }),
+		)
+	})
+})
+
+describe("handleProbeMcpServer", () => {
+	const stdioServer: ServerEntry = { command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem"] }
+	const urlServer: ServerEntry = { url: "https://mcp.example.com", auth: "oauth" }
+
+	it("throws invalidParams when mcpServerManager is undefined", async () => {
+		await expect(handleProbeMcpServer(undefined, { server: stdioServer })).rejects.toThrow(
+			expect.objectContaining({
+				code: -32602,
+				message: expect.stringContaining("MCP server manager is not available"),
+			}),
+		)
+	})
+
+	it("throws invalidParams when server is missing", async () => {
+		const manager = makeManager()
+		await expect(handleProbeMcpServer(manager, {})).rejects.toThrow(expect.objectContaining({ code: -32602 }))
+	})
+
+	it("probes a stdio server and returns the result", async () => {
+		const manager = makeManager()
+		const probeResult: ProbeResult = {
+			tools: [{ name: "read_file", description: "Read a file" }],
+			needsAuth: false,
+			error: null,
+		}
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue(probeResult)
+
+		const result = await handleProbeMcpServer(manager, { server: stdioServer, serverName: "stdio-server" })
+
+		expect(result).toEqual(probeResult)
+		expect(mockProbeTools).toHaveBeenCalledWith("stdio-server", stdioServer)
+		expect(mockAuthenticate).not.toHaveBeenCalled()
+	})
+
+	it("defaults serverName to 'probe' when omitted", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+
+		await handleProbeMcpServer(manager, { server: stdioServer })
+
+		expect(mockProbeTools).toHaveBeenCalledWith("probe", stdioServer)
+	})
+
+	it("authenticates OAuth URL servers before probing when not authenticated", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(true)
+		mockGetAuthStatus.mockResolvedValue("not_authenticated")
+		mockAuthenticate.mockResolvedValue(undefined)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+
+		await handleProbeMcpServer(manager, { server: urlServer, serverName: "oauth-server" })
+
+		expect(mockGetAuthStatus).toHaveBeenCalledWith("oauth-server", urlServer.url)
+		expect(mockAuthenticate).toHaveBeenCalledWith("oauth-server", urlServer.url, urlServer)
+		expect(mockProbeTools).toHaveBeenCalledWith("oauth-server", urlServer)
+	})
+
+	it("skips authenticate when OAuth server already has valid auth", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(true)
+		mockGetAuthStatus.mockResolvedValue("authenticated")
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+
+		await handleProbeMcpServer(manager, { server: urlServer, serverName: "oauth-server" })
+
+		expect(mockGetAuthStatus).toHaveBeenCalledWith("oauth-server", urlServer.url)
+		expect(mockAuthenticate).not.toHaveBeenCalled()
+		expect(mockProbeTools).toHaveBeenCalledWith("oauth-server", urlServer)
+	})
+
+	it("returns needsAuth with error message when authenticate fails", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(true)
+		mockGetAuthStatus.mockResolvedValue("not_authenticated")
+		mockAuthenticate.mockRejectedValue(new Error("User denied authorization"))
+
+		const result = await handleProbeMcpServer(manager, { server: urlServer, serverName: "oauth-server" })
+
+		expect(result).toEqual({ tools: [], needsAuth: true, error: "User denied authorization" })
+		expect(mockProbeTools).not.toHaveBeenCalled()
+	})
+
+	it("uses a throwaway probe name when an auth entry exists for a different URL", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+		mockGetAuthEntry.mockReturnValue({ serverUrl: "https://old.example.com" })
+
+		await handleProbeMcpServer(manager, { server: { url: "https://new.example.com" }, serverName: "my-server" })
+
+		const probeName = mockProbeTools.mock.calls[0][0] as string
+		expect(probeName).toMatch(/^__probe_[\w-]+$/)
+		expect(probeName).not.toBe("my-server")
+		expect(mockRemoveAuthEntry).toHaveBeenCalledWith(probeName)
+	})
+
+	it("uses the real serverName when no auth entry exists", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+		mockGetAuthEntry.mockReturnValue(undefined)
+
+		await handleProbeMcpServer(manager, { server: stdioServer, serverName: "my-server" })
+
+		expect(mockProbeTools).toHaveBeenCalledWith("my-server", stdioServer)
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
+
+	it("uses the real serverName when auth entry URL matches", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+		mockGetAuthEntry.mockReturnValue({ serverUrl: "https://same.example.com" })
+
+		await handleProbeMcpServer(manager, {
+			server: { url: "https://same.example.com" },
+			serverName: "my-server",
+		})
+
+		expect(mockProbeTools).toHaveBeenCalledWith("my-server", { url: "https://same.example.com" })
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
+
+	it("cleans up throwaway auth entries even when probeTools throws", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockRejectedValue(new Error("probe failed"))
+		mockGetAuthEntry.mockReturnValue({ serverUrl: "https://old.example.com" })
+
+		await expect(
+			handleProbeMcpServer(manager, { server: { url: "https://new.example.com" }, serverName: "my-server" }),
+		).rejects.toThrow("probe failed")
+
+		expect(mockRemoveAuthEntry).toHaveBeenCalled()
+	})
+})

--- a/src/modes/acp/ext-methods/set-session-title.test.ts
+++ b/src/modes/acp/ext-methods/set-session-title.test.ts
@@ -1,0 +1,152 @@
+import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { AVAILABLE_EXT_METHODS } from "../capabilities.js"
+import { type AcpSessionFactory, KimchiAcpAgent } from "../server.js"
+
+class FakeAgentSession {
+	sessionId: string
+	disposed = false
+	model = { provider: "test", id: "test-model" }
+	modelRegistry = {
+		getAvailable: () => [{ provider: "test", id: "test-model", name: "Test" }],
+		find: (provider: string, id: string) =>
+			this.modelRegistry.getAvailable().find((m) => m.provider === provider && m.id === id),
+	}
+	sessionManager = {
+		getBranch: () => [],
+		getSessionId: () => this.sessionId,
+		getEntries: () => [],
+	}
+	setSessionName = vi.fn()
+	extensionRunner = { emit: async () => {} }
+
+	constructor(sessionId: string) {
+		this.sessionId = sessionId
+	}
+
+	subscribe = () => () => {}
+	async bindExtensions(): Promise<void> {}
+	async prompt(): Promise<void> {}
+	async abort(): Promise<void> {}
+	dispose(): void {
+		this.disposed = true
+	}
+}
+
+function asSession(fake: FakeAgentSession): AgentSession {
+	return fake as unknown as AgentSession
+}
+
+function makeConn(): AgentSideConnection {
+	return {
+		sessionUpdate: async (_p: SessionNotification) => {},
+		extNotification: vi.fn(),
+		extMethod: vi.fn(),
+		requestPermission: vi.fn(),
+		unstable_createElicitation: vi.fn(),
+		closed: Promise.resolve(),
+	} as unknown as AgentSideConnection
+}
+
+function makeAgent(session: FakeAgentSession) {
+	const sessionFactory: AcpSessionFactory = async () => asSession(session)
+	return new KimchiAcpAgent(makeConn(), {
+		extensionFactories: [],
+		agentDir: "/tmp/fake-agent-dir",
+		sessionFactory,
+	})
+}
+
+describe("KimchiAcpAgent extMethod set_session_title", () => {
+	it("sets the session title for a known session", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, {
+			sessionId: "sess-1",
+			title: "My Session",
+		})
+
+		expect(result).toEqual({})
+		expect(session.setSessionName).toHaveBeenCalledWith("My Session")
+	})
+
+	it("trims the provided title", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		await agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, {
+			sessionId: "sess-1",
+			title: "  My Session  ",
+		})
+
+		expect(session.setSessionName).toHaveBeenCalledWith("My Session")
+	})
+
+	it("throws invalidParams when sessionId is missing", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { title: "My Session" }),
+		).rejects.toMatchObject({
+			code: -32602,
+		})
+	})
+
+	it("throws invalidParams when sessionId is empty", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "", title: "My Session" }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("throws invalidParams when title is missing", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-1" }),
+		).rejects.toMatchObject({
+			code: -32602,
+		})
+	})
+
+	it("throws invalidParams when title is not a string", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-1", title: 123 }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("throws invalidParams for an unknown sessionId", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-2", title: "My Session" }),
+		).rejects.toMatchObject({ code: -32602 })
+	})
+
+	it("advertises set_session_title in initialize response", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		const response = await agent.initialize({ protocolVersion: 1 })
+		const meta = response.agentCapabilities?._meta?.["kimchi.dev"] as Record<string, boolean> | undefined
+		expect(meta?.set_session_title).toBe(true)
+	})
+})

--- a/src/modes/acp/ext-methods/set-session-title.test.ts
+++ b/src/modes/acp/ext-methods/set-session-title.test.ts
@@ -74,20 +74,6 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 		expect(session.setSessionName).toHaveBeenCalledWith("My Session")
 	})
 
-	it("trims the provided title", async () => {
-		const session = new FakeAgentSession("sess-1")
-		const agent = makeAgent(session)
-		await agent.initialize({ protocolVersion: 1 })
-		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
-
-		await agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, {
-			sessionId: "sess-1",
-			title: "  My Session  ",
-		})
-
-		expect(session.setSessionName).toHaveBeenCalledWith("My Session")
-	})
-
 	it("throws invalidParams when sessionId is missing", async () => {
 		const session = new FakeAgentSession("sess-1")
 		const agent = makeAgent(session)
@@ -97,6 +83,7 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { title: "My Session" }),
 		).rejects.toMatchObject({
 			code: -32602,
+			message: "Invalid params: sessionId is required and must be a non-empty string",
 		})
 	})
 
@@ -107,7 +94,10 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 
 		await expect(
 			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "", title: "My Session" }),
-		).rejects.toMatchObject({ code: -32602 })
+		).rejects.toMatchObject({
+			code: -32602,
+			message: "Invalid params: sessionId is required and must be a non-empty string",
+		})
 	})
 
 	it("throws invalidParams when title is missing", async () => {
@@ -119,6 +109,7 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-1" }),
 		).rejects.toMatchObject({
 			code: -32602,
+			message: "Invalid params: title is required and must be a string",
 		})
 	})
 
@@ -129,7 +120,7 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 
 		await expect(
 			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-1", title: 123 }),
-		).rejects.toMatchObject({ code: -32602 })
+		).rejects.toMatchObject({ code: -32602, message: "Invalid params: title is required and must be a string" })
 	})
 
 	it("throws invalidParams for an unknown sessionId", async () => {
@@ -139,7 +130,21 @@ describe("KimchiAcpAgent extMethod set_session_title", () => {
 
 		await expect(
 			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-2", title: "My Session" }),
-		).rejects.toMatchObject({ code: -32602 })
+		).rejects.toMatchObject({ code: -32602, message: "Invalid params: unknown sessionId sess-2" })
+	})
+
+	it("throws invalidParams for a title that's too long", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.set_session_title, { sessionId: "sess-1", title: "a".repeat(300) }),
+		).rejects.toMatchObject({
+			code: -32602,
+			message: "Invalid params: title must be no longer than 256 characters (received: 300)",
+		})
 	})
 
 	it("advertises set_session_title in initialize response", async () => {

--- a/src/modes/acp/ext-methods/set-session-title.ts
+++ b/src/modes/acp/ext-methods/set-session-title.ts
@@ -7,11 +7,6 @@
 import { RequestError } from "@agentclientprotocol/sdk"
 import type { AgentSession } from "@earendil-works/pi-coding-agent"
 
-export interface SetSessionTitleParams {
-	sessionId: string
-	title: string
-}
-
 /**
  * Handler for the `_kimchi.dev/set_session_title` ACP extension method.
  *
@@ -20,10 +15,10 @@ export interface SetSessionTitleParams {
  * JSONL and emits a session_info_changed event, which the ACP agent surfaces
  * to the client as a session_info_update notification.
  */
-export async function handleSetSessionTitle(
+export function handleSetSessionTitle(
 	getSession: (sessionId: string) => AgentSession | undefined,
 	params: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
+): Record<string, unknown> {
 	const sessionId = params.sessionId
 	if (typeof sessionId !== "string" || sessionId.length === 0) {
 		throw RequestError.invalidParams(undefined, "sessionId is required and must be a non-empty string")

--- a/src/modes/acp/ext-methods/set-session-title.ts
+++ b/src/modes/acp/ext-methods/set-session-title.ts
@@ -1,0 +1,44 @@
+// ACP extension method handler for renaming a session.
+//
+// The handler validates params, looks up the live session, and
+// delegates to pi's AgentSession.setSessionName, which persists a
+// session_info entry and emits session_info_changed.
+
+import { RequestError } from "@agentclientprotocol/sdk"
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+
+export interface SetSessionTitleParams {
+	sessionId: string
+	title: string
+}
+
+/**
+ * Handler for the `_kimchi.dev/set_session_title` ACP extension method.
+ *
+ * Sets the display title of the requested session. This is the ACP equivalent
+ * of the TUI `/name <name>` command: it writes a session_info entry to the
+ * JSONL and emits a session_info_changed event, which the ACP agent surfaces
+ * to the client as a session_info_update notification.
+ */
+export async function handleSetSessionTitle(
+	getSession: (sessionId: string) => AgentSession | undefined,
+	params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const sessionId = params.sessionId
+	if (typeof sessionId !== "string" || sessionId.length === 0) {
+		throw RequestError.invalidParams(undefined, "sessionId is required and must be a non-empty string")
+	}
+
+	const title = params.title
+	if (typeof title !== "string") {
+		throw RequestError.invalidParams(undefined, "title is required and must be a string")
+	}
+
+	const session = getSession(sessionId)
+	if (!session) {
+		throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
+	}
+
+	session.setSessionName(title.trim())
+	return {}
+}

--- a/src/modes/acp/ext-methods/set-session-title.ts
+++ b/src/modes/acp/ext-methods/set-session-title.ts
@@ -34,6 +34,13 @@ export function handleSetSessionTitle(
 		throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
 	}
 
-	session.setSessionName(title.trim())
+	if (title.length > 256) {
+		throw RequestError.invalidParams(
+			undefined,
+			`title must be no longer than 256 characters (received: ${title.length})`,
+		)
+	}
+
+	session.setSessionName(title)
 	return {}
 }

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -3,7 +3,7 @@ import type { AgentSession } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../extensions/mcp-adapter/types.js"
-import { AVAILABLE_METHODS } from "./capabilities.js"
+import { AVAILABLE_EXT_METHODS } from "./capabilities.js"
 import { type AcpSessionFactory, KimchiAcpAgent } from "./server.js"
 
 // Mock the auth flow and auth store so tests don't touch real disk state.
@@ -89,7 +89,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "test-server",
 		})
@@ -108,7 +108,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = (await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = (await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})) as unknown as ProbeResult
 
@@ -128,7 +128,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		const result = (await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = (await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})) as unknown as ProbeResult
 
@@ -144,7 +144,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 
 	it("throws invalidParams when server parameter is missing", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {})).rejects.toMatchObject({ code: -32602 })
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {})).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("throws invalidParams when mcpServerManager is not configured", async () => {
@@ -157,7 +157,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 			sessionFactory,
 		})
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo" } }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: { command: "echo" } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
@@ -167,7 +167,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server", () => {
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
 
-		await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})
 
@@ -192,7 +192,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -211,7 +211,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 		vi.mocked(getAuthStatus).mockResolvedValue("authenticated")
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -229,7 +229,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 		vi.mocked(authenticate).mockRejectedValue(new Error("Browser failed to open"))
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 			serverName: "my-server",
 		})
@@ -246,7 +246,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 		vi.mocked(supportsOAuth).mockReturnValue(true)
 
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: serverEntry,
 		})
 
@@ -260,21 +260,21 @@ describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 	it("rejects non-object server param", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: "not-an-object" }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: "not-an-object" }),
 		).rejects.toMatchObject({
 			code: -32602,
 		})
-		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: null })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: null })).rejects.toMatchObject({
 			code: -32602,
 		})
-		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: [] })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: [] })).rejects.toMatchObject({
 			code: -32602,
 		})
 	})
 
 	it("rejects server without command or url", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
-		await expect(agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: {} })).rejects.toMatchObject({
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: {} })).rejects.toMatchObject({
 			code: -32602,
 		})
 	})
@@ -282,28 +282,28 @@ describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 	it("rejects non-string command", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: 123 } }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: { command: 123 } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects non-array args", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", args: "not-array" } }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: { command: "echo", args: "not-array" } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects non-string elements in args", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", args: ["ok", 42] } }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: { command: "echo", args: ["ok", 42] } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
 	it("rejects env with non-string values", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))
 		await expect(
-			agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, { server: { command: "echo", env: { KEY: 123 } } }),
+			agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, { server: { command: "echo", env: { KEY: 123 } } }),
 		).rejects.toMatchObject({ code: -32602 })
 	})
 
@@ -311,7 +311,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: { command: "echo", args: ["hello"], env: { FOO: "bar" } },
 		})
 		expect(result).toEqual(probeResult)
@@ -321,7 +321,7 @@ describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
 		const manager = makeFakeMcpServerManager(probeResult)
 		const agent = makeAgent(manager)
-		const result = await agent.extMethod(AVAILABLE_METHODS.probe_mcp_server, {
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
 			server: { url: "https://mcp.example.com/sse" },
 		})
 		expect(result).toEqual(probeResult)

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -4080,6 +4080,22 @@ describe("KimchiAcpAgent listSessions", () => {
 		const res = await agent.listSessions({ cwd: "/p" } as never)
 		expect(res.sessions[0].title).toBe(`${"z".repeat(80)}…`)
 	})
+
+	it("excludes subagent sessions that have a parentSessionPath", async () => {
+		const userSession = makePiSession({
+			id: "user-session",
+			name: "User session",
+			parentSessionPath: undefined,
+		})
+		const subagentSession = makePiSession({
+			id: "subagent-session",
+			name: "Subagent session",
+			parentSessionPath: "/tmp/sessions/parent.jsonl",
+		})
+		const agent = makeAgent(async () => [userSession, subagentSession])
+		const res = await agent.listSessions({ cwd: "/p" } as never)
+		expect(res.sessions.map((s) => s.sessionId)).toEqual(["user-session"])
+	})
 })
 
 // Helpers for replay tests: build the SessionMessageEntry shape that

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -252,6 +252,9 @@ export class KimchiAcpAgent implements Agent {
 		for (const s of piSessions) {
 			if (seen.has(s.id)) continue
 			seen.add(s.id)
+			// Skip subagent sessions: pi marks forked sessions with parentSessionPath
+			// so delegated Agent runs don't clutter the user's session list.
+			if (s.parentSessionPath) continue
 			sessions.push(toAcpSessionInfo(s))
 		}
 		// Sort newest-first by updatedAt so Zed's picker surfaces recent threads

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -82,9 +82,10 @@ import { configureHttpIdleTimeout } from "../../http/proxy.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
-import { ADVERTISED_CAPABILITIES, AVAILABLE_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
+import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
+import { handleSetSessionTitle } from "./ext-methods/set-session-title.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 
@@ -651,8 +652,10 @@ export class KimchiAcpAgent implements Agent {
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
 		switch (method) {
-			case AVAILABLE_METHODS.probe_mcp_server:
+			case AVAILABLE_EXT_METHODS.probe_mcp_server:
 				return handleProbeMcpServer(this.mcpServerManager, params) as unknown as Record<string, unknown>
+			case AVAILABLE_EXT_METHODS.set_session_title:
+				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
 			default:
 				throw RequestError.methodNotFound(method)
 		}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -57,6 +57,7 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
+import type { ProbeResult } from "../../extensions/mcp-adapter/types.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
 import { getOrchestratorModel } from "../../extensions/orchestration/model-roles.js"
@@ -655,8 +656,10 @@ export class KimchiAcpAgent implements Agent {
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
 		switch (method) {
-			case AVAILABLE_EXT_METHODS.probe_mcp_server:
-				return handleProbeMcpServer(this.mcpServerManager, params) as unknown as Record<string, unknown>
+			case AVAILABLE_EXT_METHODS.probe_mcp_server: {
+				const result = await handleProbeMcpServer(this.mcpServerManager, params)
+				return result as Record<keyof ProbeResult, unknown>
+			}
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
 			default:


### PR DESCRIPTION
## Linked issue

Closes #0
Fix for session list tracking: LLM-2745

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

* Added new `_kimchi.dev/set_session_title` `extMethod` to ACP server
* Fixed an issue where subagent sessions were listed alongside user sessions via `listSessions`
* Removed advertisement of `_kimchi.dev/pi_notify` as it is a no-op JSON RPC notification rather than a supportable method
* Added additional tests for the `ext-methods/mcp.ts` file surface

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
