### PR TITLE
fix: resolve submit_agent_report validation trap for empty arrays

### DIFF
--- a/patches/@earendil-works__pi-ai@0.79.10.patch
+++ b/patches/@earendil-works__pi-ai@0.79.10.patch
@@ -13,7 +13,8 @@
 #   3. dist/providers/openai-completions.js — fall back to cache_creation_tokens
 #      for cache write token counting (LiteLLM compatibility).
 #   4. dist/utils/validation.js — improved JSON Schema coercion for array/object
-#      tool arguments.
+#      tool arguments, including {} → [] for empty array fields (prevents
+#      Value.Convert from wrapping {} into [{}]).
 #
 # Tracking: open an upstream PR against pi-mono to add "max" as a first-class
 # ThinkingLevel in pi-ai.
@@ -60,7 +61,7 @@ diff --git a/dist/utils/validation.js b/dist/utils/validation.js
 index 9ba1a5f5aecd015b01d1e88fdb62b8dcca176e52..ca077cb942a2761f3b24459d4af916927049963e 100644
 --- a/dist/utils/validation.js
 +++ b/dist/utils/validation.js
-@@ -123,6 +123,24 @@ function coercePrimitiveByType(value, type) {
+@@ -123,6 +123,31 @@ function coercePrimitiveByType(value, type) {
              }
              return value;
          }
@@ -70,6 +71,13 @@ index 9ba1a5f5aecd015b01d1e88fdb62b8dcca176e52..ca077cb942a2761f3b24459d4af91692
 +                    const parsed = JSON.parse(value);
 +                    if (Array.isArray(parsed)) return parsed;
 +                } catch { /* fall through */ }
++            }
++            // LLMs frequently send {} instead of [] for empty arrays. Without
++            // this guard, Value.Convert wraps {} into [{}], which then fails
++            // validation with "items[0]: must be string" — a misleading error
++            // that traps the LLM in a retry loop.
++            if (typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length === 0) {
++                return [];
 +            }
 +            return value;
 +        }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991
     path: patches/@earendil-works__pi-agent-core@0.79.10.patch
   '@earendil-works/pi-ai@0.79.10':
-    hash: 34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d
+    hash: fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
     hash: b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9

--- a/src/extensions/agents/worker-report.test.ts
+++ b/src/extensions/agents/worker-report.test.ts
@@ -15,6 +15,15 @@ function registerWorkerReportTool(submit = vi.fn(() => ({ accepted: true, messag
 }
 
 describe("worker report capability", () => {
+	it("exposes a schema that makes empty arrays explicit", () => {
+		const { tool } = registerWorkerReportTool()
+
+		expect(tool.parameters.properties.remaining_steps).toMatchObject({
+			type: "array",
+			items: { type: "string" },
+			minItems: 0,
+		})
+	})
 	it("binds a report to its host capability without worker-provided credentials", async () => {
 		const { tool, submit, onAccepted } = registerWorkerReportTool()
 

--- a/src/extensions/agents/worker-report.ts
+++ b/src/extensions/agents/worker-report.ts
@@ -28,7 +28,7 @@ export function createWorkerReportExtension(
 				name: WORKER_REPORT_TOOL_NAME,
 				label: "Submit Agent Report",
 				description:
-					'Submit the final structured progress report for this Ferment-linked worker. Call this alone as the final action after completing edits and verification. When status is "completed", remaining_steps must be an empty array [] (not a placeholder string). When status is "partial", remaining_steps must list concrete work that remains.',
+					'Submit the final structured progress report for this Ferment-linked worker. Call this alone as the final action after completing edits and verification. When status is "completed", remaining_steps must be an empty array []. When status is "partial", remaining_steps must list concrete work that remains.',
 				parameters: Type.Object({
 					status: Type.Union([Type.Literal("completed"), Type.Literal("partial"), Type.Literal("blocked")]),
 					summary: Type.String(),

--- a/src/extensions/agents/worker-report.ts
+++ b/src/extensions/agents/worker-report.ts
@@ -28,12 +28,12 @@ export function createWorkerReportExtension(
 				name: WORKER_REPORT_TOOL_NAME,
 				label: "Submit Agent Report",
 				description:
-					"Submit the final structured progress report for this Ferment-linked worker. Call this alone as the final action after completing edits and verification.",
+					'Submit the final structured progress report for this Ferment-linked worker. Call this alone as the final action after completing edits and verification. When status is "completed", remaining_steps must be an empty array [] (not a placeholder string). When status is "partial", remaining_steps must list concrete work that remains.',
 				parameters: Type.Object({
 					status: Type.Union([Type.Literal("completed"), Type.Literal("partial"), Type.Literal("blocked")]),
 					summary: Type.String(),
 					steps_completed: Type.Array(Type.String()),
-					remaining_steps: Type.Array(Type.String()),
+					remaining_steps: Type.Array(Type.String(), { minItems: 0 }),
 					files_touched: Type.Optional(Type.Array(Type.String())),
 					verification: Type.Optional(Type.Array(Type.String())),
 					blockers: Type.Optional(Type.Array(Type.String())),

--- a/src/extensions/ferment/gate-validation.test.ts
+++ b/src/extensions/ferment/gate-validation.test.ts
@@ -316,4 +316,23 @@ describe("pi-ai validation patch regressions", () => {
 			} as ToolCall),
 		).not.toThrow(SyntaxError)
 	})
+
+	it("coerces empty object {} to empty array [] for array fields", () => {
+		// Regression: LLMs (especially minimax-m3) frequently send {} instead of []
+		// for empty arrays. Without the coercion fix, Value.Convert wraps {} into
+		// [{}], which fails validation with "items[0]: must be string".
+		const tool = {
+			name: "test-empty-object-to-array",
+			description: "test empty object to array coercion",
+			parameters: Type.Object({ remaining_steps: Type.Array(Type.String(), { minItems: 0 }) }),
+			execute: () => {},
+		}
+		const args = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "test-empty-object-call",
+			name: "test-empty-object-to-array",
+			arguments: { remaining_steps: {} },
+		} as ToolCall)
+		expect(args.remaining_steps).toEqual([])
+	})
 })


### PR DESCRIPTION
## Problem

LLMs (especially minimax-m3, the default Builder model) frequently send `{}` instead of `[]` for empty array fields in `submit_agent_report`. This causes a compounding failure:

1. **`Value.Convert` corrupts `{}` → `[{}]`** — schema validation fails with `remaining_steps.0: must be string`
2. **LLM compensates with `["none"]`** — schema passes but `execute()` rejects: `"A completed report must use remaining_steps: []"`
3. **No payload satisfies both layers** — the LLM is trapped in a retry loop

### Impact

Analyzed from a recent 6.5-hour ferment session (session `019fb32e`):
- **20 of 51 subagent sessions affected** (39%)
- **132 wasted retries** across those sessions
- **~25% of all subagent turns** consumed by retrying this one tool call
- Phase 1 Builders were worst hit (33-62% efficiency)

## Fix

1. **Patch coercion** (`patches/@earendil-works__pi-ai@0.79.10.patch`):
   Add `{}` → `[]` coercion in `coercePrimitiveByType` for the `"array"` case, preventing `Value.Convert` from wrapping empty objects into `[{}]`.

2. **Schema clarity** (`worker-report.ts`):
   - Add `minItems: 0` to `remaining_steps` schema (makes "empty array is valid" explicit)
   - Update tool description to state `remaining_steps` must be `[]` when `status` is `"completed"`

## Test coverage

- [x] `worker-report.test.ts`: schema `minItems: 0` check, happy path `[]`, genuine remaining work rejection, coerced `[]` acceptance
- [x] `gate-validation.test.ts`: `{}` → `[]` coercion regression at the validation layer using `validateToolArguments` from `@earendil-works/pi-ai`
- [x] All 267 existing agent tests pass


Closes #0