### PR TITLE
feat: add max thinking level support

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
 			"playwright-core@1.59.1": "patches/playwright-core@1.59.1.patch",
 			"@earendil-works/pi-tui@0.79.10": "patches/@earendil-works__pi-tui@0.79.10.patch",
 			"@earendil-works/pi-ai@0.79.10": "patches/@earendil-works__pi-ai@0.79.10.patch",
-			"@earendil-works/pi-coding-agent@0.79.10": "patches/@earendil-works__pi-coding-agent@0.79.10.patch"
+			"@earendil-works/pi-coding-agent@0.79.10": "patches/@earendil-works__pi-coding-agent@0.79.10.patch",
+			"@earendil-works/pi-agent-core@0.79.10": "patches/@earendil-works__pi-agent-core@0.79.10.patch"
 		},
 		"supportedArchitectures": {
 			"os": [

--- a/patches/@earendil-works__pi-agent-core@0.79.10.patch
+++ b/patches/@earendil-works__pi-agent-core@0.79.10.patch
@@ -1,0 +1,32 @@
+# Patch: kimchi-dev runtime extensions for pi-agent-core
+#
+# NOTE for upgraders: `pnpm patch-commit` regenerates this file and STRIPS this
+# header — re-add it (and re-run `pnpm install` to refresh the lockfile hash)
+# after every regeneration.
+#
+# Changes included:
+#   1. dist/types.d.ts — add "max" to the ThinkingLevel type so downstream
+#      type-checking (pi-coding-agent ExtensionAPI, kimchi harness) accepts
+#      the new level. Mirrors the same change in pi-ai's types.d.ts.
+#
+# Tracking: open an upstream PR against pi-mono to add "max" as a first-class
+# ThinkingLevel in pi-agent-core.
+# Issue: TODO — file against https://github.com/earendil-works/pi-mono
+#
+# Removal criteria:
+#   - upstream pi-agent-core ships ThinkingLevel with "max" included, and the
+#     fixed version is pinned in package.json.
+#
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index 05f854c2603767da44f30b9f0c6e0078a1950400..e622dd76ecae8203fd006b7d7be6560071ac23a8 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -246,7 +246,7 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
+  * Note: "xhigh" is only supported by selected model families. Use model thinking-level metadata
+  * from @earendil-works/pi-ai to detect support for a concrete model.
+  */
+-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
++export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+ /**
+  * Extensible interface for custom app messages.
+  * Apps can extend via declaration merging:

--- a/patches/@earendil-works__pi-ai@0.79.10.patch
+++ b/patches/@earendil-works__pi-ai@0.79.10.patch
@@ -1,3 +1,44 @@
+# Patch: kimchi-dev runtime extensions for pi-ai
+#
+# NOTE for upgraders: `pnpm patch-commit` regenerates this file and STRIPS this
+# header — re-add it (and re-run `pnpm install` to refresh the lockfile hash)
+# after every regeneration.
+#
+# Changes included:
+#   1. dist/models.js — add "max" to EXTENDED_THINKING_LEVELS so the upstream
+#      thinking-level machinery (getSupportedThinkingLevels, clampThinkingLevel)
+#      recognises "max" as a valid level above "xhigh".
+#   2. dist/types.d.ts — add "max" to the ThinkingLevel type so downstream
+#      type-checking accepts the new level.
+#   3. dist/providers/openai-completions.js — fall back to cache_creation_tokens
+#      for cache write token counting (LiteLLM compatibility).
+#   4. dist/utils/validation.js — improved JSON Schema coercion for array/object
+#      tool arguments.
+#
+# Tracking: open an upstream PR against pi-mono to add "max" as a first-class
+# ThinkingLevel in pi-ai.
+# Issue: TODO — file against https://github.com/earendil-works/pi-mono
+#
+# Removal criteria:
+#   - Items 1-2 (max thinking level): upstream pi-ai ships ThinkingLevel with
+#     "max" included and EXTENDED_THINKING_LEVELS updated, and the fixed version
+#     is pinned in package.json.
+#   - Items 3-4: upstream pi-ai includes the cache_creation_tokens fallback and
+#     the validation improvements, and the fixed version is pinned.
+#
+diff --git a/dist/models.js b/dist/models.js
+index 8c5de030d4b297c624dd2e35a8ea573d5b44ddfe..6c25cc59dae74b475aa2f85760fdbfacb544d41c 100644
+--- a/dist/models.js
++++ b/dist/models.js
+@@ -30,7 +30,7 @@ export function calculateCost(model, usage) {
+     usage.cost.total = usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
+     return usage.cost;
+ }
+-const EXTENDED_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
++const EXTENDED_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+ export function getSupportedThinkingLevels(model) {
+     if (!model.reasoning)
+         return ["off"];
 diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
 index b519e02d589507a283e136a96c79cf3cf9d757ad..586c3c473c5685c4db93df2a6d3fe8175765fd3b 100644
 --- a/dist/providers/openai-completions.js
@@ -66,3 +107,16 @@ index 9ba1a5f5aecd015b01d1e88fdb62b8dcca176e52..ca077cb942a2761f3b24459d4af91692
          const coerced = coerceWithJsonSchema(args, tool.parameters);
          if (coerced !== args) {
              if (isRecord(args) && isRecord(coerced)) {
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index b2a00df75a4a0f69b84afaf11527feca23abb624..15075f201389d3c278d93f492baea43be7b70ccb 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -9,7 +9,7 @@ export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "googl
+ export type Provider = KnownProvider | string;
+ export type KnownImagesProvider = "openrouter";
+ export type ImagesProvider = KnownImagesProvider | string;
+-export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
++export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+ export type ModelThinkingLevel = "off" | ThinkingLevel;
+ export type ThinkingLevelMap = Partial<Record<ModelThinkingLevel, string | null>>;
+ export type ChatTemplateKwargValue = string | number | boolean | null | {

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -8,7 +8,9 @@
 # interactive-mode.js, which previewTheme used to call).
 #
 # Changes included:
-#   1. dist/cli/args.js         — expose KIMCHI_API_KEY in --help env-var block
+#   1. dist/cli/args.js         — expose KIMCHI_API_KEY in --help env-var block;
+#                                 add "xhigh" and "max" to VALID_THINKING_LEVELS
+#                                 and --thinking help text so the CLI accepts them.
 #   2. dist/core/extensions/runner.js — add emitBeforeProviderHeaders(headers) method,
 #                                       mirroring emitBeforeProviderRequest pattern
 #   3. dist/core/sdk.js         — call emitBeforeProviderHeaders in streamFn after
@@ -18,6 +20,9 @@
 #                                   from state.tools after each tool batch, enabling
 #                                   mid-run setActiveTools() calls to take effect on
 #                                   the next model response within the same agent run.
+#                                   Also add "xhigh" and "max" to the THINKING_LEVELS
+#                                   fallback constant so getAvailableThinkingLevels()
+#                                   returns them when no model is set.
 #   5. dist/modes/interactive/  — miscellaneous upstream UI fixes bundled in this patch
 #   6. dist/modes/interactive/interactive-mode.js — add previewTheme(name) and
 #      dist/core/extensions/types.d.ts              showError(message) to createExtensionUIContext,
@@ -68,9 +73,11 @@
 #   - Items 1-3 (before_provider_headers): upstream pi-mono ships BeforeProviderHeadersEvent
 #     and ExtensionAPI.on("before_provider_headers", ...) as a first-class hook, and
 #     the fixed version is pinned in package.json.
-#   - Item 4 (prepareNextTurn): upstream pi-mono wires agent.prepareNextTurn in
-#     AgentSession._installAgentToolHooks() so context.tools refreshes after each tool
-#     batch without a patch.
+#   - Item 4 (prepareNextTurn + THINKING_LEVELS): upstream pi-mono wires
+#     agent.prepareNextTurn in AgentSession._installAgentToolHooks() so context.tools
+#     refreshes after each tool batch without a patch, AND upstream pi-coding-agent
+#     includes "xhigh" and "max" in the THINKING_LEVELS constant. Both must be
+#     fixed and the version pinned in package.json.
 #   - Item 5: individual fixes land upstream and the patched version is updated.
 #   - Item 6 (previewTheme + showError): upstream pi-coding-agent ships previewTheme
 #     and showError on ExtensionUIContext and the fixed version is pinned in package.json.
@@ -87,6 +94,18 @@ diff --git a/dist/cli/args.js b/dist/cli/args.js
 index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d198245751 100644
 --- a/dist/cli/args.js
 +++ b/dist/cli/args.js
+@@ -3,7 +3,7 @@
+  */
+ import chalk from "chalk";
+ import { APP_NAME, CONFIG_DIR_NAME, ENV_AGENT_DIR, ENV_SESSION_DIR } from "../config.js";
+-const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
++const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+ export function isValidThinkingLevel(level) {
+     return VALID_THINKING_LEVELS.includes(level);
+ }
+@@ -248,1 +248,1 @@
+-  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
++  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max
 @@ -321,6 +321,7 @@ ${chalk.bold("Examples:")}
    ${APP_NAME} --export session.jsonl output.html
  
@@ -99,6 +118,15 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 index 3b2c24d1b52869e351ea488f0c535c34eaedf127..7302cc4df1e25be2e38489afb7c8ea8364695542 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
+@@ -60,7 +60,7 @@
+ // Constants
+ // ============================================================================
+ /** Standard thinking levels */
+-const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"];
++const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+ // ============================================================================
+ // AgentSession Class
+ // ============================================================================
 @@ -203,6 +203,20 @@ export class AgentSession {
                  throw new Error(`Extension failed, blocking execution: ${String(err)}`);
              }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  '@earendil-works/pi-agent-core@0.79.10':
+    hash: 15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991
+    path: patches/@earendil-works__pi-agent-core@0.79.10.patch
   '@earendil-works/pi-ai@0.79.10':
-    hash: a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e
+    hash: 34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: 672724cf9db0e2946cecac7c8aea123a14bccdbc8b27f0197336f781b79e2bbc
+    hash: 105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -33,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=672724cf9db0e2946cecac7c8aea123a14bccdbc8b27f0197336f781b79e2bbc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -106,7 +109,7 @@ importers:
         version: 2.5.3
       '@earendil-works/pi-ai':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@microsoft/tui-test':
         specifier: 0.0.4
         version: 0.0.4
@@ -2796,9 +2799,9 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@earendil-works/pi-agent-core@0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2810,7 +2813,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2831,10 +2834,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=672724cf9db0e2946cecac7c8aea123a14bccdbc8b27f0197336f781b79e2bbc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.10(patch_hash=a9d385c837d7062a1b38fd9d81d5405543cf7149753ed9a67f685e520913453e)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: 34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: 105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005
+    hash: b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -36,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -2834,7 +2834,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=105bf8ca6a027f03d0f86b803808e30edecf95d46f367618075909be99e1f005)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -20,7 +20,7 @@ interface FlagDoc {
 const KIMCHI_FLAGS: FlagDoc[] = [
 	{ name: "--provider <name>", description: "Provider (default: kimchi-dev)" },
 	{ name: "--model <pattern>", description: "Model id or pattern, optionally `provider/id` and/or `:<thinking>`" },
-	{ name: "--thinking <level>", description: "Thinking level: off, minimal, low, medium, high, xhigh" },
+	{ name: "--thinking <level>", description: "Thinking level: off, minimal, low, medium, high, xhigh, max" },
 	{ name: "--mode <mode>", description: "Output mode: text (default), json, rpc, acp" },
 	{ name: "--print, -p", description: "Non-interactive mode: process prompt and exit" },
 	{ name: "--continue, -c", description: "Resume the most recent session" },

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -1072,7 +1072,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 				thinking: Type.Optional(
 					Type.String({
 						description:
-							"Requested thinking level: off, minimal, low, medium, high, xhigh. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
+							"Requested thinking level: off, minimal, low, medium, high, xhigh, max. Orchestrator-provided values override agent profile defaults. Omit only when Orchestration does not require an explicit level.",
 					}),
 				),
 				max_turns: Type.Optional(
@@ -2300,7 +2300,7 @@ The file format is a markdown file with YAML frontmatter and a system prompt bod
 description: <one-line description shown in UI>
 tools: <comma-separated built-in tools: read, bash, edit, write, grep, find, ls. Use "none" for no tools. Omit for all tools>
 models: <optional ordered list of models, e.g. ["kimchi-dev/minimax-m2.7"]. Omit to inherit parent model>
-thinking: <optional thinking level: off, minimal, low, medium, high, xhigh. Omit to inherit>
+thinking: <optional thinking level: off, minimal, low, medium, high, xhigh, max. Omit to inherit>
 max_turns: <optional max agentic turns. 0 or omit for unlimited (default)>
 token_budget: <optional maximum total tokens for this agent. Omit for no profile budget>
 prompt_mode: <"replace" (body IS the full system prompt) or "append" (body is appended to default prompt). Default: replace>
@@ -2389,6 +2389,7 @@ Write the file using the write tool. Only write the file, nothing else.`
 			"medium",
 			"high",
 			"xhigh",
+			"max",
 		])
 		if (!thinkingChoice) return
 

--- a/src/extensions/agents/personas/types.ts
+++ b/src/extensions/agents/personas/types.ts
@@ -9,7 +9,7 @@ import type { LifetimeUsage } from "../manager/usage.js"
 import type { FermentWorkerBudgetTier } from "../worker-budget-policy.js"
 
 /** Thinking/reasoning level for models that support it. */
-export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
+export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
 
 export type AgentAbortReason = "max_turns" | "token_budget" | "inactivity" | "max_duration"
 export type AgentOutcomeKind = "completed" | "budget_exhausted" | "failed" | "stopped"

--- a/src/extensions/agents/thinking-level-policy.test.ts
+++ b/src/extensions/agents/thinking-level-policy.test.ts
@@ -20,6 +20,11 @@ describe("resolveDelegationThinkingLevel", () => {
 		expect(resolveDelegationThinkingLevel("build", "complex", 1)).toBe("xhigh")
 	})
 
+	it("caps build retries at xhigh (build ceiling)", () => {
+		expect(resolveDelegationThinkingLevel("build", "complex", 2)).toBe("xhigh")
+		expect(resolveDelegationThinkingLevel("build", "complex", 3)).toBe("xhigh")
+	})
+
 	it("bumps explore complex to medium on retry and caps there", () => {
 		expect(resolveDelegationThinkingLevel("explore", "complex", 1)).toBe("medium")
 		expect(resolveDelegationThinkingLevel("explore", "complex", 2)).toBe("medium")
@@ -41,6 +46,18 @@ describe("bumpThinkingLevel", () => {
 
 	it("does not decrease the level when the ceiling is below the current level", () => {
 		expect(bumpThinkingLevel("high", 1, "low")).toBe("high")
+	})
+
+	it("can bump to max when ceiling allows", () => {
+		expect(bumpThinkingLevel("xhigh", 1, "max")).toBe("max")
+	})
+
+	it("defaults ceiling to max", () => {
+		expect(bumpThinkingLevel("xhigh", 1)).toBe("max")
+	})
+
+	it("caps at max when bumping from high with large steps", () => {
+		expect(bumpThinkingLevel("high", 10)).toBe("max")
 	})
 })
 

--- a/src/extensions/agents/thinking-level-policy.ts
+++ b/src/extensions/agents/thinking-level-policy.ts
@@ -20,6 +20,7 @@ export const THINKING_LEVEL_ORDER: readonly ThinkingLevel[] = [
 	"medium",
 	"high",
 	"xhigh",
+	"max",
 ] as const
 
 const DELEGATION_THINKING_BASE: Record<ThinkingTaskScope, Record<ChunkComplexity, ThinkingLevel>> = {
@@ -56,7 +57,7 @@ export function thinkingScopeForSubagentType(subagentType: string): ThinkingTask
 	return SUBAGENT_TYPE_TO_SCOPE[subagentType]
 }
 
-export function bumpThinkingLevel(level: ThinkingLevel, steps = 1, ceiling: ThinkingLevel = "xhigh"): ThinkingLevel {
+export function bumpThinkingLevel(level: ThinkingLevel, steps = 1, ceiling: ThinkingLevel = "max"): ThinkingLevel {
 	const idx = THINKING_LEVEL_ORDER.indexOf(level)
 	const ceilIdx = THINKING_LEVEL_ORDER.indexOf(ceiling)
 	if (idx < 0 || steps <= 0) return level
@@ -77,7 +78,7 @@ export function resolveDelegationThinkingLevel(
 ): ThinkingLevel {
 	const base = DELEGATION_THINKING_BASE[scope][complexity]
 	if (retryRound <= 0) return base
-	const ceiling = THINKING_RETRY_CEILING[scope] ?? "xhigh"
+	const ceiling = THINKING_RETRY_CEILING[scope] ?? "max"
 	return bumpThinkingLevel(base, retryRound, ceiling)
 }
 

--- a/src/extensions/orchestration/orchestration-instructions.ts
+++ b/src/extensions/orchestration/orchestration-instructions.ts
@@ -182,7 +182,7 @@ Always pass a \`thinking\` parameter on every Agent call — never omit it. Use 
 
 const THINKING_LEVELS = `### Thinking levels
 
-\`thinking\` controls extended reasoning for the orchestrator and each delegated worker. Levels (lowest to highest): off, minimal, low, medium, high, xhigh. Use the lowest level that fits the task — higher thinking costs more tokens and time.
+\`thinking\` controls extended reasoning for the orchestrator and each delegated worker. Levels (lowest to highest): off, minimal, low, medium, high, xhigh, max. Use the lowest level that fits the task — higher thinking costs more tokens and time.
 
 **Orchestrator (main thread):** keep thinking low while coordinating (spawning agents, reading artifact paths). Raise only when classifying the pipeline, self-validating a plan, or interpreting ambiguous subagent reports.
 

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -492,7 +492,7 @@ const SetPhaseParams = Type.Object({
 		Type.String({
 			description:
 				"Optional thinking level to use when the orchestrator performs this phase itself (not delegating). Set per the Orchestration Thinking levels table.",
-			enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+			enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
 		}),
 	),
 })


### PR DESCRIPTION
## Summary

Adds `"max"` as a new thinking level above `"xhigh"` across the entire stack:

- **pi-ai patch**: adds `"max"` to `EXTENDED_THINKING_LEVELS` and the `ThinkingLevel` type, so the upstream thinking-level machinery (`getSupportedThinkingLevels`, `clampThinkingLevel`) recognises it
- **pi-agent-core patch**: adds `"max"` to the `ThinkingLevel` type so downstream type-checking passes
- **pi-coding-agent patch**: adds `"xhigh"` and `"max"` to `THINKING_LEVELS` (no-model fallback), `VALID_THINKING_LEVELS` (CLI validation), and `--thinking` help text — so `--thinking max` is accepted at the CLI and shown in `/settings`
- **Harness code**: updates `ThinkingLevel` type, `THINKING_LEVEL_ORDER`, enum arrays (`tags.ts`, `agents/index.ts`, `help.ts`), orchestration instructions, and benchmark agent `CLI_FLAGS`

## Context

Testing confirmed all kimchi-dev API models accept `reasoning_effort: "max"`. The existing `xhigh` level already maps to `"max"` at the API level for many built-in models in pi-ai's model registry, but the kimchi-dev models (configured via `models.json`) had no `thinkingLevelMap`, so `"xhigh"` was sent literally — which some Anthropic models reject. Adding `"max"` as a first-class level lets users explicitly request the highest reasoning tier.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test -- --run` passes (all 7546 tests)
- [x] `pnpm run lint` passes
- [x] Patched files verified after `pnpm install` — `VALID_THINKING_LEVELS`, `THINKING_LEVELS`, `EXTENDED_THINKING_LEVELS`, and `ThinkingLevel` type all include `"max"`
- [ ] Manual: `kimchi --thinking max` shows "max" in `/settings` thinking level display

## Patch notes

Three upstream patches are modified/added:
- `patches/@earendil-works__pi-ai@0.79.10.patch` — new hunks for `models.js` + `types.d.ts`
- `patches/@earendil-works__pi-coding-agent@0.79.10.patch` — new hunks for `cli/args.js` + `core/agent-session.js`
- `patches/@earendil-works__pi-agent-core@0.79.10.patch` — **new file** for `types.d.ts`

All patch headers include tracking issue placeholders and removal criteria per repo conventions.

## Label

new feature