### PR TITLE
fix: classify "service is temporarily unavailable" as retryable provider error

### DIFF
--- a/src/llm-gateway-error.test.ts
+++ b/src/llm-gateway-error.test.ts
@@ -137,6 +137,17 @@ describe("classifyLLMGatewayError", () => {
 			httpStatusCode: 504,
 		},
 		{
+			name: "service is temporarily unavailable (HTTP 200 body)",
+			message: "The service is temporarily unavailable.",
+			reason: "provider_5xx",
+		},
+		{
+			name: "service unavailable (compact form)",
+			message: "503 Service Unavailable",
+			reason: "provider_5xx",
+			httpStatusCode: 503,
+		},
+		{
 			name: "hosted vLLM server disconnected",
 			message: "InternalServerError: Hosted_vllmException - Server disconnected",
 			reason: "provider_error",

--- a/src/llm-gateway-error.ts
+++ b/src/llm-gateway-error.ts
@@ -85,7 +85,7 @@ const STREAM_INTERRUPTED_RE =
 const HOSTED_VLLM_PROVIDER_ERROR_RE =
 	/Hosted_vllmException.*(?:server disconnected|cannot connect to host|connect call failed|cannot schedule new futures after shutdown|executor.*shutdown|upstream request|call_upstream_request_error)|call_upstream_request_error|error sending request/i
 const PROVIDER_5XX_TEXT_RE =
-	/bad gateway|service unavailable|gateway timeout|internal server error|overloaded|overloaded_error|cloudflare.*timeout|timeout.*cloudflare/i
+	/bad gateway|service(?:\s+is)?\s+(?:temporarily\s+)?unavailable|gateway timeout|internal server error|overloaded|overloaded_error|cloudflare.*timeout|timeout.*cloudflare/i
 // Named-phrase forms only; numeric statuses are matched via parseHttpStatusCode.
 // `(?:^|:\s)terminated\b`: when undici kills a stream mid-body, fetch rejects
 // the body read with TypeError("terminated") and layers record it either bare


### PR DESCRIPTION
Fixes #975

## Summary

The `PROVIDER_5XX_TEXT_RE` regex in `src/llm-gateway-error.ts` only matched `service unavailable` (two adjacent words). The actual error message from the `kimchi-dev/glm-5.2-fp8` API is `"The service is temporarily unavailable."` — the words "is temporarily" sit between "service" and "unavailable", so the regex never matched. `classifyLLMGatewayError()` returned `undefined`, meaning `retryable: false`, and the retry infrastructure was never engaged.

This caused 11 of 15 `agent_execution_failed` trials in the terminal-bench-2-1 benchmark to fail immediately on the first or second API call without retrying, even though the error is a transient infrastructure issue (HTTP 200 with error body).

## Fix

Updated the regex to match all three forms:
- `service unavailable` (compact, existing)
- `service is unavailable` (expanded)
- `service is temporarily unavailable` (the actual error)

Now classified as `provider_5xx` (`retryable: true`, `isInfrastructure: true`), so the existing retry infrastructure in `upstream-retry-patch.ts` will automatically retry with exponential backoff.

## Checklist

- [x] Tests added for new behavior
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes