### PR TITLE
fix(billing): soften rate-limited message per UX guidance

### DIFF
--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -75,11 +75,11 @@ export const LOW_CREDITS_THRESHOLD_USD = 5
 export const COMMUNITY_TIER_HEADER_NOTICE =
 	"You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing"
 export const BILLING_EXHAUSTED_MESSAGE = "You ran out of credits. Top up at https://app.kimchi.dev/billing"
-// "Lift", not "restore": a zero balance is reached both by a paid subscriber demoted to free-tier
-// limits and by a free user whose included credits were never spendable, who was therefore rate
-// limited all along. The payload cannot tell the two apart, so the wording must hold for both.
+// A zero balance is reached both by a paid subscriber demoted to free-tier limits and by a free
+// user whose included credits were never spendable, who was therefore rate limited all along. The
+// payload cannot tell the two apart, so the wording must hold for both.
 export const BILLING_RATE_LIMITED_MESSAGE =
-	"You're out of credits, so requests are rate limited. Top up to lift your rate limits: https://app.kimchi.dev/billing"
+	"You just ran out of credits, you can still use Kimchi, but in a slower rate-limited mode. Buy credits on https://app.kimchi.dev/billing"
 const BILLING_REFRESH_TIMEOUT_MS = 5000
 
 const TIER_FIELDS = ["tier", "tier_name", "tierName"] as const

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -118,7 +118,7 @@ test("shows a rate-limit warning when a depleted Coder plan reports as free tier
 			terminal.submit("Use remaining credits")
 
 			await expect(terminal.getByText("Done.", { full: true })).toBeVisible()
-			await waitForText(terminal, "requests are rate limited", { full: true })
+			await waitForText(terminal, "slower rate-limited mode", { full: true })
 			await waitForText(terminal, "https://app.kimchi.dev/billing", { full: true })
 		},
 	)


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Apply the UX team's suggested wording for the rate-limited billing notice: replace "You're out of credits, so requests are rate limited. Top up to lift your rate limits" with "You just ran out of credits, you can still use Kimchi, but in a slower rate-limited mode. Buy credits on https://app.kimchi.dev/billing" — the old wording read like a dead end; the new one makes clear requests keep flowing, only throttled.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
