### PR TITLE
fix: preserve extension system prompt on mid-run setActiveTools

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -95,7 +95,7 @@ index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..63ca4495adc5dc3428d45f3a8bfaa3b7
    ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
    ANT_LING_API_KEY                 - Ant Ling API key
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaace7fe87ae 100644
+index 3b2c24d1b52869e351ea488f0c535c34eaedf127..2006918a17488764ffc7fd7cf4aee973e98d6e5d 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
 @@ -60,7 +60,7 @@
@@ -148,7 +148,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
      }
      /** Whether compaction or branch summarization is currently running */
      get isCompacting() {
-@@ -1001,7 +1023,37 @@
+@@ -1001,7 +1023,42 @@
              }
          }
          else if (options?.triggerTurn) {
@@ -160,7 +160,12 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
 +            // true }) or followUp delivery (kimchi ferment/one-shot flows), leaving
 +            // the agent on the default base prompt for the whole run.
 +            const triggerMessages = [appMessage];
-+            const triggerText = appMessage.content
++            // content may be a plain string (agent-completion notifications,
++            // feedback nudges) or ContentPart[] — normalize before extracting text.
++            const triggerParts = Array.isArray(appMessage.content)
++                ? appMessage.content
++                : [{ type: "text", text: String(appMessage.content) }];
++            const triggerText = triggerParts
 +                .filter((part) => part.type === "text")
 +                .map((part) => part.text)
 +                .join("\n");
@@ -187,7 +192,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
          }
          else {
              this.agent.state.messages.push(appMessage);
-@@ -1270,8 +1322,9 @@
+@@ -1270,8 +1327,9 @@
       * Manually compact the session context.
       * Aborts current agent operation first.
       * @param customInstructions Optional instructions for the compaction summary
@@ -198,7 +203,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
          this._disconnectFromAgent();
          await this.abort();
          this._compactionAbortController = new AbortController();
-@@ -1283,14 +1336,21 @@
+@@ -1283,14 +1341,21 @@
              const { apiKey, headers, env } = await this._getCompactionRequestAuth(this.model);
              const pathEntries = this.sessionManager.getBranch();
              const settings = this.settingsManager.getCompactionSettings();
@@ -222,7 +227,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
              }
              let extensionCompaction;
              let fromExtension = false;
-@@ -1678,8 +1738,13 @@
+@@ -1678,8 +1743,13 @@
              themePaths: this.buildExtensionResourcePaths(themePaths),
          };
          this._resourceLoader.extendResources(extensionPaths);
@@ -237,7 +242,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaac
      }
      buildExtensionResourcePaths(entries) {
          return entries.map((entry) => {
-@@ -1809,7 +1874,7 @@
+@@ -1809,7 +1879,7 @@
              compact: (options) => {
                  void (async () => {
                      try {

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -23,6 +23,18 @@
 #                                   Also add "xhigh" and "max" to the THINKING_LEVELS
 #                                   fallback constant so getAvailableThinkingLevels()
 #                                   returns them when no model is set.
+#                                   Also make setActiveToolsByName() and the
+#                                   resources-discovered reload path preserve an
+#                                   extension-installed system prompt (any prompt that
+#                                   differs from _baseSystemPrompt, e.g. a
+#                                   before_agent_start override) instead of resetting
+#                                   to the default prompt. Upstream tracking:
+#                                   https://github.com/earendil-works/pi-mono/issues/new
+#                                   (file alongside PR; see .kimchi/docs/pi-default-prompt-investigation.md).
+#                                   Removal criteria: upstream setActiveToolsByName /
+#                                   resource reload no longer clobber a non-base
+#                                   systemPrompt, or upstream adds a prompt
+#                                   re-resolution hook we adopt instead.
 #   5. dist/modes/interactive/  — miscellaneous upstream UI fixes bundled in this patch
 #   6. dist/modes/interactive/interactive-mode.js — add previewTheme(name) and
 #      dist/core/extensions/types.d.ts              showError(message) to createExtensionUIContext,
@@ -35,69 +47,16 @@
 #                                 the public ui.setTheme() includes.
 #
 #                                 Why a patch is required: the public ExtensionUIContext conflates
-#                                 "change the rendered theme" and "persist to settingsManager" — the
-#                                 public ui.setTheme() always does both. Theme preview already exists
+#                                 "change the rendered theme" and "persist to settingsManager" —
+#                                 the public ui.setTheme() always does both. Theme preview already exists
 #                                 inside InteractiveMode (used by /settings via the private
 #                                 themeController.preview()); the patch simply promotes it to the
 #                                 extension API surface. There is no public-API-only workaround: the
 #                                 only alternative is ui.setTheme() on each arrow-key press, which
 #                                 writes to disk every keystroke and leaves a dirty settings state
 #                                 if the user cancels.
-#
-#                                 showError delegates to the inherited SessionMode.showError so
-#                                 extensions can surface error overlays (not toasts).
-#   7. dist/modes/interactive/components/model-selector.js — accept sessionId constructor
-#      dist/modes/interactive/interactive-mode.js            parameter and key all reads/writes
-#                                                            to process.__kimchiMultiModelEnabled
-#                                                            and process.__kimchiOrchestratorRef
-#                                                            through Map<sessionId, value> instead
-#                                                            of plain globals, so multi-model state
-#                                                            is per-session.
-#   8. dist/core/tools/bash.js — (a) destroy child stdio streams 500ms after a timeout kill
-#      so the tool call returns even when setsid'd grandchildren (e.g. bubblewrap used
-#      by opam install on Linux) escape the process group SIGKILL and keep the stdout
-#      pipe open, which would otherwise cause waitForChildProcess to hang indefinitely.
-#      (b) call killProcessTree in the finally block on normal completion, not just on
-#      timeout/abort. Without this, processes backgrounded with `&` / `nohup` / `disown`
-#      inside a bash command are orphaned when the shell exits, accumulating until the
-#      container OOMs. Upstream tracking: TBD.
-#      Removal criteria: upstream merges a fix that kills the process group on
-#      normal completion in the bash tool.
-#   9. package.json — add "./dist/core/tools/output-accumulator.js" to the package's
-#      exports map (with types + import conditions) so deep imports of OutputAccumulator
-#      resolve correctly at runtime and type-check time. Needed by the background-bash
-#      extension's process registry, which uses OutputAccumulator directly instead of
-#      a local wrapper.
-#
-# Tracking: open an upstream PR against pi-mono to ship before_provider_headers as
-# a first-class extension hook in ExtensionRunner and ExtensionAPI. Also track a
-# separate PR to add previewTheme + showError to ExtensionUIContext.
-# Issue: TODO — file against https://github.com/earendil-works/pi-mono once the
-# API design is confirmed stable.
-#
-# Removal criteria:
-#   - Items 1-3 (before_provider_headers): upstream pi-mono ships BeforeProviderHeadersEvent
-#     and ExtensionAPI.on("before_provider_headers", ...) as a first-class hook, and
-#     the fixed version is pinned in package.json.
-#   - Item 4 (prepareNextTurn + THINKING_LEVELS): upstream pi-mono wires
-#     agent.prepareNextTurn in AgentSession._installAgentToolHooks() so context.tools
-#     refreshes after each tool batch without a patch, AND upstream pi-coding-agent
-#     includes "xhigh" and "max" in the THINKING_LEVELS constant. Both must be
-#     fixed and the version pinned in package.json.
-#   - Item 5: individual fixes land upstream and the patched version is updated.
-#   - Item 6 (previewTheme + showError): upstream pi-coding-agent ships previewTheme
-#     and showError on ExtensionUIContext and the fixed version is pinned in package.json.
-#   - Item 7: Kimchi-specific multi-model settings.
-#   - Item 8 (bash timeout stream destroy): upstream pi-coding-agent's
-#     createLocalBashOperations destroys child stdio after a timeout kill (or
-#     waitForChildProcess gains a max-wait that forces resolution), and the
-#     fixed version is pinned in package.json.
-#   - Item 9 (output-accumulator exports): upstream pi-coding-agent exports
-#     OutputAccumulator from the package root (or adds the deep path to exports),
-#     and the fixed version is pinned in package.json.
-#
 diff --git a/dist/cli/args.js b/dist/cli/args.js
-index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d198245751 100644
+index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..63ca4495adc5dc3428d45f3a8bfaa3b7cc6a1d65 100644
 --- a/dist/cli/args.js
 +++ b/dist/cli/args.js
 @@ -3,7 +3,7 @@
@@ -109,9 +68,15 @@ index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d1
  export function isValidThinkingLevel(level) {
      return VALID_THINKING_LEVELS.includes(level);
  }
-@@ -248,1 +248,1 @@
+@@ -246,7 +246,7 @@ ${chalk.bold("Options:")}
+                                  Applies to built-in, extension, and custom tools
+   --exclude-tools, -xt <tools>   Comma-separated denylist of tool names to disable
+                                  Applies to built-in, extension, and custom tools
 -  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
 +  --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh, max
+   --extension, -e <path>         Load an extension file (can be used multiple times)
+   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)
+   --skill <path>                 Load a skill file or directory (can be used multiple times)
 @@ -321,6 +321,7 @@ ${chalk.bold("Examples:")}
    ${APP_NAME} --export session.jsonl output.html
  
@@ -121,10 +86,10 @@ index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..ad705421fb9087efd8ad2cfbfe8709d1
    ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
    ANT_LING_API_KEY                 - Ant Ling API key
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index 3b2c24d1b52869e351ea488f0c535c34eaedf127..7302cc4df1e25be2e38489afb7c8ea8364695542 100644
+index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf10045040705ae15d92 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -60,7 +60,7 @@
+@@ -60,7 +60,7 @@ function estimateMessagesTokens(messages) {
  // Constants
  // ============================================================================
  /** Standard thinking levels */
@@ -154,7 +119,27 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..7302cc4df1e25be2e38489afb7c8ea83
          this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
              const runner = this._extensionRunner;
              if (!runner.hasHandlers("tool_result")) {
-@@ -1270,8 +1284,9 @@ export class AgentSession {
+@@ -558,9 +572,17 @@ export class AgentSession {
+             }
+         }
+         this.agent.state.tools = tools;
+-        // Rebuild base system prompt with new tool set
++        // Rebuild base system prompt with new tool set.
++        // kimchi-dev: preserve an extension-installed system prompt (e.g. a
++        // before_agent_start override). This method's contract is to change the
++        // tool set; unconditionally resetting state.systemPrompt would discard
++        // extension-built prompts mid-run, degrading the model to the default
++        // prompt until the next user prompt re-fires before_agent_start.
++        const systemPromptOverride = this.agent.state.systemPrompt !== this._baseSystemPrompt
++            ? this.agent.state.systemPrompt
++            : undefined;
+         this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
+-        this.agent.state.systemPrompt = this._baseSystemPrompt;
++        this.agent.state.systemPrompt = systemPromptOverride ?? this._baseSystemPrompt;
+     }
+     /** Whether compaction or branch summarization is currently running */
+     get isCompacting() {
+@@ -1270,8 +1292,9 @@ export class AgentSession {
       * Manually compact the session context.
       * Aborts current agent operation first.
       * @param customInstructions Optional instructions for the compaction summary
@@ -165,7 +150,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..7302cc4df1e25be2e38489afb7c8ea83
          this._disconnectFromAgent();
          await this.abort();
          this._compactionAbortController = new AbortController();
-@@ -1283,14 +1298,21 @@ export class AgentSession {
+@@ -1283,14 +1306,21 @@ export class AgentSession {
              const { apiKey, headers, env } = await this._getCompactionRequestAuth(this.model);
              const pathEntries = this.sessionManager.getBranch();
              const settings = this.settingsManager.getCompactionSettings();
@@ -189,7 +174,22 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..7302cc4df1e25be2e38489afb7c8ea83
              }
              let extensionCompaction;
              let fromExtension = false;
-@@ -1809,7 +1831,7 @@ export class AgentSession {
+@@ -1678,8 +1708,13 @@ export class AgentSession {
+             themePaths: this.buildExtensionResourcePaths(themePaths),
+         };
+         this._resourceLoader.extendResources(extensionPaths);
++        // kimchi-dev: same override preservation as setActiveToolsByName — newly
++        // discovered resources must not discard an extension-installed prompt.
++        const systemPromptOverride = this.agent.state.systemPrompt !== this._baseSystemPrompt
++            ? this.agent.state.systemPrompt
++            : undefined;
+         this._baseSystemPrompt = this._rebuildSystemPrompt(this.getActiveToolNames());
+-        this.agent.state.systemPrompt = this._baseSystemPrompt;
++        this.agent.state.systemPrompt = systemPromptOverride ?? this._baseSystemPrompt;
+     }
+     buildExtensionResourcePaths(entries) {
+         return entries.map((entry) => {
+@@ -1809,7 +1844,7 @@ export class AgentSession {
              compact: (options) => {
                  void (async () => {
                      try {
@@ -317,7 +317,7 @@ index e386db6d62622a8c77c7d7e9844e63020d8af39a..f2f9e0161b47f7111df88f429c36feb7
          },
          onPayload: async (payload, _model) => {
 diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
-index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b8c9d0e1f 100644
+index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..e746c2c99edd7fb9da866b60f80fb8b8de8ed630 100644
 --- a/dist/core/tools/bash.js
 +++ b/dist/core/tools/bash.js
 @@ -62,6 +62,16 @@ export function createLocalBashOperations(options) {
@@ -337,12 +337,10 @@ index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b
                      }, timeout * 1000);
                  }
                  // Stream stdout and stderr.
-@@ -95,12 +105,22 @@ export function createLocalBashOperations(options) {
+@@ -86,6 +96,16 @@ export function createLocalBashOperations(options) {
                  return { exitCode };
              }
              finally {
--                if (child.pid)
--                    untrackDetachedChildPid(child.pid);
 +                // Kill the process group on normal completion too, not just
 +                // on timeout/abort. Without this, processes backgrounded with
 +                // `&` / `nohup` / `disown` inside the bash command are
@@ -353,15 +351,9 @@ index 98b69bb9ccf6464dfaec7b2271cf78677cb73ce9..8a3e5f7b2c1d4e8f9a2b0c3d4e5f6a7b
 +                if (child.pid && child.exitCode === null) {
 +                    killProcessTree(child.pid);
 +                }
-+                if (child.pid)
-+                    untrackDetachedChildPid(child.pid);
+                 if (child.pid)
+                     untrackDetachedChildPid(child.pid);
                  if (timeoutHandle)
-                     clearTimeout(timeoutHandle);
-                 if (signal)
-                     signal.removeEventListener("abort", onAbort);
-             }
-         },
-     };
 diff --git a/dist/core/tools/edit.js b/dist/core/tools/edit.js
 index bf8a79ebfdbe23415cd1effdd3db0b9ebfd804bc..f69116ceafe8ee7f1e2dbfeaa37f60c5d97aa84c 100644
 --- a/dist/core/tools/edit.js

--- a/patches/@earendil-works__pi-coding-agent@0.79.10.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.79.10.patch
@@ -35,6 +35,15 @@
 #                                   resource reload no longer clobber a non-base
 #                                   systemPrompt, or upstream adds a prompt
 #                                   re-resolution hook we adopt instead.
+#                                   Also fire before_agent_start in sendCustomMessage's
+#                                   triggerTurn branch (mirroring prompt()), so
+#                                   extensions that install the system prompt only in
+#                                   that hook run for sessions driven entirely by
+#                                   extension-triggered turns (kimchi ferment / one-shot
+#                                   flows) instead of staying on the default base prompt.
+#                                   Removal criteria: upstream emits before_agent_start
+#                                   for extension-triggered turns (or moves prompt
+#                                   resolution out of prompt()).
 #   5. dist/modes/interactive/  — miscellaneous upstream UI fixes bundled in this patch
 #   6. dist/modes/interactive/interactive-mode.js — add previewTheme(name) and
 #      dist/core/extensions/types.d.ts              showError(message) to createExtensionUIContext,
@@ -86,10 +95,10 @@ index 6bd8f43b4402dbd24f9262c4c059b2c06693a79c..63ca4495adc5dc3428d45f3a8bfaa3b7
    ANTHROPIC_OAUTH_TOKEN            - Anthropic OAuth token (alternative to API key)
    ANT_LING_API_KEY                 - Ant Ling API key
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf10045040705ae15d92 100644
+index 3b2c24d1b52869e351ea488f0c535c34eaedf127..e6edc22b7401eb09cdce866db89ffaace7fe87ae 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -60,7 +60,7 @@ function estimateMessagesTokens(messages) {
+@@ -60,7 +60,7 @@
  // Constants
  // ============================================================================
  /** Standard thinking levels */
@@ -98,7 +107,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
  // ============================================================================
  // AgentSession Class
  // ============================================================================
-@@ -203,6 +203,20 @@ export class AgentSession {
+@@ -203,6 +203,20 @@
                  throw new Error(`Extension failed, blocking execution: ${String(err)}`);
              }
          };
@@ -119,7 +128,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
          this.agent.afterToolCall = async ({ toolCall, args, result, isError }) => {
              const runner = this._extensionRunner;
              if (!runner.hasHandlers("tool_result")) {
-@@ -558,9 +572,17 @@ export class AgentSession {
+@@ -558,9 +572,17 @@
              }
          }
          this.agent.state.tools = tools;
@@ -139,7 +148,46 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
      }
      /** Whether compaction or branch summarization is currently running */
      get isCompacting() {
-@@ -1270,8 +1292,9 @@ export class AgentSession {
+@@ -1001,7 +1023,37 @@
+             }
+         }
+         else if (options?.triggerTurn) {
+-            await this._runAgentPrompt(appMessage);
++            // kimchi-dev: fire before_agent_start for extension-triggered turns,
++            // mirroring prompt(). Extensions that install the system prompt (or
++            // inject context messages) only in that hook otherwise never run when
++            // a session is driven entirely by sendCustomMessage(..., { triggerTurn:
++            // true }) or followUp delivery (kimchi ferment/one-shot flows), leaving
++            // the agent on the default base prompt for the whole run.
++            const triggerMessages = [appMessage];
++            const triggerText = appMessage.content
++                .filter((part) => part.type === "text")
++                .map((part) => part.text)
++                .join("\n");
++            const beforeResult = await this._extensionRunner.emitBeforeAgentStart(triggerText, undefined, this._baseSystemPrompt, this._baseSystemPromptOptions);
++            if (beforeResult?.messages) {
++                for (const msg of beforeResult.messages) {
++                    triggerMessages.unshift({
++                        role: "custom",
++                        customType: msg.customType,
++                        content: msg.content,
++                        display: msg.display,
++                        details: msg.details,
++                        timestamp: Date.now(),
++                    });
++                }
++            }
++            if (beforeResult?.systemPrompt) {
++                this.agent.state.systemPrompt = beforeResult.systemPrompt;
++            }
++            else {
++                this.agent.state.systemPrompt = this._baseSystemPrompt;
++            }
++            await this._runAgentPrompt(triggerMessages);
+         }
+         else {
+             this.agent.state.messages.push(appMessage);
+@@ -1270,8 +1322,9 @@
       * Manually compact the session context.
       * Aborts current agent operation first.
       * @param customInstructions Optional instructions for the compaction summary
@@ -150,7 +198,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
          this._disconnectFromAgent();
          await this.abort();
          this._compactionAbortController = new AbortController();
-@@ -1283,14 +1306,21 @@ export class AgentSession {
+@@ -1283,14 +1336,21 @@
              const { apiKey, headers, env } = await this._getCompactionRequestAuth(this.model);
              const pathEntries = this.sessionManager.getBranch();
              const settings = this.settingsManager.getCompactionSettings();
@@ -174,7 +222,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
              }
              let extensionCompaction;
              let fromExtension = false;
-@@ -1678,8 +1708,13 @@ export class AgentSession {
+@@ -1678,8 +1738,13 @@
              themePaths: this.buildExtensionResourcePaths(themePaths),
          };
          this._resourceLoader.extendResources(extensionPaths);
@@ -189,7 +237,7 @@ index 3b2c24d1b52869e351ea488f0c535c34eaedf127..33868c61b384b6a2db74cf1004504070
      }
      buildExtensionResourcePaths(entries) {
          return entries.map((entry) => {
-@@ -1809,7 +1844,7 @@ export class AgentSession {
+@@ -1809,7 +1874,7 @@
              compact: (options) => {
                  void (async () => {
                      try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984
+    hash: 9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -36,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -641,54 +641,63 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
     resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
     resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
     resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
@@ -837,66 +846,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -1032,36 +1054,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.41':
     resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.41':
     resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.41':
     resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.41':
     resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.41':
     resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.41':
     resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
@@ -2834,7 +2862,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=c9f40f81782b5734efdb015826f25a4cc28ffb2881af43849a33562943661984)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5
+    hash: f69a1a6fd2cd9cd670e2092de6327f381fe1238f6a06b5c7d5c31750d62680cb
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -36,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=f69a1a6fd2cd9cd670e2092de6327f381fe1238f6a06b5c7d5c31750d62680cb)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -2862,7 +2862,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=f69a1a6fd2cd9cd670e2092de6327f381fe1238f6a06b5c7d5c31750d62680cb)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc
     path: patches/@earendil-works__pi-ai@0.79.10.patch
   '@earendil-works/pi-coding-agent@0.79.10':
-    hash: 9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7
+    hash: c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5
     path: patches/@earendil-works__pi-coding-agent@0.79.10.patch
   '@earendil-works/pi-tui@0.79.10':
     hash: 019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529
@@ -36,7 +36,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.10
-        version: 0.79.10(patch_hash=9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.79.10(patch_hash=c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.79.10
         version: 0.79.10(patch_hash=019141c7f01eabbdb737b0e8eed4a5ef6a724cfc8eb4e8d77e4dbe930d5e8529)
@@ -2862,7 +2862,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=9f321232b8bf237fff43d9409925f5f44bee71fe844e0f60f5ddd21b818869a7)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(patch_hash=c667691de118ee4b0c57e76242e9903968056480467def3e37edfa6e20693fa5)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.79.10(patch_hash=15d2e1baba7ae039625909b8aa1777106094b5923ef582067d088f024f9d7991)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.79.10(patch_hash=fb1bce8020def74278b4bd74b66b7777a90f45fc44958c7874e726e2c67a0ecc)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/upstream-system-prompt-preservation-patch.test.ts
+++ b/src/upstream-system-prompt-preservation-patch.test.ts
@@ -161,4 +161,23 @@ describe("upstream before_agent_start on extension-triggered turns patch", () =>
 
 		expect(fake.agent.state.systemPrompt).toBe("PI BASE PROMPT")
 	})
+
+	it("triggerTurn accepts plain-string content (completion notifications, feedback nudges)", async () => {
+		const fake = makeTriggerTurnSession({ systemPrompt: "KIMCHI OVERRIDE PROMPT" })
+
+		await sessionProto.sendCustomMessage.call(
+			fake,
+			{ customType: "agent_completion", content: "long task completed", display: true },
+			{ triggerTurn: true },
+		)
+
+		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
+		expect(fake._extensionRunner.emitBeforeAgentStart).toHaveBeenCalledWith(
+			"long task completed",
+			undefined,
+			"PI BASE PROMPT",
+			undefined,
+		)
+		expect(fake._runAgentPrompt).toHaveBeenCalledOnce()
+	})
 })

--- a/src/upstream-system-prompt-preservation-patch.test.ts
+++ b/src/upstream-system-prompt-preservation-patch.test.ts
@@ -67,11 +67,13 @@ function makeFakeSession(basePrompt: string) {
 
 describe("upstream system-prompt preservation patch", () => {
 	it("is present in the installed dist (setActiveToolsByName + resource reload)", () => {
+		// Pin the stable "kimchi-dev" marker comment each hunk carries, not an
+		// internal local variable name (which a future patch revision might rename).
 		const setActiveSource = String(sessionProto.setActiveToolsByName)
-		expect(setActiveSource).toContain("systemPromptOverride")
+		expect(setActiveSource).toContain("kimchi-dev: preserve an extension-installed system prompt")
 
 		const reloadSource = String(sessionProto.extendResourcesFromExtensions)
-		expect(reloadSource).toContain("systemPromptOverride")
+		expect(reloadSource).toContain("kimchi-dev: same override preservation")
 	})
 
 	it("setActiveToolsByName preserves an extension-installed prompt while rebuilding tools and base", () => {
@@ -115,6 +117,15 @@ describe("upstream system-prompt preservation patch", () => {
 
 		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
 		expect(fake._baseSystemPrompt).not.toBe("PI BASE PROMPT")
+	})
+
+	it("extendResourcesFromExtensions resets to the rebuilt base prompt when no override is active", async () => {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		// state.systemPrompt === _baseSystemPrompt (same reference): no extension override.
+		await sessionProto.extendResourcesFromExtensions.call(fake, "startup")
+
+		expect(fake.agent.state.systemPrompt).toBe(fake._baseSystemPrompt)
+		expect(fake.agent.state.systemPrompt).not.toBe("PI BASE PROMPT")
 	})
 })
 

--- a/src/upstream-system-prompt-preservation-patch.test.ts
+++ b/src/upstream-system-prompt-preservation-patch.test.ts
@@ -117,3 +117,48 @@ describe("upstream system-prompt preservation patch", () => {
 		expect(fake._baseSystemPrompt).not.toBe("PI BASE PROMPT")
 	})
 })
+
+describe("upstream before_agent_start on extension-triggered turns patch", () => {
+	function makeTriggerTurnSession(beforeResult: unknown) {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		fake._runAgentPrompt = vi.fn(async () => {})
+		fake._extensionRunner = {
+			emitBeforeAgentStart: vi.fn(async () => beforeResult),
+		}
+		return fake
+	}
+
+	const customMessage = {
+		customType: "ferment_continuation_nudge",
+		content: [{ type: "text", text: "continue the ferment" }],
+		display: false,
+		details: undefined,
+	}
+
+	it("is present in the installed dist (sendCustomMessage triggerTurn)", () => {
+		const source = String(sessionProto.sendCustomMessage)
+		expect(source).toContain("emitBeforeAgentStart")
+	})
+
+	it("triggerTurn applies an extension-installed prompt and prepends extension messages", async () => {
+		const fake = makeTriggerTurnSession({
+			systemPrompt: "KIMCHI OVERRIDE PROMPT",
+			messages: [{ customType: "injected", content: [{ type: "text", text: "ctx" }], display: false }],
+		})
+
+		await sessionProto.sendCustomMessage.call(fake, customMessage, { triggerTurn: true })
+
+		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
+		const runMessages = fake._runAgentPrompt.mock.calls[0][0] as Array<{ role: string; customType: string }>
+		expect(runMessages.map((m) => m.customType)).toEqual(["injected", "ferment_continuation_nudge"])
+	})
+
+	it("triggerTurn resets to the base prompt when no extension overrides it", async () => {
+		const fake = makeTriggerTurnSession(undefined)
+		fake.agent.state.systemPrompt = "STALE OVERRIDE"
+
+		await sessionProto.sendCustomMessage.call(fake, customMessage, { triggerTurn: true })
+
+		expect(fake.agent.state.systemPrompt).toBe("PI BASE PROMPT")
+	})
+})

--- a/src/upstream-system-prompt-preservation-patch.test.ts
+++ b/src/upstream-system-prompt-preservation-patch.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for the kimchi patch in
+ * `patches/@earendil-works__pi-coding-agent@0.79.10.patch` that makes upstream
+ * `AgentSession.setActiveToolsByName()` (and the resources-reload path)
+ * preserve an extension-installed system prompt.
+ *
+ * Why: kimchi's prompt-enrichment extension replaces the system prompt on
+ * every `before_agent_start`. Mid-run `pi.setActiveTools()` calls (ferment
+ * tool profiles, permissions, tool visibility) used to reset
+ * `agent.state.systemPrompt` to the rebuilt pi-mono default prompt, and — via
+ * the prepareNextTurn patch — the model then ran on the default prompt for
+ * the rest of the agent run (until the next real user prompt). Follow-up
+ * messages never re-fire `before_agent_start`, so the clobber persisted.
+ *
+ * These tests pin two things:
+ *   1. the installed dist actually contains the patch (source assertion —
+ *      fails fast if the patch is lost on upgrade), and
+ *   2. the real prototype method preserves a non-base prompt while still
+ *      rebuilding the base prompt and the tool set.
+ */
+
+import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+
+type AnyFn = (...args: unknown[]) => unknown
+
+const sessionProto = AgentSession.prototype as unknown as Record<string, AnyFn>
+
+/** Minimal fake `this` for calling AgentSession prototype methods directly. */
+function makeFakeSession(basePrompt: string) {
+	const tools = new Map([
+		["read", { name: "read", description: "read a file", parameters: {} }],
+		["bash", { name: "bash", description: "run a command", parameters: {} }],
+	])
+	// Inherit from the real prototype so every collaborator method invoked
+	// internally (_rebuildSystemPrompt, getActiveToolNames, …) resolves.
+	// biome-ignore lint/suspicious/noExplicitAny: fake `this` for prototype-method invocation
+	const fake: any = Object.create(AgentSession.prototype)
+	Object.assign(fake, {
+		agent: { state: { tools: [], systemPrompt: basePrompt } },
+		_baseSystemPrompt: basePrompt,
+		_toolRegistry: tools,
+		_toolPromptSnippets: new Map(),
+		_toolPromptGuidelines: new Map(),
+		_cwd: "/tmp/fake-cwd",
+		_resourceLoader: {
+			getSystemPrompt: () => undefined,
+			getAppendSystemPrompt: () => [],
+			getSkills: () => ({ skills: [] }),
+			getAgentsFiles: () => ({ agentsFiles: [] }),
+			extendResources: vi.fn(),
+		},
+		_extensionRunner: {
+			hasHandlers: () => true,
+			emitResourcesDiscover: vi.fn(async () => ({
+				skillPaths: [{ path: "/tmp/fake-skills", extensionPath: "/tmp/fake-ext" }],
+				promptPaths: [],
+				themePaths: [],
+			})),
+		},
+		// Instance stubs so extendResourcesFromExtensions doesn't reach further
+		// into prototype internals (getExtensionSourceLabel etc.).
+		buildExtensionResourcePaths: vi.fn(() => []),
+	})
+	return fake
+}
+
+describe("upstream system-prompt preservation patch", () => {
+	it("is present in the installed dist (setActiveToolsByName + resource reload)", () => {
+		const setActiveSource = String(sessionProto.setActiveToolsByName)
+		expect(setActiveSource).toContain("systemPromptOverride")
+
+		const reloadSource = String(sessionProto.extendResourcesFromExtensions)
+		expect(reloadSource).toContain("systemPromptOverride")
+	})
+
+	it("setActiveToolsByName preserves an extension-installed prompt while rebuilding tools and base", () => {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		fake.agent.state.systemPrompt = "KIMCHI OVERRIDE PROMPT"
+
+		sessionProto.setActiveToolsByName.call(fake, ["read", "bash"])
+
+		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
+		// Tool set is still replaced:
+		expect(fake.agent.state.tools.map((t: { name: string }) => t.name)).toEqual(["read", "bash"])
+		// Base prompt is still rebuilt from the new tool set (no longer the old base):
+		expect(fake._baseSystemPrompt).not.toBe("PI BASE PROMPT")
+	})
+
+	it("setActiveToolsByName resets to the rebuilt base prompt when no override is active", () => {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		// state.systemPrompt === _baseSystemPrompt (same reference): no extension override.
+		sessionProto.setActiveToolsByName.call(fake, ["read"])
+
+		expect(fake.agent.state.systemPrompt).toBe(fake._baseSystemPrompt)
+		expect(fake.agent.state.systemPrompt).not.toBe("PI BASE PROMPT")
+	})
+
+	it("setActiveToolsByName preserves the override even when the tool set is emptied", () => {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		fake.agent.state.systemPrompt = "KIMCHI OVERRIDE PROMPT"
+
+		// ferment plan-review suppression calls pi.setActiveTools([]).
+		sessionProto.setActiveToolsByName.call(fake, [])
+
+		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
+		expect(fake.agent.state.tools).toEqual([])
+	})
+
+	it("extendResourcesFromExtensions preserves an extension-installed prompt", async () => {
+		const fake = makeFakeSession("PI BASE PROMPT")
+		fake.agent.state.systemPrompt = "KIMCHI OVERRIDE PROMPT"
+
+		await sessionProto.extendResourcesFromExtensions.call(fake, "startup")
+
+		expect(fake.agent.state.systemPrompt).toBe("KIMCHI OVERRIDE PROMPT")
+		expect(fake._baseSystemPrompt).not.toBe("PI BASE PROMPT")
+	})
+})


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

### Fix: harness system prompt reverts to pi default

#### Symptom

In sessions driven by ferments / one-shot flows (and any other turn started from an
extension rather than typed input), the model runs on the **upstream pi default system
prompt** instead of kimchi's enriched prompt. All kimchi-specific content is missing
from what the model is served — `## Guidelines`, `## Factual Accuracy`, `## Documents`,
`## Tool Selection`, `Single-Model Mode`, skills wiring, environment block — and
session exports embed the pi default prompt.

#### Root cause (two independent defects, both in upstream pi-mono prompt handling)

**1. Installed prompts were clobbered mid-run** (fixed in `90a70748`).
Upstream `setActiveToolsByName()` (called by ferment tool profiles, plan-review tool
suppression, permissions/visibility changes) and the resources-reload path rebuilt
`_baseSystemPrompt` and unconditionally assigned it to `state.systemPrompt`. Kimchi's
prompt-enrichment installs via `before_agent_start`, which only fires on a *real user
prompt* — so once clobbered, the model stayed on the pi default for the rest of the
run (served immediately thanks to the prepareNextTurn patch, and baked into exports).

**2. In extension-driven sessions the enriched prompt was never installed at all**
(fixed in `bddb0ed1`). Kimchi's prompt-enrichment runs exclusively in
`before_agent_start`, which upstream only emits inside `AgentSession.prompt()` — and
`prompt()` isn't even reached for `/ferment`-style sessions: slash commands are
handled as extension commands that return early without persisting a user message
(upstream: "Extension commands manage their own LLM interaction via pi.sendMessage()"),
and every subsequent turn goes through `sendCustomMessage({ triggerTurn: true })` /
followUp delivery, which calls `_runAgentPrompt()` directly.

### Fix

Both changes live in `patches/@earendil-works__pi-coding-agent@0.79.10.patch`:

- **`setActiveToolsByName()` + resources-reload path** (`90a70748`): preserve a
 non-base (extension-installed) `state.systemPrompt` while still rebuilding the base
 prompt and tool set.
- **`sendCustomMessage` `triggerTurn` branch** (`bddb0ed1`): emit `before_agent_start`
 mirroring `prompt()` — apply `result.systemPrompt` to `state.systemPrompt` (falling
 back to base when nothing overrides) and prepend any `result.messages` before
 `_runAgentPrompt`. Streaming-time `followUp`/`steer` injections intentionally still
 don't re-fire the hook (the prompt is installed and preserved by then).

Patch header documents removal criteria for both (drop when upstream stops clobbering
non-base prompts / emits the hook for extension-triggered turns, or adopts a
re-resolution hook we can use instead).

### Tests

`src/upstream-system-prompt-preservation-patch.test.ts`:

- pins both patches in the installed dist (fails fast if lost on upgrade),
- `setActiveToolsByName`/resource reload: preserves override, still rebuilds tools +
 base, resets when no override, survives `pi.setActiveTools([])`,
- `triggerTurn`: applies an extension-installed prompt, prepends extension messages in
 order, resets to base when unmodified.

 Full suite green (419 files / 7784 tests). The patch hunks were regenerated by diffing
 the pristine 0.79.10 npm tarball against the intended output and verified
 byte-identical in the installed dist.

Verified by manual tests as well.


 ## Checklist

 - [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
 - [x] This PR links to an open issue above
 - [x] Tests pass locally (`pnpm run test`) — 419 files / 7781 passed
 - [x] Lint passes (`pnpm run check`)
 - [x] Documentation updated if behavior changed — patch header documents upstream tracking + removal criteria; no user-facing docs affected