### PR TITLE
fix(billing): show rate-limit warning instead of exhausted/upsell when Coder plan is demoted to free tier

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,7 @@ import pluginPackageHooksAdapter from "./extensions/plugin-package-hook-adapter/
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
 import questionnaireExtension from "./extensions/questionnaire/index.js"
+import rateLimitNoticeExtension from "./extensions/rate-limit-notice.js"
 import reportBugExtension from "./extensions/report-bug.js"
 import requestTimingExtension from "./extensions/request-timing.js"
 import reviewWriteGuardExtension from "./extensions/review-write-guard.js"
@@ -627,6 +628,7 @@ try {
 			infrastructureErrorTracker.extension,
 			infrastructureBreakerExtension,
 			interactiveErrorSurfaceExtension,
+			rateLimitNoticeExtension,
 		]
 
 		if (IS_ACP_MODE) {

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const {
 	AUTOMATIC_REFRESH_MIN_INTERVAL_MS,
 	BILLING_EXHAUSTED_MESSAGE,
+	BILLING_RATE_LIMITED_MESSAGE,
 	COMMUNITY_TIER_HEADER_NOTICE,
 	budgetEndpointFromLlmEndpoint,
 	configureBillingCreditsApi,
@@ -49,7 +50,7 @@ describe("billing status", () => {
 		expect(formatBudgetLimit("0.000000")).toBe("unlimited")
 	})
 
-	it("maps the proxy Community tier to header upsell without paid warnings", () => {
+	it("warns and drops the upsell for a Community tier reported as blocked", () => {
 		observeCreditsPayload({
 			serverless: true,
 			tier: "community",
@@ -66,11 +67,84 @@ describe("billing status", () => {
 			creditStatus: "exhausted",
 			remainingCredits: 0,
 		})
-		expect(getCommunityTierHeaderNotice()).toBe(
-			"You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing",
-		)
-		expect(getBillingWarnings()[0]).toBeUndefined()
+		expect(getCommunityTierHeaderNotice()).toBeUndefined()
+		expect(getBillingWarnings()[0]).toEqual({ kind: "exhausted", message: BILLING_EXHAUSTED_MESSAGE })
 		expect(getBillingStatusLine()).toEqual({ amount: "$0.00" })
+	})
+
+	// The reported failure: a Coder subscriber that exhausts its credits is demoted to a free tier for
+	// rate limiting, and the server reports that demoted tier as the billing identity. Every field
+	// except `remaining` describes a user who never paid.
+	it("warns about rate limiting when a demoted paid subscriber reports as free tier", () => {
+		observeCreditsPayload({
+			serverless: true,
+			tier: "community",
+			is_paid_tier: false,
+			billing_status: "free_tier",
+			has_credits: true,
+			remaining: "0",
+		})
+
+		expect(getBillingStatus()).toMatchObject({
+			plan: "community",
+			isPaidTier: false,
+			creditStatus: "ok",
+			restrictedMode: false,
+			remainingCredits: 0,
+		})
+		expect(getBillingWarnings()[0]).toEqual({ kind: "rate-limited", message: BILLING_RATE_LIMITED_MESSAGE })
+		expect(getCommunityTierHeaderNotice()).toBeUndefined()
+	})
+
+	// The warning kind turns on who said what: an explicit billing_status outranks the balance
+	// inference, so a server that declares depletion is never downgraded to the softer variant.
+	it("separates a server-declared depletion from an inferred zero balance", () => {
+		observeCreditsPayload({
+			serverless: true,
+			tier: "coder",
+			is_paid_tier: true,
+			billing_status: "depleted",
+			has_credits: false,
+			remaining: "0",
+		})
+		expect(getBillingWarnings()[0]?.kind).toBe("exhausted")
+
+		// Same declaration, but the payload omits has_credits entirely.
+		observeCreditsPayload({ serverless: false })
+		observeCreditsPayload({
+			serverless: true,
+			tier: "coder",
+			is_paid_tier: true,
+			billing_status: "depleted",
+			remaining: "0",
+		})
+		expect(getBillingWarnings()[0]?.kind).toBe("exhausted")
+
+		// Nothing declared: the balance is the only evidence, and the server is still serving.
+		observeCreditsPayload({ serverless: false })
+		observeCreditsPayload({
+			serverless: true,
+			tier: "community",
+			is_paid_tier: false,
+			billing_status: "free_tier",
+			has_credits: true,
+			remaining: "0",
+		})
+		expect(getBillingWarnings()[0]?.kind).toBe("rate-limited")
+	})
+
+	it("keeps the Community upsell while a free-tier user still has credits", () => {
+		observeCreditsPayload({
+			serverless: true,
+			tier: "community",
+			is_paid_tier: false,
+			billing_status: "free_tier",
+			has_credits: true,
+			remaining: "12",
+		})
+
+		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_HEADER_NOTICE)
+		expect(getBillingWarnings()[0]).toBeUndefined()
 	})
 
 	it("still accepts internal free/free-slow tiers if proxy mapping is not deployed yet", () => {

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -16,7 +16,10 @@ export interface BillingStatus {
 }
 
 export interface BillingWarning {
-	kind: "low" | "exhausted"
+	// "exhausted" is a hard stop (the server refuses the request); "rate-limited" still serves, just
+	// slower. Kept apart so the tip surfaces the second as a warning rather than an error — for a
+	// free-tier user a zero balance is a steady state, not a failure.
+	kind: "low" | "exhausted" | "rate-limited"
 	message: string
 }
 
@@ -72,6 +75,11 @@ export const LOW_CREDITS_THRESHOLD_USD = 5
 export const COMMUNITY_TIER_HEADER_NOTICE =
 	"You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing"
 export const BILLING_EXHAUSTED_MESSAGE = "You ran out of credits. Top up at https://app.kimchi.dev/billing"
+// "Lift", not "restore": a zero balance is reached both by a paid subscriber demoted to free-tier
+// limits and by a free user whose included credits were never spendable, who was therefore rate
+// limited all along. The payload cannot tell the two apart, so the wording must hold for both.
+export const BILLING_RATE_LIMITED_MESSAGE =
+	"You're out of credits, so requests are rate limited. Top up to lift your rate limits: https://app.kimchi.dev/billing"
 const BILLING_REFRESH_TIMEOUT_MS = 5000
 
 const TIER_FIELDS = ["tier", "tier_name", "tierName"] as const
@@ -305,7 +313,11 @@ export function observeCreditsPayload(payload: unknown): BillingStatus | undefin
 export function getCommunityTierHeaderNotice(
 	status: BillingStatus | undefined = currentBillingStatus,
 ): string | undefined {
-	return status?.plan === "community" ? COMMUNITY_TIER_HEADER_NOTICE : undefined
+	if (status?.plan !== "community") return undefined
+	// A depleted paid subscriber is reported as community, so this would tell them to upgrade to the
+	// plan they already pay for. The credit warning carries the actionable remedy instead.
+	if (isCreditsExhausted(status)) return undefined
+	return COMMUNITY_TIER_HEADER_NOTICE
 }
 
 export function getBillingWarnings(status: BillingStatus | undefined = currentBillingStatus): BillingWarning[] {
@@ -316,17 +328,22 @@ export function getBillingWarnings(status: BillingStatus | undefined = currentBi
 }
 
 function getCreditBillingWarning(status: BillingStatus | undefined): BillingWarning | undefined {
-	if (!status || !isPaidPlan(status)) return undefined
+	if (!status) return undefined
 
-	if (status.creditStatus === "ok") return undefined
-
-	const exhausted =
-		status.creditStatus === "exhausted" ||
-		(status.creditStatus === undefined &&
-			(status.restrictedMode === true || (typeof status.remainingCredits === "number" && status.remainingCredits <= 0)))
-	if (exhausted) {
+	// Server-declared: it named the balance spent, or has_credits=false says it is refusing
+	// requests outright. Never soften an explicit statement with an inference.
+	if (status.creditStatus === "exhausted" || status.restrictedMode === true) {
 		return { kind: "exhausted", message: BILLING_EXHAUSTED_MESSAGE }
 	}
+
+	// Inferred from the balance alone — all a demoted subscriber's payload carries.
+	if (typeof status.remainingCredits === "number" && status.remainingCredits <= 0) {
+		return { kind: "rate-limited", message: BILLING_RATE_LIMITED_MESSAGE }
+	}
+
+	if (!isPaidPlan(status)) return undefined
+
+	if (status.creditStatus === "ok") return undefined
 
 	const isLow =
 		status.creditStatus === "low" ||
@@ -344,6 +361,19 @@ function getCreditBillingWarning(status: BillingStatus | undefined): BillingWarn
 	}
 
 	return undefined
+}
+
+/**
+ * Deliberately keyed on the balance before any tier or billing-status field.
+ *
+ * When a paid subscriber exhausts their credits the server demotes them to a free tier for rate
+ * limiting and then reports that demoted tier as their billing identity, so the payload arrives as
+ * `is_paid_tier: false` / `billing_status: "free_tier"` — indistinguishable from a user who never
+ * paid. `remaining` is the only field the demotion does not rewrite.
+ */
+function isCreditsExhausted(status: BillingStatus): boolean {
+	if (status.creditStatus === "exhausted" || status.restrictedMode === true) return true
+	return typeof status.remainingCredits === "number" && status.remainingCredits <= 0
 }
 
 export function getBillingStatusLine(

--- a/src/extensions/billing/tips.test.ts
+++ b/src/extensions/billing/tips.test.ts
@@ -25,11 +25,35 @@ describe("billing tips", () => {
 		])
 	})
 
+	// A zero balance while the server keeps serving is a steady state for free-tier users, not a
+	// failure, so it must not render as an error.
+	it("uses warning tone when a zero balance only means reduced rate limits", () => {
+		setBillingStatusForTest({
+			plan: "community",
+			isPaidTier: false,
+			creditStatus: "ok",
+			restrictedMode: false,
+			remainingCredits: 0,
+			updatedAt: "2026-08-04T00:00:00.000Z",
+		})
+
+		expect(createBillingTipProvider().getTips()).toEqual([
+			expect.objectContaining({
+				id: "billing-rate-limited-0",
+				tone: "warning",
+				showPrefix: false,
+			}),
+		])
+	})
+
+	// restrictedMode is has_credits=false: the server refuses the request outright, which is the one
+	// credit state that is genuinely an error rather than a slowdown.
 	it("uses error tone for exhausted-credit warnings", () => {
 		setBillingStatusForTest({
 			plan: "coder",
 			isPaidTier: true,
 			creditStatus: "exhausted",
+			restrictedMode: true,
 			remainingCredits: 0,
 			updatedAt: "2026-07-08T00:00:00.000Z",
 		})

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest"
-import { ExplorationGuard, type ExplorationGuardOptions, STEER_MESSAGE_TYPE } from "./exploration-guard.js"
+import { describe, expect, it, vi } from "vitest"
+import explorationGuardExtension, {
+	ExplorationGuard,
+	type ExplorationGuardOptions,
+	STEER_MESSAGE_TYPE,
+} from "./exploration-guard.js"
 
 function createGuard(options?: ExplorationGuardOptions): ExplorationGuard {
 	return new ExplorationGuard(options)
@@ -687,5 +691,58 @@ describe("Subagent terminate behavior", () => {
 		expect(mainSteers[1]).toContain("5 consecutive turns with no tool calls")
 		expect(mainSteers[1]).toContain("You must use a tool this turn")
 		expect(mainSteers[1]).not.toContain("terminated")
+	})
+})
+
+describe("explorationGuardExtension turn_end", () => {
+	function createHarness(options?: ExplorationGuardOptions) {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>()
+		const sendMessage = vi.fn()
+		const abort = vi.fn()
+		const pi = {
+			on: (event: string, handler: (e: unknown, ctx: unknown) => unknown) => {
+				handlers.set(event, handler)
+			},
+			sendMessage,
+		}
+		explorationGuardExtension(pi as never, options)
+		// The extension gates itself on a session id resolved from the context captured here.
+		handlers.get("session_start")?.({}, { abort, sessionManager: { getSessionId: () => "session-under-test" } })
+
+		function turn(stopReason: "stop" | "error" = "stop") {
+			handlers.get("turn_start")?.({}, {})
+			handlers.get("turn_end")?.({ message: { role: "assistant", stopReason } }, {})
+		}
+
+		return { sendMessage, abort, turn }
+	}
+
+	it("does not count a failed request toward the no-tool streak", () => {
+		const { sendMessage, turn } = createHarness()
+
+		for (let i = 0; i < 5; i++) turn("error")
+		expect(sendMessage).not.toHaveBeenCalled()
+
+		// The warning fires on the third turn the model actually took.
+		turn()
+		turn()
+		expect(sendMessage).not.toHaveBeenCalled()
+		turn()
+		expect(sendMessage).toHaveBeenCalledTimes(1)
+	})
+
+	// The errored turn is retried upstream, and the retried turn produces the summary the
+	// orchestrator consumes — aborting on the failure itself would hand it nothing.
+	it("defers a pending subagent abort past a failed request", () => {
+		const { abort, turn } = createHarness({ isSubagent: () => true })
+
+		for (let i = 0; i < 5; i++) turn()
+		expect(abort).not.toHaveBeenCalled()
+
+		turn("error")
+		expect(abort).not.toHaveBeenCalled()
+
+		turn()
+		expect(abort).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -278,6 +278,12 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 	})
 
 	pi.on("turn_end", (event) => {
+		// A failed request produces a turn with no tool calls, but the model never got to act — count
+		// it and the guard steers a turn that was never lazy, re-sending the request that just failed.
+		// This also defers a pending subagent abort: the failed turn is retried upstream, and the
+		// retried turn is the one that produces the summary the orchestrator receives.
+		if (event.message.role === "assistant" && event.message.stopReason === "error") return
+
 		// If a subagent abort is pending, fire it NOW before processing the
 		// steer. The subagent already received the summary-request steer last
 		// turn; whatever it produced this turn becomes the orchestrator output.
@@ -285,8 +291,6 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 			ctx?.abort()
 			return
 		}
-
-		const isError = event.message.role === "assistant" && event.message.stopReason === "error"
 
 		guard.turnEnd((text) => {
 			pi.sendMessage(
@@ -297,6 +301,6 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 				},
 				{ deliverAs: "steer" },
 			)
-		}, isError)
+		})
 	})
 }

--- a/src/extensions/interactive-error-surface.test.ts
+++ b/src/extensions/interactive-error-surface.test.ts
@@ -144,6 +144,34 @@ describe("interactiveErrorSurfaceExtension (pending-state tracking)", () => {
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Please retry your request."), "error")
 	})
 
+	it("does NOT set pending state when the rate-limit deadline is past the wait bound", () => {
+		// The rate-limit notice already renders the "not retrying" guidance on the message;
+		// an agent_end exhaustion notification would duplicate it.
+		const { emitMessageEnd, emitAgentEnd } = createHarness()
+		const notify = vi.fn()
+		const deadline = new Date(Date.now() + 20 * 60_000).toISOString()
+		const message = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: `kimi-k2.5 model is rate limited until ${deadline}`,
+		}
+		emitMessageEnd(message)
+		expect(__getPendingProviderError()).toBeUndefined()
+		// The per-attempt placeholder mutation still applies; the notice overwrites it later.
+		expect(message.errorMessage).toBe("Retrying…")
+
+		emitAgentEnd({ willRetry: false }, { ui: { notify } })
+		expect(notify).not.toHaveBeenCalled()
+	})
+
+	it("sets pending state for a rate-limit deadline under the wait bound", () => {
+		const { emitMessageEnd } = createHarness()
+		const deadline = new Date(Date.now() + 5 * 60_000).toISOString()
+		const raw = `kimi-k2.5 model is rate limited until ${deadline}`
+		emitMessageEnd({ role: "assistant", stopReason: "error", errorMessage: raw })
+		expect(__getPendingProviderError()?.rawMessage).toBe(raw)
+	})
+
 	it("agent_end does NOT render for non-retryable errors (no pending state)", () => {
 		const { emitMessageEnd, emitAgentEnd } = createHarness()
 		const notify = vi.fn()

--- a/src/extensions/interactive-error-surface.ts
+++ b/src/extensions/interactive-error-surface.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { InteractiveMode } from "@earendil-works/pi-coding-agent"
 import { classifyLLMGatewayError } from "../llm-gateway-error.js"
 import { formatSanitizedErrorMessage } from "../sanitized-error-message.js"
+import { RATE_LIMIT_MAX_WAIT_MS, rateLimitWaitMs } from "../upstream-retry-patch.js"
 import { preserveRawErrorMessage } from "./error-preservation.js"
 
 interface PendingProviderError {
@@ -109,9 +110,17 @@ export default function interactiveErrorSurfaceExtension(pi: ExtensionAPI): void
 		// AssistantMessageComponent. Extensions register before the mode's
 		// own message_end handler, so this mutation takes effect first.
 		if (classified.retryable) {
+			// A rate-limit deadline past the wait bound is refused by the retry classifier, and
+			// the rate-limit-notice extension (registered after this one) renders the definitive
+			// "not retrying" guidance on the message itself — pending state here would only
+			// duplicate it as an agent_end exhaustion notification.
+			const waitMs = rateLimitWaitMs(message)
+			const noticeOwnsMessaging = waitMs !== undefined && waitMs > RATE_LIMIT_MAX_WAIT_MS
 			// Track only retryable errors — agent_end renders the sanitized
 			// exhaustion message when retries are exhausted.
-			lastPendingProviderError = { rawMessage: message.errorMessage, willRetry: true }
+			if (!noticeOwnsMessaging) {
+				lastPendingProviderError = { rawMessage: message.errorMessage, willRetry: true }
+			}
 			// Preserve the original error for the retry classifier, which runs
 			// in _handlePostAgentRun AFTER this mutation. Without this, the
 			// classifier sees "Retrying…" and fails to identify the error as

--- a/src/extensions/rate-limit-notice.test.ts
+++ b/src/extensions/rate-limit-notice.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { RATE_LIMIT_MAX_WAIT_MS } from "../upstream-retry-patch.js"
+import { rateLimitNotice } from "./rate-limit-notice.js"
+
+describe("rateLimitNotice", () => {
+	const NOW = Date.parse("2026-08-05T16:00:00Z")
+	const localTime = (epochMs: number) => new Date(epochMs).toLocaleTimeString(undefined, { timeStyle: "short" })
+
+	it("states the deadline without promising a retry", () => {
+		const retryAt = NOW + 4 * 60_000
+
+		const notice = rateLimitNotice(retryAt, "kimi-k2.7", NOW)
+
+		expect(notice).toBe(`kimi-k2.7 is rate limited until ${localTime(retryAt)} (4 minutes).`)
+		expect(notice).not.toContain("retrying")
+	})
+
+	it("names the remedy when the deadline is past the wait bound", () => {
+		const retryAt = NOW + RATE_LIMIT_MAX_WAIT_MS + 60_000
+
+		const notice = rateLimitNotice(retryAt, "kimi-k2.7", NOW)
+
+		expect(notice).toContain("not retrying")
+		expect(notice).toContain("/model")
+		expect(notice).toContain("https://app.kimchi.dev/billing")
+	})
+
+	it("falls back to a generic subject when the model is unknown", () => {
+		expect(rateLimitNotice(NOW + 30_000, undefined, NOW)).toBe(
+			`Requests are rate limited until ${localTime(NOW + 30_000)} (30 seconds).`,
+		)
+	})
+
+	// Upstream's retry countdown renders bare seconds, so this is the only place the wait appears
+	// in readable units.
+	it("reports the wait in human units", () => {
+		expect(rateLimitNotice(NOW + 90 * 60_000, undefined, NOW)).toContain("(2 hours)")
+	})
+})

--- a/src/extensions/rate-limit-notice.ts
+++ b/src/extensions/rate-limit-notice.ts
@@ -1,0 +1,41 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { formatLocalTime, formatWait, parseRateLimitRetryAt } from "../llm-gateway-error.js"
+import { RATE_LIMIT_MAX_WAIT_MS, rememberRateLimitDeadline } from "../upstream-retry-patch.js"
+import { getRawErrorMessage } from "./error-preservation.js"
+
+export function rateLimitNotice(retryAt: number, model?: string, now: number = Date.now()): string {
+	const subject = model ? `${model} is` : "Requests are"
+	const waitMs = retryAt - now
+	const until = `${subject} rate limited until ${formatLocalTime(retryAt)} (${formatWait(waitMs)})`
+	// Past the bound the retry classifier refuses outright, so this is the one outcome decidable
+	// here. Below it, whether a retry happens at all is settled later — upstream's countdown
+	// reports the real wait, so do not pre-announce one.
+	if (waitMs > RATE_LIMIT_MAX_WAIT_MS) {
+		return `${until} — not retrying. Switch model with /model, or top up at https://app.kimchi.dev/billing`
+	}
+	return `${until}.`
+}
+
+/**
+ * Restates a rate-limit deadline in local time, in place of the gateway's UTC wording. Registered
+ * last so earlier extensions — classification, telemetry, diagnostics — still see the raw message;
+ * interactive-error-surface has already swapped in its "Retrying…" placeholder by now, so the
+ * deadline is parsed from the preserved original and the notice replaces the placeholder.
+ */
+export default function rateLimitNoticeExtension(pi: ExtensionAPI): void {
+	pi.on("message_end", (event) => {
+		const message = event.message
+		if (message.role !== "assistant" || message.stopReason !== "error") return
+
+		const rawMessage = getRawErrorMessage(message)
+		if (typeof rawMessage !== "string") return
+
+		const retryAt = parseRateLimitRetryAt(rawMessage)
+		if (retryAt === undefined) return
+
+		// The retry policy reads the deadline off this same message after the rewrite, and local time
+		// does not parse back. `_replaceMessageInPlace` mutates the original object, so keying on it holds.
+		rememberRateLimitDeadline(message, retryAt)
+		return { message: { ...message, errorMessage: rateLimitNotice(retryAt, message.model) } }
+	})
+}

--- a/src/extensions/session-name.test.ts
+++ b/src/extensions/session-name.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import {
+import sessionNameExtension, {
 	deterministicFallback,
 	extractFirstUserMessage,
 	SESSION_NAME_MODEL,
@@ -249,5 +249,72 @@ describe("sessionNameExtension turn_end handler", () => {
 		// All branches are covered by the suggestSessionName tests above
 		// and mocking pi.setSessionName would be trivial but low value
 		expect(true).toBe(true)
+	})
+})
+
+describe("sessionNameExtension shutdown", () => {
+	function createHarness() {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => unknown>()
+		const setSessionName = vi.fn()
+		const pi = {
+			on: (event: string, handler: (e: unknown, c: unknown) => unknown) => {
+				handlers.set(event, handler)
+			},
+			setSessionName,
+		}
+		sessionNameExtension()(pi as never)
+		const entries = [{ type: "message", message: { role: "user", content: "Please review this branch" } }]
+		const ctx = {
+			cwd: "/home/user/my-project",
+			hasUI: false,
+			sessionManager: {
+				getSessionName: () => undefined,
+				getBranch: () => entries,
+				getEntries: () => entries,
+			},
+		}
+		return { handlers, setSessionName, ctx }
+	}
+
+	// turn_end deliberately does not await (a slow listener starves the steering queue), so
+	// shutdown is the only place left to keep a one-shot run from exiting mid-request.
+	it("waits for an in-flight suggestion before shutting down", async () => {
+		let releaseFetch: (() => void) | undefined
+		const fetchGate = new Promise<void>((resolve) => {
+			releaseFetch = resolve
+		})
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				await fetchGate
+				return new Response(JSON.stringify({ choices: [{ message: { content: "Review Branch" } }] }), {
+					status: 200,
+				})
+			}),
+		)
+		mockLoadConfig.mockReturnValue({ apiKey: "test-key", llmEndpoint: "https://llm.test/openai/v1" })
+		const { handlers, setSessionName, ctx } = createHarness()
+
+		handlers.get("turn_end")?.({}, ctx)
+		expect(setSessionName).not.toHaveBeenCalled()
+
+		let shutdownSettled = false
+		const shutdown = Promise.resolve(handlers.get("session_shutdown")?.({}, ctx)).then(() => {
+			shutdownSettled = true
+		})
+		await Promise.resolve()
+		expect(shutdownSettled).toBe(false)
+
+		releaseFetch?.()
+		await shutdown
+
+		expect(shutdownSettled).toBe(true)
+		expect(setSessionName).toHaveBeenCalledWith("Review Branch")
+	})
+
+	it("shuts down immediately when no suggestion is in flight", async () => {
+		const { handlers, ctx } = createHarness()
+
+		await expect(Promise.resolve(handlers.get("session_shutdown")?.({}, ctx))).resolves.toBeUndefined()
 	})
 })

--- a/src/extensions/session-name.ts
+++ b/src/extensions/session-name.ts
@@ -182,24 +182,46 @@ export async function suggestSessionName(ctx: ExtensionContext, hint?: string, q
 export default function sessionNameExtension() {
 	return (pi: ExtensionAPI) => {
 		let hasAutoNamed = false
+		let pendingAutoName: Promise<void> | undefined
 
 		// Auto-name sessions after the first turn when no name was set.
-		pi.on("turn_end", async (_event: TurnEndEvent, ctx: ExtensionContext) => {
-			if (hasAutoNamed) return
-			if (ctx.sessionManager.getSessionName()) {
+		//
+		// Never await here. `isStreaming` clears only after every turn_end listener settles, but the
+		// model loop — the only thing that drains the steering queue — has already stopped by then.
+		// Anything typed while a slow listener holds the run open is queued as steering and never sent.
+		pi.on("turn_end", (_event: TurnEndEvent, ctx: ExtensionContext) => {
+			try {
+				if (hasAutoNamed) return
+				if (ctx.sessionManager.getSessionName()) {
+					hasAutoNamed = true
+					return
+				}
+				const hint = extractFirstUserMessage(ctx)
+				if (!hint) {
+					hasAutoNamed = true
+					return
+				}
 				hasAutoNamed = true
-				return
-			}
-			const hint = extractFirstUserMessage(ctx)
-			if (!hint) {
+				pendingAutoName = suggestSessionName(ctx, hint, true)
+					// ctx may be stale once this resolves; a throw here would surface as a model error.
+					.then((suggestion) => {
+						if (suggestion && !ctx.sessionManager.getSessionName()) {
+							pi.setSessionName(suggestion)
+						}
+					})
+					.catch(() => {})
+					.finally(() => {
+						pendingAutoName = undefined
+					})
+			} catch {
 				hasAutoNamed = true
-				return
 			}
-			hasAutoNamed = true
-			const suggestion = await suggestSessionName(ctx, hint, true)
-			if (suggestion && !ctx.sessionManager.getSessionName()) {
-				pi.setSessionName(suggestion)
-			}
+		})
+
+		// One-shot runs exit as soon as the turn ends, which would drop the in-flight request.
+		// Safe to await: suggestSessionName is bounded by SESSION_NAME_TIMEOUT_MS.
+		pi.on("session_shutdown", async () => {
+			await pendingAutoName
 		})
 	}
 }

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { classifyLLMGatewayError, LLMGatewayError } from "./llm-gateway-error.js"
+import { classifyLLMGatewayError, formatWait, LLMGatewayError, parseRateLimitRetryAt } from "./llm-gateway-error.js"
 
 describe("classifyLLMGatewayError", () => {
 	it.each([
@@ -316,5 +316,48 @@ describe("classifyLLMGatewayError", () => {
 		"failed after 503 iterations of the loop",
 	])("does not classify a bare status number outside status context: %s", (message) => {
 		expect(classifyLLMGatewayError(message)).toBeUndefined()
+	})
+})
+
+describe("parseRateLimitRetryAt", () => {
+	const NOW = Date.parse("2026-08-05T12:00:00Z")
+	const EXPECTED = Date.parse("2026-08-05T16:27:33Z")
+
+	it.each([
+		{ name: "bare UTC stamp", stamp: "2026-08-05T16:27:33Z", expected: EXPECTED },
+		{ name: "sentence-final period", stamp: "2026-08-05T16:27:33Z.", expected: EXPECTED },
+		{ name: "trailing clause", stamp: "2026-08-05T16:27:33Z, retry later.", expected: EXPECTED },
+		{ name: "closing parenthesis", stamp: "2026-08-05T16:27:33Z)", expected: EXPECTED },
+		// The gateway reports UTC, so an unzoned stamp must not be read as local time.
+		{ name: "no zone", stamp: "2026-08-05T16:27:33", expected: EXPECTED },
+		{ name: "fractional seconds", stamp: "2026-08-05T16:27:33.123Z", expected: EXPECTED + 123 },
+		{ name: "explicit offset", stamp: "2026-08-05T18:27:33+02:00", expected: EXPECTED },
+	])("parses $name", ({ stamp, expected }) => {
+		expect(parseRateLimitRetryAt(`kimi-k2.7 model is rate limited until ${stamp}`, NOW)).toBe(expected)
+	})
+
+	it.each([
+		{ name: "a bare number", message: "rate limited until 5" },
+		{ name: "no deadline at all", message: "429 Too Many Requests" },
+		{ name: "an unparseable stamp", message: "rate limited until 2026-13-45T99:99:99Z" },
+		{ name: "a deadline already passed", message: "rate limited until 2026-08-05T11:00:00Z" },
+	])("returns undefined for $name", ({ message }) => {
+		expect(parseRateLimitRetryAt(message, NOW)).toBeUndefined()
+	})
+})
+
+describe("formatWait", () => {
+	it.each([
+		{ ms: 1_000, expected: "1 second" },
+		{ ms: 30_000, expected: "30 seconds" },
+		{ ms: 59_000, expected: "59 seconds" },
+		{ ms: 60_000, expected: "1 minute" },
+		{ ms: 90_000, expected: "2 minutes" },
+		{ ms: 59 * 60_000, expected: "59 minutes" },
+		{ ms: 60 * 60_000, expected: "1 hour" },
+		{ ms: 120 * 60_000, expected: "2 hours" },
+		{ ms: -5_000, expected: "0 seconds" },
+	])("formats $ms ms as $expected", ({ ms, expected }) => {
+		expect(formatWait(ms)).toBe(expected)
 	})
 })

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -98,6 +98,38 @@ const TRANSPORT_TERMINATION_RE =
 	/\b(?:connection|request|stream|response|socket|http2 request)\b.{0,40}\b(?:terminated unexpectedly|unexpectedly (?:ended|closed|terminated)|ended unexpectedly|closed unexpectedly)\b/i
 const BAD_REQUEST_TEXT_RE = /bad request|BadRequest/i
 
+// "kimi-k2.7 model is rate limited until 2026-08-05T16:27:33Z" — the gateway states an absolute
+// reopening time, so every attempt before it fails by construction. Anchored on a digit or Z so
+// sentence punctuation backtracks out of the capture instead of reaching Date.parse.
+const RATE_LIMIT_UNTIL_RE = /rate.?limited\s+until\s+([0-9T][0-9TZ:+.-]*[0-9Z])/i
+const EXPLICIT_ZONE_RE = /[Zz]$|[+-]\d{2}:?\d{2}$/
+
+/** Epoch ms the gateway says the limit lifts, or undefined when it named none or it has passed. */
+export function parseRateLimitRetryAt(rawMessage: string, now: number = Date.now()): number | undefined {
+	const match = RATE_LIMIT_UNTIL_RE.exec(rawMessage)
+	if (!match?.[1]) return undefined
+	const stamp = match[1]
+	// The gateway reports UTC; Date.parse would read an unzoned stamp as local time.
+	const retryAt = Date.parse(EXPLICIT_ZONE_RE.test(stamp) ? stamp : `${stamp}Z`)
+	if (Number.isNaN(retryAt) || retryAt <= now) return undefined
+	return retryAt
+}
+
+/** The gateway reports UTC; only local wall-clock time tells the user when to come back. */
+export function formatLocalTime(epochMs: number): string {
+	return new Date(epochMs).toLocaleTimeString(undefined, { timeStyle: "short" })
+}
+
+/** Rounded to one unit: the exact second of a multi-minute wait is noise. */
+export function formatWait(ms: number): string {
+	const seconds = Math.max(Math.round(ms / 1000), 0)
+	if (seconds < 60) return `${seconds} second${seconds === 1 ? "" : "s"}`
+	const minutes = Math.round(seconds / 60)
+	if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`
+	const hours = Math.round(minutes / 60)
+	return `${hours} hour${hours === 1 ? "" : "s"}`
+}
+
 function parseHttpStatusCode(rawMessage: string): number | undefined {
 	for (const pattern of HTTP_STATUS_RES) {
 		const match = pattern.exec(rawMessage)

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -1,3 +1,4 @@
+import { AgentSession } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { preserveRawErrorMessage } from "./extensions/error-preservation.js"
 import {
@@ -6,7 +7,10 @@ import {
 	installInfrastructureRetryPatch,
 	isInfrastructureBreakerTripped,
 	isInfrastructureErrorRetryable,
+	RATE_LIMIT_MAX_WAIT_MS,
+	rateLimitWaitMs,
 	recordInfrastructureBreakerFailure,
+	rememberRateLimitDeadline,
 	resetInfrastructureBreaker,
 	resolveInfrastructureBreakerThreshold,
 } from "./upstream-retry-patch.js"
@@ -109,6 +113,175 @@ describe("upstream retry patch", () => {
 
 		expect(wrapped({ stopReason: "error", errorMessage: "429 rate limit exceeded" })).toBe(true)
 		expect(wrapped({ stopReason: "error", errorMessage: "429 model queue full" })).toBe(true)
+	})
+})
+
+describe("rate-limit deadline retry", () => {
+	const NOW = Date.parse("2026-08-05T16:00:00Z")
+	const DEADLINE = Date.parse("2026-08-05T16:04:00Z")
+	const WAIT_MS = DEADLINE - NOW
+	const deadlineError = {
+		stopReason: "error" as const,
+		errorMessage: "kimi-k2.7 model is rate limited until 2026-08-05T16:04:00Z",
+	}
+
+	type RetryMessage = { stopReason?: string; errorMessage?: string }
+
+	type FakeSession = {
+		settingsManager: { getRetrySettings: () => { enabled: boolean; maxRetries: number; baseDelayMs: number } }
+		agent: { state: { messages: { role: string }[] } }
+		_retryAttempt: number
+		_retryAbortController?: AbortController
+		_emit: ReturnType<typeof vi.fn>
+	}
+
+	function createSession(
+		overrides: { enabled?: boolean; maxRetries?: number; retryAttempt?: number } = {},
+	): FakeSession {
+		return {
+			settingsManager: {
+				getRetrySettings: () => ({
+					enabled: overrides.enabled ?? true,
+					maxRetries: overrides.maxRetries ?? 3,
+					baseDelayMs: 2000,
+				}),
+			},
+			agent: { state: { messages: [{ role: "user" }, { role: "assistant" }] } },
+			_retryAttempt: overrides.retryAttempt ?? 0,
+			_emit: vi.fn(),
+		}
+	}
+
+	function installPatchedPreparer() {
+		const original = vi.fn<(message: RetryMessage) => Promise<boolean>>(async () => true)
+		const sessionClass = {
+			prototype: {
+				_isRetryableError: (_message: RetryMessage) => true,
+				_prepareRetry: original,
+			},
+		}
+		installInfrastructureRetryPatch(sessionClass, 0)
+		// biome-ignore lint/style/noNonNullAssertion: installInfrastructureRetryPatch always wraps the preparer above
+		return { prepareRetry: sessionClass.prototype._prepareRetry!, original }
+	}
+
+	afterEach(() => {
+		vi.useRealTimers()
+		configureInfrastructureBreaker(0)
+	})
+
+	// The patch wraps a private upstream method. An upstream rename would silently disable the
+	// deadline wait rather than fail, so assert the method still exists.
+	it("upstream still exposes the _prepareRetry hook the patch wraps", () => {
+		const proto = (AgentSession as unknown as { prototype: Record<string, unknown> }).prototype
+		expect(typeof proto._prepareRetry).toBe("function")
+		expect(typeof proto._isRetryableError).toBe("function")
+	})
+
+	it("does not retry when retries are disabled", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry } = installPatchedPreparer()
+		const session = createSession({ enabled: false })
+
+		await expect(prepareRetry.call(session as never, deadlineError)).resolves.toBe(false)
+		expect(session._retryAttempt).toBe(0)
+		expect(session._emit).not.toHaveBeenCalled()
+	})
+
+	// Only reachable at maxRetries 0: any higher budget with a spent counter takes the
+	// _retryAttempt > 0 branch and never enters the deadline wait.
+	it("restores the attempt counter when the retry budget is spent", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry } = installPatchedPreparer()
+		const session = createSession({ maxRetries: 0 })
+
+		await expect(prepareRetry.call(session as never, deadlineError)).resolves.toBe(false)
+		expect(session._retryAttempt).toBe(0)
+		expect(session._emit).not.toHaveBeenCalled()
+	})
+
+	it("sleeps to the stated deadline rather than backing off exponentially", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry, original } = installPatchedPreparer()
+		const session = createSession()
+
+		const pending = prepareRetry.call(session as never, deadlineError)
+
+		expect(session._emit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "auto_retry_start", attempt: 1, maxAttempts: 3, delayMs: WAIT_MS }),
+		)
+		// The errored assistant message must leave agent state or the retried turn resumes from it.
+		expect(session.agent.state.messages).toEqual([{ role: "user" }])
+
+		await vi.advanceTimersByTimeAsync(WAIT_MS)
+		await expect(pending).resolves.toBe(true)
+		expect(original).not.toHaveBeenCalled()
+	})
+
+	it("cancels the wait when the retry is aborted", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry } = installPatchedPreparer()
+		const session = createSession()
+
+		const pending = prepareRetry.call(session as never, deadlineError)
+		session._retryAbortController?.abort()
+
+		await expect(pending).resolves.toBe(false)
+		expect(session._retryAttempt).toBe(0)
+		expect(session._emit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "auto_retry_end", success: false, finalError: "Retry cancelled" }),
+		)
+	})
+
+	it("hands later attempts back to upstream backoff", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry, original } = installPatchedPreparer()
+		const session = createSession({ retryAttempt: 1 })
+
+		await expect(prepareRetry.call(session as never, deadlineError)).resolves.toBe(true)
+		expect(original).toHaveBeenCalledWith(deadlineError)
+		expect(session._emit).not.toHaveBeenCalled()
+	})
+
+	it("hands messages without a stated deadline back to upstream backoff", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const { prepareRetry, original } = installPatchedPreparer()
+		const session = createSession()
+		const plainError = { stopReason: "error" as const, errorMessage: "429 rate limit exceeded" }
+
+		await expect(prepareRetry.call(session as never, plainError)).resolves.toBe(true)
+		expect(original).toHaveBeenCalledWith(plainError)
+	})
+
+	it("refuses to retry a deadline past the wait bound", () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(NOW)
+		const sessionClass = { prototype: { _isRetryableError: (_message: RetryMessage) => true } }
+		installInfrastructureRetryPatch(sessionClass, 0)
+		const farOff = {
+			stopReason: "error" as const,
+			errorMessage: `rate limited until ${new Date(NOW + RATE_LIMIT_MAX_WAIT_MS + 60_000).toISOString()}`,
+		}
+
+		expect(sessionClass.prototype._isRetryableError?.(farOff)).toBe(false)
+		expect(sessionClass.prototype._isRetryableError?.(deadlineError)).toBe(true)
+	})
+
+	// The notice extension rewrites the message into local time, which Date.parse cannot read back.
+	it("resolves a remembered deadline after the message text is rewritten", () => {
+		const message = { ...deadlineError }
+		rememberRateLimitDeadline(message, DEADLINE)
+		message.errorMessage = "kimi-k2.7 is rate limited until 3:45 PM"
+
+		expect(rateLimitWaitMs(message, NOW)).toBe(WAIT_MS)
+		// Identity, not content, is the key.
+		expect(rateLimitWaitMs({ ...message }, NOW)).toBeUndefined()
 	})
 })
 

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,16 +1,24 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import { getRawErrorMessage } from "./extensions/error-preservation.js"
-import { classifyLLMGatewayError } from "./llm-gateway-error.js"
+import { classifyLLMGatewayError, parseRateLimitRetryAt } from "./llm-gateway-error.js"
 
 type RetryableMessage = Partial<Pick<AssistantMessage, "stopReason" | "errorMessage">>
 type RetryableClassifier = (message: RetryableMessage) => boolean
+type RetryPreparer = (message: RetryableMessage) => Promise<boolean>
 type PatchableAgentSession = {
 	prototype: {
 		_isRetryableError?: RetryableClassifier
+		_prepareRetry?: RetryPreparer
 		_kimchiInfrastructureRetryPatch?: boolean
 	}
 }
+
+/**
+ * Longest we will hold a turn open waiting for a stated rate-limit deadline. Beyond it the wait is
+ * indistinguishable from a hang, so the error is reported once instead.
+ */
+export const RATE_LIMIT_MAX_WAIT_MS = 10 * 60_000
 
 export function isInfrastructureErrorRetryable(message: RetryableMessage): boolean {
 	if (message.stopReason !== "error") return false
@@ -20,6 +28,28 @@ export function isInfrastructureErrorRetryable(message: RetryableMessage): boole
 	const rawMessage = getRawErrorMessage(message)
 	if (!rawMessage) return false
 	return classifyLLMGatewayError(rawMessage)?.retryable ?? false
+}
+
+const rateLimitDeadlines = new WeakMap<object, number>()
+
+/**
+ * Keeps a parsed deadline reachable after the message text is rewritten for display. The rewrite
+ * replaces the gateway's UTC wording with local time, which `Date.parse` cannot read back.
+ */
+export function rememberRateLimitDeadline(message: object, retryAt: number): void {
+	rateLimitDeadlines.set(message, retryAt)
+}
+
+/** Milliseconds until the gateway's stated reopening time, or undefined when it named none. */
+export function rateLimitWaitMs(message: RetryableMessage, now: number = Date.now()): number | undefined {
+	if (message.stopReason !== "error") return undefined
+	const remembered = rateLimitDeadlines.get(message)
+	if (remembered !== undefined) return remembered - now
+	// The visible errorMessage may already be a display placeholder; parse the preserved original.
+	const rawMessage = getRawErrorMessage(message)
+	if (!rawMessage) return undefined
+	const retryAt = parseRateLimitRetryAt(rawMessage, now)
+	return retryAt === undefined ? undefined : retryAt - now
 }
 
 // --- Infrastructure-error circuit breaker ---
@@ -114,6 +144,11 @@ export function installInfrastructureRetryPatch(
 		// can force a retry storm.
 		if (classification && !classification.retryable) return false
 
+		// A reopening time past the wait bound: no attempt before it can succeed, and each one spends
+		// from the same throttled budget that is already exhausted.
+		const waitMs = rateLimitWaitMs(message)
+		if (waitMs !== undefined && waitMs > RATE_LIMIT_MAX_WAIT_MS) return false
+
 		const kimchiRetryable = classification?.retryable === true
 		if (!(original.call(this, message) || kimchiRetryable)) return false
 		// Only infrastructure-classified errors are blocked by the breaker;
@@ -121,5 +156,93 @@ export function installInfrastructureRetryPatch(
 		if (!kimchiRetryable) return true
 		return !isInfrastructureBreakerTripped()
 	}
+
+	const originalPrepareRetry = proto._prepareRetry
+	if (originalPrepareRetry) {
+		proto._prepareRetry = async function patchedPrepareRetry(
+			this: unknown,
+			message: RetryableMessage,
+		): Promise<boolean> {
+			const session = this as RetryingSession
+			const waitMs = rateLimitWaitMs(message)
+			// Only the first retry waits out a deadline; a chain of fresh deadlines would otherwise add up
+			// past the bound. Everything else keeps upstream's exponential backoff.
+			if (waitMs === undefined || waitMs > RATE_LIMIT_MAX_WAIT_MS || session._retryAttempt > 0) {
+				return originalPrepareRetry.call(this as never, message)
+			}
+			return await waitForRateLimitDeadline(session, message, waitMs)
+		}
+	}
+
 	proto._kimchiInfrastructureRetryPatch = true
+}
+
+type RetryingSession = {
+	settingsManager: { getRetrySettings: () => { enabled: boolean; maxRetries: number } }
+	agent: { state: { messages: { role: string }[] } }
+	_retryAttempt: number
+	_retryAbortController?: AbortController
+	_emit: (event: Record<string, unknown>) => void
+}
+
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(resolve, ms)
+		signal.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer)
+				reject(signal.reason)
+			},
+			{ once: true },
+		)
+	})
+}
+
+/**
+ * Sleep until the gateway's stated reopening time instead of backing off blindly, mirroring
+ * upstream's `_prepareRetry` bookkeeping so the countdown UI and Esc-to-cancel keep working.
+ */
+async function waitForRateLimitDeadline(
+	session: RetryingSession,
+	message: RetryableMessage,
+	waitMs: number,
+): Promise<boolean> {
+	const settings = session.settingsManager.getRetrySettings()
+	if (!settings.enabled) return false
+
+	session._retryAttempt++
+	if (session._retryAttempt > settings.maxRetries) {
+		session._retryAttempt--
+		return false
+	}
+
+	session._emit({
+		type: "auto_retry_start",
+		attempt: session._retryAttempt,
+		maxAttempts: settings.maxRetries,
+		delayMs: waitMs,
+		errorMessage: message.errorMessage || "Unknown error",
+	})
+
+	// The errored assistant message stays in the session for history but must leave agent state, or
+	// the retried turn resumes from a failure.
+	const messages = session.agent.state.messages
+	if (messages.length > 0 && messages[messages.length - 1]?.role === "assistant") {
+		session.agent.state.messages = messages.slice(0, -1)
+	}
+
+	const controller = new AbortController()
+	session._retryAbortController = controller
+	try {
+		await abortableSleep(waitMs, controller.signal)
+	} catch {
+		const attempt = session._retryAttempt
+		session._retryAttempt = 0
+		session._emit({ type: "auto_retry_end", success: false, attempt, finalError: "Retry cancelled" })
+		return false
+	} finally {
+		session._retryAbortController = undefined
+	}
+	return true
 }

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -86,6 +86,44 @@ test("shows exhausted-credit warning from credits API after a model response", a
 	)
 })
 
+// A Coder subscriber that runs out of credits is demoted to a free tier for rate limiting, and the
+// credits API reports that demoted tier as the billing identity. Every field except `remaining`
+// describes a user who never paid, so the warning has to key on the balance.
+test("shows a rate-limit warning when a depleted Coder plan reports as free tier", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "billing-demoted-rate-limited",
+			creditsResponses: [
+				{
+					serverless: true,
+					tier: "coder",
+					is_paid_tier: true,
+					billing_status: "ok",
+					has_credits: true,
+					remaining: "10",
+				},
+				{
+					serverless: true,
+					tier: "community",
+					is_paid_tier: false,
+					billing_status: "free_tier",
+					has_credits: true,
+					remaining: "0",
+				},
+			],
+			responses: [{ stream: ["Done."] }],
+		},
+		async () => {
+			terminal.submit("Use remaining credits")
+
+			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
+			await waitForText(terminal, "requests are rate limited", { full: true })
+			await waitForText(terminal, "https://app.kimchi.dev/billing", { full: true })
+		},
+	)
+})
+
 test("shows Community tier notice from the credits API in the startup header", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,


### PR DESCRIPTION
## Linked issue

Closes #0

## Summary

When a paid Coder subscriber exhausts their credits, the server demotes them to a free tier for rate limiting and reports that demoted tier as their billing identity — every payload field except `remaining` describes a user who never paid. The previous behavior either misrendered this as a hard exhausted error or surfaced an upsell to the plan they already pay for.

### Billing classification
- Introduce a `rate-limited` warning kind keyed on the balance alone (the one field the demotion does not rewrite), rendered in warning tone rather than error.
- Reserve the hard `exhausted`/error tone for explicit server declarations (`billing_status: depleted/exhausted`, `has_credits=false`/restrictedMode). Never downgrade a server-declared depletion to the softer inference.
- Suppress the Community upsell notice while credits are exhausted, since it would tell a paid subscriber to upgrade to the plan they already pay for.

### Retry policy (upstream-retry-patch + llm-gateway-error)
- Parse the gateway's stated reopening time ("rate limited until &lt;UTC&gt;"), sleep to it on the first retry instead of blind exponential backoff, and refuse deadlines beyond 10 minutes — that wait is indistinguishable from a hang, so the error is reported once with a /model + top-up remedy.
- Keep upstream's bookkeeping (retry counter, countdown UI, Esc-to-cancel) by mirroring its `_prepareRetry` contract; only the first retry waits out the deadline so a chain of fresh deadlines cannot accumulate past the bound.
- Persist the parsed deadline across the message rewrite via a WeakMap keyed on the message object, since upstream mutates the message in place and local wall-clock time does not parse back.

### Rate-limit notice extension
- New extension (registered last) rewrites the gateway's UTC deadline into local time with a human-readable wait, replacing the "Retrying…" placeholder. Past the wait bound it renders the definitive "not retrying" guidance with the remedy.

### Interactive error surface
- Skip pending-state tracking for deadlines past the wait bound, since the rate-limit notice already renders the "not retrying" guidance on the message; an agent_end exhaustion notification would duplicate it.

### Exploration guard
- Stop counting `stopReason: "error"` turns toward the no-tool streak — they have no tool calls by construction, and counting them caused the guard and continuation nudges to steer, re-sending the rate-limited request in a loop.
- Defer a pending subagent abort past a failed turn so the retried turn, not the failure, is the one that produces the orchestrator's summary.

### Session auto-naming
- Stop awaiting the naming request in `turn_end`: `isStreaming` only clears after every listener settles, so a slow request starved the steering queue — anything typed during it was queued as steering and never sent.
- Fire-and-forget the suggestion in `turn_end` and await the in-flight request in `session_shutdown` so print-mode runs still get named before exit.

## Test Coverage
- `src/extensions/billing/status.test.ts` — demoted-subscriber rate-limited warning, server-declared depletion vs inferred zero balance, upsell suppression, free-tier-with-credits kept.
- `src/extensions/billing/tips.test.ts` — warning tone for rate-limited state, error tone reserved for `restrictedMode`.
- `src/extensions/rate-limit-notice.test.ts` (new) — local-time deadline, wait-bound remedy, generic subject, human-unit wait.
- `src/extensions/interactive-error-surface.test.ts` — pending state skipped past wait bound, set under it.
- `src/extensions/exploration-guard.test.ts` — failed turns excluded from no-tool streak, subagent abort deferred past failure.
- `src/extensions/session-name.test.ts` — shutdown awaits in-flight suggestion, exits immediately when none.
- `src/llm-gateway-error.test.ts` — deadline parsing (zoned/unzoned/trailing punctuation), local-time + wait formatting.
- `src/upstream-retry-patch.test.ts` — deadline wait, cancel, backoff handoff, wait-bound refusal, WeakMap deadline recall, upstream hook presence.
- `tests/e2e/tui/billing-warnings.test.ts` — depleted Coder plan reported as free tier shows rate-limit warning.

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed