### PR TITLE
fix: prevent infinite agent loop on non-retryable provider errors

### DIFF
--- a/src/extensions/error-preservation.test.ts
+++ b/src/extensions/error-preservation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { getRawErrorMessage, preserveRawErrorMessage } from "./error-preservation.js"
+
+describe("preserveRawErrorMessage", () => {
+	it("preserves the original errorMessage before mutation", () => {
+		const message = { errorMessage: "InternalServerError: Hosted_vllmException - Cannot connect to host" }
+		preserveRawErrorMessage(message)
+		message.errorMessage = "Retrying…"
+		expect(getRawErrorMessage(message)).toBe("InternalServerError: Hosted_vllmException - Cannot connect to host")
+	})
+
+	it("does not overwrite a previously preserved value", () => {
+		const message = { errorMessage: "original error" }
+		preserveRawErrorMessage(message)
+		message.errorMessage = "Retrying…"
+		preserveRawErrorMessage(message) // should be a no-op
+		message.errorMessage = "Retrying… again"
+		expect(getRawErrorMessage(message)).toBe("original error")
+	})
+
+	it("is a no-op when errorMessage is absent", () => {
+		const message = {}
+		preserveRawErrorMessage(message)
+		expect(getRawErrorMessage(message)).toBeUndefined()
+	})
+
+	it("is a no-op when errorMessage is empty", () => {
+		const message = { errorMessage: "" }
+		preserveRawErrorMessage(message)
+		expect(getRawErrorMessage(message)).toBe("")
+	})
+
+	it("stores the value as non-enumerable (not visible in serialization)", () => {
+		const message = { errorMessage: "secret internal error" }
+		preserveRawErrorMessage(message)
+		message.errorMessage = "Retrying…"
+		// JSON.stringify should not include the preserved value
+		expect(JSON.stringify(message)).not.toContain("secret internal error")
+		expect(JSON.stringify(message)).toContain("Retrying…")
+		// Object.keys should not include the symbol
+		expect(Object.keys(message)).toEqual(["errorMessage"])
+	})
+
+	it("falls back to current errorMessage when nothing was preserved", () => {
+		const message = { errorMessage: "current error" }
+		expect(getRawErrorMessage(message)).toBe("current error")
+	})
+
+	it("falls back to current errorMessage after mutation when nothing was preserved", () => {
+		const message = { errorMessage: "original" }
+		message.errorMessage = "mutated"
+		expect(getRawErrorMessage(message)).toBe("mutated")
+	})
+})

--- a/src/extensions/error-preservation.ts
+++ b/src/extensions/error-preservation.ts
@@ -1,0 +1,46 @@
+/**
+ * Preserve the original provider error message on an assistant message before
+ * it is mutated for display purposes (e.g. replaced with "Retrying…").
+ *
+ * The upstream retry classifier (`_isRetryableError`) runs in
+ * `_handlePostAgentRun`, which fires AFTER `message_end` extensions. If an
+ * extension mutates `message.errorMessage` before the classifier reads it,
+ * the classifier sees the display placeholder instead of the raw error and
+ * fails to identify retryable errors — causing retries to silently stop.
+ *
+ * The preserved value is stored as a non-enumerable symbol property so it
+ * never appears in serialized output or LLM context.
+ */
+
+const RAW_ERROR_SYMBOL = Symbol("rawErrorMessage")
+
+/** Message shape that has an optional `errorMessage` string. */
+interface ErrorMessageHolder {
+	errorMessage?: string
+}
+
+/**
+ * Store the current `errorMessage` on the message object before it is
+ * mutated. Safe to call multiple times — only the first call preserves
+ * (subsequent calls see the mutated value and are no-ops because the symbol
+ * is already set).
+ */
+export function preserveRawErrorMessage(message: ErrorMessageHolder): void {
+	if (message.errorMessage && !(RAW_ERROR_SYMBOL in message)) {
+		Object.defineProperty(message, RAW_ERROR_SYMBOL, {
+			value: message.errorMessage,
+			enumerable: false,
+			writable: false,
+			configurable: false,
+		})
+	}
+}
+
+/**
+ * Return the original (pre-mutation) error message if one was preserved,
+ * otherwise fall back to the current `errorMessage`.
+ */
+export function getRawErrorMessage(message: ErrorMessageHolder): string | undefined {
+	const preserved = (message as Record<symbol, unknown>)[RAW_ERROR_SYMBOL]
+	return (typeof preserved === "string" ? preserved : undefined) ?? message.errorMessage
+}

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -553,7 +553,7 @@ describe("bash tool classification", () => {
 	})
 })
 
-	describe("STEER_MESSAGE_TYPE", () => {
+describe("STEER_MESSAGE_TYPE", () => {
 	it("has a stable custom type string", () => {
 		expect(STEER_MESSAGE_TYPE).toBe("exploration-guard-steer")
 	})

--- a/src/extensions/exploration-guard.test.ts
+++ b/src/extensions/exploration-guard.test.ts
@@ -553,9 +553,54 @@ describe("bash tool classification", () => {
 	})
 })
 
-describe("STEER_MESSAGE_TYPE", () => {
+	describe("STEER_MESSAGE_TYPE", () => {
 	it("has a stable custom type string", () => {
 		expect(STEER_MESSAGE_TYPE).toBe("exploration-guard-steer")
+	})
+})
+
+describe("Provider error suppression", () => {
+	// Provider errors (e.g. content_filter, budget exhausted) produce empty
+	// responses with no tool calls. Without this guard the no-tool counter
+	// increments on every error response, triggering steer messages that
+	// re-queue into the agent loop and cause infinite retries until budget
+	// is exhausted.
+
+	it("does not increment no-tool counter on an error turn", () => {
+		const guard = createGuard()
+		guard.turnStart()
+		guard.turnEnd(() => {}, true) // isError = true
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("does not fire steers on consecutive error turns", () => {
+		const guard = createGuard()
+		const steers: string[] = []
+		for (let i = 0; i < 10; i++) {
+			guard.turnStart()
+			guard.turnEnd((text) => steers.push(text), true)
+		}
+		expect(steers).toHaveLength(0)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(0)
+	})
+
+	it("does not reset the no-tool counter on error turns", () => {
+		// An error turn should be neutral — it should not reset an existing
+		// no-tool streak (that would hide real stalls) nor increment it.
+		const guard = createGuard()
+		simulateNoToolTurn(guard)
+		simulateNoToolTurn(guard)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+		guard.turnStart()
+		guard.turnEnd(() => {}, true)
+		expect(guard.getConsecutiveNoToolTurns()).toBe(2)
+	})
+
+	it("defaults to non-error when isError is omitted", () => {
+		const guard = createGuard()
+		guard.turnStart()
+		guard.turnEnd(() => {})
+		expect(guard.getConsecutiveNoToolTurns()).toBe(1)
 	})
 })
 

--- a/src/extensions/exploration-guard.ts
+++ b/src/extensions/exploration-guard.ts
@@ -133,7 +133,7 @@ export class ExplorationGuard {
 		}
 	}
 
-	turnEnd(sendSteer: (text: string) => void): void {
+	turnEnd(sendSteer: (text: string) => void, isError = false): void {
 		if (!this.isEnabled()) {
 			// Reset both streaks while the guard is suppressed so they don't
 			// fire immediately when it becomes re-enabled (e.g. after scoping).
@@ -141,6 +141,13 @@ export class ExplorationGuard {
 			this.consecutiveNoToolTurns = 0
 			return
 		}
+
+		// Provider errors (e.g. content_filter, budget exhausted) produce empty
+		// responses with no tool calls. Without this guard the no-tool counter
+		// increments on every error response, triggering steer messages that
+		// re-queue into the agent loop and cause infinite retries until budget
+		// is exhausted.
+		if (isError) return
 
 		// No-tool turn: the model produced a response without calling any tools.
 		// Track separately from the read-only streak. Do NOT reset
@@ -270,7 +277,7 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 		return { block: false }
 	})
 
-	pi.on("turn_end", () => {
+	pi.on("turn_end", (event) => {
 		// If a subagent abort is pending, fire it NOW before processing the
 		// steer. The subagent already received the summary-request steer last
 		// turn; whatever it produced this turn becomes the orchestrator output.
@@ -278,6 +285,8 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 			ctx?.abort()
 			return
 		}
+
+		const isError = event.message.role === "assistant" && event.message.stopReason === "error"
 
 		guard.turnEnd((text) => {
 			pi.sendMessage(
@@ -288,6 +297,6 @@ export default function explorationGuardExtension(pi: ExtensionAPI, options?: Ex
 				},
 				{ deliverAs: "steer" },
 			)
-		})
+		}, isError)
 	})
 }

--- a/src/extensions/interactive-error-surface.ts
+++ b/src/extensions/interactive-error-surface.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { InteractiveMode } from "@earendil-works/pi-coding-agent"
+import { preserveRawErrorMessage } from "./error-preservation.js"
 import { classifyLLMGatewayError } from "../llm-gateway-error.js"
 import { formatSanitizedErrorMessage } from "../sanitized-error-message.js"
 
@@ -111,6 +112,11 @@ export default function interactiveErrorSurfaceExtension(pi: ExtensionAPI): void
 			// Track only retryable errors — agent_end renders the sanitized
 			// exhaustion message when retries are exhausted.
 			lastPendingProviderError = { rawMessage: message.errorMessage, willRetry: true }
+			// Preserve the original error for the retry classifier, which runs
+			// in _handlePostAgentRun AFTER this mutation. Without this, the
+			// classifier sees "Retrying…" and fails to identify the error as
+			// retryable, causing retries to silently stop.
+			preserveRawErrorMessage(message)
 			// Replace with a muted placeholder so the component doesn't leak
 			// internals but still renders something. The placeholder is
 			// suppressed by interceptShowError if it reaches showError.

--- a/src/extensions/interactive-error-surface.ts
+++ b/src/extensions/interactive-error-surface.ts
@@ -1,8 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { InteractiveMode } from "@earendil-works/pi-coding-agent"
-import { preserveRawErrorMessage } from "./error-preservation.js"
 import { classifyLLMGatewayError } from "../llm-gateway-error.js"
 import { formatSanitizedErrorMessage } from "../sanitized-error-message.js"
+import { preserveRawErrorMessage } from "./error-preservation.js"
 
 interface PendingProviderError {
 	readonly rawMessage: string

--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -175,6 +175,28 @@ describe("ContinuationNudge.evaluateTurn", () => {
 		expect(guard.evaluateTurn(aborted)).toBe(false)
 	})
 
+	it("does not nudge when the turn ended with a provider error (stopReason: error)", () => {
+		// Provider errors (e.g. content_filter, budget exhausted) must not
+		// trigger nudges — the nudge would re-queue a followUp message and
+		// cause the agent loop to retry indefinitely until budget is exhausted.
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		const error = { ...textOnlyMessage, stopReason: "error" as const }
+		expect(guard.evaluateTurn(error)).toBe(false)
+	})
+
+	it("does not consume a nudge slot when the turn was a provider error", () => {
+		// An error turn must not decrement the per-cycle budget — a subsequent
+		// legitimate text-only turn in the same cycle should still get its nudge.
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		const error = { ...textOnlyMessage, stopReason: "error" as const }
+		expect(guard.evaluateTurn(error)).toBe(false)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(true)
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
 	it("does not consume a nudge slot when the turn was aborted", () => {
 		// An aborted turn must not decrement the per-cycle budget — a subsequent
 		// legitimate text-only turn in the same cycle should still get its nudge.
@@ -529,6 +551,29 @@ describe("EmptyTurnNudge", () => {
 		const guard = new EmptyTurnNudge()
 		const aborted = { ...emptyMessage, stopReason: "aborted" as const }
 		expect(guard.evaluateTurn(aborted)).toBe(false)
+	})
+
+	describe("provider error suppression", () => {
+		// Provider errors (e.g. content_filter, budget exhausted) produce empty
+		// responses. Without this guard the nudge re-queues a followUp message,
+		// causing the agent loop to retry indefinitely until budget is exhausted.
+		it("does not nudge on an empty turn with stopReason: error", () => {
+			const guard = new EmptyTurnNudge()
+			const error = { ...emptyMessage, stopReason: "error" as const }
+			expect(guard.evaluateTurn(error)).toBe(false)
+		})
+
+		it("does not consume a nudge slot on error turns", () => {
+			const guard = new EmptyTurnNudge()
+			const error = { ...emptyMessage, stopReason: "error" as const }
+			expect(guard.evaluateTurn(error)).toBe(false)
+			expect(guard.evaluateTurn(error)).toBe(false)
+			expect(guard.evaluateTurn(error)).toBe(false)
+			// Full budget still available for a genuine empty turn.
+			expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+			expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+			expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		})
 	})
 })
 

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -137,6 +137,10 @@ export class ContinuationNudge {
 		// The user explicitly cancelled this turn (Esc / Ctrl+C). Respect the
 		// abort — they don't want the model to be re-prompted with a nudge.
 		if (message.stopReason === "aborted") return false
+		// Provider errors (e.g. content_filter, budget exhausted) produce empty
+		// content. Without this guard the nudge re-queues a followUp message,
+		// causing the agent loop to retry indefinitely until budget is exhausted.
+		if (message.stopReason === "error") return false
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		if (hasToolCalls || !hasText) return false
@@ -198,6 +202,10 @@ export class EmptyTurnNudge {
 	evaluateTurn(message: AssistantMessage): boolean {
 		if (this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES) return false
 		if (message.stopReason === "aborted") return false
+		// Provider errors (e.g. content_filter, budget exhausted) produce empty
+		// responses. Without this guard the nudge re-queues a followUp message,
+		// causing the agent loop to retry indefinitely until budget is exhausted.
+		if (message.stopReason === "error") return false
 
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -44,6 +44,18 @@ export const SECOND_NUDGE_TEXT =
 export const EMPTY_TURN_NUDGE_TEXT =
 	"If you have finished, please summarize the result for the user. Otherwise, continue with the next tool call."
 
+/** Stop reasons that should never trigger a nudge. Both `aborted` (user
+ *  cancelled) and `error` (provider failure) are terminal for this turn —
+ *  nudging would either disrespect the user's intent or re-queue a followUp
+ *  message that keeps the agent loop alive on a non-retryable error. */
+const NON_NUDGE_STOP_REASONS = new Set(["aborted", "error"])
+
+/** Returns true when the message's stop reason means the turn is terminal
+ *  and must not be nudged (user abort or provider error). */
+function isNonNudgeStopReason(message: AssistantMessage): boolean {
+	return NON_NUDGE_STOP_REASONS.has(message.stopReason)
+}
+
 /** Post-turn state machine for the "text-only drift" nudge.
  *
  * Fires at most twice per user-input cycle, and only when no tool has been
@@ -136,11 +148,10 @@ export class ContinuationNudge {
 		if (this.pendingDelegationCount > 0) return false
 		// The user explicitly cancelled this turn (Esc / Ctrl+C). Respect the
 		// abort — they don't want the model to be re-prompted with a nudge.
-		if (message.stopReason === "aborted") return false
 		// Provider errors (e.g. content_filter, budget exhausted) produce empty
 		// content. Without this guard the nudge re-queues a followUp message,
 		// causing the agent loop to retry indefinitely until budget is exhausted.
-		if (message.stopReason === "error") return false
+		if (isNonNudgeStopReason(message)) return false
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		if (hasToolCalls || !hasText) return false
@@ -201,11 +212,7 @@ export class EmptyTurnNudge {
 
 	evaluateTurn(message: AssistantMessage): boolean {
 		if (this.nudgeCountThisCycle >= EmptyTurnNudge.MAX_NUDGES) return false
-		if (message.stopReason === "aborted") return false
-		// Provider errors (e.g. content_filter, budget exhausted) produce empty
-		// responses. Without this guard the nudge re-queues a followUp message,
-		// causing the agent loop to retry indefinitely until budget is exhausted.
-		if (message.stopReason === "error") return false
+		if (isNonNudgeStopReason(message)) return false
 
 		const hasText = message.content.some((c) => c.type === "text" && c.text.trim().length > 0)
 		const hasToolCalls = message.content.some((c) => c.type === "toolCall")

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -300,6 +300,8 @@ describe("classifyLLMGatewayError", () => {
 		"model returned 500 tokens before stopping",
 		"tool call unexpectedly missing argument",
 		"model response terminated by safety policy",
+		"response was filtered by the content policy",
+		"content was filtered for safety reasons",
 	])("ignores non-gateway provider verdicts: %s", (message) => {
 		expect(classifyLLMGatewayError(message)).toBeUndefined()
 	})

--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -252,6 +252,16 @@ describe("classifyLLMGatewayError", () => {
 			httpStatusCode: 400,
 		},
 		{
+			name: "provider content_filter finish reason",
+			message: "Provider finish_reason: content_filter",
+			reason: "content_filter",
+		},
+		{
+			name: "content filter variant",
+			message: "Response filtered by content filter policy",
+			reason: "content_filter",
+		},
+		{
 			name: "bad request with hosted vLLM transport wording",
 			message: "BadRequestError: Hosted_vllmException - error sending request, code 400",
 			reason: "bad_request",

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -72,7 +72,7 @@ const HTTP_STATUS_RES = [
 const FIVE_XX_STATUS_CODES = new Set([500, 502, 503, 504, 524, 529])
 
 const INVALID_REQUEST_PAYLOAD_RE = /tools must not be an empty array/i
-const CONTENT_FILTER_RE = /finish_reason:\s*content_filter|content.?filter/i
+const CONTENT_FILTER_RE = /\bfinish_reason:\s*content_filter\b|\bcontent[- ]?filter\b/i
 const CONTEXT_WINDOW_RE =
 	/ContextWindowExceeded|context(?:\s|-)?(?:window|length|overflow)|maximum context|prompt too long|longer than the model'?s context length/i
 const NON_GATEWAY_PROVIDER_VERDICT_RE =

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -6,6 +6,7 @@ export type LLMGatewayErrorReason =
 	| "provider_5xx"
 	| "provider_error"
 	| "bad_request"
+	| "content_filter"
 	| "context_window_exceeded"
 	| "invalid_request_payload"
 
@@ -23,6 +24,7 @@ const LLM_GATEWAY_REASON_POLICIES: Record<
 	provider_5xx: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
 	provider_error: { retryable: true, isInfrastructure: true, exitCode: LLM_GATEWAY_INFRASTRUCTURE_EXIT_CODE },
 	bad_request: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
+	content_filter: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
 	context_window_exceeded: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
 	invalid_request_payload: { retryable: false, isInfrastructure: false, exitCode: LLM_GATEWAY_REQUEST_EXIT_CODE },
 }
@@ -70,6 +72,7 @@ const HTTP_STATUS_RES = [
 const FIVE_XX_STATUS_CODES = new Set([500, 502, 503, 504, 524, 529])
 
 const INVALID_REQUEST_PAYLOAD_RE = /tools must not be an empty array/i
+const CONTENT_FILTER_RE = /finish_reason:\s*content_filter|content.?filter/i
 const CONTEXT_WINDOW_RE =
 	/ContextWindowExceeded|context(?:\s|-)?(?:window|length|overflow)|maximum context|prompt too long|longer than the model'?s context length/i
 const NON_GATEWAY_PROVIDER_VERDICT_RE =
@@ -121,6 +124,7 @@ export function classifyLLMGatewayError(rawMessage: string): LLMGatewayError | u
 	const status = parseHttpStatusCode(rawMessage)
 
 	if (INVALID_REQUEST_PAYLOAD_RE.test(rawMessage)) return createError("invalid_request_payload", rawMessage, status)
+	if (CONTENT_FILTER_RE.test(rawMessage)) return createError("content_filter", rawMessage, status)
 	if (CONTEXT_WINDOW_RE.test(rawMessage)) return createError("context_window_exceeded", rawMessage, status)
 	// Budget exhaustion is a terminal Kimchi verdict even when the gateway
 	// describes it using provider-verdict words such as "billing".

--- a/src/sanitized-error-message.ts
+++ b/src/sanitized-error-message.ts
@@ -61,6 +61,7 @@ const REASON_CATEGORY: Record<LLMGatewayErrorReason, ReasonCategory> = {
 	provider_5xx: { retryable: true, label: "provider unavailable" },
 	provider_error: { retryable: true, label: "provider unavailable" },
 	bad_request: { retryable: false, label: "bad request" },
+	content_filter: { retryable: false, label: "content filter" },
 	context_window_exceeded: { retryable: false, label: "context window exceeded" },
 	invalid_request_payload: { retryable: false, label: "invalid request payload" },
 }

--- a/src/sanitized-error-message.ts
+++ b/src/sanitized-error-message.ts
@@ -61,6 +61,7 @@ const REASON_CATEGORY: Record<LLMGatewayErrorReason, ReasonCategory> = {
 	provider_5xx: { retryable: true, label: "provider unavailable" },
 	provider_error: { retryable: true, label: "provider unavailable" },
 	bad_request: { retryable: false, label: "bad request" },
+	budget_exhausted: { retryable: false, label: "budget exhausted" },
 	content_filter: { retryable: false, label: "content filter" },
 	context_window_exceeded: { retryable: false, label: "context window exceeded" },
 	invalid_request_payload: { retryable: false, label: "invalid request payload" },

--- a/src/upstream-retry-patch.test.ts
+++ b/src/upstream-retry-patch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { preserveRawErrorMessage } from "./extensions/error-preservation.js"
 import {
 	configureInfrastructureBreaker,
 	INFRA_BREAKER_THRESHOLD_ENV,
@@ -134,6 +135,28 @@ describe("isInfrastructureErrorRetryable", () => {
 					"The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
 			}),
 		).toBe(true)
+	})
+
+	it("uses the preserved original error when errorMessage was mutated to a display placeholder", () => {
+		// Simulates the interactive-error-surface extension mutating
+		// errorMessage to "Retrying…" before the retry classifier runs.
+		const message = {
+			stopReason: "error" as const,
+			errorMessage:
+				"InternalServerError: Hosted_vllmException - Cannot connect to host serverless-glm-5-2-fp8.castai-llms.svc.cluster.local.:11434",
+		}
+		preserveRawErrorMessage(message)
+		message.errorMessage = "Retrying…"
+
+		expect(isInfrastructureErrorRetryable(message)).toBe(true)
+	})
+
+	it("returns false for a non-retryable error preserved then mutated", () => {
+		const message = { stopReason: "error" as const, errorMessage: "400 Bad Request" }
+		preserveRawErrorMessage(message)
+		message.errorMessage = "Retrying…"
+
+		expect(isInfrastructureErrorRetryable(message)).toBe(false)
 	})
 })
 

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -98,9 +98,15 @@ export function installInfrastructureRetryPatch(
 	if (!original) return
 
 	proto._isRetryableError = function patchedIsRetryableError(message: RetryableMessage): boolean {
-		if (message.stopReason !== "error" || !message.errorMessage) return false
+		if (message.stopReason !== "error") return false
 
-		const classification = classifyLLMGatewayError(message.errorMessage)
+		// The errorMessage may have been mutated to a display placeholder (e.g.
+		// "Retrying…") by the interactive-error-surface extension before this
+		// classifier runs. Use the preserved original if available.
+		const rawMessage = getRawErrorMessage(message)
+		if (!rawMessage) return false
+
+		const classification = classifyLLMGatewayError(rawMessage)
 
 		// Kimchi's explicit non-retryable verdicts take precedence over Pi's
 		// generic 429 retry — e.g. "budget exhausted" arrives as a 429 but must

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { getRawErrorMessage } from "./extensions/error-preservation.js"
 import { classifyLLMGatewayError } from "./llm-gateway-error.js"
 
 type RetryableMessage = Partial<Pick<AssistantMessage, "stopReason" | "errorMessage">>
@@ -12,8 +13,13 @@ type PatchableAgentSession = {
 }
 
 export function isInfrastructureErrorRetryable(message: RetryableMessage): boolean {
-	if (message.stopReason !== "error" || !message.errorMessage) return false
-	return classifyLLMGatewayError(message.errorMessage)?.retryable ?? false
+	if (message.stopReason !== "error") return false
+	// The errorMessage may have been mutated to a display placeholder (e.g.
+	// "Retrying…") by the interactive-error-surface extension before this
+	// classifier runs. Use the preserved original if available.
+	const rawMessage = getRawErrorMessage(message)
+	if (!rawMessage) return false
+	return classifyLLMGatewayError(rawMessage)?.retryable ?? false
 }
 
 // --- Infrastructure-error circuit breaker ---


### PR DESCRIPTION
## Problem

When a provider returns a `content_filter` error (HTTP 200, empty content, `stopReason: "error"`), three extensions treated the empty response as a genuine model stall and queued continuation messages:

- **EmptyTurnNudge** queued a followUp nudge (up to 2x per cycle)
- **ContinuationNudge** queued a followUp nudge (up to 2x per cycle)
- **ExplorationGuard** queued steer messages indefinitely (resetting every 5 turns)

These queued messages caused `hasQueuedMessages()` to return `true` in `_handlePostAgentRun()`, keeping the agent loop alive. The same request was re-sent **78 times** over ~6.5 minutes until the provider budget was exhausted.

Fixes #971

### Incident trace

The session JSONL shows the exact loop: each `content_filter` response produced empty content → `agent_end` → nudge/guard queued a message → `hasQueuedMessages()` returned true → `agent.continue()` → same request → same `content_filter` → repeat.

## Fix

1. **`src/llm-gateway-error.ts`** — Added `"content_filter"` as a recognized error reason (`retryable: false`, `isInfrastructure: false`). New `CONTENT_FILTER_RE` regex matches `finish_reason: content_filter` and `content filter` variants.

2. **`src/extensions/orchestration/continuation-nudge.ts`** — Both `ContinuationNudge.evaluateTurn()` and `EmptyTurnNudge.evaluateTurn()` now return `false` when the message stop reason is `"aborted"` or `"error"` (extracted to shared `isNonNudgeStopReason()` helper). Provider errors produce empty/text-only content that would otherwise trigger these nudges.

3. **`src/extensions/exploration-guard.ts`** — `turnEnd()` now takes an `isError` parameter (defaults to `false`). When `true`, it returns early without incrementing `consecutiveNoToolTurns` or firing steers. The extension handler checks `event.message.stopReason === "error"` and passes it through.

## Test coverage

- `llm-gateway-error.test.ts`: 2 new cases classifying `content_filter` messages + 2 near-miss cases that should NOT classify as content_filter
- `continuation-nudge.test.ts`: 4 new tests — error suppression + budget preservation for both `ContinuationNudge` and `EmptyTurnNudge`
- `exploration-guard.test.ts`: 4 new tests — no counter increment on error, no steers on consecutive errors, no reset of existing streak, backward-compatible default

## Checklist

- [x] Bug fix — regression tests that would have failed before the fix
- [x] Tests pass (`pnpm run test`)
- [x] Typecheck passes (`pnpm run typecheck`)
- [x] Lint passes (`pnpm run lint`)