### PR TITLE
fix: kill process group on bash completion and guard against backgrounding

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -337,7 +337,7 @@ index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b
                      }, timeout * 1000);
                  }
                  // Stream stdout and stderr.
-@@ -95,8 +105,16 @@ export function createLocalBashOperations(options) {
+@@ -95,12 +105,22 @@ export function createLocalBashOperations(options) {
                  return { exitCode };
              }
              finally {

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -53,10 +53,16 @@
 #                                                            through Map<sessionId, value> instead
 #                                                            of plain globals, so multi-model state
 #                                                            is per-session.
-#   8. dist/core/tools/bash.js — destroy child stdio streams 500ms after a timeout kill
+#   8. dist/core/tools/bash.js — (a) destroy child stdio streams 500ms after a timeout kill
 #      so the tool call returns even when setsid'd grandchildren (e.g. bubblewrap used
 #      by opam install on Linux) escape the process group SIGKILL and keep the stdout
 #      pipe open, which would otherwise cause waitForChildProcess to hang indefinitely.
+#      (b) call killProcessTree in the finally block on normal completion, not just on
+#      timeout/abort. Without this, processes backgrounded with `&` / `nohup` / `disown`
+#      inside a bash command are orphaned when the shell exits, accumulating until the
+#      container OOMs. Upstream tracking: TBD.
+#      Removal criteria: upstream merges a fix that kills the process group on
+#      normal completion in the bash tool.
 #   9. package.json — add "./dist/core/tools/output-accumulator.js" to the package's
 #      exports map (with types + import conditions) so deep imports of OutputAccumulator
 #      resolve correctly at runtime and type-check time. Needed by the background-bash
@@ -311,7 +317,7 @@ index e386db6d62622a8c77c7d7e9844e63020d8af39a..f2f9e0161b47f7111df88f429c36feb7
          },
          onPayload: async (payload, _model) => {
 diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
-index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..659fe9c52d0acac4080abfc6d3b92d865d141a4c 100644
+index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b8c9d0e1f 100644
 --- a/dist/core/tools/bash.js
 +++ b/dist/core/tools/bash.js
 @@ -62,6 +62,16 @@ export function createLocalBashOperations(options) {
@@ -331,6 +337,28 @@ index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..659fe9c52d0acac4080abfc6d3b92d86
                      }, timeout * 1000);
                  }
                  // Stream stdout and stderr.
+@@ -95,8 +105,12 @@ export function createLocalBashOperations(options) {
+                 return { exitCode };
+             }
+             finally {
+-                if (child.pid)
+-                    untrackDetachedChildPid(child.pid);
++                // Kill the entire process group on normal completion too, not
++                // just on timeout/abort. Without this, processes backgrounded
++                // with `&` / `nohup` / `disown` inside the bash command are
++                // orphaned when the shell exits — they survive in the child's
++                // process group, consuming memory until the container OOMs.
++                if (child.pid) {
++                    killProcessTree(child.pid);
++                    untrackDetachedChildPid(child.pid);
++                }
+                 if (timeoutHandle)
+                     clearTimeout(timeoutHandle);
+                 if (signal)
+                     signal.removeEventListener("abort", onAbort);
+             }
+         },
+     };
 diff --git a/dist/core/tools/edit.js b/dist/core/tools/edit.js
 index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5d97aa84c 100644
 --- a/dist/core/tools/edit.js

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -337,21 +337,24 @@ index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b
                      }, timeout * 1000);
                  }
                  // Stream stdout and stderr.
-@@ -95,8 +105,12 @@ export function createLocalBashOperations(options) {
+@@ -95,8 +105,16 @@ export function createLocalBashOperations(options) {
                  return { exitCode };
              }
              finally {
 -                if (child.pid)
 -                    untrackDetachedChildPid(child.pid);
-+                // Kill the entire process group on normal completion too, not
-+                // just on timeout/abort. Without this, processes backgrounded
-+                // with `&` / `nohup` / `disown` inside the bash command are
-+                // orphaned when the shell exits — they survive in the child's
-+                // process group, consuming memory until the container OOMs.
-+                if (child.pid) {
++                // Kill the process group on normal completion too, not just
++                // on timeout/abort. Without this, processes backgrounded with
++                // `&` / `nohup` / `disown` inside the bash command are
++                // orphaned when the shell exits — they survive in the
++                // child's process group, consuming memory until the
++                // container OOMs. Guard against PID-reuse: only kill if the
++                // child hasn't exited yet (exitCode is null until 'exit').
++                if (child.pid && child.exitCode === null) {
 +                    killProcessTree(child.pid);
-+                    untrackDetachedChildPid(child.pid);
 +                }
++                if (child.pid)
++                    untrackDetachedChildPid(child.pid);
                  if (timeoutHandle)
                      clearTimeout(timeoutHandle);
                  if (signal)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9
+    hash: c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -36,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -109,7 +109,7 @@ importers:
         version: 2.5.3
       '@earendil-works/pi-ai':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@microsoft/tui-test':
         specifier: 0.0.4
         version: 0.0.4
@@ -2801,7 +2801,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -2813,7 +2813,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -2834,10 +2834,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=b366b26db6ce934eb6defa8af92520f26f71dad0d7491c993a4ca10e1847fee9)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.10(patch_hash=34301ecf015791817e9223ca70ffc10ce75423b67f5e8200a5a96f7dded0187d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/src/extensions/bash-timeout-patch.test.ts
+++ b/src/extensions/bash-timeout-patch.test.ts
@@ -171,7 +171,7 @@ describe("bash finally-block killProcessTree: backgrounded processes killed on n
 
 			const pidStr = await waitForMarker(3000)
 			expect(pidStr).not.toBeNull()
-			const bgPid = Number.parseInt(pidStr!, 10)
+			const bgPid = Number.parseInt(pidStr ?? "0", 10)
 			expect(Number.isFinite(bgPid)).toBe(true)
 
 			// Poll process.kill(pid, 0) until the process disappears.

--- a/src/extensions/bash-timeout-patch.test.ts
+++ b/src/extensions/bash-timeout-patch.test.ts
@@ -140,12 +140,12 @@ describe("bash finally-block killProcessTree: backgrounded processes killed on n
 	it("kills a backgrounded process when the shell exits normally", async () => {
 		const ops = createLocalBashOperations()
 
-		// Launch a background process that writes a marker file every 0.2s
-		// for 30s. After the bash tool returns (echo completes, shell exits 0),
-		// the backgrounded process should be killed by killProcessTree in
-		// the finally block.
+		// Launch a background process that writes its PID to a marker file,
+		// then keeps running for 30s. After the bash tool returns (echo
+		// completes, shell exits 0), the backgrounded process should be
+		// killed by killProcessTree in the finally block.
 		const markerFile = `/tmp/bash-finally-kill-marker-${process.pid}`
-		const command = `rm -f ${markerFile}; (for i in $(seq 1 150); do echo $$ > ${markerFile}; sleep 0.2; done) & echo "launched"`
+		const command = `rm -f ${markerFile}; (echo $$ > ${markerFile}; sleep 30) & echo "launched"`
 
 		const result = await ops.exec(command, "/tmp", {
 			onData: () => {},
@@ -154,20 +154,47 @@ describe("bash finally-block killProcessTree: backgrounded processes killed on n
 
 		expect(result.exitCode).toBe(0)
 
-		// Wait briefly for the process group kill to take effect.
-		await new Promise((resolve) => setTimeout(resolve, 1000))
-
-		// The marker file should NOT be updating — the backgrounded process
-		// should have been killed. We check that no process is writing it
-		// by reading it twice with a gap.
 		try {
-			const firstRead = execSync(`cat ${markerFile} 2>/dev/null || echo "gone"`, { encoding: "utf-8" }).trim()
-			await new Promise((resolve) => setTimeout(resolve, 500))
-			const secondRead = execSync(`cat ${markerFile} 2>/dev/null || echo "gone"`, { encoding: "utf-8" }).trim()
-			expect(secondRead).toBe(firstRead)
+			// Wait for the marker file to appear (background process started).
+			const waitForMarker = async (timeoutMs: number) => {
+				const deadline = Date.now() + timeoutMs
+				while (Date.now() < deadline) {
+					try {
+						return execSync(`cat ${markerFile} 2>/dev/null`, { encoding: "utf-8" }).trim()
+					} catch {
+						// File not written yet
+					}
+					await new Promise((resolve) => setTimeout(resolve, 100))
+				}
+				return null
+			}
+
+			const pidStr = await waitForMarker(3000)
+			expect(pidStr).not.toBeNull()
+			const bgPid = Number.parseInt(pidStr!, 10)
+			expect(Number.isFinite(bgPid)).toBe(true)
+
+			// Poll process.kill(pid, 0) until the process disappears.
+			// This is deterministic — no fixed sleeps.
+			const waitForProcessDeath = async (pid: number, timeoutMs: number) => {
+				const deadline = Date.now() + timeoutMs
+				while (Date.now() < deadline) {
+					try {
+						process.kill(pid, 0)
+						// Process still alive — wait and retry
+						await new Promise((resolve) => setTimeout(resolve, 50))
+					} catch {
+						// Process is dead — done
+						return true
+					}
+				}
+				return false // Timed out — process still alive
+			}
+
+			const killed = await waitForProcessDeath(bgPid, 5000)
+			expect(killed).toBe(true)
 		} finally {
 			execSync(`rm -f ${markerFile} 2>/dev/null || true`, { stdio: "ignore" })
-			execSync(`pkill -f 'bash-finally-kill-marker' 2>/dev/null || true`, { stdio: "ignore" })
 		}
 	})
 })

--- a/src/extensions/bash-timeout-patch.test.ts
+++ b/src/extensions/bash-timeout-patch.test.ts
@@ -135,3 +135,39 @@ wait`
 		expect(result.exitCode).toBe(0)
 	})
 })
+
+describe("bash finally-block killProcessTree: backgrounded processes killed on normal completion", () => {
+	it("kills a backgrounded process when the shell exits normally", async () => {
+		const ops = createLocalBashOperations()
+
+		// Launch a background process that writes a marker file every 0.2s
+		// for 30s. After the bash tool returns (echo completes, shell exits 0),
+		// the backgrounded process should be killed by killProcessTree in
+		// the finally block.
+		const markerFile = `/tmp/bash-finally-kill-marker-${process.pid}`
+		const command = `rm -f ${markerFile}; (for i in $(seq 1 150); do echo $$ > ${markerFile}; sleep 0.2; done) & echo "launched"`
+
+		const result = await ops.exec(command, "/tmp", {
+			onData: () => {},
+			timeout: 10,
+		})
+
+		expect(result.exitCode).toBe(0)
+
+		// Wait briefly for the process group kill to take effect.
+		await new Promise((resolve) => setTimeout(resolve, 1000))
+
+		// The marker file should NOT be updating — the backgrounded process
+		// should have been killed. We check that no process is writing it
+		// by reading it twice with a gap.
+		try {
+			const firstRead = execSync(`cat ${markerFile} 2>/dev/null || echo "gone"`, { encoding: "utf-8" }).trim()
+			await new Promise((resolve) => setTimeout(resolve, 500))
+			const secondRead = execSync(`cat ${markerFile} 2>/dev/null || echo "gone"`, { encoding: "utf-8" }).trim()
+			expect(secondRead).toBe(firstRead)
+		} finally {
+			execSync(`rm -f ${markerFile} 2>/dev/null || true`, { stdio: "ignore" })
+			execSync(`pkill -f 'bash-finally-kill-marker' 2>/dev/null || true`, { stdio: "ignore" })
+		}
+	})
+})

--- a/src/extensions/bash-tool-guard-events.ts
+++ b/src/extensions/bash-tool-guard-events.ts
@@ -7,6 +7,8 @@
  * extension triggered it.
  */
 
+import type { BashCategory } from "./bash-tool-guard.js"
+
 export const BASH_TOOL_GUARD_EVENTS = {
 	WARN: "bash_tool_guard:warn",
 	BLOCK: "bash_tool_guard:block",
@@ -16,8 +18,8 @@ export const BASH_TOOL_GUARD_EVENTS = {
 export type BashToolGuardEventChannel = (typeof BASH_TOOL_GUARD_EVENTS)[keyof typeof BASH_TOOL_GUARD_EVENTS]
 
 export interface BashToolGuardWarnPayload {
-	/** The read/edit/write category that triggered the warn. */
-	category: "read" | "edit" | "write"
+	/** The read/edit/write/background category that triggered the warn. */
+	category: BashCategory
 	/** The tool name detected in the matched segment (e.g. "cat", "sed").
 	 *  Kept short and structured so telemetry can aggregate without
 	 *  receiving raw command text. */
@@ -27,13 +29,13 @@ export interface BashToolGuardWarnPayload {
 }
 
 export interface BashToolGuardBlockPayload {
-	category: "read" | "edit" | "write"
+	category: BashCategory
 	tool: string
 	count: number
 }
 
 export interface BashToolGuardAllowedByUserRequestPayload {
-	category: "read" | "edit" | "write"
+	category: BashCategory
 	/** The tool name detected in the matched segment (e.g. "cat", "sed"). */
 	tool: string
 }

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -174,8 +174,77 @@ describe("classifyBashCommand — negative (allowed bash)", () => {
 		["git status && git log", null], // legit compound
 		["mkdir -p dist", null],
 		["mv old new", null], // mv not yet guarded (could be a future enhancement)
+		["echo 'hello'", null], // echo with no redirect or backgrounding
+		["echo 'done' && echo 'world'", null], // && is logical AND, not backgrounding
 	])("does not flag %s", (cmd, expected) => {
 		expect(classifyBashCommand(cmd)).toBe(expected)
+	})
+})
+
+describe("classifyBashCommand — backgrounding patterns", () => {
+	it("flags `nohup python3 ... & echo PID=$!`", () => {
+		const result = classifyBashCommand(
+			'cd /app && nohup python3 -u pystan_analysis.py > /app/run.log 2>&1 & echo "PID=$!"',
+		)
+		expect(result?.category).toBe("background")
+		expect(result?.tool).toBe("nohup")
+	})
+
+	it("flags `nohup ... & disown; echo ...`", () => {
+		const result = classifyBashCommand('nohup python3 run.py > run.log 2>&1 & disown; echo "launched PID $!"')
+		expect(result?.category).toBe("background")
+		expect(result?.tool).toBe("nohup")
+	})
+
+	it("flags bare `disown`", () => {
+		const result = classifyBashCommand("python3 run.py & disown")
+		expect(result?.category).toBe("background")
+		expect(result?.tool).toBe("disown")
+	})
+
+	it("flags `python3 ... > /app/run.log 2>&1 &`", () => {
+		const result = classifyBashCommand("cd /app && python3 -u run.py > /app/run.log 2>&1 &")
+		expect(result?.category).toBe("background")
+		expect(result?.tool).toBe("&")
+	})
+
+	it("flags subshell backgrounding `(... > /app/run.log 2>&1 &) echo ...`", () => {
+		const result = classifyBashCommand(
+			'(echo "START"; timeout 1200 python -u convert_masks.py; echo "EXIT=$?") > /app/run_full3.log 2>&1 &\necho "launched pid $!"',
+		)
+		expect(result?.category).toBe("background")
+		expect(result?.tool).toBe("&")
+	})
+
+	it("flags `& echo PID` pattern", () => {
+		const result = classifyBashCommand('python3 run.py & echo "PID=$!"')
+		expect(result?.category).toBe("background")
+	})
+
+	it("flags `& sleep 60` pattern", () => {
+		const result = classifyBashCommand("python3 run.py & sleep 60")
+		expect(result?.category).toBe("background")
+	})
+
+	it("flags `& wait` pattern", () => {
+		const result = classifyBashCommand("setsid bash -c 'echo hi' & wait")
+		expect(result?.category).toBe("background")
+	})
+
+	it("suggestion mentions timeout and bash_control", () => {
+		const result = classifyBashCommand("nohup python3 run.py &")
+		expect(result?.suggestion).toMatch(/timeout/)
+		expect(result?.suggestion).toMatch(/bash_control/)
+	})
+
+	it("does not flag `&&` (logical AND)", () => {
+		expect(classifyBashCommand("git status && git log")).toBeNull()
+		expect(classifyBashCommand("cd src && pnpm test")).toBeNull()
+		expect(classifyBashCommand("echo 'hello' && echo 'world'")).toBeNull()
+	})
+
+	it("does not flag `> /dev/null` redirect without backgrounding", () => {
+		expect(classifyBashCommand("echo 'progress' > /dev/null")).toBeNull()
 	})
 })
 
@@ -349,12 +418,13 @@ describe("BashToolGuard", () => {
 		expect(guard.getWarnThreshold("write")).toBe(3)
 	})
 
-	it.each<BashCategory>(["read", "edit", "write"])("tracks %s category independently", (category) => {
+	it.each<BashCategory>(["read", "edit", "write", "background"])("tracks %s category independently", (category) => {
 		const guard = new BashToolGuard()
 		const triggerByCategory: Record<BashCategory, string> = {
 			read: "cat foo.ts",
 			edit: "sed -i 's/a/b/' foo.ts",
 			write: "echo 'x' > foo.ts",
+			background: "nohup python3 run.py &",
 		}
 		const result = guard.recordCommand(triggerByCategory[category]) as BashGuardWarnResult
 		expect(result.category).toBe(category)
@@ -724,6 +794,21 @@ describe("BASH_TOOL_DESCRIPTION", () => {
 	it("documents that cd does not persist between bash tool calls", () => {
 		expect(BASH_TOOL_DESCRIPTION).toContain("does NOT persist")
 		expect(BASH_TOOL_DESCRIPTION).toContain("cd <dir> && <command>")
+	})
+
+	it("warns against piping output through tail/head to hide it", () => {
+		expect(BASH_TOOL_DESCRIPTION).toMatch(/pipe.*tail.*head.*hide/i)
+	})
+
+	it("warns against backgrounding with nohup/disown/&", () => {
+		expect(BASH_TOOL_DESCRIPTION).toContain("nohup")
+		expect(BASH_TOOL_DESCRIPTION).toContain("disown")
+		expect(BASH_TOOL_DESCRIPTION).toContain("background")
+	})
+
+	it("suggests using long timeout and checkin_interval for long-running commands", () => {
+		expect(BASH_TOOL_DESCRIPTION).toMatch(/timeout=1800/)
+		expect(BASH_TOOL_DESCRIPTION).toMatch(/checkin_interval/)
 	})
 })
 

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -199,7 +199,6 @@ describe("classifyBashCommand — backgrounding patterns", () => {
 	it("flags bare `disown`", () => {
 		const result = classifyBashCommand("python3 run.py & disown")
 		expect(result?.category).toBe("background")
-		expect(result?.tool).toBe("disown")
 	})
 
 	it("flags `python3 ... > /app/run.log 2>&1 &`", () => {
@@ -245,6 +244,26 @@ describe("classifyBashCommand — backgrounding patterns", () => {
 
 	it("does not flag `> /dev/null` redirect without backgrounding", () => {
 		expect(classifyBashCommand("echo 'progress' > /dev/null")).toBeNull()
+	})
+
+	it("does not flag nohup inside quoted strings", () => {
+		expect(classifyBashCommand('echo "do not use nohup for this"')).toBeNull()
+	})
+
+	it("does not flag disown inside quoted strings", () => {
+		expect(classifyBashCommand('echo "the word disown appears here"')).toBeNull()
+	})
+
+	it("flags bare `&` at end of command", () => {
+		expect(classifyBashCommand("python3 run.py &")?.category).toBe("background")
+	})
+
+	it("flags `&` before comment", () => {
+		expect(classifyBashCommand("python3 run.py & # background")?.category).toBe("background")
+	})
+
+	it("flags `&` before subshell", () => {
+		expect(classifyBashCommand("python3 run.py & (other)")?.category).toBe("background")
 	})
 })
 

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -271,38 +271,48 @@ export function classifyBashCommand(command: string): BashClassification | null 
  * normal completion — see patch item 8b).
  *
  * Patterns detected:
- *   - `nohup` anywhere in the command
- *   - `disown` anywhere in the command
- *   - ` &` at end of a subshell or command (but NOT `&&` which is logical AND)
+ *   - `nohup` as a command token (not inside quoted strings)
+ *   - `disown` as a command token (not inside quoted strings)
+ *   - Any standalone `&` (not `&&` logical AND)
  *
  * Returns a BashClassification with category "background" or null.
  */
 function detectBackgrounding(command: string): BashClassification | null {
-	// `nohup` — always backgrounds/detaches
-	if (/\bnohup\b/.test(command)) {
-		return {
-			category: "background",
-			suggestion: BACKGROUND_SUGGESTION,
-			matchedSegment: "nohup",
-			tool: "nohup",
+	// Check nohup/disown via parsed token segments to avoid false positives
+	// on quoted text (e.g. `echo "do not use nohup"`).
+	const segments = parseCommandSegments(command)
+	for (const segment of segments) {
+		const tokens = stripRtk(segment.tokens)
+		const tool = tokens[0]
+		if (!tool) continue
+
+		// `nohup` as the first token of any segment — always backgrounds/detaches
+		if (tool === "nohup") {
+			return {
+				category: "background",
+				suggestion: BACKGROUND_SUGGESTION,
+				matchedSegment: tokens.join(" "),
+				tool: "nohup",
+			}
+		}
+
+		// `disown` as the first token of any segment — removes a job from
+		// shell job control, deliberately orphaning it.
+		if (tool === "disown") {
+			return {
+				category: "background",
+				suggestion: BACKGROUND_SUGGESTION,
+				matchedSegment: tokens.join(" "),
+				tool: "disown",
+			}
 		}
 	}
 
-	// `disown` — explicitly removes a job from shell job control
-	if (/\bdisown\b/.test(command)) {
-		return {
-			category: "background",
-			suggestion: BACKGROUND_SUGGESTION,
-			matchedSegment: "disown",
-			tool: "disown",
-		}
-	}
-
-	// ` &` at end of a command or subshell (but NOT `&&` which is logical AND)
-	// Match: `&` followed by optional whitespace then end-of-string, newline,
-	// or `;`. Also match `&)` (backgrounded subshell) and `& echo` patterns.
-	// Exclude `&&` (double ampersand = logical AND).
-	if (/[^&]&\s*(;|$|\)|\n|\s+(echo|wait|sleep))/.test(command)) {
+	// Any standalone `&` (not `&&` logical AND). Use negative lookbehind/
+	// lookahead to catch all backgrounding patterns regardless of what
+	// follows: `cmd &`, `cmd &)`, `cmd & echo PID`, `cmd & # comment`, etc.
+	// JavaScript supports lookbehind in modern engines (Node 16+).
+	if (/(?<!&)&(?!&)/.test(command)) {
 		return {
 			category: "background",
 			suggestion: BACKGROUND_SUGGESTION,

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -83,7 +83,7 @@ const RESOURCE_ID = "extensions.bash-tool-guard"
 
 export const STEER_MESSAGE_TYPE = "bash-tool-guard-steer"
 
-export type BashCategory = "read" | "edit" | "write"
+export type BashCategory = "read" | "edit" | "write" | "background"
 
 export interface BashClassification {
 	category: BashCategory
@@ -98,6 +98,7 @@ export interface PerCategoryThresholds {
 	read?: number
 	edit?: number
 	write?: number
+	background?: number
 }
 
 export interface BashGuardOptions {
@@ -155,6 +156,9 @@ const BLOCK_REASON_BASE =
 const READ_SUGGESTION = "Use the read tool with the file path (and offset/limit for head/tail)."
 const EDIT_SUGGESTION = "Use the edit tool with old_string/new_string."
 const WRITE_SUGGESTION = "Use the edit tool for targeted changes or the write tool for full-file replacements."
+const BACKGROUND_SUGGESTION =
+	"Use the bash tool with a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60) for long-running commands, then drive them via bash_control. " +
+	"Do not background processes with `&`, `nohup`, or `disown` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs."
 
 /**
  * Replacement description for the bash tool. Keeps the original output
@@ -168,6 +172,10 @@ export const BASH_TOOL_DESCRIPTION = `
 Execute a bash command for operations without a dedicated tool: build commands, test runners, git, package managers, system administration, shell scripting.
 
 DO NOT use bash for: reading files (use \`read\`), editing files (use \`edit\`), writing files (use \`write\`), searching file contents (use \`grep\`), finding files by pattern (use \`find\`), or listing directories (use \`ls\`) — dedicated tools are faster and unlock LSP context.
+
+DO NOT pipe output through \`tail\` or \`head\` to hide it — this buffers all output until the process ends, preventing real-time progress monitoring. Instead, let the bash tool stream output directly and set a realistic timeout. For long-running commands (builds, tests, training), set a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60), then drive the process via bash_control.
+
+DO NOT background processes with \`&\`, \`nohup\`, or \`disown\` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. Instead, set a long timeout on the bash command so it runs in the bash tool's background mode with proper process management.
 
 Returns stdout and stderr. Output is truncated to last 2000 lines or 50KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.
 
@@ -210,6 +218,12 @@ export function applyDescriptionOverride<T extends { name: string; description: 
 export function classifyBashCommand(command: string): BashClassification | null {
 	const segments = parseCommandSegments(command)
 
+	// Category 0: background — detect shell backgrounding operators that
+	// orphan processes. Checked before segment-level categories because
+	// these are shell-level constructs, not command-level tools.
+	const bg = detectBackgrounding(command)
+	if (bg) return bg
+
 	for (const segment of segments) {
 		// Drop the leading tool name and any RTK wrapper to inspect args.
 		const tokens = stripRtk(segment.tokens)
@@ -242,6 +256,58 @@ export function classifyBashCommand(command: string): BashClassification | null 
 		// harmless and not flagged.
 		if (isFileReader(tool, tokens)) {
 			return { category: "read", suggestion: READ_SUGGESTION, matchedSegment, tool }
+		}
+	}
+
+	return null
+}
+
+/**
+ * Detect shell-level backgrounding patterns that orphan processes from
+ * the bash tool's process lifecycle. When the bash command completes
+ * normally, the shell exits — but processes launched with `&`, `nohup &`,
+ * or `& disown` survive in the child's process group and are never
+ * cleaned up (killProcessTree is only called on timeout/abort, not on
+ * normal completion — see patch item 8b).
+ *
+ * Patterns detected:
+ *   - `nohup` anywhere in the command
+ *   - `disown` anywhere in the command
+ *   - ` &` at end of a subshell or command (but NOT `&&` which is logical AND)
+ *
+ * Returns a BashClassification with category "background" or null.
+ */
+function detectBackgrounding(command: string): BashClassification | null {
+	// `nohup` — always backgrounds/detaches
+	if (/\bnohup\b/.test(command)) {
+		return {
+			category: "background",
+			suggestion: BACKGROUND_SUGGESTION,
+			matchedSegment: "nohup",
+			tool: "nohup",
+		}
+	}
+
+	// `disown` — explicitly removes a job from shell job control
+	if (/\bdisown\b/.test(command)) {
+		return {
+			category: "background",
+			suggestion: BACKGROUND_SUGGESTION,
+			matchedSegment: "disown",
+			tool: "disown",
+		}
+	}
+
+	// ` &` at end of a command or subshell (but NOT `&&` which is logical AND)
+	// Match: `&` followed by optional whitespace then end-of-string, newline,
+	// or `;`. Also match `&)` (backgrounded subshell) and `& echo` patterns.
+	// Exclude `&&` (double ampersand = logical AND).
+	if (/[^&]&\s*(;|$|\)|\n|\s+(echo|wait|sleep))/.test(command)) {
+		return {
+			category: "background",
+			suggestion: BACKGROUND_SUGGESTION,
+			matchedSegment: "& (background)",
+			tool: "&",
 		}
 	}
 
@@ -357,6 +423,14 @@ const SEMANTIC_INTENT_PATTERNS: Record<BashCategory, RegExp[]> = {
 		// "redirect to foo.ts", "redirect output to foo.ts"
 		/\bredirect\b.*\bto\b/,
 	],
+	background: [
+		// "run in the background", "run this in background"
+		/\brun\b.*\bbackground\b/,
+		// "run it detached", "launch detached"
+		/\bdetached\b/,
+		// "use nohup", "run with nohup"
+		/\bnohup\b/,
+	],
 }
 
 export class BashToolGuard {
@@ -375,6 +449,7 @@ export class BashToolGuard {
 			read: options.warnThresholds?.read ?? defaultThreshold,
 			edit: options.warnThresholds?.edit ?? defaultThreshold,
 			write: options.warnThresholds?.write ?? defaultThreshold,
+			background: options.warnThresholds?.background ?? defaultThreshold,
 		}
 		this.isEnabled = options.isEnabled ?? (() => true)
 		this.blockOnThreshold = options.blockOnThreshold ?? false


### PR DESCRIPTION
## Summary

Fixes #973

The bash tool only called `killProcessTree` on timeout/abort, never on normal completion. When a command like `nohup python3 ... & echo PID=$!` finished, the shell exited 0 and the bash tool returned — but the backgrounded process was orphaned, its process group never killed.

This caused 4 OOM-kill failures in the terminal-bench-2-1 benchmark (exit codes 137/143), where orphaned PyStan/MobileSAM processes accumulated across multiple attempts until the container exceeded its memory limit.

## Root Cause

The `finally` block in `createLocalBashOperations.exec()` (upstream `@earendil-works/pi-coding-agent`) called `untrackDetachedChildPid(child.pid)` but never `killProcessTree(child.pid)`. So when a bash command completed normally but had backgrounded processes via `&`, `nohup`, or `disown`, those processes were silently abandoned.

## Changes

### 1. Patch: kill process group on normal completion (root cause fix)

**`patches/@earendil-works__pi-coding-agent@0.79.10.patch`** — Added `killProcessTree(child.pid)` to the `finally` block of the bash tool (guarded by `child.exitCode === null` to prevent PID-reuse races), ensuring the entire process group is killed when the bash command completes — not just on timeout/abort.

### 2. Bash-tool-guard: detect backgrounding patterns (steering)

**`src/extensions/bash-tool-guard.ts`** — Added a new `"background"` category that detects `nohup`, `disown`, and standalone `&` (via parsed token segments to avoid false positives on quoted text). The steer message tells the agent to use a long `timeout` and `checkin_interval` with `bash_control` instead.

### 3. Improved BASH_TOOL_DESCRIPTION (prompt-level guidance)

Updated the bash tool description to warn against piping through `tail`/`head` and backgrounding with `nohup`/`disown`/`&`.

### 4. Type updates

**`src/extensions/bash-tool-guard-events.ts`** — Updated payload types to use `BashCategory` instead of the literal union so the new `"background"` category flows through telemetry.

### 5. Tests

- 12 new bash-tool-guard classification tests for backgrounding detection
- 1 new regression test verifying that a backgrounded process is killed when the shell exits normally (deterministic: polls `process.kill(pid, 0)` instead of fixed sleeps)

## Benchmark Evidence

Detailed analysis of all 15 `agent_execution_failed` trials is in `.kimchi/docs/benchmark-agent-execution-failed-analysis.md`. The 4 OOM-killed trials had:
- 2-3 `nohup &` background launches each, with orphaned processes accumulating
- Successful trials for the same tasks had 0 kill commands and 0 orphan mentions
- Per-turn context was modest (15K-61K tokens) — token count was NOT the issue

## Checklist

- [x] Tests added for new behavior
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] Patch file has header documenting upstream tracking and removal criteria