### PR TITLE
fix(acp): enforce tool call id uniqueness, move tool related fns into utils

### DIFF
--- a/src/modes/acp/acp-prompter.ts
+++ b/src/modes/acp/acp-prompter.ts
@@ -1,8 +1,8 @@
-import type { AgentSideConnection, PermissionOption, SessionUpdate } from "@agentclientprotocol/sdk"
+import type { AgentSideConnection, PermissionOption, ToolCall } from "@agentclientprotocol/sdk"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import type { PermissionChoice, ToolPermissionPrompter } from "../../extensions/permissions/prompter.js"
 import type { ApprovalOutcome } from "../../extensions/permissions/prompts.js"
-import { buildToolCall } from "./tool-calls/utils.js"
+import { buildToolCallShape } from "./tool-calls/utils.js"
 import { requestWithAbort } from "./utils.js"
 
 export type AcpToolCallIdResolver = (piToolCallId: string, toolName: string) => string
@@ -29,16 +29,14 @@ export function createAcpPermissionPrompter(
 			})
 
 			const acpToolCallId = resolveAcpToolCallId(req.toolCallId, req.toolName)
-			const toolCallUpdate: SessionUpdate = buildToolCall({
+			const toolCall: ToolCall = buildToolCallShape({
 				toolCallId: acpToolCallId,
 				piToolCallId: req.toolCallId,
 				toolName: req.toolName,
 				rawInput: req.input,
+				status: "pending",
 			})
-			const response = await requestWithAbort(
-				conn.requestPermission({ sessionId, toolCall: toolCallUpdate, options }),
-				req.signal,
-			)
+			const response = await requestWithAbort(conn.requestPermission({ sessionId, toolCall, options }), req.signal)
 
 			if (response === "aborted" || response.outcome.outcome === "cancelled") return { kind: "aborted" }
 

--- a/src/modes/acp/acp-prompter.ts
+++ b/src/modes/acp/acp-prompter.ts
@@ -1,20 +1,17 @@
-import type { AgentSideConnection, PermissionOption, ToolCallUpdate } from "@agentclientprotocol/sdk"
+import type { AgentSideConnection, PermissionOption, SessionUpdate } from "@agentclientprotocol/sdk"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import type { PermissionChoice, ToolPermissionPrompter } from "../../extensions/permissions/prompter.js"
 import type { ApprovalOutcome } from "../../extensions/permissions/prompts.js"
+import { buildToolCall } from "./tool-calls/utils.js"
 import { requestWithAbort } from "./utils.js"
 
-export type ToolCallUpdateBuilder = (
-	toolCallId: string,
-	toolName: string,
-	input: Record<string, unknown>,
-) => ToolCallUpdate
+export type AcpToolCallIdResolver = (piToolCallId: string, toolName: string) => string
 
 export function createAcpPermissionPrompter(
 	conn: AgentSideConnection,
 	sessionId: string,
 	uiContext: ExtensionUIContext,
-	buildToolCallUpdate: ToolCallUpdateBuilder,
+	resolveAcpToolCallId: AcpToolCallIdResolver,
 ): ToolPermissionPrompter {
 	return {
 		async request(req): Promise<ApprovalOutcome> {
@@ -31,12 +28,15 @@ export function createAcpPermissionPrompter(
 				}
 			})
 
+			const acpToolCallId = resolveAcpToolCallId(req.toolCallId, req.toolName)
+			const toolCallUpdate: SessionUpdate = buildToolCall({
+				toolCallId: acpToolCallId,
+				piToolCallId: req.toolCallId,
+				toolName: req.toolName,
+				rawInput: req.input,
+			})
 			const response = await requestWithAbort(
-				conn.requestPermission({
-					sessionId,
-					toolCall: buildToolCallUpdate(req.toolCallId, req.toolName, req.input),
-					options,
-				}),
+				conn.requestPermission({ sessionId, toolCall: toolCallUpdate, options }),
 				req.signal,
 			)
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -865,6 +865,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 				{ optionId: "choice-1", name: "Deny", kind: "reject_once" },
 			],
 		})
+		expect(requests[0].toolCall).not.toHaveProperty("sessionUpdate")
 
 		await localAgent.shutdown()
 		expect(getAcpPrompter("session-permission")).toBeUndefined()
@@ -1814,6 +1815,60 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		])
 	})
 
+	it("disambiguates a reused upstream toolCallId within the same turn", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				args: { command: "echo first" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "first" }] },
+				isError: false,
+			})
+			// Same upstream id reused immediately in the same turn.
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				args: { command: "echo second" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "second" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run" }],
+		})
+
+		const calls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		expect(calls).toHaveLength(2)
+		const firstId = (calls[0].update as { toolCallId: string }).toolCallId
+		const secondId = (calls[1].update as { toolCallId: string }).toolCallId
+		expect(firstId).not.toBe(secondId)
+
+		const firstUpdates = updates.filter(
+			(u) => u.update.sessionUpdate === "tool_call_update" && u.update.toolCallId === firstId,
+		)
+		const secondUpdates = updates.filter(
+			(u) => u.update.sessionUpdate === "tool_call_update" && u.update.toolCallId === secondId,
+		)
+		expect(firstUpdates).toHaveLength(1)
+		expect(secondUpdates).toHaveLength(1)
+	})
+
 	// Chunk 1: toolcall_start must emit a tool_call notification with status="pending"
 	// so clients can show progress while the model streams tool call arguments.
 	// See spec-tool-call-streaming-harness.md.
@@ -2278,17 +2333,15 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		])
 		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
 
-		const inProgressUpdates = updates.filter(
+		const pendingUpdates = updates.filter(
 			(u) =>
-				u.update.sessionUpdate === "tool_call_update" &&
-				u.update.status === "in_progress" &&
-				u.update.toolCallId === acpId,
+				u.update.sessionUpdate === "tool_call_update" && u.update.status === "pending" && u.update.toolCallId === acpId,
 		)
-		expect(inProgressUpdates).toEqual([
+		expect(pendingUpdates).toEqual([
 			expect.objectContaining({
 				update: expect.objectContaining({
 					sessionUpdate: "tool_call_update",
-					status: "in_progress",
+					status: "pending",
 					toolCallId: acpId,
 					rawOutput: { delta: "chunk1" },
 					_meta: { generatedChars: "chunk1".length, piToolCallId: "tc-every-delta-1" },
@@ -2297,7 +2350,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 			expect.objectContaining({
 				update: expect.objectContaining({
 					sessionUpdate: "tool_call_update",
-					status: "in_progress",
+					status: "pending",
 					toolCallId: acpId,
 					rawOutput: { delta: "chunk2" },
 					_meta: { generatedChars: "chunk1chunk2".length, piToolCallId: "tc-every-delta-1" },
@@ -2306,7 +2359,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 			expect.objectContaining({
 				update: expect.objectContaining({
 					sessionUpdate: "tool_call_update",
-					status: "in_progress",
+					status: "pending",
 					toolCallId: acpId,
 					rawOutput: { delta: "chunk3" },
 					_meta: { generatedChars: "chunk1chunk2chunk3".length, piToolCallId: "tc-every-delta-1" },
@@ -2494,7 +2547,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 			expect.objectContaining({
 				update: expect.objectContaining({
 					sessionUpdate: "tool_call_update",
-					status: "in_progress",
+					status: "pending",
 					toolCallId: writeAcpId,
 					rawOutput: { delta: "hello world" },
 					_meta: { generatedChars: 11, piToolCallId: "tc-write-1" },
@@ -2503,7 +2556,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 			expect.objectContaining({
 				update: expect.objectContaining({
 					sessionUpdate: "tool_call_update",
-					status: "in_progress",
+					status: "pending",
 					toolCallId: editAcpId,
 					rawOutput: { delta: "abc" },
 					_meta: { generatedChars: 3, piToolCallId: "tc-edit-1" },
@@ -4907,7 +4960,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			const toolCall = replay[1].update as Record<string, unknown>
 			expect(toolCall).toMatchObject({
 				sessionUpdate: "tool_call",
-				toolCallId: `kt.${c.toolName}.2`,
+				toolCallId: `kt.${c.toolName}.0`,
 				kind: c.expect.kind,
 				title: c.expect.title,
 				status: c.expect.status,
@@ -4917,7 +4970,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			const update = replay[2].update as Record<string, unknown>
 			expect(update).toMatchObject({
 				sessionUpdate: "tool_call_update",
-				toolCallId: `kt.${c.toolName}.2`,
+				toolCallId: `kt.${c.toolName}.0`,
 				status: c.expect.status,
 			})
 			const content = (update as { content: Array<{ content: { text: string } }> }).content

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -37,9 +37,7 @@ import {
 	type AcpSessionLoader,
 	assertSessionHasModel,
 	buildSessionModelState,
-	describeToolCall,
 	initializeHeadlessTheme,
-	isHiddenToolCall,
 	KimchiAcpAgent,
 	stripAnsi,
 	toAcpSessionInfo,
@@ -855,11 +853,12 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(requests[0]).toMatchObject({
 			sessionId: "session-permission",
 			toolCall: {
-				toolCallId: "tc-permission",
+				toolCallId: "kt.bash.0",
 				title: "touch allowed.txt",
 				kind: "execute",
 				status: "pending",
 				rawInput: { command: "touch allowed.txt" },
+				_meta: { piToolCallId: "tc-permission" },
 			},
 			options: [
 				{ optionId: "choice-0", name: "Allow once", kind: "allow_once" },
@@ -1211,14 +1210,7 @@ describe("KimchiAcpAgent messageId on streaming chunks", () => {
 			prompt: [{ type: "text", text: "two blocks" }],
 		})
 		expect(result.stopReason).toBe("end_turn")
-		expect(messageIdsFor("agent_message_chunk")).toEqual([
-			"kimchi_msg_0",
-			"kimchi_msg_0",
-			"kimchi_msg_0",
-			"kimchi_msg_1",
-			"kimchi_msg_1",
-			"kimchi_msg_1",
-		])
+		expect(messageIdsFor("agent_message_chunk")).toEqual(["km.0", "km.0", "km.0", "km.1", "km.1", "km.1"])
 	})
 
 	it("emits messageId on agent_thought_chunk the same way (same contentIndex → same id)", async () => {
@@ -1235,7 +1227,7 @@ describe("KimchiAcpAgent messageId on streaming chunks", () => {
 			prompt: [{ type: "text", text: "think" }],
 		})
 		expect(result.stopReason).toBe("end_turn")
-		expect(messageIdsFor("agent_thought_chunk")).toEqual(["kimchi_msg_0", "kimchi_msg_0", "kimchi_msg_0"])
+		expect(messageIdsFor("agent_thought_chunk")).toEqual(["km.0", "km.0", "km.0"])
 	})
 
 	it("advances the counter across turns so two turns both starting at contentIndex=0 get distinct ids", async () => {
@@ -1261,7 +1253,7 @@ describe("KimchiAcpAgent messageId on streaming chunks", () => {
 			prompt: [{ type: "text", text: "two turns" }],
 		})
 		expect(result.stopReason).toBe("end_turn")
-		expect(messageIdsFor("agent_message_chunk")).toEqual(["kimchi_msg_0", "kimchi_msg_1"])
+		expect(messageIdsFor("agent_message_chunk")).toEqual(["km.0", "km.1"])
 	})
 })
 
@@ -1619,6 +1611,209 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(updates.some((u) => u.update.sessionUpdate === "tool_call_update")).toBe(false)
 	})
 
+	it("rewrites upstream toolCallIds to session-unique ACP ids", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-1",
+				toolName: "bash",
+				args: { command: "echo a" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-1",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "a" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run" }],
+		})
+
+		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "tc-1" },
+				}),
+			}),
+		])
+		expect(toolCallUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: acpId,
+					_meta: { piToolCallId: "tc-1" },
+				}),
+			}),
+		])
+		// The upstream id must not leak to the ACP surface.
+		expect(acpId).not.toBe("tc-1")
+	})
+
+	it("routes updates and end events to the allocated ACP toolCallId", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-partial",
+				toolName: "bash",
+				args: { command: "echo a" },
+			})
+			fake.emit({
+				type: "tool_execution_update",
+				toolCallId: "tc-partial",
+				toolName: "bash",
+				args: { command: "echo a" },
+				partialResult: { content: [{ type: "text", text: "partial" }] },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-partial",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "final" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run" }],
+		})
+
+		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
+		expect(toolCalls).toHaveLength(1)
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		expect(toolCalls[0]).toEqual(
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: acpId,
+					_meta: { piToolCallId: "tc-partial" },
+				}),
+			}),
+		)
+		expect(toolCallUpdates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					update: expect.objectContaining({
+						sessionUpdate: "tool_call_update",
+						toolCallId: acpId,
+						_meta: { piToolCallId: "tc-partial" },
+					}),
+				}),
+			]),
+		)
+	})
+
+	it("disambiguates a reused upstream toolCallId across compaction as two distinct calls", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				args: { command: "echo first" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "first" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run" }],
+		})
+
+		// Simulate compaction reusing the same upstream id for a new call.
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				args: { command: "echo second" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-reused",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "second" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run again" }],
+		})
+
+		const calls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		expect(calls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "tc-reused" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "tc-reused" },
+				}),
+			}),
+		])
+		const firstId = (calls[0].update as { toolCallId: string }).toolCallId
+		const secondId = (calls[1].update as { toolCallId: string }).toolCallId
+		expect(firstId).not.toBe(secondId)
+
+		const firstUpdates = updates.filter(
+			(u) =>
+				u.update.sessionUpdate === "tool_call_update" && (u.update as { toolCallId: string }).toolCallId === firstId,
+		)
+		const secondUpdates = updates.filter(
+			(u) =>
+				u.update.sessionUpdate === "tool_call_update" && (u.update as { toolCallId: string }).toolCallId === secondId,
+		)
+		expect(firstUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: firstId,
+					_meta: { piToolCallId: "tc-reused" },
+				}),
+			}),
+		])
+		expect(secondUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: secondId,
+					_meta: { piToolCallId: "tc-reused" },
+				}),
+			}),
+		])
+	})
+
 	// Chunk 1: toolcall_start must emit a tool_call notification with status="pending"
 	// so clients can show progress while the model streams tool call arguments.
 	// See spec-tool-call-streaming-harness.md.
@@ -1654,15 +1849,17 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(res.stopReason).toBe("end_turn")
 
 		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
-		expect(toolCalls).toHaveLength(1)
-		const pending = toolCalls[0].update as {
-			toolCallId: string
-			status: string
-			title?: string
-		}
-		expect(pending.toolCallId).toBe("tc-pending-1")
-		expect(pending.status).toBe("pending")
-		expect(pending.title).toBeDefined()
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.write\.\d+$/),
+					status: "pending",
+					title: expect.any(String),
+					_meta: { piToolCallId: "tc-pending-1" },
+				}),
+			}),
+		])
 	})
 
 	// toolcall_start → tool_execution_start must produce exactly ONE tool_call
@@ -1712,18 +1909,37 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(res.stopReason).toBe("end_turn")
 
 		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
-		expect(toolCalls).toHaveLength(1)
-		expect((toolCalls[0].update as { status: string }).status).toBe("pending")
-		expect((toolCalls[0].update as { toolCallId: string }).toolCallId).toBe("tc-flow-1")
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					status: "pending",
+					_meta: { piToolCallId: "tc-flow-1" },
+				}),
+			}),
+		])
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
 
 		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
-		expect(toolCallUpdates).toHaveLength(2)
-		const inProgress = toolCallUpdates.find((u) => (u.update as { status?: string }).status === "in_progress")
-		const completed = toolCallUpdates.find((u) => (u.update as { status?: string }).status === "completed")
-		expect(inProgress).toBeDefined()
-		expect((inProgress?.update as { toolCallId: string }).toolCallId).toBe("tc-flow-1")
-		expect(completed).toBeDefined()
-		expect((completed?.update as { toolCallId: string }).toolCallId).toBe("tc-flow-1")
+		expect(toolCallUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: acpId,
+					status: "in_progress",
+					_meta: { piToolCallId: "tc-flow-1" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: acpId,
+					status: "completed",
+					_meta: { piToolCallId: "tc-flow-1" },
+				}),
+			}),
+		])
 	})
 
 	// Back-compat: providers that don't emit toolcall_start must still get the
@@ -1754,13 +1970,29 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(res.stopReason).toBe("end_turn")
 
 		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
-		expect(toolCalls).toHaveLength(1)
-		expect((toolCalls[0].update as { toolCallId: string }).toolCallId).toBe("tc-backcompat-1")
-		expect((toolCalls[0].update as { status: string }).status).toBe("in_progress")
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					status: "in_progress",
+					_meta: { piToolCallId: "tc-backcompat-1" },
+				}),
+			}),
+		])
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
 
 		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
-		expect(toolCallUpdates).toHaveLength(1)
-		expect((toolCallUpdates[0].update as { status: string }).status).toBe("completed")
+		expect(toolCallUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					toolCallId: acpId,
+					status: "completed",
+					_meta: { piToolCallId: "tc-backcompat-1" },
+				}),
+			}),
+		])
 	})
 
 	// Hidden tool calls (system Agent) must produce zero ACP events even when
@@ -1897,25 +2129,63 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(res.stopReason).toBe("end_turn")
 
 		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
-		expect(toolCalls).toHaveLength(2)
-		const ids = toolCalls.map((u) => (u.update as { toolCallId: string }).toolCallId).sort()
-		expect(ids).toEqual(["tc-multi-a", "tc-multi-b"])
-		for (const tc of toolCalls) {
-			expect((tc.update as { status: string }).status).toBe("pending")
-		}
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					status: "pending",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "tc-multi-a" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					status: "pending",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "tc-multi-b" },
+				}),
+			}),
+		])
+		const acpA = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		const acpB = (toolCalls[1].update as { toolCallId: string }).toolCallId
+		expect(acpA).not.toBe(acpB)
 
 		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
-		expect(toolCallUpdates).toHaveLength(4)
-
-		const inProgress = toolCallUpdates.filter((u) => (u.update as { status?: string }).status === "in_progress")
-		const completed = toolCallUpdates.filter((u) => (u.update as { status?: string }).status === "completed")
-		expect(inProgress).toHaveLength(2)
-		expect(completed).toHaveLength(2)
-
-		const inProgressIds = inProgress.map((u) => (u.update as { toolCallId: string }).toolCallId).sort()
-		expect(inProgressIds).toEqual(["tc-multi-a", "tc-multi-b"])
-		const completedIds = completed.map((u) => (u.update as { toolCallId: string }).toolCallId).sort()
-		expect(completedIds).toEqual(["tc-multi-a", "tc-multi-b"])
+		expect(toolCallUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: acpA,
+					_meta: { piToolCallId: "tc-multi-a" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "completed",
+					toolCallId: acpA,
+					_meta: { piToolCallId: "tc-multi-a" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: acpB,
+					_meta: { piToolCallId: "tc-multi-b" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "completed",
+					toolCallId: acpB,
+					_meta: { piToolCallId: "tc-multi-b" },
+				}),
+			}),
+		])
 	})
 
 	// Helper to build a toolcall_delta message_update event with a given toolCallId,
@@ -1995,30 +2265,54 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		})
 		expect(res.stopReason).toBe("end_turn")
 
-		const pendingUpdates = updates.filter(
+		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					status: "pending",
+					toolCallId: expect.stringMatching(/^kt\.write\.\d+$/),
+					_meta: { piToolCallId: "tc-every-delta-1" },
+				}),
+			}),
+		])
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+
+		const inProgressUpdates = updates.filter(
 			(u) =>
 				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { status?: string }).status === "pending" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-every-delta-1",
+				u.update.status === "in_progress" &&
+				u.update.toolCallId === acpId,
 		)
-		expect(pendingUpdates).toHaveLength(3)
-
-		// Verify each delta's rawOutput reflects only the new characters and
-		// _meta.generatedChars reflects the cumulative content length.
-		const rawOutputs = pendingUpdates.map(
-			(u) => (u.update as { rawOutput?: { delta?: unknown } }).rawOutput?.delta ?? "",
-		)
-		expect(rawOutputs[0]).toBe("chunk1")
-		expect(rawOutputs[1]).toBe("chunk2")
-		expect(rawOutputs[2]).toBe("chunk3")
-
-		const generatedChars = pendingUpdates.map(
-			(u) => (u.update as { _meta?: { generatedChars?: number } })._meta?.generatedChars ?? 0,
-		)
-		expect(generatedChars).toEqual(["chunk1".length, "chunk1chunk2".length, "chunk1chunk2chunk3".length])
-
-		// Concatenating all rawOutput strings reconstructs the final content.
-		expect(rawOutputs.join("")).toBe("chunk1chunk2chunk3")
+		expect(inProgressUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: acpId,
+					rawOutput: { delta: "chunk1" },
+					_meta: { generatedChars: "chunk1".length, piToolCallId: "tc-every-delta-1" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: acpId,
+					rawOutput: { delta: "chunk2" },
+					_meta: { generatedChars: "chunk1chunk2".length, piToolCallId: "tc-every-delta-1" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: acpId,
+					rawOutput: { delta: "chunk3" },
+					_meta: { generatedChars: "chunk1chunk2chunk3".length, piToolCallId: "tc-every-delta-1" },
+				}),
+			}),
+		])
 	})
 
 	// Spec test 3: deltas for a toolCallId that was never announced via
@@ -2040,8 +2334,8 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		const pendingUpdates = updates.filter(
 			(u) =>
 				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { status?: string }).status === "pending" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-orphan-1",
+				u.update.status === "pending" &&
+				u.update.toolCallId === "tc-orphan-1",
 		)
 		expect(pendingUpdates).toHaveLength(0)
 	})
@@ -2088,9 +2382,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		// No tool_call (from toolcall_start) AND no tool_call_update (from delta).
 		expect(updates.some((u) => u.update.sessionUpdate === "tool_call")).toBe(false)
 		const pendingUpdates = updates.filter(
-			(u) =>
-				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-hidden-delta-1",
+			(u) => u.update.sessionUpdate === "tool_call_update" && u.update.toolCallId === "tc-hidden-delta-1",
 		)
 		expect(pendingUpdates).toHaveLength(0)
 	})
@@ -2130,9 +2422,7 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		expect(res.stopReason).toBe("end_turn")
 
 		const pendingUpdates = updates.filter(
-			(u) =>
-				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-empty-1",
+			(u) => u.update.sessionUpdate === "tool_call_update" && u.update.toolCallId === "tc-empty-1",
 		)
 		expect(pendingUpdates).toHaveLength(0)
 	})
@@ -2177,58 +2467,49 @@ describe("KimchiAcpAgent tool execution stream", () => {
 		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "run" }] })
 		expect(res.stopReason).toBe("end_turn")
 
-		const writeUpdate = updates.find(
-			(u) =>
-				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-write-1",
-		)
-		expect(writeUpdate).toBeDefined()
-		const writeU = writeUpdate?.update as {
-			rawOutput?: { delta?: string }
-			_meta?: { generatedChars?: number }
-		}
-		expect(writeU.rawOutput?.delta).toBe("hello world")
-		expect(writeU._meta?.generatedChars).toBe(11)
+		const toolCalls = updates.filter((u) => u.update.sessionUpdate === "tool_call")
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					status: "pending",
+					toolCallId: expect.stringMatching(/^kt\.write\.\d+$/),
+					_meta: { piToolCallId: "tc-write-1" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					status: "pending",
+					toolCallId: expect.stringMatching(/^kt\.edit\.\d+$/),
+					_meta: { piToolCallId: "tc-edit-1" },
+				}),
+			}),
+		])
+		const writeAcpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		const editAcpId = (toolCalls[1].update as { toolCallId: string }).toolCallId
 
-		const editUpdate = updates.find(
-			(u) =>
-				u.update.sessionUpdate === "tool_call_update" &&
-				(u.update as { toolCallId: string }).toolCallId === "tc-edit-1",
-		)
-		expect(editUpdate).toBeDefined()
-		const editU = editUpdate?.update as {
-			rawOutput?: { delta?: string }
-			_meta?: { generatedChars?: number }
-		}
-		expect(editU.rawOutput?.delta).toBe("abc")
-		expect(editU._meta?.generatedChars).toBe(3)
-	})
-})
-
-describe("isHiddenToolCall", () => {
-	it("returns false for non-Agent tool names", () => {
-		expect(isHiddenToolCall("bash", {})).toBe(false)
-		expect(isHiddenToolCall("read", { visibility: "system" })).toBe(false)
-	})
-
-	it("returns false when visibility is missing", () => {
-		expect(isHiddenToolCall("Agent", {})).toBe(false)
-		expect(isHiddenToolCall("Agent", { prompt: "hello" })).toBe(false)
-	})
-
-	it("returns false when visibility is not 'system' (any casing)", () => {
-		expect(isHiddenToolCall("Agent", { visibility: "public" })).toBe(false)
-		expect(isHiddenToolCall("Agent", { visibility: "private" })).toBe(false)
-	})
-
-	it("returns true when visibility is 'system' (case-insensitive)", () => {
-		expect(isHiddenToolCall("Agent", { visibility: "system" })).toBe(true)
-		expect(isHiddenToolCall("Agent", { visibility: "System" })).toBe(true)
-		expect(isHiddenToolCall("Agent", { visibility: "SYSTEM" })).toBe(true)
-	})
-
-	it("returns true for Agent with mixed-case 'System' visibility", () => {
-		expect(isHiddenToolCall("Agent", { visibility: "SyStEm" })).toBe(true)
+		const toolCallUpdates = updates.filter((u) => u.update.sessionUpdate === "tool_call_update")
+		expect(toolCallUpdates).toEqual([
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: writeAcpId,
+					rawOutput: { delta: "hello world" },
+					_meta: { generatedChars: 11, piToolCallId: "tc-write-1" },
+				}),
+			}),
+			expect.objectContaining({
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call_update",
+					status: "in_progress",
+					toolCallId: editAcpId,
+					rawOutput: { delta: "abc" },
+					_meta: { generatedChars: 3, piToolCallId: "tc-edit-1" },
+				}),
+			}),
+		])
 	})
 })
 
@@ -3755,154 +4036,6 @@ describe("session mode controller lifecycle", () => {
 	})
 })
 
-// Direct coverage for describeToolCall. The function drives the tool_call
-// notification's title, kind, and locations — ACP clients key UI affordances
-// off these. Two recent fixes (064ff92, 00f58f3) landed on it; table-driven
-// cases here keep the title/kind matrix from silently drifting.
-describe("describeToolCall", () => {
-	it("detects hidden system Agent calls", () => {
-		expect(isHiddenToolCall("Agent", { visibility: "system" })).toBe(true)
-		expect(isHiddenToolCall("Agent", { visibility: "user" })).toBe(false)
-		expect(isHiddenToolCall("bash", { visibility: "system" })).toBe(false)
-	})
-
-	const longCommand = "a".repeat(120)
-	const longPath = `/tmp/${"x".repeat(120)}`
-	const longPattern = "p".repeat(120)
-	const cases: Array<{
-		name: string
-		toolName: string
-		args: unknown
-		expect: { title: string; kind: string; locations: Array<{ path: string }> }
-	}> = [
-		{
-			name: "bash with command uses command as title and execute kind",
-			toolName: "bash",
-			args: { command: "ls -la" },
-			expect: { title: "ls -la", kind: "execute", locations: [] },
-		},
-		{
-			name: "bash without command falls back to tool name",
-			toolName: "bash",
-			args: {},
-			expect: { title: "bash", kind: "execute", locations: [] },
-		},
-		{
-			name: "bash command is truncated at TITLE_MAX",
-			toolName: "bash",
-			args: { command: longCommand },
-			expect: { title: `${"a".repeat(80)}…`, kind: "execute", locations: [] },
-		},
-		{
-			name: "read with file_path uses path and populates locations",
-			toolName: "read",
-			args: { file_path: "/etc/hosts" },
-			expect: {
-				title: "/etc/hosts",
-				kind: "read",
-				locations: [{ path: "/etc/hosts" }],
-			},
-		},
-		{
-			name: "edit with file_path uses path and edit kind",
-			toolName: "edit",
-			args: { file_path: "/tmp/a.ts" },
-			expect: {
-				title: "/tmp/a.ts",
-				kind: "edit",
-				locations: [{ path: "/tmp/a.ts" }],
-			},
-		},
-		{
-			name: "write with path (not file_path) still populates locations",
-			toolName: "write",
-			args: { path: "/tmp/b.ts" },
-			expect: {
-				title: "/tmp/b.ts",
-				kind: "edit",
-				locations: [{ path: "/tmp/b.ts" }],
-			},
-		},
-		{
-			name: "grep with pattern uses pattern as title and search kind",
-			toolName: "grep",
-			args: { pattern: "foo.*bar" },
-			expect: { title: "foo.*bar", kind: "search", locations: [] },
-		},
-		{
-			name: "ls maps to read kind",
-			toolName: "ls",
-			args: { path: "/tmp" },
-			expect: { title: "/tmp", kind: "read", locations: [{ path: "/tmp" }] },
-		},
-		{
-			name: "find maps to search kind",
-			toolName: "find",
-			args: { pattern: "*.ts" },
-			expect: { title: "*.ts", kind: "search", locations: [] },
-		},
-		{
-			name: "web_fetch maps to fetch kind",
-			toolName: "web_fetch",
-			args: { url: "https://example.com" },
-			expect: { title: "web_fetch", kind: "fetch", locations: [] },
-		},
-		{
-			name: "web_search maps to search kind",
-			toolName: "web_search",
-			args: { query: "kimchi" },
-			expect: { title: "web_search", kind: "search", locations: [] },
-		},
-		{
-			name: "Agent maps to think kind",
-			toolName: "Agent",
-			args: { prompt: "go", visibility: "user" },
-			expect: { title: "Agent", kind: "think", locations: [] },
-		},
-		{
-			name: "unknown tool falls back to other kind",
-			toolName: "mcp__foo__bar",
-			args: { arg: 1 },
-			expect: { title: "mcp__foo__bar", kind: "other", locations: [] },
-		},
-		{
-			name: "null args is tolerated",
-			toolName: "bash",
-			args: null,
-			expect: { title: "bash", kind: "execute", locations: [] },
-		},
-		{
-			name: "long path title is truncated (locations keep full path)",
-			toolName: "read",
-			args: { file_path: longPath },
-			expect: {
-				title: `${longPath.slice(0, 80)}…`,
-				kind: "read",
-				locations: [{ path: longPath }],
-			},
-		},
-		{
-			name: "long pattern title is truncated",
-			toolName: "grep",
-			args: { pattern: longPattern },
-			expect: {
-				title: `${longPattern.slice(0, 80)}…`,
-				kind: "search",
-				locations: [],
-			},
-		},
-	]
-
-	for (const c of cases) {
-		it(c.name, () => {
-			const result = describeToolCall(c.toolName, c.args)
-			expect(result.title).toBe(c.expect.title)
-			expect(result.kind).toBe(c.expect.kind)
-			expect(result.locations).toEqual(c.expect.locations)
-		})
-	}
-})
-
 // Helper for the listSessions tests: builds a pi SessionInfo with sensible
 // defaults so each test only spells out the fields it cares about.
 function makePiSession(overrides: Partial<PiSessionInfo> = {}): PiSessionInfo {
@@ -4774,7 +4907,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			const toolCall = replay[1].update as Record<string, unknown>
 			expect(toolCall).toMatchObject({
 				sessionUpdate: "tool_call",
-				toolCallId: "tc-1",
+				toolCallId: `kt.${c.toolName}.2`,
 				kind: c.expect.kind,
 				title: c.expect.title,
 				status: c.expect.status,
@@ -4784,7 +4917,7 @@ describe("KimchiAcpAgent loadSession", () => {
 			const update = replay[2].update as Record<string, unknown>
 			expect(update).toMatchObject({
 				sessionUpdate: "tool_call_update",
-				toolCallId: "tc-1",
+				toolCallId: `kt.${c.toolName}.2`,
 				status: c.expect.status,
 			})
 			const content = (update as { content: Array<{ content: { text: string } }> }).content

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -158,12 +158,17 @@ type SessionRecord = {
 	 */
 	contentIndexToBlockId: Map<number, string>
 	/**
-	 * Session-wide monotonic counter for ACP toolCallIds. Pi's toolCall.id
-	 * values are only unique within a compaction segment, so the ACP surface
-	 * rewrites each tool_execution_start to a fresh session-unique id. This
-	 * satisfies the ACP contract "Unique identifier for a tool call within a
-	 * session." Seeded from the branch on loadSession so replay emits matching
-	 * ids.
+	 * Session-wide monotonic counter for ACP toolCallIds.
+	 *
+	 * toolCall.id comes straight from the model provider and carries no
+	 * uniqueness guarantee beyond a single request — nothing in pi renumbers it,
+	 * and providers do recycle ids. The ACP surface therefore rewrites every call
+	 * to a fresh id so it satisfies the ACP contract "Unique identifier for a
+	 * tool call within a session."
+	 *
+	 * This counter is the only source of `kt.*` ids and it never decrements, so
+	 * every id it hands out is distinct regardless of where it starts — it does
+	 * not need seeding from the persisted branch on loadSession.
 	 */
 	nextToolCallId: number
 	/**
@@ -557,7 +562,6 @@ export class KimchiAcpAgent implements Agent {
 			// same messageIds the live turn would have — and so any new block the
 			// user creates after the load gets a fresh, non-colliding id.
 			this.seedBlockCounterFromBranch(session, record)
-			this.seedToolCallCounterFromBranch(session, record)
 
 			// Replay BEFORE the response resolves so client sees a coherent transcript
 			// when the loadSession promise settles. No turn context is created, so a
@@ -808,6 +812,9 @@ export class KimchiAcpAgent implements Agent {
 							toolCallId: this.getOrAllocateAcpToolCallId(entry, block.id, block.name),
 							piToolCallId: block.id,
 							rawInput: block.arguments,
+							// Arguments are still streaming: the call hasn't been approved or started
+							// executing yet, so ACP status is `pending`, not `in_progress`.
+							status: "pending",
 						})
 						this.send({ sessionId, update })
 						turn.announcedToolCallIds.add(block.id)
@@ -837,6 +844,9 @@ export class KimchiAcpAgent implements Agent {
 									piToolCallId: block.id,
 									rawOutput: { delta },
 									_meta: { generatedChars: content.length },
+									// Arguments are still streaming: the call hasn't been approved or started
+									// executing yet, so ACP status is `pending`, not `in_progress`.
+									status: "pending",
 								})
 								this.send({ sessionId, update })
 							}
@@ -855,6 +865,9 @@ export class KimchiAcpAgent implements Agent {
 				if (!turn) return
 				if (isHiddenToolCall(event.toolName, event.args)) {
 					turn.hiddenToolCallIds.add(event.toolCallId)
+					// A hidden call may already have an allocated ACP id if the permission
+					// prompter ran before we knew it was hidden — retire its state.
+					this.retireToolCall(entry, turn, event.toolCallId)
 					return
 				}
 				const acpToolCallId = this.getOrAllocateAcpToolCallId(entry, event.toolCallId, event.toolName)
@@ -868,6 +881,7 @@ export class KimchiAcpAgent implements Agent {
 						kind,
 						locations,
 						rawInput: event.args,
+						status: "in_progress",
 					})
 					this.send({ sessionId, update })
 				} else {
@@ -887,6 +901,9 @@ export class KimchiAcpAgent implements Agent {
 				if (!turn) return
 				if (turn.hiddenToolCallIds.has(event.toolCallId) || isHiddenToolCall(event.toolName, event.args)) {
 					turn.hiddenToolCallIds.add(event.toolCallId)
+					// A hidden call may already have an allocated ACP id if the permission
+					// prompter ran before we knew it was hidden — retire its state.
+					this.retireToolCall(entry, turn, event.toolCallId)
 					return
 				}
 				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
@@ -896,6 +913,7 @@ export class KimchiAcpAgent implements Agent {
 					toolCallId: acpToolCallId,
 					piToolCallId: event.toolCallId,
 					content: partial,
+					status: "in_progress",
 				})
 				this.send({ sessionId, update })
 				return
@@ -903,7 +921,7 @@ export class KimchiAcpAgent implements Agent {
 			case "tool_execution_end": {
 				if (!turn) return
 				if (turn.hiddenToolCallIds.has(event.toolCallId)) {
-					turn.hiddenToolCallIds.delete(event.toolCallId)
+					this.retireToolCall(entry, turn, event.toolCallId, { removeFromHidden: true })
 					return
 				}
 				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
@@ -915,9 +933,10 @@ export class KimchiAcpAgent implements Agent {
 					rawOutput: event.result,
 				})
 				this.send({ sessionId, update })
-				// The upstream id may be reused after compaction; drop the mapping
-				// once the call is terminal so a future start allocates a fresh id.
-				entry.toolCallIdMap.delete(event.toolCallId)
+				// Upstream ids can repeat after compaction or even within a turn. Retire
+				// all state keyed on this upstream id so a future call reusing it starts
+				// with a fresh ACP id and clean streaming/announcement state.
+				this.retireToolCall(entry, turn, event.toolCallId, { removeFromHidden: true })
 				return
 			}
 			case "session_info_changed": {
@@ -1025,34 +1044,6 @@ export class KimchiAcpAgent implements Agent {
 			}
 		}
 		record.nextBlockId = count + 1
-	}
-
-	/**
-	 * Walk the persisted branch and count how many toolCall blocks the replay
-	 * would emit. Sets `record.nextToolCallId` so replay emits the same ACP
-	 * toolCallIds the live turns would have produced, and so any new tool call
-	 * after the load gets a fresh, non-colliding id.
-	 *
-	 * Mirrors replayAssistantBlocks' emission logic exactly — only non-hidden
-	 * toolCall blocks count, matching the live path's `isHiddenToolCall` filter.
-	 */
-	private seedToolCallCounterFromBranch(session: AgentSession, record: SessionRecord): void {
-		const entries = session.sessionManager.getBranch()
-
-		let count = 0
-		for (const entry of entries) {
-			if (entry?.type !== "message" || entry.message.role !== "assistant") continue
-			const content = entry.message.content
-			if (!Array.isArray(content)) continue
-			for (const block of content) {
-				if (block.type !== "toolCall") continue
-				const args = block.arguments
-				if (typeof block.name === "string" && !isHiddenToolCall(block.name, args)) {
-					count++
-				}
-			}
-		}
-		record.nextToolCallId = count + 1
 	}
 
 	private replayAssistantBlocks(
@@ -1208,6 +1199,28 @@ export class KimchiAcpAgent implements Agent {
 	 */
 	private resolveAcpToolCallId(record: SessionRecord, piToolCallId: string): string {
 		return record.toolCallIdMap.get(piToolCallId) ?? piToolCallId
+	}
+
+	/**
+	 * Retire all per-call state keyed on an upstream toolCallId.
+	 *
+	 * Upstream ids are provider-supplied and can repeat within a turn (e.g. after
+	 * compaction). Leaving stale entries in `announcedToolCallIds` or
+	 * `lastStreamedContent` causes corrupted deltas or updates for ids the client
+	 * never saw when the id is reused.
+	 */
+	private retireToolCall(
+		record: SessionRecord,
+		turn: TurnContext,
+		piToolCallId: string,
+		opts: { removeFromHidden?: boolean } = {},
+	): void {
+		record.toolCallIdMap.delete(piToolCallId)
+		turn.announcedToolCallIds.delete(piToolCallId)
+		turn.lastStreamedContent.delete(piToolCallId)
+		if (opts.removeFromHidden) {
+			turn.hiddenToolCallIds.delete(piToolCallId)
+		}
 	}
 
 	private sendAvailableCommandsUpdate(sessionId: string): void {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -32,16 +32,14 @@ import {
 	type SessionConfigSelectOption,
 	type SessionModelState,
 	type SessionNotification,
+	type SessionUpdate,
 	type SetSessionConfigOptionRequest,
 	type SetSessionConfigOptionResponse,
 	type SetSessionModelRequest,
 	type SetSessionModelResponse,
 	type ToolCallContent,
-	type ToolCallLocation,
-	type ToolCallUpdate,
-	type ToolKind,
 } from "@agentclientprotocol/sdk"
-import type { ImageContent } from "@earendil-works/pi-ai"
+import type { AssistantMessage, ImageContent } from "@earendil-works/pi-ai"
 import type { AgentSessionEvent, ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import {
 	type AgentSession,
@@ -87,6 +85,8 @@ import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
+import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./tool-calls/utils.js"
+import { asString, truncate } from "./utils.js"
 
 /**
  * Produces an unbound AgentSession for a newSession request. The ACP agent owns
@@ -157,6 +157,21 @@ type SessionRecord = {
 	 * previous message's assignments.
 	 */
 	contentIndexToBlockId: Map<number, string>
+	/**
+	 * Session-wide monotonic counter for ACP toolCallIds. Pi's toolCall.id
+	 * values are only unique within a compaction segment, so the ACP surface
+	 * rewrites each tool_execution_start to a fresh session-unique id. This
+	 * satisfies the ACP contract "Unique identifier for a tool call within a
+	 * session." Seeded from the branch on loadSession so replay emits matching
+	 * ids.
+	 */
+	nextToolCallId: number
+	/**
+	 * Maps the upstream pi-mono toolCallId to the ACP toolCallId for the call
+	 * currently in flight. A new `tool_execution_start` always allocates a fresh
+	 * ACP id, so collisions across compaction boundaries are disambiguated.
+	 */
+	toolCallIdMap: Map<string, string>
 }
 
 export class KimchiAcpAgent implements Agent {
@@ -289,16 +304,28 @@ export class KimchiAcpAgent implements Agent {
 			const sessionId = session.sessionId
 			const uiContext = this.createUiContext(session)
 			registerPermissionFlagController(session, initialMode, (params) => this.send(params))
-			registerAcpPrompter(sessionId, createAcpPermissionPrompter(this.conn, sessionId, uiContext, buildToolCallUpdate))
-			await this.bindAcpExtensions(session, uiContext)
-
-			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
-			this.sessions.set(sessionId, {
+			// Build the record early so the ACP prompter can allocate ACP
+			// toolCallIds that match the ids later emitted by tool_execution_start.
+			// The unsubscribe placeholder is replaced after bindAcpExtensions so no
+			// extension events are dropped before this.sessions is populated.
+			const record: SessionRecord = {
 				session,
-				unsubscribe,
+				unsubscribe: () => {},
 				nextBlockId: 0,
 				contentIndexToBlockId: new Map(),
-			})
+				nextToolCallId: 0,
+				toolCallIdMap: new Map(),
+			}
+			registerAcpPrompter(
+				sessionId,
+				createAcpPermissionPrompter(this.conn, sessionId, uiContext, (piToolCallId, toolName) =>
+					this.getOrAllocateAcpToolCallId(record, piToolCallId, toolName),
+				),
+			)
+			await this.bindAcpExtensions(session, uiContext)
+
+			record.unsubscribe = session.subscribe((event) => this.onSessionEvent(sessionId, event))
+			this.sessions.set(sessionId, record)
 
 			this.sendAvailableCommandsUpdate(sessionId)
 
@@ -503,22 +530,34 @@ export class KimchiAcpAgent implements Agent {
 
 			const uiContext = this.createUiContext(session)
 			registerPermissionFlagController(session, initialMode, (params) => this.send(params))
-			registerAcpPrompter(sid, createAcpPermissionPrompter(this.conn, sid, uiContext, buildToolCallUpdate))
-			await this.bindAcpExtensions(session, uiContext)
-
-			const unsubscribe = session.subscribe((event) => this.onSessionEvent(sid, event))
+			// Build the record early so the ACP prompter can allocate ACP
+			// toolCallIds that match the ids later emitted by tool_execution_start.
+			// The unsubscribe placeholder is replaced after bindAcpExtensions so no
+			// extension events are dropped before this.sessions is populated.
 			const record: SessionRecord = {
 				session,
-				unsubscribe,
+				unsubscribe: () => {},
 				nextBlockId: 0,
 				contentIndexToBlockId: new Map(),
+				nextToolCallId: 0,
+				toolCallIdMap: new Map(),
 			}
+			registerAcpPrompter(
+				sid,
+				createAcpPermissionPrompter(this.conn, sid, uiContext, (piToolCallId, toolName) =>
+					this.getOrAllocateAcpToolCallId(record, piToolCallId, toolName),
+				),
+			)
+			await this.bindAcpExtensions(session, uiContext)
+
+			record.unsubscribe = session.subscribe((event) => this.onSessionEvent(sid, event))
 			this.sessions.set(sid, record)
 
 			// Seed the block counter from the persisted branch so replay emits the
 			// same messageIds the live turn would have — and so any new block the
 			// user creates after the load gets a fresh, non-colliding id.
 			this.seedBlockCounterFromBranch(session, record)
+			this.seedToolCallCounterFromBranch(session, record)
 
 			// Replay BEFORE the response resolves so client sees a coherent transcript
 			// when the loadSession promise settles. No turn context is created, so a
@@ -720,7 +759,15 @@ export class KimchiAcpAgent implements Agent {
 		if (!entry) return
 		const turn = entry.turn
 		switch (event.type) {
-			case "agent_start":
+			case "agent_start": {
+				// New turn → contentIndex restarts from 0 and any in-flight tool
+				// id mappings from the previous turn are stale (the calls either
+				// ended or were orphaned). Wipe both maps so fresh allocations
+				// don't reuse old ids.
+				entry.contentIndexToBlockId.clear()
+				entry.toolCallIdMap.clear()
+				return
+			}
 			case "message_start": {
 				// New assistant message → contentIndex restarts from 0. Wipe the
 				// per-message map so a fresh block at index 0 gets a fresh id
@@ -734,7 +781,7 @@ export class KimchiAcpAgent implements Agent {
 				if ((ame.type === "text_delta" || ame.type === "thinking_delta") && ame.delta) {
 					let messageId = entry.contentIndexToBlockId.get(ame.contentIndex)
 					if (messageId === undefined) {
-						messageId = `kimchi_msg_${entry.nextBlockId++}`
+						messageId = `km.${entry.nextBlockId++}`
 						entry.contentIndexToBlockId.set(ame.contentIndex, messageId)
 					}
 					this.send({
@@ -756,19 +803,13 @@ export class KimchiAcpAgent implements Agent {
 							turn.hiddenToolCallIds.add(block.id)
 							return
 						}
-						const { title, kind, locations } = describeToolCall(block.name, block.arguments)
-						this.send({
-							sessionId,
-							update: {
-								sessionUpdate: "tool_call",
-								toolCallId: block.id,
-								title,
-								kind,
-								status: "pending",
-								locations,
-								rawInput: block.arguments,
-							},
+						const update: SessionUpdate = buildToolCall({
+							toolName: block.name,
+							toolCallId: this.getOrAllocateAcpToolCallId(entry, block.id, block.name),
+							piToolCallId: block.id,
+							rawInput: block.arguments,
 						})
+						this.send({ sessionId, update })
 						turn.announcedToolCallIds.add(block.id)
 					}
 					return
@@ -791,16 +832,13 @@ export class KimchiAcpAgent implements Agent {
 							const delta = content.slice(prev.length)
 							if (delta.length > 0) {
 								turn.lastStreamedContent.set(block.id, content)
-								this.send({
-									sessionId,
-									update: {
-										sessionUpdate: "tool_call_update",
-										toolCallId: block.id,
-										status: "pending",
-										rawOutput: { delta },
-										_meta: { generatedChars: content.length },
-									},
+								const update: SessionUpdate = buildToolCallUpdate({
+									toolCallId: this.getOrAllocateAcpToolCallId(entry, block.id, block.name),
+									piToolCallId: block.id,
+									rawOutput: { delta },
+									_meta: { generatedChars: content.length },
 								})
+								this.send({ sessionId, update })
 							}
 						}
 					}
@@ -819,35 +857,29 @@ export class KimchiAcpAgent implements Agent {
 					turn.hiddenToolCallIds.add(event.toolCallId)
 					return
 				}
-				const { title, kind, locations } = describeToolCall(event.toolName, event.args)
+				const acpToolCallId = this.getOrAllocateAcpToolCallId(entry, event.toolCallId, event.toolName)
 				if (turn.announcedToolCallIds.has(event.toolCallId)) {
 					// Pending tool_call was already sent via toolcall_start → emit update
-					this.send({
-						sessionId,
-						update: {
-							sessionUpdate: "tool_call_update",
-							toolCallId: event.toolCallId,
-							status: "in_progress",
-							title,
-							kind,
-							locations,
-							rawInput: event.args,
-						},
+					const { title, kind, locations } = describeToolCall(event.toolName, event.args)
+					const update: SessionUpdate = buildToolCallUpdate({
+						toolCallId: acpToolCallId,
+						piToolCallId: event.toolCallId,
+						title,
+						kind,
+						locations,
+						rawInput: event.args,
 					})
+					this.send({ sessionId, update })
 				} else {
-					// No pending notification was sent (back-compat) → emit tool_call as before
-					this.send({
-						sessionId,
-						update: {
-							sessionUpdate: "tool_call",
-							toolCallId: event.toolCallId,
-							title,
-							kind,
-							status: "in_progress",
-							locations,
-							rawInput: event.args,
-						},
+					const update: SessionUpdate = buildToolCall({
+						toolCallId: acpToolCallId,
+						piToolCallId: event.toolCallId,
+						toolName: event.toolName,
+						rawInput: event.args,
+						status: "in_progress",
 					})
+					// No pending notification was sent (back-compat) → emit tool_call as before
+					this.send({ sessionId, update })
 				}
 				return
 			}
@@ -857,17 +889,15 @@ export class KimchiAcpAgent implements Agent {
 					turn.hiddenToolCallIds.add(event.toolCallId)
 					return
 				}
+				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
 				const partial = toolResultContent(event.partialResult)
 				if (partial.length === 0) return
-				this.send({
-					sessionId,
-					update: {
-						sessionUpdate: "tool_call_update",
-						toolCallId: event.toolCallId,
-						status: "in_progress",
-						content: partial,
-					},
+				const update: SessionUpdate = buildToolCallUpdate({
+					toolCallId: acpToolCallId,
+					piToolCallId: event.toolCallId,
+					content: partial,
 				})
+				this.send({ sessionId, update })
 				return
 			}
 			case "tool_execution_end": {
@@ -876,16 +906,18 @@ export class KimchiAcpAgent implements Agent {
 					turn.hiddenToolCallIds.delete(event.toolCallId)
 					return
 				}
-				this.send({
-					sessionId,
-					update: {
-						sessionUpdate: "tool_call_update",
-						toolCallId: event.toolCallId,
-						status: event.isError ? "failed" : "completed",
-						content: toolResultContent(event.result),
-						rawOutput: event.result,
-					},
+				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
+				const update: SessionUpdate = buildToolCallUpdate({
+					toolCallId: acpToolCallId,
+					piToolCallId: event.toolCallId,
+					status: event.isError ? "failed" : "completed",
+					content: toolResultContent(event.result),
+					rawOutput: event.result,
 				})
+				this.send({ sessionId, update })
+				// The upstream id may be reused after compaction; drop the mapping
+				// once the call is terminal so a future start allocates a fresh id.
+				entry.toolCallIdMap.delete(event.toolCallId)
 				return
 			}
 			case "session_info_changed": {
@@ -995,9 +1027,37 @@ export class KimchiAcpAgent implements Agent {
 		record.nextBlockId = count + 1
 	}
 
+	/**
+	 * Walk the persisted branch and count how many toolCall blocks the replay
+	 * would emit. Sets `record.nextToolCallId` so replay emits the same ACP
+	 * toolCallIds the live turns would have produced, and so any new tool call
+	 * after the load gets a fresh, non-colliding id.
+	 *
+	 * Mirrors replayAssistantBlocks' emission logic exactly — only non-hidden
+	 * toolCall blocks count, matching the live path's `isHiddenToolCall` filter.
+	 */
+	private seedToolCallCounterFromBranch(session: AgentSession, record: SessionRecord): void {
+		const entries = session.sessionManager.getBranch()
+
+		let count = 0
+		for (const entry of entries) {
+			if (entry?.type !== "message" || entry.message.role !== "assistant") continue
+			const content = entry.message.content
+			if (!Array.isArray(content)) continue
+			for (const block of content) {
+				if (block.type !== "toolCall") continue
+				const args = block.arguments
+				if (typeof block.name === "string" && !isHiddenToolCall(block.name, args)) {
+					count++
+				}
+			}
+		}
+		record.nextToolCallId = count + 1
+	}
+
 	private replayAssistantBlocks(
 		sessionId: string,
-		content: unknown,
+		content: AssistantMessage["content"],
 		toolResults: Map<string, ReplayToolResult>,
 		record: SessionRecord | undefined,
 	): void {
@@ -1007,7 +1067,7 @@ export class KimchiAcpAgent implements Agent {
 		// the unit-test harness wiring a partial replay path).
 		const nextMessageId = () => {
 			if (!record) return undefined
-			return `kimchi_msg_${record.nextBlockId++}`
+			return `km.${record.nextBlockId++}`
 		}
 		// Buffer contiguous text blocks so a single assistant message renders as
 		// one agent_message_chunk per natural text segment — emit the full
@@ -1030,7 +1090,7 @@ export class KimchiAcpAgent implements Agent {
 		}
 		for (const block of content) {
 			if (!block || typeof block !== "object") continue
-			const b = block as { type?: string }
+			const b = block
 			if (b.type === "text") {
 				const text = (b as { text?: unknown }).text
 				if (typeof text !== "string" || text.length === 0) continue
@@ -1068,40 +1128,42 @@ export class KimchiAcpAgent implements Agent {
 				})
 			} else if (b.type === "toolCall") {
 				flushText()
-				const tc = b as { id?: unknown; name?: unknown; arguments?: unknown }
-				const id = typeof tc.id === "string" ? tc.id : undefined
+				const tc = b
+				const upstreamId = typeof tc.id === "string" ? tc.id : undefined
 				const name = typeof tc.name === "string" ? tc.name : undefined
-				if (!id || !name) continue
+				if (!upstreamId || !name) continue
 				const args = (tc.arguments ?? {}) as Record<string, unknown>
 				if (isHiddenToolCall(name, args)) continue
-				const result = toolResults.get(id)
+				const acpToolCallId = record ? this.getOrAllocateAcpToolCallId(record, upstreamId, name) : upstreamId
+				const result = toolResults.get(upstreamId)
 				// No persisted result → the call never finished (interrupted mid
 				// turn). "failed" is the closest terminal status; leaving the call
 				// in_progress would hang the client's spinner forever on replay.
 				const status: "completed" | "failed" = result ? (result.isError ? "failed" : "completed") : "failed"
-				const { title, kind, locations } = describeToolCall(name, args)
 				this.send({
 					sessionId,
-					update: {
-						sessionUpdate: "tool_call",
-						toolCallId: id,
-						title,
-						kind,
+					update: buildToolCall({
+						toolName: name,
+						toolCallId: acpToolCallId,
+						piToolCallId: tc.id,
 						status,
-						locations,
 						rawInput: args,
-					},
+					}),
 				})
 				this.send({
 					sessionId,
-					update: {
-						sessionUpdate: "tool_call_update",
-						toolCallId: id,
+					update: buildToolCallUpdate({
+						toolCallId: acpToolCallId,
+						piToolCallId: tc.id,
 						status,
 						content: result ? toolResultContent(result) : [],
 						rawOutput: result,
-					},
+					}),
 				})
+				// The branch may contain multiple toolCalls with the same upstream id
+				// (e.g., across a compaction boundary). Drop the mapping after replaying
+				// each call so the next one with the same upstream id gets a fresh id.
+				record?.toolCallIdMap.delete(upstreamId)
 			}
 		}
 		// Trailing text after the last structural block (or a text-only message)
@@ -1122,6 +1184,30 @@ export class KimchiAcpAgent implements Agent {
 		this.conn.sessionUpdate(params).catch((err: unknown) => {
 			process.stderr.write(`acp sessionUpdate failed: ${String(err)}\n`)
 		})
+	}
+
+	/**
+	 * Return the existing ACP toolCallId for an upstream id, allocating a fresh
+	 * session-unique id if none exists. Permission prompts fire before
+	 * `tool_execution_start`, so this ensures the permission request and the
+	 * subsequent tool_call notification share the same id.
+	 */
+	private getOrAllocateAcpToolCallId(record: SessionRecord, piToolCallId: string, toolName: string): string {
+		let acpId = record.toolCallIdMap.get(piToolCallId)
+		if (acpId === undefined) {
+			acpId = `kt.${toolName}.${record.nextToolCallId++}`
+			record.toolCallIdMap.set(piToolCallId, acpId)
+		}
+		return acpId
+	}
+
+	/**
+	 * Look up the ACP toolCallId for an in-flight upstream call. Falls back to
+	 * the upstream id if no mapping exists (defensive: should only happen for
+	 * events that arrived before their start, which pi-mono does not emit).
+	 */
+	private resolveAcpToolCallId(record: SessionRecord, piToolCallId: string): string {
+		return record.toolCallIdMap.get(piToolCallId) ?? piToolCallId
 	}
 
 	private sendAvailableCommandsUpdate(sessionId: string): void {
@@ -1270,6 +1356,8 @@ function registerPermissionFlagController(
 	})
 }
 
+const TITLE_MAX = 80
+
 // Title falls back to the truncated first user message when the session has no
 // user-defined name. ACP clients render this in the thread-picker UI; we do
 // NOT trigger a fresh prompt-summary on listSessions because that would mean
@@ -1279,7 +1367,7 @@ export function toAcpSessionInfo(info: PiSessionInfo): AcpSessionInfo {
 	// hand-edited session-info entry) still falls through to firstMessage —
 	// `??` only short-circuits on null/undefined and would otherwise leave the
 	// title as the empty string and end up null below.
-	const fallback = info.firstMessage ? truncate(info.firstMessage) : ""
+	const fallback = info.firstMessage ? truncate(info.firstMessage, TITLE_MAX) : ""
 	const title = info.name && info.name.length > 0 ? info.name : fallback
 	return {
 		sessionId: info.id,
@@ -1520,40 +1608,6 @@ function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
 	}
 }
 
-// Mirrors the tool names kimchi actually exposes: pi-coding-agent core tools
-// plus the kimchi extensions in src/extensions (web-fetch, web-search, Agent).
-// ACP clients key UI affordances (icon, grouping, permission messaging) off the
-// kind field, so every registered tool should map to the most specific kind in
-// the ToolKind vocabulary before falling back to "other". MCP tools arrive with
-// dynamic `mcp__server__name` identifiers we can't enumerate statically — those
-// still hit the "other" fallback in describeToolCall().
-const TOOL_KINDS: Record<string, ToolKind> = {
-	bash: "execute",
-	read: "read",
-	ls: "read",
-	grep: "search",
-	find: "search",
-	edit: "edit",
-	write: "edit",
-	web_fetch: "fetch",
-	web_search: "search",
-	Agent: "think",
-}
-const TITLE_MAX = 80
-
-const asString = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined)
-const truncate = (s: string): string => (s.length > TITLE_MAX ? `${s.slice(0, TITLE_MAX)}…` : s)
-
-export function isHiddenToolCall(toolName: string, args: unknown): boolean {
-	// Defense-in-depth: the Agent tool's public schema deliberately omits `visibility`
-	// (see src/extensions/agents/index.ts:execute), so this normally returns false. If a
-	// misbehaving LLM emits the field anyway, we hide the ACP-side tool_call rather than
-	// trust the schema to have caught it.
-	if (toolName !== "Agent") return false
-	const a = (args ?? {}) as Record<string, unknown>
-	return typeof a.visibility === "string" && a.visibility.toLowerCase() === "system"
-}
-
 // Persisted assistant text from hide-thinking-aware models (DeepSeek, QwQ, ...)
 // can contain ANSI styling around inner <think> content. Live TUI styling means
 // "this is reasoning"; ACP plaintext has no such styling, so replay splits the
@@ -1599,44 +1653,6 @@ function replayTextParts(text: string): ReplayTextPart[] {
 function extractStreamContent(args: unknown): string | undefined {
 	const a = (args ?? {}) as Record<string, unknown>
 	return asString(a.content) ?? asString(a.newText) ?? asString(a.command)
-}
-
-export function describeToolCall(
-	toolName: string,
-	args: unknown,
-): { title: string; kind: ToolKind; locations: ToolCallLocation[] } {
-	const a = (args ?? {}) as Record<string, unknown>
-	const path = asString(a.file_path) ?? asString(a.path)
-	const command = asString(a.command)
-	const pattern = asString(a.pattern)
-	// title carries the target/argument only; the ACP `kind` field drives the verb
-	// and icon on the client side. Bash puts its command here; file ops put the
-	// path; search ops put the pattern. Falls back to the tool name when we have
-	// no specific argument to show. Truncate every branch so a long absolute
-	// path or regex doesn't blow up client UIs (locations[].path keeps the full
-	// value for clients that want it).
-	const rawTitle = toolName === "bash" && command ? command : (path ?? pattern ?? toolName)
-	return {
-		title: truncate(rawTitle),
-		kind: TOOL_KINDS[toolName] ?? "other",
-		locations: path ? [{ path }] : [],
-	}
-}
-
-export function buildToolCallUpdate(
-	toolCallId: string,
-	toolName: string,
-	args: Record<string, unknown>,
-): ToolCallUpdate {
-	const { title, kind, locations } = describeToolCall(toolName, args)
-	return {
-		toolCallId,
-		title,
-		kind,
-		status: "pending",
-		locations,
-		rawInput: args,
-	}
 }
 
 // UserMessage.content is `string | (TextContent | ImageContent)[]` per pi-ai

--- a/src/modes/acp/tool-calls/utils.test.ts
+++ b/src/modes/acp/tool-calls/utils.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest"
+import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./utils.js"
+
+describe("isHiddenToolCall", () => {
+	it("returns false for non-Agent tool names", () => {
+		expect(isHiddenToolCall("bash", {})).toBe(false)
+		expect(isHiddenToolCall("read", { visibility: "system" })).toBe(false)
+	})
+
+	it("returns false when visibility is missing", () => {
+		expect(isHiddenToolCall("Agent", {})).toBe(false)
+		expect(isHiddenToolCall("Agent", { prompt: "hello" })).toBe(false)
+	})
+
+	it("returns false when visibility is not 'system' (any casing)", () => {
+		expect(isHiddenToolCall("Agent", { visibility: "public" })).toBe(false)
+		expect(isHiddenToolCall("Agent", { visibility: "private" })).toBe(false)
+	})
+
+	it("returns true when visibility is 'system' (case-insensitive)", () => {
+		expect(isHiddenToolCall("Agent", { visibility: "system" })).toBe(true)
+		expect(isHiddenToolCall("Agent", { visibility: "System" })).toBe(true)
+		expect(isHiddenToolCall("Agent", { visibility: "SYSTEM" })).toBe(true)
+	})
+
+	it("detects hidden system Agent calls", () => {
+		expect(isHiddenToolCall("Agent", { visibility: "system" })).toBe(true)
+		expect(isHiddenToolCall("Agent", { visibility: "user" })).toBe(false)
+		expect(isHiddenToolCall("bash", { visibility: "system" })).toBe(false)
+	})
+
+	it("returns true for Agent with mixed-case 'System' visibility", () => {
+		expect(isHiddenToolCall("Agent", { visibility: "SyStEm" })).toBe(true)
+	})
+})
+
+describe("buildToolCall", () => {
+	it("builds a pending tool_call from derived display fields", () => {
+		const result = buildToolCall({
+			toolName: "read",
+			toolCallId: "acp-1",
+			piToolCallId: "pi-1",
+			rawInput: { file_path: "/etc/hosts" },
+		})
+		expect(result).toEqual({
+			sessionUpdate: "tool_call",
+			toolCallId: "acp-1",
+			status: "pending",
+			title: "/etc/hosts",
+			kind: "read",
+			locations: [{ path: "/etc/hosts" }],
+			rawInput: { file_path: "/etc/hosts" },
+			_meta: { piToolCallId: "pi-1" },
+		})
+	})
+
+	it("merges additional _meta fields", () => {
+		const result = buildToolCall({
+			toolName: "bash",
+			toolCallId: "acp-2",
+			piToolCallId: "pi-2",
+			rawInput: { command: "echo hi" },
+			_meta: { source: "test" },
+		})
+		expect(result._meta).toEqual({ piToolCallId: "pi-2", source: "test" })
+	})
+
+	it("input status overrides the default pending status", () => {
+		const result = buildToolCall({
+			toolName: "Agent",
+			toolCallId: "acp-3",
+			piToolCallId: "pi-3",
+			status: "in_progress",
+			rawInput: { prompt: "go" },
+		})
+		expect((result as { status?: string }).status).toBe("in_progress")
+	})
+})
+
+describe("buildToolCallUpdate", () => {
+	it("builds an in_progress tool_call_update with required fields", () => {
+		const result = buildToolCallUpdate({
+			toolCallId: "acp-1",
+			piToolCallId: "pi-1",
+		})
+		expect(result).toEqual({
+			sessionUpdate: "tool_call_update",
+			toolCallId: "acp-1",
+			status: "in_progress",
+			_meta: { piToolCallId: "pi-1" },
+		})
+	})
+
+	it("carries through optional display and content fields", () => {
+		const result = buildToolCallUpdate({
+			toolCallId: "acp-2",
+			piToolCallId: "pi-2",
+			title: "custom title",
+			kind: "search",
+			locations: [{ path: "/tmp" }],
+			content: [{ type: "content", content: { type: "text", text: "done" } }],
+			rawInput: { pattern: "foo" },
+			rawOutput: { result: "bar" },
+		})
+		expect(result).toEqual({
+			sessionUpdate: "tool_call_update",
+			toolCallId: "acp-2",
+			status: "in_progress",
+			title: "custom title",
+			kind: "search",
+			locations: [{ path: "/tmp" }],
+			content: [{ type: "content", content: { type: "text", text: "done" } }],
+			rawInput: { pattern: "foo" },
+			rawOutput: { result: "bar" },
+			_meta: { piToolCallId: "pi-2" },
+		})
+	})
+
+	it("merges additional _meta fields", () => {
+		const result = buildToolCallUpdate({
+			toolCallId: "acp-3",
+			piToolCallId: "pi-3",
+			_meta: { source: "test" },
+		})
+		expect(result._meta).toEqual({ piToolCallId: "pi-3", source: "test" })
+	})
+
+	it("input status overrides the default in_progress status", () => {
+		const result = buildToolCallUpdate({
+			toolCallId: "acp-4",
+			piToolCallId: "pi-4",
+			status: "completed",
+		})
+		expect((result as { status?: string }).status).toBe("completed")
+	})
+})
+
+describe("describeToolCall", () => {
+	const longCommand = "a".repeat(120)
+	const longPath = `/tmp/${"x".repeat(120)}`
+	const longPattern = "p".repeat(120)
+	const cases: Array<{
+		name: string
+		toolName: string
+		args: unknown
+		expect: { title: string; kind: string; locations: Array<{ path: string }> }
+	}> = [
+		{
+			name: "bash with command uses command as title and execute kind",
+			toolName: "bash",
+			args: { command: "ls -la" },
+			expect: { title: "ls -la", kind: "execute", locations: [] },
+		},
+		{
+			name: "bash without command falls back to tool name",
+			toolName: "bash",
+			args: {},
+			expect: { title: "bash", kind: "execute", locations: [] },
+		},
+		{
+			name: "bash command is truncated at TITLE_MAX",
+			toolName: "bash",
+			args: { command: longCommand },
+			expect: { title: `${"a".repeat(80)}…`, kind: "execute", locations: [] },
+		},
+		{
+			name: "read with file_path uses path and populates locations",
+			toolName: "read",
+			args: { file_path: "/etc/hosts" },
+			expect: {
+				title: "/etc/hosts",
+				kind: "read",
+				locations: [{ path: "/etc/hosts" }],
+			},
+		},
+		{
+			name: "edit with file_path uses path and edit kind",
+			toolName: "edit",
+			args: { file_path: "/tmp/a.ts" },
+			expect: {
+				title: "/tmp/a.ts",
+				kind: "edit",
+				locations: [{ path: "/tmp/a.ts" }],
+			},
+		},
+		{
+			name: "write with path (not file_path) still populates locations",
+			toolName: "write",
+			args: { path: "/tmp/b.ts" },
+			expect: {
+				title: "/tmp/b.ts",
+				kind: "edit",
+				locations: [{ path: "/tmp/b.ts" }],
+			},
+		},
+		{
+			name: "grep with pattern uses pattern as title and search kind",
+			toolName: "grep",
+			args: { pattern: "foo.*bar" },
+			expect: { title: "foo.*bar", kind: "search", locations: [] },
+		},
+		{
+			name: "ls maps to read kind",
+			toolName: "ls",
+			args: { path: "/tmp" },
+			expect: { title: "/tmp", kind: "read", locations: [{ path: "/tmp" }] },
+		},
+		{
+			name: "find maps to search kind",
+			toolName: "find",
+			args: { pattern: "*.ts" },
+			expect: { title: "*.ts", kind: "search", locations: [] },
+		},
+		{
+			name: "web_fetch maps to fetch kind",
+			toolName: "web_fetch",
+			args: { url: "https://example.com" },
+			expect: { title: "web_fetch", kind: "fetch", locations: [] },
+		},
+		{
+			name: "web_search maps to search kind",
+			toolName: "web_search",
+			args: { query: "kimchi" },
+			expect: { title: "web_search", kind: "search", locations: [] },
+		},
+		{
+			name: "Agent maps to think kind",
+			toolName: "Agent",
+			args: { prompt: "go", visibility: "user" },
+			expect: { title: "Agent", kind: "think", locations: [] },
+		},
+		{
+			name: "unknown tool falls back to other kind",
+			toolName: "mcp__foo__bar",
+			args: { arg: 1 },
+			expect: { title: "mcp__foo__bar", kind: "other", locations: [] },
+		},
+		{
+			name: "null args is tolerated",
+			toolName: "bash",
+			args: null,
+			expect: { title: "bash", kind: "execute", locations: [] },
+		},
+		{
+			name: "long path title is truncated (locations keep full path)",
+			toolName: "read",
+			args: { file_path: longPath },
+			expect: {
+				title: `${longPath.slice(0, 80)}…`,
+				kind: "read",
+				locations: [{ path: longPath }],
+			},
+		},
+		{
+			name: "long pattern title is truncated",
+			toolName: "grep",
+			args: { pattern: longPattern },
+			expect: {
+				title: `${longPattern.slice(0, 80)}…`,
+				kind: "search",
+				locations: [],
+			},
+		},
+	]
+
+	for (const c of cases) {
+		it(c.name, () => {
+			const result = describeToolCall(c.toolName, c.args)
+			expect(result.title).toBe(c.expect.title)
+			expect(result.kind).toBe(c.expect.kind)
+			expect(result.locations).toEqual(c.expect.locations)
+		})
+	}
+})

--- a/src/modes/acp/tool-calls/utils.test.ts
+++ b/src/modes/acp/tool-calls/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./utils.js"
+import { buildToolCall, buildToolCallShape, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./utils.js"
 
 describe("isHiddenToolCall", () => {
 	it("returns false for non-Agent tool names", () => {
@@ -35,11 +35,12 @@ describe("isHiddenToolCall", () => {
 })
 
 describe("buildToolCall", () => {
-	it("builds a pending tool_call from derived display fields", () => {
+	it("builds a tool_call from derived display fields", () => {
 		const result = buildToolCall({
 			toolName: "read",
 			toolCallId: "acp-1",
 			piToolCallId: "pi-1",
+			status: "pending",
 			rawInput: { file_path: "/etc/hosts" },
 		})
 		expect(result).toEqual({
@@ -59,29 +60,40 @@ describe("buildToolCall", () => {
 			toolName: "bash",
 			toolCallId: "acp-2",
 			piToolCallId: "pi-2",
+			status: "in_progress",
 			rawInput: { command: "echo hi" },
 			_meta: { source: "test" },
 		})
 		expect(result._meta).toEqual({ piToolCallId: "pi-2", source: "test" })
 	})
 
-	it("input status overrides the default pending status", () => {
-		const result = buildToolCall({
+	it("builds a bare ToolCall shape without sessionUpdate discriminant", () => {
+		const result = buildToolCallShape({
 			toolName: "Agent",
 			toolCallId: "acp-3",
 			piToolCallId: "pi-3",
 			status: "in_progress",
 			rawInput: { prompt: "go" },
 		})
-		expect((result as { status?: string }).status).toBe("in_progress")
+		expect(result).toEqual({
+			toolCallId: "acp-3",
+			status: "in_progress",
+			title: "Agent",
+			kind: "think",
+			locations: [],
+			rawInput: { prompt: "go" },
+			_meta: { piToolCallId: "pi-3" },
+		})
+		expect(result).not.toHaveProperty("sessionUpdate")
 	})
 })
 
 describe("buildToolCallUpdate", () => {
-	it("builds an in_progress tool_call_update with required fields", () => {
+	it("builds a tool_call_update with required fields", () => {
 		const result = buildToolCallUpdate({
 			toolCallId: "acp-1",
 			piToolCallId: "pi-1",
+			status: "in_progress",
 		})
 		expect(result).toEqual({
 			sessionUpdate: "tool_call_update",
@@ -95,6 +107,7 @@ describe("buildToolCallUpdate", () => {
 		const result = buildToolCallUpdate({
 			toolCallId: "acp-2",
 			piToolCallId: "pi-2",
+			status: "in_progress",
 			title: "custom title",
 			kind: "search",
 			locations: [{ path: "/tmp" }],
@@ -120,12 +133,13 @@ describe("buildToolCallUpdate", () => {
 		const result = buildToolCallUpdate({
 			toolCallId: "acp-3",
 			piToolCallId: "pi-3",
+			status: "pending",
 			_meta: { source: "test" },
 		})
 		expect(result._meta).toEqual({ piToolCallId: "pi-3", source: "test" })
 	})
 
-	it("input status overrides the default in_progress status", () => {
+	it("carries through the input status", () => {
 		const result = buildToolCallUpdate({
 			toolCallId: "acp-4",
 			piToolCallId: "pi-4",

--- a/src/modes/acp/tool-calls/utils.ts
+++ b/src/modes/acp/tool-calls/utils.ts
@@ -1,0 +1,103 @@
+import type {
+	SessionUpdate,
+	ToolCallContent,
+	ToolCallLocation,
+	ToolCallStatus,
+	ToolKind,
+} from "@agentclientprotocol/sdk"
+import { asString, truncate } from "../utils.js"
+
+// Mirrors the tool names kimchi actually exposes: pi-coding-agent core tools
+// plus the kimchi extensions in src/extensions (web-fetch, web-search, Agent).
+// ACP clients key UI affordances (icon, grouping, permission messaging) off the
+// kind field, so every registered tool should map to the most specific kind in
+// the ToolKind vocabulary before falling back to "other". MCP tools arrive with
+// dynamic `mcp__server__name` identifiers we can't enumerate statically — those
+// still hit the "other" fallback in describeToolCall().
+const TOOL_KINDS: Record<string, ToolKind> = {
+	bash: "execute",
+	read: "read",
+	ls: "read",
+	grep: "search",
+	find: "search",
+	edit: "edit",
+	write: "edit",
+	web_fetch: "fetch",
+	web_search: "search",
+	Agent: "think",
+}
+
+export function describeToolCall(
+	toolName: string,
+	args: unknown,
+): { title: string; kind: ToolKind; locations: ToolCallLocation[] } {
+	const a = (args ?? {}) as Record<string, unknown>
+	const path = asString(a.file_path) ?? asString(a.path)
+	const command = asString(a.command)
+	const pattern = asString(a.pattern)
+	// title carries the target/argument only; the ACP `kind` field drives the verb
+	// and icon on the client side. Bash puts its command here; file ops put the
+	// path; search ops put the pattern. Falls back to the tool name when we have
+	// no specific argument to show. Truncate every branch so a long absolute
+	// path or regex doesn't blow up client UIs (locations[].path keeps the full
+	// value for clients that want it).
+	const rawTitle = toolName === "bash" && command ? command : (path ?? pattern ?? toolName)
+	return {
+		title: truncate(rawTitle, 80),
+		kind: TOOL_KINDS[toolName] ?? "other",
+		locations: path ? [{ path }] : [],
+	}
+}
+
+export function isHiddenToolCall(toolName: string, args: unknown): boolean {
+	// Defense-in-depth: the Agent tool's public schema deliberately omits `visibility`
+	// (see src/extensions/agents/index.ts:execute), so this normally returns false. If a
+	// misbehaving LLM emits the field anyway, we hide the ACP-side tool_call rather than
+	// trust the schema to have caught it.
+	if (toolName !== "Agent") return false
+	const a = (args ?? {}) as Record<string, unknown>
+	return typeof a.visibility === "string" && a.visibility.toLowerCase() === "system"
+}
+
+type ToolCallFields = {
+	toolName: string
+	toolCallId: string
+	piToolCallId: string
+	status?: ToolCallStatus
+	rawInput: Record<string, unknown>
+	_meta?: Record<string, unknown>
+}
+export function buildToolCall({ toolName, piToolCallId, rawInput, ...params }: ToolCallFields): SessionUpdate {
+	const { title, kind, locations } = describeToolCall(toolName, rawInput)
+	return {
+		sessionUpdate: "tool_call",
+		status: "pending",
+		title,
+		kind,
+		locations,
+		rawInput,
+		...params,
+		_meta: { piToolCallId, ...params._meta },
+	}
+}
+
+type ToolCallUpdateFields = {
+	toolCallId: string
+	piToolCallId: string
+	title?: string
+	kind?: ToolKind
+	locations?: ToolCallLocation[]
+	status?: ToolCallStatus
+	content?: ToolCallContent[]
+	rawInput?: Record<string, unknown>
+	rawOutput?: Record<string, unknown>
+	_meta?: Record<string, unknown>
+}
+export function buildToolCallUpdate({ piToolCallId, ...params }: ToolCallUpdateFields): SessionUpdate {
+	return {
+		sessionUpdate: "tool_call_update",
+		status: "in_progress",
+		...params,
+		_meta: { piToolCallId, ...(params._meta ?? {}) },
+	}
+}

--- a/src/modes/acp/tool-calls/utils.ts
+++ b/src/modes/acp/tool-calls/utils.ts
@@ -1,5 +1,6 @@
 import type {
 	SessionUpdate,
+	ToolCall,
 	ToolCallContent,
 	ToolCallLocation,
 	ToolCallStatus,
@@ -63,15 +64,21 @@ type ToolCallFields = {
 	toolName: string
 	toolCallId: string
 	piToolCallId: string
-	status?: ToolCallStatus
+	status: ToolCallStatus
 	rawInput: Record<string, unknown>
 	_meta?: Record<string, unknown>
 }
-export function buildToolCall({ toolName, piToolCallId, rawInput, ...params }: ToolCallFields): SessionUpdate {
+
+/**
+ * Build the bare ToolCall shape (no `sessionUpdate` discriminant).
+ *
+ * `session/request_permission` carries a `ToolCallUpdate`, which has no
+ * `sessionUpdate` field — passing a session-notification object there puts an
+ * out-of-schema key on the wire.
+ */
+export function buildToolCallShape({ toolName, piToolCallId, rawInput, ...params }: ToolCallFields): ToolCall {
 	const { title, kind, locations } = describeToolCall(toolName, rawInput)
 	return {
-		sessionUpdate: "tool_call",
-		status: "pending",
 		title,
 		kind,
 		locations,
@@ -81,13 +88,17 @@ export function buildToolCall({ toolName, piToolCallId, rawInput, ...params }: T
 	}
 }
 
+export function buildToolCall(fields: ToolCallFields): SessionUpdate {
+	return { sessionUpdate: "tool_call", ...buildToolCallShape(fields) }
+}
+
 type ToolCallUpdateFields = {
 	toolCallId: string
 	piToolCallId: string
+	status: ToolCallStatus
 	title?: string
 	kind?: ToolKind
 	locations?: ToolCallLocation[]
-	status?: ToolCallStatus
 	content?: ToolCallContent[]
 	rawInput?: Record<string, unknown>
 	rawOutput?: Record<string, unknown>
@@ -96,7 +107,6 @@ type ToolCallUpdateFields = {
 export function buildToolCallUpdate({ piToolCallId, ...params }: ToolCallUpdateFields): SessionUpdate {
 	return {
 		sessionUpdate: "tool_call_update",
-		status: "in_progress",
 		...params,
 		_meta: { piToolCallId, ...(params._meta ?? {}) },
 	}

--- a/src/modes/acp/utils.ts
+++ b/src/modes/acp/utils.ts
@@ -1,3 +1,6 @@
+export const asString = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined)
+export const truncate = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max)}…` : s)
+
 export function requestWithAbort<T>(request: Promise<T>, signal: AbortSignal | undefined): Promise<T | "aborted"> {
 	if (!signal) return request
 	if (signal.aborted) return Promise.resolve("aborted")

--- a/tests/e2e/acp/tool-call-id.test.ts
+++ b/tests/e2e/acp/tool-call-id.test.ts
@@ -1,0 +1,403 @@
+// ACP integration: toolCallId uniqueness and namespacing.
+//
+// Pi's toolCall.id values are only unique within a compaction segment. The ACP
+// surface must rewrite them to session-unique ids that satisfy the ACP contract
+// "Unique identifier for a tool call within a session." This test drives a real
+// binary end-to-end and asserts the wire shape the client observes.
+
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type AcpFixture, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
+import { newSession, prompt } from "./support/scenarios.js"
+
+/** True for `[ACP]` UI fallback warnings, which come from a non-streaming code path. */
+function isAcpWarning(update: unknown): boolean {
+	const u = update as { content?: { type?: string; text?: string } }
+	return u.content?.type === "text" && (u.content.text?.startsWith("[ACP]") ?? false)
+}
+
+describe("ACP integration — toolCallId uniqueness", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		fixture = await startAcpFixture({
+			artifactName: "tool-call-id",
+			responses: [
+				{
+					stream: ["Running echo."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: "echo first" }),
+							},
+						},
+					],
+				},
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("rewrites upstream toolCallIds to kt.<name>.<index>", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Run echo first")
+		expect(result.stopReason, "turn stop reason").toBe("end_turn")
+
+		const toolCalls = fixture.client.sessionUpdates.filter(
+			(u) => u.sessionId === sessionId && u.update.sessionUpdate === "tool_call" && !isAcpWarning(u.update),
+		)
+		const toolCallUpdates = fixture.client.sessionUpdates.filter(
+			(u) => u.sessionId === sessionId && u.update.sessionUpdate === "tool_call_update" && !isAcpWarning(u.update),
+		)
+
+		expect(toolCalls, "exactly one tool_call notification").toHaveLength(1)
+		expect(toolCallUpdates.length, "at least one tool_call_update notification").toBeGreaterThanOrEqual(1)
+
+		const acpId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "call_fake" },
+				}),
+			}),
+		])
+		expect(toolCallUpdates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					sessionId,
+					update: expect.objectContaining({
+						sessionUpdate: "tool_call_update",
+						toolCallId: acpId,
+						_meta: { piToolCallId: "call_fake" },
+					}),
+				}),
+			]),
+		)
+	})
+})
+
+describe("ACP integration — permission request toolCallId correlation", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		fixture = await startAcpFixture({
+			artifactName: "tool-call-id-permission",
+			responses: [
+				{
+					stream: ["Touching file."],
+					toolCalls: [
+						{
+							id: "call_permission",
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: "touch /tmp/kimchi-acp-tool-call-id-marker.txt" }),
+							},
+						},
+					],
+				},
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("uses the same ACP toolCallId in the permission request and tool_call notification", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Touch a marker file")
+		expect(result.stopReason, "turn stop reason").toBe("end_turn")
+
+		const permissionRequests = fixture.client.permissionRequests.filter((r) => r.sessionId === sessionId)
+		const toolCalls = fixture.client.sessionUpdates.filter(
+			(u) => u.sessionId === sessionId && u.update.sessionUpdate === "tool_call" && !isAcpWarning(u.update),
+		)
+
+		expect(permissionRequests, "exactly one permission request").toHaveLength(1)
+		expect(toolCalls, "exactly one tool_call notification").toHaveLength(1)
+
+		const permissionToolCallId = (permissionRequests[0].toolCall as { toolCallId?: string }).toolCallId
+		const notificationToolCallId = (toolCalls[0].update as { toolCallId?: string }).toolCallId
+
+		expect(permissionToolCallId, "permission request id is rewritten").toMatch(/^kt\.bash\.\d+$/)
+		expect(notificationToolCallId, "tool_call id matches permission request id").toBe(permissionToolCallId)
+		expect(permissionRequests[0]).toEqual(
+			expect.objectContaining({
+				sessionId,
+				toolCall: expect.objectContaining({
+					toolCallId: permissionToolCallId,
+					_meta: { piToolCallId: "call_permission" },
+				}),
+			}),
+		)
+		expect(toolCalls[0]).toEqual(
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: permissionToolCallId,
+					_meta: { piToolCallId: "call_permission" },
+				}),
+			}),
+		)
+	})
+})
+
+describe("ACP integration — reused upstream toolCallId disambiguation", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		// Both responses omit an explicit toolCall id, so FakeOpenAiServer reuses
+		// its default "call_fake" id for both. This simulates Pi reusing an id
+		// after compaction.
+		fixture = await startAcpFixture({
+			artifactName: "tool-call-id-reuse",
+			responses: [
+				{
+					stream: ["First call."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: "echo first" }),
+							},
+						},
+					],
+				},
+				{
+					stream: ["Second call."],
+					toolCalls: [
+						{
+							function: {
+								name: "bash",
+								arguments: JSON.stringify({ command: "echo second" }),
+							},
+						},
+					],
+				},
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("allocates distinct ACP ids when the upstream id is reused across turns", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+
+		const first = await prompt(fixture, sessionId, "Run echo first")
+		expect(first.stopReason, "first turn stop reason").toBe("end_turn")
+
+		const second = await prompt(fixture, sessionId, "Run echo second")
+		expect(second.stopReason, "second turn stop reason").toBe("end_turn")
+
+		const toolCalls = fixture.client.sessionUpdates.filter(
+			(u) => u.sessionId === sessionId && u.update.sessionUpdate === "tool_call" && !isAcpWarning(u.update),
+		)
+
+		expect(toolCalls, "two tool_call notifications").toHaveLength(2)
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "call_fake" },
+				}),
+			}),
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "call_fake" },
+				}),
+			}),
+		])
+		const firstId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		const secondId = (toolCalls[1].update as { toolCallId: string }).toolCallId
+		expect(firstId).not.toBe(secondId)
+	})
+})
+
+// Helpers for writing a hand-crafted session JSONL that contains a compaction
+// entry. Kimchi's session files live under ~/.config/kimchi/harness/sessions/<cwd-encoded>/.
+function encodeCwdDir(cwd: string): string {
+	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`
+}
+
+function writeSessionFile(homeDir: string, sessionId: string, cwd: string, entries: unknown[]): void {
+	const sessionDir = join(homeDir, ".config", "kimchi", "harness", "sessions", encodeCwdDir(cwd))
+	mkdirSync(sessionDir, { recursive: true })
+	const fileName = `2026-05-09T00-00-00.000Z_${sessionId}.jsonl`
+	const lines = entries.map((e) => JSON.stringify(e)).join("\n")
+	writeFileSync(join(sessionDir, fileName), `${lines}\n`)
+}
+
+describe("ACP integration — toolCallId across compaction boundary", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		// No fake LLM responses needed: we load a persisted session and only
+		// assert on the replayed notifications.
+		fixture = await startAcpFixture({
+			artifactName: "tool-call-id-compaction",
+			responses: [],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("assigns distinct ACP ids to tool calls whose upstream id is reused across a compaction entry", async () => {
+		const sessionId = "compaction-tool-id-reuse"
+		const cwd = fixture.workDir
+
+		// Both the pre-compaction and post-compaction assistant messages carry a
+		// bash toolCall with the same upstream id "call_fake". This mirrors Pi
+		// reusing an id after it compacted the earlier segment away.
+		writeSessionFile(fixture.homeDir, sessionId, cwd, [
+			{
+				type: "session",
+				version: 3,
+				id: sessionId,
+				timestamp: "2026-05-09T00:00:00Z",
+				cwd,
+			},
+			{
+				type: "model_change",
+				id: "mc1",
+				parentId: null,
+				timestamp: "2026-05-09T00:00:00Z",
+				provider: "openai",
+				modelId: "gpt-4",
+			},
+			{
+				type: "message",
+				id: "u1",
+				parentId: "mc1",
+				timestamp: "2026-05-09T00:00:00Z",
+				message: { role: "user", content: "pre" },
+			},
+			{
+				type: "message",
+				id: "a1",
+				parentId: "u1",
+				timestamp: "2026-05-09T00:00:01Z",
+				message: {
+					role: "assistant",
+					provider: "openai",
+					model: "gpt-4",
+					content: [
+						{
+							type: "toolCall",
+							id: "call_fake",
+							name: "bash",
+							arguments: { command: "echo pre" },
+						},
+					],
+				},
+			},
+			{
+				type: "message",
+				id: "tr1",
+				parentId: "a1",
+				timestamp: "2026-05-09T00:00:02Z",
+				message: {
+					role: "toolResult",
+					toolCallId: "call_fake",
+					toolName: "bash",
+					content: [{ type: "text", text: "pre" }],
+					isError: false,
+				},
+			},
+			{
+				type: "compaction",
+				id: "c1",
+				parentId: "tr1",
+				timestamp: "2026-05-09T00:00:03Z",
+				summary: "compacted pre segment",
+				firstKeptEntryId: "u1",
+				tokensBefore: 100,
+			},
+			{
+				type: "message",
+				id: "u2",
+				parentId: "c1",
+				timestamp: "2026-05-09T00:00:04Z",
+				message: { role: "user", content: "post" },
+			},
+			{
+				type: "message",
+				id: "a2",
+				parentId: "u2",
+				timestamp: "2026-05-09T00:00:05Z",
+				message: {
+					role: "assistant",
+					provider: "openai",
+					model: "gpt-4",
+					content: [
+						{
+							type: "toolCall",
+							id: "call_fake",
+							name: "bash",
+							arguments: { command: "echo post" },
+						},
+					],
+				},
+			},
+			{
+				type: "message",
+				id: "tr2",
+				parentId: "a2",
+				timestamp: "2026-05-09T00:00:06Z",
+				message: {
+					role: "toolResult",
+					toolCallId: "call_fake",
+					toolName: "bash",
+					content: [{ type: "text", text: "post" }],
+					isError: false,
+				},
+			},
+		])
+
+		await fixture.conn.loadSession({ sessionId, cwd, mcpServers: [] })
+
+		const toolCalls = fixture.client.sessionUpdates.filter(
+			(u) => u.sessionId === sessionId && u.update.sessionUpdate === "tool_call" && !isAcpWarning(u.update),
+		)
+
+		expect(toolCalls, "two tool_call notifications replayed").toHaveLength(2)
+		expect(toolCalls).toEqual([
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "call_fake" },
+				}),
+			}),
+			expect.objectContaining({
+				sessionId,
+				update: expect.objectContaining({
+					sessionUpdate: "tool_call",
+					toolCallId: expect.stringMatching(/^kt\.bash\.\d+$/),
+					_meta: { piToolCallId: "call_fake" },
+				}),
+			}),
+		])
+		const firstId = (toolCalls[0].update as { toolCallId: string }).toolCallId
+		const secondId = (toolCalls[1].update as { toolCallId: string }).toolCallId
+		expect(firstId).not.toBe(secondId)
+	})
+})


### PR DESCRIPTION
## Linked issue

Closes #0
LLM-2824

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

This PR ensures ACP `toolCallId` values are unique across a session, and cleans up the supporting code:                                                          
                                                                                                                                                                
 - **Tool call ID uniqueness**: Pi tool call IDs can be reused after compaction, so the ACP surface now allocates fresh session-unique `toolCallIds` while preserving the original Pi ID in `_meta.piToolCallId`. A mapping tracks the allocation per session and is seeded on loadSession so replay emits consistent IDs.           
 - **Builder utilities moved**: `buildToolCall`, `buildToolCallUpdate`, `describeToolCall`, and `isHiddenToolCall` are extracted from `server.ts` into a dedicated `src/modes/acp/tool-calls/utils.ts` module.                                                                                                                    
 - **Test coverage improved**: Added focused unit tests for `buildToolCall` and `buildToolCallUpdate` covering default status, `_meta` merging, optional display/content fields, and status override behavior. E2E coverage for tool-call ID uniqueness is included in `tests/e2e/acp/tool-call-id.test.ts`. 

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
