### PR TITLE
Teleport syncs local settings

### DIFF
--- a/src/extensions/teleport/commands/attach.test.ts
+++ b/src/extensions/teleport/commands/attach.test.ts
@@ -1,7 +1,15 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { authMock, waitReadyMock, listSessionsMock, overlayMock, progressMock, progressInstances } = vi.hoisted(() => ({
+const {
+	authMock,
+	waitReadyMock,
+	listSessionsMock,
+	overlayMock,
+	progressMock,
+	progressInstances,
+	provisionHarnessConfigMock,
+} = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	waitReadyMock: vi.fn(),
 	listSessionsMock: vi.fn(),
@@ -14,6 +22,7 @@ const { authMock, waitReadyMock, listSessionsMock, overlayMock, progressMock, pr
 		stop: ReturnType<typeof vi.fn>
 		promptGitToken: ReturnType<typeof vi.fn>
 	}>,
+	provisionHarnessConfigMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
@@ -21,6 +30,9 @@ vi.mock("../../../sandbox/cloud/readiness.js", () => ({ waitForWorkspaceReady: w
 vi.mock("../../../sandbox/worker/client.js", () => ({ WorkerClient: class {} }))
 vi.mock("../../../sandbox/worker/sessions.js", () => ({ listSessions: listSessionsMock }))
 vi.mock("../overlay/overlay-component.js", () => ({ createTabsOverlay: overlayMock }))
+vi.mock("../provisioning/harness-config.js", () => ({
+	provisionHarnessConfig: provisionHarnessConfigMock,
+}))
 vi.mock("../ui/progress.js", () => ({
 	createTeleportProgress: (...args: unknown[]) => {
 		progressMock(...args)
@@ -115,6 +127,7 @@ beforeEach(() => {
 	}))
 	progressMock.mockReset()
 	progressInstances.length = 0
+	provisionHarnessConfigMock.mockReset().mockResolvedValue({ ok: true })
 })
 
 describe("runAttachSession", () => {
@@ -204,6 +217,16 @@ describe("runAttachSession", () => {
 
 		await runAttachSession({ workspaceId: "w-1", sessionName: "x" }, ctx)
 
+		expect(overlayMock).toHaveBeenCalledOnce()
+	})
+
+	it("does not sync harness config (config sync is teleport-only)", async () => {
+		listSessionsMock.mockResolvedValue([{ name: "x", agentMode: "PTY" }])
+		const { ctx } = makeCtx()
+
+		await runAttachSession({ workspaceId: "w-1", sessionName: "x" }, ctx)
+
+		expect(provisionHarnessConfigMock).not.toHaveBeenCalled()
 		expect(overlayMock).toHaveBeenCalledOnce()
 	})
 })

--- a/src/extensions/teleport/commands/sync.test.ts
+++ b/src/extensions/teleport/commands/sync.test.ts
@@ -1,9 +1,45 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+	authMock,
+	resolveWorkspaceRefMock,
+	runRsyncMock,
+	formatRsyncFailureMock,
+	provisionHarnessConfigMock,
+	whichRsyncMock,
+	rsyncInstallHintMock,
+} = vi.hoisted(() => ({
+	authMock: vi.fn(),
+	resolveWorkspaceRefMock: vi.fn(),
+	runRsyncMock: vi.fn(),
+	formatRsyncFailureMock: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
+	provisionHarnessConfigMock: vi.fn(),
+	whichRsyncMock: vi.fn(() => true),
+	rsyncInstallHintMock: vi.fn(() => "Install rsync"),
+}))
+
+vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
+vi.mock("./workspace-ref.js", () => ({ resolveWorkspaceRef: resolveWorkspaceRefMock }))
+vi.mock("../provisioning/rsync-runner.js", () => ({
+	runRsync: runRsyncMock,
+	formatRsyncFailure: formatRsyncFailureMock,
+}))
+vi.mock("../provisioning/harness-config.js", () => ({
+	provisionHarnessConfig: provisionHarnessConfigMock,
+}))
+vi.mock("../preflight/rsync.js", () => ({
+	whichRsync: whichRsyncMock,
+	rsyncInstallHint: rsyncInstallHintMock,
+}))
+
+import type { TeleportContext } from "../types.js"
 import type { SyncArgs } from "./args.js"
-import { resolveSyncPaths } from "./sync.js"
+import { TeleportRefusal } from "./errors.js"
+import { resolveSyncPaths, runSync } from "./sync.js"
 
 function syncArgs(overrides: Partial<SyncArgs>): SyncArgs {
 	return {
@@ -18,6 +54,61 @@ function syncArgs(overrides: Partial<SyncArgs>): SyncArgs {
 		...overrides,
 	}
 }
+
+const CREDS = {
+	connectToken: "tok-1",
+	expiresAt: "2030-01-01T00:00:00Z",
+	wsUrl: "wss://host.example",
+	host: "host.example",
+}
+
+function makeUi() {
+	return {
+		notify: vi.fn(),
+		setStatus: vi.fn(),
+		setWidget: vi.fn(),
+	} as unknown as ExtensionUIContext & {
+		notify: ReturnType<typeof vi.fn>
+		setStatus: ReturnType<typeof vi.fn>
+		setWidget: ReturnType<typeof vi.fn>
+	}
+}
+
+function makeCtx(over: Partial<TeleportContext> = {}): {
+	ctx: TeleportContext
+	ui: ReturnType<typeof makeUi>
+} {
+	const ui = makeUi()
+	const ctx: TeleportContext = {
+		apiKey: "test-key",
+		endpoint: "https://api.example.com",
+		cwd: "/work/proj",
+		ui,
+		signal: undefined,
+		...over,
+	}
+	return { ctx, ui }
+}
+
+let syncTempDir = ""
+
+beforeEach(() => {
+	syncTempDir = mkdtempSync(join(tmpdir(), "kimchi-sync-run-"))
+	writeFileSync(join(syncTempDir, "file.txt"), "hello", "utf-8")
+	authMock.mockReset().mockResolvedValue(CREDS)
+	resolveWorkspaceRefMock.mockReset().mockResolvedValue({ id: "ws-1", name: "my-ws" })
+	runRsyncMock.mockReset().mockResolvedValue({ totalBytes: 1024, durationMs: 500, fileCount: 3 })
+	formatRsyncFailureMock
+		.mockReset()
+		.mockImplementation((err: unknown) => (err instanceof Error ? err.message : String(err)))
+	provisionHarnessConfigMock.mockReset().mockResolvedValue({ ok: true })
+	whichRsyncMock.mockReset().mockReturnValue(true)
+	rsyncInstallHintMock.mockReset().mockReturnValue("Install rsync")
+})
+
+afterEach(() => {
+	if (syncTempDir) rmSync(syncTempDir, { recursive: true, force: true })
+})
 
 describe("resolveSyncPaths — up", () => {
 	let cwd: string
@@ -100,5 +191,52 @@ describe("resolveSyncPaths — down", () => {
 		const r = resolveSyncPaths(cwd, syncArgs({ direction: "down", source: "~/project/dist/", target: "./dist/" }))
 		expect(r.remotePath).toBe("/home/sandbox/project/dist/")
 		expect(r.isSourceDirectory).toBe(true)
+	})
+})
+
+describe("harness config sync", () => {
+	it("/sync up calls provisionHarnessConfig with resolved creds and signal after the workspace rsync", async () => {
+		const ac = new AbortController()
+		const { ctx } = makeCtx({ cwd: syncTempDir, signal: ac.signal })
+
+		await runSync("up --workspace my-ws --source file.txt --target /remote/path", ctx)
+
+		expect(runRsyncMock).toHaveBeenCalledOnce()
+		expect(runRsyncMock).toHaveBeenCalledBefore(provisionHarnessConfigMock)
+		expect(provisionHarnessConfigMock).toHaveBeenCalledOnce()
+		expect(provisionHarnessConfigMock.mock.calls[0][0]).toMatchObject({
+			remoteHost: "host.example",
+			authToken: "tok-1",
+			signal: ac.signal,
+		})
+	})
+
+	it("/sync down does NOT call provisionHarnessConfig", async () => {
+		const { ctx } = makeCtx({ cwd: syncTempDir })
+
+		await runSync("down --workspace my-ws --source /remote/path --target file.txt", ctx)
+
+		expect(runRsyncMock).toHaveBeenCalledOnce()
+		expect(provisionHarnessConfigMock).not.toHaveBeenCalled()
+	})
+
+	it("/sync up --dry-run does NOT call provisionHarnessConfig", async () => {
+		const { ctx } = makeCtx({ cwd: syncTempDir })
+
+		await runSync("up --workspace my-ws --source file.txt --target /remote/path --dry-run", ctx)
+
+		expect(runRsyncMock).toHaveBeenCalledOnce()
+		expect(provisionHarnessConfigMock).not.toHaveBeenCalled()
+	})
+
+	it("refuses when provisionHarnessConfig returns ok: false", async () => {
+		provisionHarnessConfigMock.mockResolvedValueOnce({ ok: false, error: "boom" })
+		const { ctx, ui } = makeCtx({ cwd: syncTempDir })
+
+		await expect(runSync("up --workspace my-ws --source file.txt --target /remote/path", ctx)).rejects.toBeInstanceOf(
+			TeleportRefusal,
+		)
+		expect(provisionHarnessConfigMock).toHaveBeenCalledOnce()
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Could not sync harness config: boom"), "error")
 	})
 })

--- a/src/extensions/teleport/commands/sync.ts
+++ b/src/extensions/teleport/commands/sync.ts
@@ -5,6 +5,7 @@ import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
 import { rsyncInstallHint, whichRsync } from "../preflight/rsync.js"
 import { SANDBOX_HOME, SANDBOX_USER } from "../provisioning/constants.js"
+import { provisionHarnessConfig } from "../provisioning/harness-config.js"
 import { formatRsyncFailure, runRsync } from "../provisioning/rsync-runner.js"
 import type { TeleportContext } from "../types.js"
 import { formatBytes } from "../ui/format-bytes.js"
@@ -82,6 +83,18 @@ export async function runSync(rawArgs: string, ctx: TeleportContext): Promise<vo
 			info(ctx, `${prefix}: ${result.fileCount} file(s), ${kb} KB in ${sec}s.`)
 		} catch (err) {
 			refuse(ctx, `rsync failed: ${formatRsyncFailure(err)}`)
+		}
+
+		if (args.direction === "up" && !args.dryRun) {
+			progress.setPhase("Syncing harness config…")
+			const configResult = await provisionHarnessConfig({
+				remoteHost: creds.host,
+				authToken: creds.connectToken,
+				signal: ctx.signal,
+			})
+			if (!configResult.ok) {
+				refuse(ctx, `Could not sync harness config: ${configResult.error}`)
+			}
 		}
 	} finally {
 		progress.stop()

--- a/src/extensions/teleport/commands/sync.ts
+++ b/src/extensions/teleport/commands/sync.ts
@@ -85,6 +85,8 @@ export async function runSync(rawArgs: string, ctx: TeleportContext): Promise<vo
 			refuse(ctx, `rsync failed: ${formatRsyncFailure(err)}`)
 		}
 
+		// Fatal here (vs warn-and-continue in /teleport): /sync is an explicit user
+		// action where a config-sync failure should be surfaced clearly, not silent.
 		if (args.direction === "up" && !args.dryRun) {
 			progress.setPhase("Syncing harness config…")
 			const configResult = await provisionHarnessConfig({

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -24,6 +24,7 @@ const {
 	readLocalGitConfigMock,
 	provisionGitIdentityMock,
 	provisionGitCredentialMock,
+	provisionHarnessConfigMock,
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	waitReadyMock: vi.fn(),
@@ -52,6 +53,7 @@ const {
 	readLocalGitConfigMock: vi.fn(),
 	provisionGitIdentityMock: vi.fn(),
 	provisionGitCredentialMock: vi.fn(),
+	provisionHarnessConfigMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
@@ -80,6 +82,9 @@ vi.mock("../../../config.js", () => ({
 vi.mock("../provisioning/git-provision.js", () => ({
 	provisionGitIdentity: provisionGitIdentityMock,
 	provisionGitCredential: provisionGitCredentialMock,
+}))
+vi.mock("../provisioning/harness-config.js", () => ({
+	provisionHarnessConfig: provisionHarnessConfigMock,
 }))
 vi.mock("../ui/progress.js", () => ({
 	createTeleportProgress: (...args: unknown[]) => {
@@ -195,6 +200,7 @@ beforeEach(() => {
 	readLocalGitConfigMock.mockReset().mockResolvedValue({})
 	provisionGitIdentityMock.mockReset().mockResolvedValue(undefined)
 	provisionGitCredentialMock.mockReset().mockResolvedValue(undefined)
+	provisionHarnessConfigMock.mockReset().mockResolvedValue({ ok: true })
 })
 
 afterEach(() => {
@@ -424,6 +430,52 @@ describe("runTeleport", () => {
 		expect(createSessionMock).toHaveBeenCalledOnce()
 		const sessionName = createSessionMock.mock.calls[0][1] as string
 		expect(sessionName).toMatch(/^pty-[0-9a-f]{8}$/)
+	})
+
+	describe("harness config sync", () => {
+		it("calls provisionHarnessConfig with the resolved creds and completes the teleport", async () => {
+			const { ctx, ui } = makeCtx()
+
+			await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+			expect(provisionHarnessConfigMock).toHaveBeenCalledOnce()
+			expect(provisionHarnessConfigMock.mock.calls[0][0]).toMatchObject({
+				remoteHost: CREDS.host,
+				authToken: CREDS.connectToken,
+			})
+			// Teleport still completes — overlay opens, no warning emitted.
+			expect(ui.custom).toHaveBeenCalledOnce()
+			expect(ui.notify).not.toHaveBeenCalledWith(expect.stringMatching(/Could not sync harness config/), "warning")
+		})
+
+		it("syncs harness config even when workspace rsync is skipped (non-git cwd)", async () => {
+			// cwd /work/proj is not a git repo, so shouldRsyncWorkspace is false
+			// and the workspace runRsync is never invoked — but config sync must
+			// still run. Pins the invariant that config sync is not gated behind
+			// shouldRsyncWorkspace.
+			const { ctx, ui } = makeCtx()
+
+			await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+			expect(provisionHarnessConfigMock).toHaveBeenCalledOnce()
+			expect(ui.custom).toHaveBeenCalledOnce()
+		})
+
+		it("warns but continues when config sync fails", async () => {
+			provisionHarnessConfigMock.mockResolvedValueOnce({ ok: false, error: "boom" })
+			const { ctx, ui } = makeCtx()
+
+			await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+			expect(provisionHarnessConfigMock).toHaveBeenCalledOnce()
+			expect(ui.notify).toHaveBeenCalledWith(
+				expect.stringContaining("Could not sync harness config to sandbox: boom"),
+				"warning",
+			)
+			// Teleport still completes — overlay opens, session created.
+			expect(createSessionMock).toHaveBeenCalledOnce()
+			expect(ui.custom).toHaveBeenCalledOnce()
+		})
 	})
 
 	describe("git provisioning", () => {

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -16,6 +16,7 @@ import { SIZE_REFUSE_BYTES, SIZE_WARN_BYTES } from "../preflight/workspace-size.
 import { SANDBOX_USER } from "../provisioning/constants.js"
 import { sumIncludeListBytes } from "../provisioning/estimate-bytes.js"
 import { provisionGitCredential, provisionGitIdentity } from "../provisioning/git-provision.js"
+import { provisionHarnessConfig } from "../provisioning/harness-config.js"
 import { buildIncludeList } from "../provisioning/include-list.js"
 import { deriveSandboxDest, deriveSandboxDestFromRepoUrl, repoBasename } from "../provisioning/paths.js"
 import { formatRsyncFailure, runRsync } from "../provisioning/rsync-runner.js"
@@ -234,10 +235,24 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 			throw new ListFailure(err instanceof Error ? err.message : String(err))
 		})
 
+		// Harness config sync runs in parallel with the rest of the fan-out —
+		// it's a tiny rsync of ~/.config/kimchi/harness/ and never blocks the
+		// teleport. Failures warn but don't abort (config sync is a nicety, not
+		// a requirement for the session to function).
+		const configSyncP = provisionHarnessConfig({
+			remoteHost: creds.host,
+			authToken: creds.connectToken,
+			signal,
+		}).then((result) => {
+			if (!result.ok && !signal.aborted) {
+				warn(ctx, `Could not sync harness config to sandbox: ${result.error}`)
+			}
+		})
+
 		let existing: Awaited<ReturnType<typeof listSessions>>
 		try {
-			const settled = await Promise.all([identityP, credsPropP, rsyncP, listP])
-			existing = settled[3]
+			const settled = await Promise.all([identityP, credsPropP, rsyncP, configSyncP, listP])
+			existing = settled[4] // listP is now index 4 (was 3)
 		} catch (err) {
 			if (signal.aborted) throw err
 			if (err instanceof SyncFailure) refuse(ctx, `Workspace sync failed: ${err.message}`)

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -239,21 +239,26 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 		// it's a tiny rsync of ~/.config/kimchi/harness/ and never blocks the
 		// teleport. Failures warn but don't abort (config sync is a nicety, not
 		// a requirement for the session to function).
+		// Guard so a late configSyncP .then can't emit a spurious warn() after
+		// the command already refused via the catch below (configSyncP races the
+		// other fan-out promises; if Promise.all rejects first on another failure,
+		// this .then may still fire afterward).
+		let commandFailed = false
 		const configSyncP = provisionHarnessConfig({
 			remoteHost: creds.host,
 			authToken: creds.connectToken,
 			signal,
 		}).then((result) => {
-			if (!result.ok && !signal.aborted) {
+			if (!result.ok && !signal.aborted && !commandFailed) {
 				warn(ctx, `Could not sync harness config to sandbox: ${result.error}`)
 			}
 		})
 
 		let existing: Awaited<ReturnType<typeof listSessions>>
 		try {
-			const settled = await Promise.all([identityP, credsPropP, rsyncP, configSyncP, listP])
-			existing = settled[4] // listP is now index 4 (was 3)
+			;[, , , , existing] = await Promise.all([identityP, credsPropP, rsyncP, configSyncP, listP])
 		} catch (err) {
+			commandFailed = true
 			if (signal.aborted) throw err
 			if (err instanceof SyncFailure) refuse(ctx, `Workspace sync failed: ${err.message}`)
 			if (err instanceof ListFailure) refuse(ctx, `Could not list sessions: ${err.message}`)

--- a/src/extensions/teleport/provisioning/harness-config.test.ts
+++ b/src/extensions/teleport/provisioning/harness-config.test.ts
@@ -41,7 +41,7 @@ describe("provisionHarnessConfig", () => {
 
 		expect(mockedRunRsync).toHaveBeenCalledTimes(1)
 		expect(mockedRunRsync).toHaveBeenCalledWith({
-			localPath: MOCK_CONFIG_DIR,
+			localPath: `${MOCK_CONFIG_DIR}/`,
 			remotePath: REMOTE_HARNESS_CONFIG_DIR,
 			isSourceDirectory: true,
 			remoteHost: "session-host.example.com",

--- a/src/extensions/teleport/provisioning/harness-config.test.ts
+++ b/src/extensions/teleport/provisioning/harness-config.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../../config.js", () => ({
 
 import { SANDBOX_USER } from "./constants.js"
 // Import after mocks are registered so the mocked modules are wired in.
-import { HARNESS_CONFIG_EXCLUDES, provisionHarnessConfig, REMOTE_HARNESS_CONFIG_DIR } from "./harness-config.js"
+import { HARNESS_CONFIG_ALLOWLIST, provisionHarnessConfig, REMOTE_HARNESS_CONFIG_DIR } from "./harness-config.js"
 import { runRsync } from "./rsync-runner.js"
 
 const mockedRunRsync = vi.mocked(runRsync)
@@ -47,8 +47,7 @@ describe("provisionHarnessConfig", () => {
 			remoteHost: "session-host.example.com",
 			remoteUser: SANDBOX_USER,
 			authToken: "tok-123",
-			excludeGlobs: [...HARNESS_CONFIG_EXCLUDES],
-			gitignoredPaths: [],
+			filesFrom: [...HARNESS_CONFIG_ALLOWLIST],
 			deleteExtraneous: false,
 			signal,
 		})
@@ -81,47 +80,8 @@ describe("provisionHarnessConfig", () => {
 	})
 })
 
-describe("HARNESS_CONFIG_EXCLUDES", () => {
-	it("contains all sensitive/runtime entries", () => {
-		const required = [
-			"auth.json",
-			"mcp.json",
-			"mcp-cache.json",
-			"models.json",
-			"skills/",
-			"sessions/",
-			"ferment-locks/",
-			"git/",
-			"bin/",
-			"rtk/",
-			"trust.json",
-			"auto-update.json",
-			".curator_state.json",
-			".usage.json",
-			".usage.json.lock",
-		]
-		for (const entry of required) {
-			expect(HARNESS_CONFIG_EXCLUDES).toContain(entry)
-		}
-	})
-
-	it("matches the exact ordered list", () => {
-		expect([...HARNESS_CONFIG_EXCLUDES]).toEqual([
-			"auth.json",
-			"mcp.json",
-			"mcp-cache.json",
-			"models.json",
-			"skills/",
-			"sessions/",
-			"ferment-locks/",
-			"git/",
-			"bin/",
-			"rtk/",
-			"trust.json",
-			"auto-update.json",
-			".curator_state.json",
-			".usage.json",
-			".usage.json.lock",
-		])
+describe("HARNESS_CONFIG_ALLOWLIST", () => {
+	it("contains exactly the safe harness config entries", () => {
+		expect([...HARNESS_CONFIG_ALLOWLIST]).toEqual(["settings.json", "keybindings.json", "themes"])
 	})
 })

--- a/src/extensions/teleport/provisioning/harness-config.test.ts
+++ b/src/extensions/teleport/provisioning/harness-config.test.ts
@@ -81,7 +81,7 @@ describe("provisionHarnessConfig", () => {
 })
 
 describe("HARNESS_CONFIG_ALLOWLIST", () => {
-	it("contains exactly the safe harness config entries", () => {
-		expect([...HARNESS_CONFIG_ALLOWLIST]).toEqual(["settings.json", "keybindings.json", "themes"])
+	it("contains exactly the synced harness config entries", () => {
+		expect([...HARNESS_CONFIG_ALLOWLIST]).toEqual(["settings.json", "keybindings.json", "themes", "models.json"])
 	})
 })

--- a/src/extensions/teleport/provisioning/harness-config.test.ts
+++ b/src/extensions/teleport/provisioning/harness-config.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest"
+import { formatRsyncFailure, RsyncError } from "./rsync-runner.js"
+
+// Mock runRsync so tests never invoke rsync. formatRsyncFailure is kept real
+// so we can assert the exact error string the helper produces.
+vi.mock("./rsync-runner.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./rsync-runner.js")>()
+	return {
+		...actual,
+		runRsync: vi.fn(),
+	}
+})
+
+// Mock the config dir so getAgentConfigDir returns a fixed path.
+const MOCK_CONFIG_DIR = "/home/test/.config/kimchi/harness"
+vi.mock("../../../config.js", () => ({
+	getAgentConfigDir: () => MOCK_CONFIG_DIR,
+}))
+
+import { SANDBOX_USER } from "./constants.js"
+// Import after mocks are registered so the mocked modules are wired in.
+import { HARNESS_CONFIG_EXCLUDES, provisionHarnessConfig, REMOTE_HARNESS_CONFIG_DIR } from "./harness-config.js"
+import { runRsync } from "./rsync-runner.js"
+
+const mockedRunRsync = vi.mocked(runRsync)
+
+function baseArgs(overrides: Partial<{ remoteHost: string; authToken: string; signal: AbortSignal }> = {}) {
+	return {
+		remoteHost: "session-host.example.com",
+		authToken: "tok-123",
+		...overrides,
+	}
+}
+
+describe("provisionHarnessConfig", () => {
+	it("calls runRsync with the correct options", async () => {
+		mockedRunRsync.mockResolvedValueOnce({ fileCount: 0, totalBytes: 0, durationMs: 0 })
+		const signal = new AbortController().signal
+
+		await provisionHarnessConfig(baseArgs({ signal }))
+
+		expect(mockedRunRsync).toHaveBeenCalledTimes(1)
+		expect(mockedRunRsync).toHaveBeenCalledWith({
+			localPath: MOCK_CONFIG_DIR,
+			remotePath: REMOTE_HARNESS_CONFIG_DIR,
+			isSourceDirectory: true,
+			remoteHost: "session-host.example.com",
+			remoteUser: SANDBOX_USER,
+			authToken: "tok-123",
+			excludeGlobs: [...HARNESS_CONFIG_EXCLUDES],
+			gitignoredPaths: [],
+			deleteExtraneous: false,
+			signal,
+		})
+	})
+
+	it("returns { ok: true } on success", async () => {
+		mockedRunRsync.mockResolvedValueOnce({ fileCount: 3, totalBytes: 1024, durationMs: 50 })
+		const result = await provisionHarnessConfig(baseArgs())
+		expect(result).toEqual({ ok: true })
+	})
+
+	it("returns { ok: false, error } on rsync failure without throwing", async () => {
+		const err = new RsyncError(23, "rsync: link_stat failed")
+		mockedRunRsync.mockRejectedValueOnce(err)
+
+		const result = await provisionHarnessConfig(baseArgs())
+
+		expect(result.ok).toBe(false)
+		expect(result.error).toBe(formatRsyncFailure(err))
+		expect(result.error).toContain("rsync exited with code 23")
+	})
+
+	it("re-throws when the signal is already aborted", async () => {
+		const err = new RsyncError(143, "")
+		mockedRunRsync.mockRejectedValueOnce(err)
+		const controller = new AbortController()
+		controller.abort()
+
+		await expect(provisionHarnessConfig(baseArgs({ signal: controller.signal }))).rejects.toBe(err)
+	})
+})
+
+describe("HARNESS_CONFIG_EXCLUDES", () => {
+	it("contains all sensitive/runtime entries", () => {
+		const required = [
+			"auth.json",
+			"mcp.json",
+			"mcp-cache.json",
+			"models.json",
+			"skills/",
+			"sessions/",
+			"ferment-locks/",
+			"git/",
+			"bin/",
+			"rtk/",
+			"trust.json",
+			"auto-update.json",
+			".curator_state.json",
+			".usage.json",
+			".usage.json.lock",
+		]
+		for (const entry of required) {
+			expect(HARNESS_CONFIG_EXCLUDES).toContain(entry)
+		}
+	})
+
+	it("matches the exact ordered list", () => {
+		expect([...HARNESS_CONFIG_EXCLUDES]).toEqual([
+			"auth.json",
+			"mcp.json",
+			"mcp-cache.json",
+			"models.json",
+			"skills/",
+			"sessions/",
+			"ferment-locks/",
+			"git/",
+			"bin/",
+			"rtk/",
+			"trust.json",
+			"auto-update.json",
+			".curator_state.json",
+			".usage.json",
+			".usage.json.lock",
+		])
+	})
+})

--- a/src/extensions/teleport/provisioning/harness-config.ts
+++ b/src/extensions/teleport/provisioning/harness-config.ts
@@ -2,29 +2,10 @@ import { getAgentConfigDir } from "../../../config.js"
 import { SANDBOX_HOME, SANDBOX_USER } from "./constants.js"
 import { formatRsyncFailure, runRsync } from "./rsync-runner.js"
 
-/**
- * Exclude patterns for the harness config rsync. Applied on top of
- * BASE_EXCLUDE_GLOBS from rsync-runner (which already excludes .env,
- * .DS_Store, node_modules, etc.). These are the harness-specific files
- * that are either secret, runtime state, or machine-specific.
- */
-export const HARNESS_CONFIG_EXCLUDES: readonly string[] = [
-	"auth.json",
-	"mcp.json",
-	"mcp-cache.json",
-	"models.json",
-	"skills/",
-	"sessions/",
-	"ferment-locks/",
-	"git/",
-	"bin/",
-	"rtk/",
-	"trust.json",
-	"auto-update.json",
-	".curator_state.json",
-	".usage.json",
-	".usage.json.lock",
-]
+/** Allowlist — only these transfer. --files-from is case-sensitive, so a
+ * hypothetical Auth.json can't bypass this the way it would a lowercase
+ * denylist. New secret files are safe by default. */
+export const HARNESS_CONFIG_ALLOWLIST: readonly string[] = ["settings.json", "keybindings.json", "themes"]
 
 /** Remote destination for harness config: ~/.config/kimchi/harness/ (derived from SANDBOX_HOME). */
 export const REMOTE_HARNESS_CONFIG_DIR = `${SANDBOX_HOME}/.config/kimchi/harness`
@@ -37,8 +18,9 @@ export interface ProvisionHarnessConfigResult {
 /**
  * Sync the user's harness config (~/.config/kimchi/harness/) to the remote
  * sandbox. Only safe, non-secret files are transferred (settings.json,
- * keybindings.json, themes/). Sensitive files are excluded via
- * HARNESS_CONFIG_EXCLUDES.
+ * keybindings.json, themes/). Everything else — including auth.json,
+ * mcp.json, models.json, and any future secret file — is implicitly
+ * excluded.
  *
  * Runs with deleteExtraneous=false so remote-only files (auth.json, mcp.json
  * created by the remote) are preserved — we overwrite synced files but don't
@@ -67,8 +49,7 @@ export async function provisionHarnessConfig(args: {
 			remoteHost: args.remoteHost,
 			remoteUser: SANDBOX_USER,
 			authToken: args.authToken,
-			excludeGlobs: [...HARNESS_CONFIG_EXCLUDES],
-			gitignoredPaths: [],
+			filesFrom: [...HARNESS_CONFIG_ALLOWLIST],
 			deleteExtraneous: false,
 			signal: args.signal,
 		})

--- a/src/extensions/teleport/provisioning/harness-config.ts
+++ b/src/extensions/teleport/provisioning/harness-config.ts
@@ -56,7 +56,12 @@ export async function provisionHarnessConfig(args: {
 	const localConfigDir = getAgentConfigDir()
 	try {
 		await runRsync({
-			localPath: localConfigDir,
+			// Trailing slash is load-bearing: without it rsync copies the `harness`
+			// directory *into* the remote `harness` dir (which mkdir just created),
+			// nesting it as .../harness/harness/settings.json instead of
+			// .../harness/settings.json. The trailing slash copies the dir's
+			// *contents* into the dest.
+			localPath: `${localConfigDir}/`,
 			remotePath: REMOTE_HARNESS_CONFIG_DIR,
 			isSourceDirectory: true,
 			remoteHost: args.remoteHost,

--- a/src/extensions/teleport/provisioning/harness-config.ts
+++ b/src/extensions/teleport/provisioning/harness-config.ts
@@ -1,0 +1,75 @@
+import { getAgentConfigDir } from "../../../config.js"
+import { SANDBOX_HOME, SANDBOX_USER } from "./constants.js"
+import { formatRsyncFailure, runRsync } from "./rsync-runner.js"
+
+/**
+ * Exclude patterns for the harness config rsync. Applied on top of
+ * BASE_EXCLUDE_GLOBS from rsync-runner (which already excludes .env,
+ * .DS_Store, node_modules, etc.). These are the harness-specific files
+ * that are either secret, runtime state, or machine-specific.
+ */
+export const HARNESS_CONFIG_EXCLUDES: readonly string[] = [
+	"auth.json",
+	"mcp.json",
+	"mcp-cache.json",
+	"models.json",
+	"skills/",
+	"sessions/",
+	"ferment-locks/",
+	"git/",
+	"bin/",
+	"rtk/",
+	"trust.json",
+	"auto-update.json",
+	".curator_state.json",
+	".usage.json",
+	".usage.json.lock",
+]
+
+/** Remote destination for harness config: ~/.config/kimchi/harness/ (derived from SANDBOX_HOME). */
+export const REMOTE_HARNESS_CONFIG_DIR = `${SANDBOX_HOME}/.config/kimchi/harness`
+
+export interface ProvisionHarnessConfigResult {
+	ok: boolean
+	error?: string
+}
+
+/**
+ * Sync the user's harness config (~/.config/kimchi/harness/) to the remote
+ * sandbox. Only safe, non-secret files are transferred (settings.json,
+ * keybindings.json, themes/). Sensitive files are excluded via
+ * HARNESS_CONFIG_EXCLUDES.
+ *
+ * Runs with deleteExtraneous=false so remote-only files (auth.json, mcp.json
+ * created by the remote) are preserved — we overwrite synced files but don't
+ * wipe the remote's own state.
+ *
+ * Failures are non-fatal: the caller decides whether to warn or refuse.
+ * On abort (signal already aborted), re-throws so the caller's cancellation
+ * path handles it.
+ */
+export async function provisionHarnessConfig(args: {
+	remoteHost: string
+	authToken: string
+	signal?: AbortSignal
+}): Promise<ProvisionHarnessConfigResult> {
+	const localConfigDir = getAgentConfigDir()
+	try {
+		await runRsync({
+			localPath: localConfigDir,
+			remotePath: REMOTE_HARNESS_CONFIG_DIR,
+			isSourceDirectory: true,
+			remoteHost: args.remoteHost,
+			remoteUser: SANDBOX_USER,
+			authToken: args.authToken,
+			excludeGlobs: [...HARNESS_CONFIG_EXCLUDES],
+			gitignoredPaths: [],
+			deleteExtraneous: false,
+			signal: args.signal,
+		})
+		return { ok: true }
+	} catch (err) {
+		if (args.signal?.aborted) throw err
+		return { ok: false, error: formatRsyncFailure(err) }
+	}
+}

--- a/src/extensions/teleport/provisioning/harness-config.ts
+++ b/src/extensions/teleport/provisioning/harness-config.ts
@@ -4,8 +4,17 @@ import { formatRsyncFailure, runRsync } from "./rsync-runner.js"
 
 /** Allowlist — only these transfer. --files-from is case-sensitive, so a
  * hypothetical Auth.json can't bypass this the way it would a lowercase
- * denylist. New secret files are safe by default. */
-export const HARNESS_CONFIG_ALLOWLIST: readonly string[] = ["settings.json", "keybindings.json", "themes"]
+ * denylist. New secret files are safe by default.
+ *
+ * NOTE: models.json may carry provider `apiKey` fields. Syncing it verbatim
+ * is an accepted trade-off: those keys land on the remote sandbox the user
+ * owns. auth.json / mcp.json (OAuth + MCP tokens) stay excluded. */
+export const HARNESS_CONFIG_ALLOWLIST: readonly string[] = [
+	"settings.json",
+	"keybindings.json",
+	"themes",
+	"models.json",
+]
 
 /** Remote destination for harness config: ~/.config/kimchi/harness/ (derived from SANDBOX_HOME). */
 export const REMOTE_HARNESS_CONFIG_DIR = `${SANDBOX_HOME}/.config/kimchi/harness`
@@ -17,10 +26,10 @@ export interface ProvisionHarnessConfigResult {
 
 /**
  * Sync the user's harness config (~/.config/kimchi/harness/) to the remote
- * sandbox. Only safe, non-secret files are transferred (settings.json,
- * keybindings.json, themes/). Everything else — including auth.json,
- * mcp.json, models.json, and any future secret file — is implicitly
- * excluded.
+ * sandbox. Only allowlisted files transfer (settings.json, keybindings.json,
+ * themes/, models.json). auth.json and mcp.json (OAuth + MCP tokens) and any
+ * future secret file are implicitly excluded. models.json may carry provider
+ * apiKey fields — see HARNESS_CONFIG_ALLOWLIST note.
  *
  * Runs with deleteExtraneous=false so remote-only files (auth.json, mcp.json
  * created by the remote) are preserved — we overwrite synced files but don't


### PR DESCRIPTION
## Linked issue

Closes #968

## What does this PR do?

Adds automatic harness-config sync to the remote sandbox so all kimchi harness settings (model roles, theme, keybindings, retry config, packages) are the same in a teleported session as they are locally — no manual re-configuration after teleport.                                                                                                           
                                                                                                                                                                                    
New helper: provisionHarnessConfig rsyncs `~/.config/kimchi/harness/` to `/home/sandbox/.config/kimchi/harness` on the sandbox via an explicit allowlist (settings.json, keybindings.json, themes) using rsync --files-from.                                                       
                                                                                                                                                                                    
 Wired into two places via the shared helper:                                                                                                                                       
 - `/teleport` — runs in the parallel fan-out alongside workspace rsync, git identity/credentials, and session listing. Failure warns but does not abort the teleport (config sync is a nicety, not a requirement for the session to function).                                                                                                                        
 - `/sync up` (non-dry-run) — runs after the workspace rsync completes. Failure is fatal (refuse()), matching how workspace rsync failures are treated.                               
                                                                                                                                                                                    
 /sync down and /attach do not sync config — local is the source of truth and config never flows remote→local.                                                                      
                                                                                                                                                                                   
## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
