### PR TITLE
feat: track workflow domain events in telemetry

### DIFF
--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -87,13 +87,13 @@ Common attributes: `run_id`, `workflow_name`, `at` (producer ISO timestamp). Ste
 | `workflow.run.resumed` | Run resumed | — |
 | `workflow.run.blocked` | Run handed control back, waiting on a human | — |
 | `workflow.run.completed` | Run finished | `duration_ms` |
-| `workflow.run.crashed` | Run failed terminally (incl. stale-lock reclaim) | `error.message` *(truncated to 300 chars)*, `duration_ms` |
+| `workflow.run.failed` | Run failed terminally (incl. stale-lock reclaim) | `error.message` *(truncated to 300 chars)*, `duration_ms` |
 | `workflow.run.cancelled` | Run cancelled (incl. cold cancel of a blocked run) | — |
 | `workflow.step.started` | Step execution begins | — |
 | `workflow.step.retried` | Step attempt failed and is retried | `attempt`, `reason`, `error.message` *(truncated)* |
 | `workflow.step.completed` | Step succeeded | `duration_ms` |
 | `workflow.step.failed` | `optional` step exhausted retries, run continues — the health signal for shipped workflows | `error.message` *(truncated)*, `duration_ms` |
-| `workflow.step.cancelled` | Blocked step abandoned after a sibling crashed | — |
+| `workflow.step.cancelled` | Blocked step abandoned after a sibling failed | — |
 
 > **Privacy:** payloads are content-free at the source (asserted by test in the producer): no step inputs/outputs, no questionnaire text or answers, no log text, no node paths or session keys. Error messages name schemas/fields/tools, never values, and arrive pre-truncated.
 

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -73,6 +73,30 @@ Fired from `session-context.ts` via `ctx.emit()`. Batched (max 20) and flushed e
 
 > **Privacy:** Loop-guard events carry only structured fields — `detector` (which loop detector fired), `count` (per-session warn count), and `is_subagent`. Raw tool args, command text, and the human-readable reason string are intentionally **not** emitted, to avoid leaking user data or secrets.
 
+## Workflow Events
+
+Published by `@kimchi-dev/kimchi-workflows` on the **single** pi.events channel `workflow:telemetry` (an envelope: every payload carries an `event` discriminator), translated here by one handler (`handlers/workflows.ts`). The OTLP name is a mechanical derivation — `workflow.` + `event` with `_` → `.` — and payload fields pass through as attributes unchanged (minus `event`). Object-valued fields are flattened generically, one level, into dotted attributes: the error envelope `error: { message }` becomes `error.message`, and envelope fields the producer adds later (`error.retryable`, `error.kind`) ship with no change here. Unknown `event` values are forwarded the same way, so producer-side additions ship without a change here. The canonical contract (channel, event types, payload shapes) lives in the producer's `src/host/telemetry-events.ts`; `workflow-events.ts` here is a mirror.
+
+Common attributes: `run_id`, `workflow_name`, `at` (producer ISO timestamp). Step-scoped events add `step_name` — the leaf of the producer's node path, and the only piece of run structure exported (dynamic paths, static keys and resume keys deliberately stay in the producer's run log). Durations are producer-computed (`duration_ms`), so no subscriber-side state exists for them. Retry reasons are the producer's own telemetry vocabulary: `exception` | `invalid_output` | `budget_exceeded` | `provider_error` | `context_window` — the last two absorb agent-turn request failures, so there is no separate agent-error event.
+
+> **Correlation:** aggregate by (`run_id`, `workflow_name`, `step_name`) and no finer — there is no per-execution key, so under workflow concurrency (`parallel`/`foreach`) events of same-named steps are indistinguishable beyond timestamps. Never pair started/completed events by adjacency; `duration_ms` exists precisely so no pairing is needed. `workflow_name` is unique per project by convention only; it is `""` for a crash recorded by a stale-lock reclaim (join via `run_id`).
+
+| Event | When | Attributes beyond common |
+|-------|------|--------------------------|
+| `workflow.run.started` | Run begins | — |
+| `workflow.run.resumed` | Run resumed | — |
+| `workflow.run.blocked` | Run handed control back, waiting on a human | — |
+| `workflow.run.completed` | Run finished | `duration_ms` |
+| `workflow.run.crashed` | Run failed terminally (incl. stale-lock reclaim) | `error.message` *(truncated to 300 chars)*, `duration_ms` |
+| `workflow.run.cancelled` | Run cancelled (incl. cold cancel of a blocked run) | — |
+| `workflow.step.started` | Step execution begins | — |
+| `workflow.step.retried` | Step attempt failed and is retried | `attempt`, `reason`, `error.message` *(truncated)* |
+| `workflow.step.completed` | Step succeeded | `duration_ms` |
+| `workflow.step.failed` | `optional` step exhausted retries, run continues — the health signal for shipped workflows | `error.message` *(truncated)*, `duration_ms` |
+| `workflow.step.cancelled` | Blocked step abandoned after a sibling crashed | — |
+
+> **Privacy:** payloads are content-free at the source (asserted by test in the producer): no step inputs/outputs, no questionnaire text or answers, no log text, no node paths or session keys. Error messages name schemas/fields/tools, never values, and arrive pre-truncated.
+
 ## Cumulative Metrics (OTLP Sum)
 
 Accumulated across the whole session and flushed every 30s to the **metrics endpoint**.

--- a/src/extensions/telemetry/handlers/workflows.test.ts
+++ b/src/extensions/telemetry/handlers/workflows.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../../config.js"
+import { logEvents, type RecordedEvent } from "../otlp-test-utils.js"
 import { _resetSharedAccumulators, TelemetryContext } from "../session-context.js"
-import type { LogRecord } from "../transport.js"
 import { handleWorkflowEvent } from "./workflows.js"
 
 vi.mock("../../../api/me.js", () => ({
@@ -17,35 +17,6 @@ function makeConfig(overrides: Partial<TelemetryConfig> = {}): TelemetryConfig {
 		apiKey: "",
 		...overrides,
 	}
-}
-
-interface RecordedEvent {
-	eventName: string
-	attrs: Record<string, string>
-}
-
-function attrText(value: LogRecord["attributes"][number]["value"]): string {
-	if ("stringValue" in value) return value.stringValue
-	if ("intValue" in value) return value.intValue
-	return String(value.doubleValue)
-}
-
-/** Every log record POSTed to the logs endpoint, in send order. */
-function logEvents(fetchMock: ReturnType<typeof vi.fn>): RecordedEvent[] {
-	return fetchMock.mock.calls
-		.filter(([url]) => String(url).includes("/logs"))
-		.flatMap(([, init]) => {
-			const body = JSON.parse(String((init as { body?: unknown })?.body)) as {
-				resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }>
-			}
-			return (body.resourceLogs ?? [])
-				.flatMap((resource) => resource.scopeLogs ?? [])
-				.flatMap((scope) => scope.logRecords ?? [])
-				.map((record) => ({
-					eventName: record.eventName,
-					attrs: Object.fromEntries(record.attributes.map((a) => [a.key, attrText(a.value)])),
-				}))
-		})
 }
 
 /** Attrs of one record by its full OTLP name — spelled out per call site to assert the name derivation. */

--- a/src/extensions/telemetry/handlers/workflows.test.ts
+++ b/src/extensions/telemetry/handlers/workflows.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { TelemetryConfig } from "../../../config.js"
+import { _resetSharedAccumulators, TelemetryContext } from "../session-context.js"
+import type { LogRecord } from "../transport.js"
+import { handleWorkflowEvent } from "./workflows.js"
+
+vi.mock("../../../api/me.js", () => ({
+	getMe: vi.fn().mockResolvedValue({ id: "test-user", email: "test@example.com" }),
+}))
+
+function makeConfig(overrides: Partial<TelemetryConfig> = {}): TelemetryConfig {
+	return {
+		enabled: true,
+		endpoint: "https://test.example.com/logs",
+		metricsEndpoint: "https://test.example.com/metrics",
+		headers: { Authorization: "Bearer test" },
+		apiKey: "",
+		...overrides,
+	}
+}
+
+interface RecordedEvent {
+	eventName: string
+	attrs: Record<string, string>
+}
+
+function attrText(value: LogRecord["attributes"][number]["value"]): string {
+	if ("stringValue" in value) return value.stringValue
+	if ("intValue" in value) return value.intValue
+	return String(value.doubleValue)
+}
+
+/** Every log record POSTed to the logs endpoint, in send order. */
+function logEvents(fetchMock: ReturnType<typeof vi.fn>): RecordedEvent[] {
+	return fetchMock.mock.calls
+		.filter(([url]) => String(url).includes("/logs"))
+		.flatMap(([, init]) => {
+			const body = JSON.parse(String((init as { body?: unknown })?.body)) as {
+				resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }>
+			}
+			return (body.resourceLogs ?? [])
+				.flatMap((resource) => resource.scopeLogs ?? [])
+				.flatMap((scope) => scope.logRecords ?? [])
+				.map((record) => ({
+					eventName: record.eventName,
+					attrs: Object.fromEntries(record.attributes.map((a) => [a.key, attrText(a.value)])),
+				}))
+		})
+}
+
+/** Attrs of one record by its full OTLP name — spelled out per call site to assert the name derivation. */
+function attrsOf(events: RecordedEvent[], eventName: string): Record<string, string> | undefined {
+	return events.find((record) => record.eventName === eventName)?.attrs
+}
+
+const RUN_ID = "workflow-demo-1a2b3c4d"
+const AT = "2026-01-01T00:00:00.000Z"
+
+describe("handlers/workflows", () => {
+	let originalFetch: typeof globalThis.fetch
+	let fetchMock: ReturnType<typeof vi.fn>
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+		fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: vi.fn().mockResolvedValue(""),
+		} as unknown as Response)
+		globalThis.fetch = fetchMock
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+		_resetSharedAccumulators()
+		vi.restoreAllMocks()
+	})
+
+	async function emitted(raw: unknown): Promise<RecordedEvent[]> {
+		const ctx = new TelemetryContext(makeConfig())
+		handleWorkflowEvent(ctx, raw)
+		ctx.flushLogBuffer()
+		await Promise.allSettled([...ctx.inFlight])
+		return logEvents(fetchMock)
+	}
+
+	it("derives the OTLP name mechanically and passes the fields through, minus `event`", async () => {
+		const events = await emitted({
+			event: "run_started",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+		})
+
+		const attrs = attrsOf(events, "workflow.run.started")
+		expect(attrs?.run_id).toBe(RUN_ID)
+		expect(attrs?.workflow_name).toBe("demo")
+		expect(attrs?.at).toBe(AT)
+		// The discriminator is encoded in the event name; carrying it again would be noise.
+		expect(attrs).not.toHaveProperty("event")
+		// Ambient identifiers are layered on by the shared emit path.
+		expect(attrs?.["session.id"]).toBeDefined()
+	})
+
+	it("flattens the error envelope into dotted attributes — the step_retried shape end to end", async () => {
+		const events = await emitted({
+			event: "step_retried",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+			step_name: "review",
+			attempt: 3,
+			reason: "context_window",
+			error: { message: "the input is longer than the context length" },
+		})
+
+		const attrs = attrsOf(events, "workflow.step.retried")
+		expect(attrs?.step_name).toBe("review")
+		expect(attrs?.attempt).toBe("3")
+		expect(attrs?.reason).toBe("context_window")
+		expect(attrs?.["error.message"]).toBe("the input is longer than the context length")
+		expect(attrs).not.toHaveProperty("error")
+	})
+
+	it("flattens envelope fields it has never heard of — producer envelope growth ships without a change here", async () => {
+		const events = await emitted({
+			event: "step_failed",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+			step_name: "gate",
+			error: { message: "gate did not pass", retryable: false, kind: "verification" },
+		})
+
+		const attrs = attrsOf(events, "workflow.step.failed")
+		expect(attrs).toBeDefined()
+		expect(attrs?.["error.message"]).toBe("gate did not pass")
+		expect(attrs?.["error.retryable"]).toBe("false")
+		expect(attrs?.["error.kind"]).toBe("verification")
+	})
+
+	it("forwards an event type it has never heard of — producer additions ship without a change here", async () => {
+		const events = await emitted({
+			event: "loop_iteration",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+			iteration: 2,
+		})
+
+		const attrs = attrsOf(events, "workflow.loop.iteration")
+		expect(attrs).toBeDefined()
+		expect(attrs?.iteration).toBe("2")
+	})
+
+	it("drops arrays and anything nested past one level — the contract says one level of primitives", async () => {
+		const events = await emitted({
+			event: "run_completed",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+			tags: ["a", "b"],
+			error: { message: "ok", details: { stack: "do-not-export-this" } },
+		})
+
+		const attrs = attrsOf(events, "workflow.run.completed")
+		expect(attrs).toBeDefined()
+		expect(attrs).not.toHaveProperty("tags")
+		expect(attrs?.["error.message"]).toBe("ok")
+		expect(attrs).not.toHaveProperty("error.details")
+		expect(JSON.stringify(attrs)).not.toContain("do-not-export-this")
+	})
+
+	it("omits undefined fields instead of exporting empty attributes", async () => {
+		const events = await emitted({
+			event: "run_completed",
+			run_id: RUN_ID,
+			workflow_name: "demo",
+			at: AT,
+			duration_ms: undefined,
+		})
+
+		const attrs = attrsOf(events, "workflow.run.completed")
+		expect(attrs).toBeDefined()
+		expect(attrs).not.toHaveProperty("duration_ms")
+	})
+
+	it.each([
+		undefined,
+		null,
+		"not an object",
+		42,
+		{},
+		{ event: "" },
+		{ event: 7 },
+	])("emits nothing for a payload with no usable discriminator: %j", async (raw) => {
+		const events = await emitted(raw)
+		expect(events.filter((record) => record.eventName.startsWith("workflow."))).toEqual([])
+	})
+})

--- a/src/extensions/telemetry/handlers/workflows.ts
+++ b/src/extensions/telemetry/handlers/workflows.ts
@@ -1,0 +1,39 @@
+/**
+ * Translates workflow domain events (@kimchi-dev/kimchi-workflows) into OTLP log records.
+ *
+ * One generic handler for the whole contract — unlike the one-handler-per-channel ferment shape —
+ * in three deliberate ways:
+ *
+ *  - Unknown `event` values are FORWARDED, not dropped: content-freedom is enforced producer-side,
+ *    so a new producer event ships end-to-end with no change here.
+ *  - Object fields flatten GENERICALLY, one level, into dotted attributes (`error.message`). Deeper
+ *    nesting is dropped: anything past one level is a producer bug this side must not amplify.
+ *  - No subscriber-side start-time maps: durations arrive producer-computed.
+ */
+import type { TelemetryAttributes, TelemetryContext } from "../session-context.js"
+import type { WorkflowEventCommon } from "../workflow-events.js"
+
+function isPrimitive(value: unknown): value is string | number | boolean {
+	return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+}
+
+export function handleWorkflowEvent(ctx: TelemetryContext, raw: unknown): void {
+	// Partial<common>, not the payload union: unknown events must pass; malformed input must fail the guards.
+	const payload = raw as Partial<WorkflowEventCommon> | null | undefined
+	const event = payload?.event
+	if (typeof event !== "string" || event === "") return
+
+	const attrs: TelemetryAttributes = {}
+	for (const [key, value] of Object.entries(payload as object)) {
+		if (key === "event") continue
+		if (isPrimitive(value)) {
+			attrs[key] = value
+		} else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+			for (const [innerKey, innerValue] of Object.entries(value)) {
+				if (isPrimitive(innerValue)) attrs[`${key}.${innerKey}`] = innerValue
+			}
+		}
+	}
+
+	ctx.emit(`workflow.${event.replaceAll("_", ".")}`, attrs)
+}

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -9,8 +9,8 @@ import telemetryExtension, {
 	trackSurveyDismissed,
 	trackSurveyShown,
 } from "./index.js"
+import { logEvents } from "./otlp-test-utils.js"
 import { _resetSharedAccumulators } from "./session-context.js"
-import type { LogRecord } from "./transport.js"
 
 vi.mock("../ferment/index.js", () => ({
 	getActiveFerment: vi.fn(() => undefined),
@@ -1548,21 +1548,7 @@ describe("workflow telemetry via pi.events", () => {
 
 	/** One record's attributes, looked up by its OTLP event name. */
 	function attrsOf(eventName: string): Record<string, string> | undefined {
-		const record = fetchMock.mock.calls
-			.filter(([url]: unknown[]) => String(url).includes("/logs"))
-			.flatMap(([, opts]: unknown[]) => {
-				const body = JSON.parse((opts as { body: string }).body) as {
-					resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }>
-				}
-				return (body.resourceLogs ?? [])
-					.flatMap((resource) => resource.scopeLogs ?? [])
-					.flatMap((scope) => scope.logRecords ?? [])
-			})
-			.find((rec) => rec.eventName === eventName)
-		return (
-			record &&
-			Object.fromEntries(record.attributes.map((a) => [a.key, "stringValue" in a.value ? a.value.stringValue : ""]))
-		)
+		return logEvents(fetchMock).find((record) => record.eventName === eventName)?.attrs
 	}
 
 	/** Flush buffered OTLP log records by triggering session_shutdown. */

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -10,6 +10,7 @@ import telemetryExtension, {
 	trackSurveyShown,
 } from "./index.js"
 import { _resetSharedAccumulators } from "./session-context.js"
+import type { LogRecord } from "./transport.js"
 
 vi.mock("../ferment/index.js", () => ({
 	getActiveFerment: vi.fn(() => undefined),
@@ -1513,6 +1514,104 @@ describe("loop-guard telemetry via pi.events", () => {
 			detector: "edit_run",
 			count: 1,
 			is_subagent: false,
+		})
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})
+
+describe("workflow telemetry via pi.events", () => {
+	let fetchMock: ReturnType<typeof vi.fn>
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "" })
+		originalFetch = globalThis.fetch
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		globalThis.fetch = fetchMock as any
+	})
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch
+		_resetSharedAccumulators()
+		const { _resetFermentTrackingState } = await import("./index.js")
+		_resetFermentTrackingState()
+		vi.restoreAllMocks()
+	})
+
+	async function setup() {
+		const { handlers, events, api, ctx } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+		return { handlers, events }
+	}
+
+	/** One record's attributes, looked up by its OTLP event name. */
+	function attrsOf(eventName: string): Record<string, string> | undefined {
+		const record = fetchMock.mock.calls
+			.filter(([url]: unknown[]) => String(url).includes("/logs"))
+			.flatMap(([, opts]: unknown[]) => {
+				const body = JSON.parse((opts as { body: string }).body) as {
+					resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }>
+				}
+				return (body.resourceLogs ?? [])
+					.flatMap((resource) => resource.scopeLogs ?? [])
+					.flatMap((scope) => scope.logRecords ?? [])
+			})
+			.find((rec) => rec.eventName === eventName)
+		return (
+			record &&
+			Object.fromEntries(record.attributes.map((a) => [a.key, "stringValue" in a.value ? a.value.stringValue : ""]))
+		)
+	}
+
+	/** Flush buffered OTLP log records by triggering session_shutdown. */
+	async function flushTelemetry(handlers: Map<string, Handler[]>) {
+		await getHandler(handlers, "session_shutdown")({ reason: "test" })
+	}
+
+	it("one envelope subscription: every workflow event arrives through workflow:telemetry", async () => {
+		const { handlers, events } = await setup()
+		const { WORKFLOW_TELEMETRY_CHANNEL } = await import("./workflow-events.js")
+
+		events.emit(WORKFLOW_TELEMETRY_CHANNEL, {
+			event: "run_started",
+			run_id: "workflow-demo-1a2b3c4d",
+			workflow_name: "demo",
+			at: "2026-01-01T00:00:00.000Z",
+		})
+		events.emit(WORKFLOW_TELEMETRY_CHANNEL, {
+			event: "step_failed",
+			run_id: "workflow-demo-1a2b3c4d",
+			workflow_name: "demo",
+			at: "2026-01-01T00:00:05.000Z",
+			step_name: "gate",
+			error: { message: "gate did not pass" },
+			duration_ms: 5000,
+		})
+		await flushTelemetry(handlers)
+
+		const started = attrsOf("workflow.run.started")
+		expect(started?.run_id).toBe("workflow-demo-1a2b3c4d")
+		expect(started?.workflow_name).toBe("demo")
+		expect(started?.["session.id"]).toBeDefined()
+
+		const failed = attrsOf("workflow.step.failed")
+		expect(failed?.step_name).toBe("gate")
+		expect(failed?.["error.message"]).toBe("gate did not pass")
+		expect(failed?.duration_ms).toBe("5000")
+	})
+
+	it("does NOT emit OTLP records when telemetry is disabled", async () => {
+		const { events } = createMockApi()
+		const { default: ext } = await import("./index.js")
+		ext(makeConfig({ enabled: false }))({ on: vi.fn(), events } as unknown as ExtensionAPI)
+		const { WORKFLOW_TELEMETRY_CHANNEL } = await import("./workflow-events.js")
+		events.emit(WORKFLOW_TELEMETRY_CHANNEL, {
+			event: "run_started",
+			run_id: "workflow-demo-1a2b3c4d",
+			workflow_name: "demo",
+			at: "2026-01-01T00:00:00.000Z",
 		})
 		expect(fetchMock).not.toHaveBeenCalled()
 	})

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -38,6 +38,7 @@ import {
 	handleSessionStart,
 } from "./handlers/session.js"
 import { handleToolExecutionEnd, handleToolExecutionStart } from "./handlers/tools.js"
+import { handleWorkflowEvent } from "./handlers/workflows.js"
 import { type TelemetryAttributes, TelemetryContext } from "./session-context.js"
 import { startSettingsChangeWatcher } from "./settings-change-emitter.js"
 import {
@@ -48,6 +49,7 @@ import {
 	type SurveyDismissedTelemetry,
 	type SurveyShownTelemetry,
 } from "./survey.js"
+import { WORKFLOW_TELEMETRY_CHANNEL } from "./workflow-events.js"
 
 // ---------------------------------------------------------------------------
 // Module-level state for ferment lifecycle tracking
@@ -632,6 +634,17 @@ function onLoopGuardSubagentAbort(raw: unknown): void {
 }
 
 // ---------------------------------------------------------------------------
+// Workflow domain event handler (subscribed via pi.events)
+// ---------------------------------------------------------------------------
+
+function onWorkflowTelemetry(raw: unknown): void {
+	if (!isEnabled()) return
+	const ctx = _telemetryCtx
+	if (!ctx) return
+	handleWorkflowEvent(ctx, raw)
+}
+
+// ---------------------------------------------------------------------------
 // Extension factory
 // ---------------------------------------------------------------------------
 
@@ -676,6 +689,9 @@ export default function telemetryExtension(config: TelemetryConfig) {
 		// telemetry translates them into OTLP records for analytics.
 		pi.events.on(LOOP_GUARD_EVENTS.WARN, onLoopGuardWarn)
 		pi.events.on(LOOP_GUARD_EVENTS.SUBAGENT_ABORT, onLoopGuardSubagentAbort)
+
+		// Workflow domain events (kimchi-workflows): one envelope channel covers the whole contract.
+		pi.events.on(WORKFLOW_TELEMETRY_CHANNEL, onWorkflowTelemetry)
 
 		pi.on("session_start", async (_event, ctx) => {
 			resetBashGuardCounts()

--- a/src/extensions/telemetry/otlp-test-utils.ts
+++ b/src/extensions/telemetry/otlp-test-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Test-side helpers for reading back what the OTLP transport POSTed.
+ *
+ * Parsed with the transport's own {@link LogRecord}, so the production wire format is the test
+ * type — shared by every test file in this folder rather than inlined per file.
+ */
+import type { LogRecord } from "./transport.js"
+
+/** One POSTed log record: event name plus flattened string attributes. */
+export interface RecordedEvent {
+	eventName: string
+	attrs: Record<string, string>
+}
+
+function attrText(value: LogRecord["attributes"][number]["value"]): string {
+	if ("stringValue" in value) return value.stringValue
+	if ("intValue" in value) return value.intValue
+	return String(value.doubleValue)
+}
+
+/** Every log record POSTed to the logs endpoint by the given fetch mock, in send order. */
+export function logEvents(fetchMock: { mock: { calls: unknown[][] } }): RecordedEvent[] {
+	return fetchMock.mock.calls
+		.filter(([url]) => String(url).includes("/logs"))
+		.flatMap(([, init]) => {
+			const body = JSON.parse(String((init as { body?: unknown })?.body)) as {
+				resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }>
+			}
+			return (body.resourceLogs ?? [])
+				.flatMap((resource) => resource.scopeLogs ?? [])
+				.flatMap((scope) => scope.logRecords ?? [])
+				.map((record) => ({
+					eventName: record.eventName,
+					attrs: Object.fromEntries(record.attributes.map((a) => [a.key, attrText(a.value)])),
+				}))
+		})
+}

--- a/src/extensions/telemetry/workflow-events.ts
+++ b/src/extensions/telemetry/workflow-events.ts
@@ -65,8 +65,8 @@ export interface WorkflowRunCompletedPayload extends WorkflowEventCommon {
 	readonly duration_ms?: number
 }
 
-export interface WorkflowRunCrashedPayload extends WorkflowEventCommon {
-	readonly event: "run_crashed"
+export interface WorkflowRunFailedPayload extends WorkflowEventCommon {
+	readonly event: "run_failed"
 	readonly error: WorkflowError
 	readonly duration_ms?: number
 }
@@ -94,7 +94,7 @@ export interface WorkflowStepCompletedPayload extends WorkflowStepEventCommon {
 /**
  * An `optional` step exhausted retries while the run carried on — for shipped workflows (most agent
  * steps are optional, so a run can complete "successfully" with many failed steps) this, not
- * `run_crashed`, is the health signal.
+ * `run_failed`, is the health signal.
  */
 export interface WorkflowStepFailedPayload extends WorkflowStepEventCommon {
 	readonly event: "step_failed"
@@ -112,7 +112,7 @@ export type WorkflowEventPayload =
 	| WorkflowRunResumedPayload
 	| WorkflowRunBlockedPayload
 	| WorkflowRunCompletedPayload
-	| WorkflowRunCrashedPayload
+	| WorkflowRunFailedPayload
 	| WorkflowRunCancelledPayload
 	| WorkflowStepStartedPayload
 	| WorkflowStepRetriedPayload

--- a/src/extensions/telemetry/workflow-events.ts
+++ b/src/extensions/telemetry/workflow-events.ts
@@ -1,0 +1,121 @@
+/**
+ * Workflow domain events published via pi.events by @kimchi-dev/kimchi-workflows.
+ *
+ * MIRROR, not source: the canonical contract (channel, payload shapes) lives in the producer's
+ * `src/host/telemetry-events.ts` (rationale in its `specs/telemetry.md`). Nothing is imported from
+ * it by design, so drift is silent rather than a compile error — reconcile changes manually. This
+ * file is the stepping stone to a shared contract package and should be deleted once one exists.
+ *
+ * Everything arrives on the single envelope {@link WORKFLOW_TELEMETRY_CHANNEL}, discriminated by
+ * each payload's `event` field; translation policy lives in `handlers/workflows.ts`, consumer-facing
+ * detail (correlation, privacy, retry semantics) in this folder's README.
+ */
+
+/** The single channel every workflow event arrives on. */
+export const WORKFLOW_TELEMETRY_CHANNEL = "workflow:telemetry"
+
+/**
+ * Why a step attempt was retried — the producer's own vocabulary (translated from its engine's).
+ * `provider_error`/`context_window` absorb agent-turn request failures into the retry they cause,
+ * preserving the provider-failed-vs-model-misbehaved distinction without a separate agent event.
+ */
+export type WorkflowRetryReason =
+	| "exception"
+	| "invalid_output"
+	| "budget_exceeded"
+	| "provider_error"
+	| "context_window"
+
+/** The error envelope — the contract's only object field, one level of primitives. */
+export interface WorkflowError {
+	readonly message: string
+}
+
+/**
+ * On every payload. `workflow_name` is author-declared (unique per project by convention); it is `""`
+ * for a terminal event from a stale-lock reclaim — join those via `run_id`. `at` is the producer's ISO timestamp.
+ */
+export interface WorkflowEventCommon {
+	readonly event: string
+	readonly run_id: string
+	readonly workflow_name: string
+	readonly at: string
+}
+
+/** Step-scoped events add `step_name`: the leaf of the producer's node path — the only run structure exported (data minimization). */
+export interface WorkflowStepEventCommon extends WorkflowEventCommon {
+	readonly step_name: string
+}
+
+export interface WorkflowRunStartedPayload extends WorkflowEventCommon {
+	readonly event: "run_started"
+}
+
+export interface WorkflowRunResumedPayload extends WorkflowEventCommon {
+	readonly event: "run_resumed"
+}
+
+/** The run handed control back and waits on a human. What it waits FOR is the producer's run log's business. */
+export interface WorkflowRunBlockedPayload extends WorkflowEventCommon {
+	readonly event: "run_blocked"
+}
+
+export interface WorkflowRunCompletedPayload extends WorkflowEventCommon {
+	readonly event: "run_completed"
+	readonly duration_ms?: number
+}
+
+export interface WorkflowRunCrashedPayload extends WorkflowEventCommon {
+	readonly event: "run_crashed"
+	readonly error: WorkflowError
+	readonly duration_ms?: number
+}
+
+export interface WorkflowRunCancelledPayload extends WorkflowEventCommon {
+	readonly event: "run_cancelled"
+}
+
+export interface WorkflowStepStartedPayload extends WorkflowStepEventCommon {
+	readonly event: "step_started"
+}
+
+export interface WorkflowStepRetriedPayload extends WorkflowStepEventCommon {
+	readonly event: "step_retried"
+	readonly attempt: number
+	readonly reason: WorkflowRetryReason
+	readonly error: WorkflowError
+}
+
+export interface WorkflowStepCompletedPayload extends WorkflowStepEventCommon {
+	readonly event: "step_completed"
+	readonly duration_ms?: number
+}
+
+/**
+ * An `optional` step exhausted retries while the run carried on — for shipped workflows (most agent
+ * steps are optional, so a run can complete "successfully" with many failed steps) this, not
+ * `run_crashed`, is the health signal.
+ */
+export interface WorkflowStepFailedPayload extends WorkflowStepEventCommon {
+	readonly event: "step_failed"
+	readonly error: WorkflowError
+	readonly duration_ms?: number
+}
+
+export interface WorkflowStepCancelledPayload extends WorkflowStepEventCommon {
+	readonly event: "step_cancelled"
+}
+
+/** Every payload the producer publishes today, discriminated by `event`. */
+export type WorkflowEventPayload =
+	| WorkflowRunStartedPayload
+	| WorkflowRunResumedPayload
+	| WorkflowRunBlockedPayload
+	| WorkflowRunCompletedPayload
+	| WorkflowRunCrashedPayload
+	| WorkflowRunCancelledPayload
+	| WorkflowStepStartedPayload
+	| WorkflowStepRetriedPayload
+	| WorkflowStepCompletedPayload
+	| WorkflowStepFailedPayload
+	| WorkflowStepCancelledPayload


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Subscribe once to the single workflow:telemetry envelope channel published by @kimchi-dev/kimchi-workflows and export each event as an OTLP log record.

The handler is deliberately generic: the event name is derived mechanically (workflow. + event with _ -> .), payload fields pass through as attributes with one-level dotted flattening, and unknown event types or envelope fields are forwarded — producer-side additions ship without changes here. The payload contract is mirrored in workflow-events.ts until a shared contract package exists; consumer-facing detail (correlation rules, privacy) lives in the telemetry README.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
