### PR TITLE
fix: teach permission classifier prompt about rtk wrapper

### DIFF
--- a/src/extensions/permissions/prompts/classifier-system-prompt.ts
+++ b/src/extensions/permissions/prompts/classifier-system-prompt.ts
@@ -22,6 +22,8 @@ Focus on concrete blast radius:
   - Process control: sudo, kill, systemctl, shutdown, reboot.
   - Privilege escalation, sandbox escape, or disabling safety hooks.
 
+"rtk" is an optimization wrapper with no side effects; when a command begins with "rtk", evaluate the underlying command as if the prefix were not present.
+
 Commands that are typically safe inside a project directory:
   - Reading, listing, grepping files the agent already has context on.
   - Building, testing, linting, formatting the current project.


### PR DESCRIPTION
## Problem

The permission classifier LLM was flagging rtk-wrapped commands (e.g. `rtk git status`) as medium risk because it saw the unknown `rtk` prefix and defaulted to caution with messages like:

> This command uses rtk (likely a custom tool) for git operations; if it modifies or rewrites history (e.g. via amend or force push), it could be destructive

rtk (github.com/rtk-ai/rtk) is a transparent CLI output-compression proxy that wraps commands, compresses output, preserves exit codes, and passes commands through unchanged with no side effects.

## Changes

Added a note to the classifier system prompt (`classifier-system-prompt.ts`) explaining what the `rtk` prefix is. The LLM now evaluates rtk-wrapped commands as if the prefix were not present.

Rather than stripping rtk from the command string before classification (which would lose quoting/operators and risk parse failures), this teaches the classifier LLM what rtk is — a simpler, more robust approach that avoids touching command parsing.

## Test results
```
Test Files  411 passed | 1 skipped (412)
     Tests  7588 passed | 7 skipped (7595)
```

Typecheck passes clean.

Closes #0