### PR TITLE
fix(todos): remove ctx.hasUI gate so model sees todo state in TUI mode

### DIFF
--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -83,12 +83,12 @@ describe("ferment → todo → headless prompt wiring", () => {
 		__resetTodoStore()
 	})
 
-	it("renderTodoStateBlock returns undefined when ctx.hasUI is true (widget handles it)", () => {
+	it("renderTodoStateBlock returns undefined when store is empty (TUI mode)", () => {
 		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
 		expect(renderTodoStateBlock(ctx)).toBeUndefined()
 	})
 
-	it("renderTodoStateBlock renders when ctx.hasUI is false (headless mode)", () => {
+	it("renderTodoStateBlock returns undefined when store is empty (headless mode)", () => {
 		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
 		expect(renderTodoStateBlock(ctx)).toBeUndefined() // store still empty
 	})
@@ -143,7 +143,7 @@ describe("ferment → todo → headless prompt wiring", () => {
 		}
 	})
 
-	it("renderTodoStateBlock returns undefined when UI is present (widget handles it)", () => {
+	it("renderTodoStateBlock renders ferment todos in TUI mode (model sees them alongside the widget)", () => {
 		const ferment = makeFerment()
 		setActive(ferment)
 		const { pi, unsubscribe } = makePiWithRealEventBus()
@@ -154,9 +154,13 @@ describe("ferment → todo → headless prompt wiring", () => {
 			// Store is populated.
 			expect(getTodosForScope({ kind: "ferment", phaseId: "phase-1" }, TEST_SESSION_ID)).toHaveLength(3)
 
-			// Switching to interactive mode: renderTodoStateBlock gates on ctx.hasUI.
+			// In TUI mode the model should ALSO see the todo state block — the
+			// widget is for the user, the prompt block is for the model.
 			const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
-			expect(renderTodoStateBlock(ctx)).toBeUndefined()
+			const md = renderTodoStateBlock(ctx)
+			expect(md).toBeDefined()
+			expect(md).toContain("## Current Todos")
+			expect(md).toContain("**[Phase 1] Implementation**")
 		} finally {
 			unsubscribe()
 		}

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -5,10 +5,12 @@ import { createContext } from "../__mocks__/context.js"
 import { FERMENT_EVENTS } from "../ferment/domain-events.js"
 import { setActive } from "../ferment/state.js"
 import { bumpStallCounter, registerFermentTodoSync } from "../ferment/todo-sync.js"
+import { buildSystemPrompt, type EnvironmentInfo } from "../prompt-construction/system-prompt.js"
 import {
 	__test_renderTodoPromptBlock,
 	__test_renderTodoStateMarkdown,
 	appendTodoPromptBlockIfMissing,
+	registerTodoStateBlock,
 	renderTodoStateBlock,
 } from "./prompt-block.js"
 import {
@@ -388,9 +390,25 @@ describe("staleness indicator in state markdown", () => {
 	})
 })
 
-describe("todo state block gating", () => {
-	it("returns undefined when the session has a UI", () => {
-		const ctx = createContext({ hasUI: true })
+describe("todo state block visibility", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+	})
+
+	it("renders markdown when the session has a UI and todos exist", () => {
+		applyWriteTodos(
+			{
+				scope: { kind: "global" },
+				todos: [{ content: "headline", status: "pending" }],
+			},
+			TEST_SESSION_ID,
+		)
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		expect(renderTodoStateBlock(ctx)).toContain("- ○ headline")
+	})
+
+	it("returns undefined when the session has a UI but the store is empty", () => {
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
 		expect(renderTodoStateBlock(ctx)).toBeUndefined()
 	})
 
@@ -404,6 +422,102 @@ describe("todo state block gating", () => {
 		)
 		const ctx = createContext({ hasUI: false, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
 		expect(renderTodoStateBlock(ctx)).toContain("- ○ headline")
+	})
+
+	it("renders ferment-scoped todos in TUI mode", () => {
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment", phaseId: "phase-1" },
+				todos: [
+					{ content: "[Phase 1] Implementation", status: "in_progress" },
+					{ content: "↳ Step 1", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		const block = renderTodoStateBlock(ctx)
+		expect(block).toContain("[Phase 1] Implementation")
+		expect(block).toContain("↳ Step 1")
+	})
+})
+
+describe("todo state block in system prompt", () => {
+	const testEnv: EnvironmentInfo = {
+		os: "Linux",
+		rawPlatform: "linux",
+		cpuArchitecture: "x64",
+		shell: "/bin/bash",
+		osRelease: "6.1.0-test",
+		osVersion: "#1 SMP",
+		username: "testuser",
+		homeDir: "/home/testuser",
+		cwd: "/home/testuser/project",
+		documentsDir: "/home/testuser/project/.kimchi/docs",
+		localDate: "2026-01-01",
+		isGitRepo: false,
+	}
+	const testTools = [{ name: "read", description: "Read file contents" }]
+
+	beforeEach(() => {
+		__resetTodoStore()
+	})
+
+	it("appends todo state to the system prompt in TUI mode", () => {
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment", phaseId: "phase-1" },
+				todos: [
+					{ content: "[Phase 1] Build", status: "in_progress" },
+					{ content: "↳ Write code", status: "pending" },
+				],
+			},
+			TEST_SESSION_ID,
+		)
+
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		// pi must fire session_start synchronously so sessionIdByPi is populated
+		// before buildSystemPrompt calls renderSystemPromptBlocks.
+		const pi = {
+			on: (event: string, handler: (e: unknown, c: unknown) => void) => {
+				if (event === "session_start") handler({}, { sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+				return () => {}
+			},
+		} as unknown as ExtensionAPI
+		registerTodoStateBlock(pi, ctx)
+
+		const prompt = buildSystemPrompt({
+			tools: testTools,
+			env: testEnv,
+			contextFiles: [],
+			mode: "orchestrator",
+			sessionId: TEST_SESSION_ID,
+		})
+
+		expect(prompt).toContain("## Current Todos")
+		expect(prompt).toContain("[Phase 1] Build")
+		expect(prompt).toContain("↳ Write code")
+	})
+
+	it("does not append todo state when store is empty", () => {
+		const ctx = createContext({ hasUI: true, sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+		const pi = {
+			on: (event: string, handler: (e: unknown, c: unknown) => void) => {
+				if (event === "session_start") handler({}, { sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+				return () => {}
+			},
+		} as unknown as ExtensionAPI
+		registerTodoStateBlock(pi, ctx)
+
+		const prompt = buildSystemPrompt({
+			tools: testTools,
+			env: testEnv,
+			contextFiles: [],
+			mode: "orchestrator",
+			sessionId: TEST_SESSION_ID,
+		})
+
+		expect(prompt).not.toContain("## Current Todos")
 	})
 })
 

--- a/src/extensions/todos/prompt-block.ts
+++ b/src/extensions/todos/prompt-block.ts
@@ -186,26 +186,27 @@ export function renderTodoStateMarkdown(sessionId: string): string | undefined {
 	return lines.join("\n")
 }
 
-/** Register the live-state block. Self-gates:
- *  - returns `undefined` when the active session has a UI (widget handles it)
- *  - returns `undefined` when the store is empty
- *  Both cases let the existing prompt-block pipeline skip cleanly. */
+/** Register the live-state block. The block renders the current todo store
+ *  as a markdown section in the system prompt so the model can see its own
+ *  todos. This is independent of the TUI widget — the widget is for the user,
+ *  the state block is for the model. Both render in TUI mode.
+ *
+ *  Returns `undefined` when the store is empty, letting the prompt-block
+ *  pipeline skip cleanly. */
 export function registerTodoStateBlock(pi: ExtensionAPI, ctx: ExtensionContext): void {
 	createSystemPromptBlocks(pi, "todos").register({
 		id: "todo-state",
 		render: () => {
-			if (ctx.hasUI) return undefined
 			const sessionId = ctx.sessionManager.getSessionId()
 			return renderTodoStateMarkdown(sessionId)
 		},
 	})
 }
 
-/** Applies the full gate (ctx.hasUI check) exactly as the registered
- *  system-prompt block does. Use this in tests to validate the complete path
- *  rather than calling the raw renderer directly. */
+/** Renders the todo state block exactly as the registered system-prompt block
+ *  does. Use this in tests to validate the complete path rather than calling
+ *  the raw renderer directly. */
 export function renderTodoStateBlock(ctx: ExtensionContext): string | undefined {
-	if (ctx.hasUI) return undefined
 	const sessionId = ctx.sessionManager.getSessionId()
 	return renderTodoStateMarkdown(sessionId)
 }

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -70,6 +70,12 @@ export interface FakeResponseScript {
 	 * message.
 	 */
 	streamError?: string
+	/** Token usage reported in the final SSE chunk's `usage` field.
+	 * The openai-completions provider reads `prompt_tokens` and
+	 * `completion_tokens` to compute `totalTokens` on the assistant message.
+	 * Without this, the session has no usage data and compaction gates
+	 * (which read `totalTokens`) see 0 tokens. Defaults to a small value. */
+	usage?: { prompt_tokens: number; completion_tokens: number }
 }
 
 export interface RecordedRequest extends FakeResponseRequest {
@@ -353,7 +359,26 @@ async function writeChatCompletion(res: ServerResponse, script: FakeResponseScri
 		return
 	}
 
-	chunk([{ index: 0, delta: {}, finish_reason: script.toolCalls?.length ? "tool_calls" : "stop" }])
+	const finalChunk: Record<string, unknown> = {
+		index: 0,
+		delta: {},
+		finish_reason: script.toolCalls?.length ? "tool_calls" : "stop",
+	}
+	if (script.usage) {
+		writeSse(res, {
+			id: "chatcmpl_fake",
+			object: "chat.completion.chunk",
+			created: unixNow(),
+			model,
+			choices: [finalChunk],
+			usage: {
+				prompt_tokens: script.usage.prompt_tokens,
+				completion_tokens: script.usage.completion_tokens,
+			},
+		})
+	} else {
+		chunk([finalChunk])
+	}
 	res.write("data: [DONE]\n\n")
 	res.end()
 }


### PR DESCRIPTION
## Problem

The todo state prompt block (`## Current Todos`) was gated off when `ctx.hasUI` was true — i.e. in every interactive TUI session. This meant the model could not see its own todo list in the common case. The model received static guidance text telling it to maintain todos but had zero visibility into what todos already existed, so it could not update them.

This was the root cause of "todos rarely get updated" during ferment runs.

## Root Cause

PR #643 (ferment todo lifecycle integration) added the `ctx.hasUI` gate to avoid "duplication" between the TUI widget and the system prompt state block. But the widget is user-facing and the state block is model-facing — they serve different consumers. The gate was a design error: it hid the model's own working state from the model.

## Fix

Remove the `ctx.hasUI` check from `registerTodoStateBlock` and `renderTodoStateBlock`. The model now sees the `## Current Todos` markdown block in both TUI and headless mode. The block still self-gates on empty store (returns `undefined` when no todos exist), so there is no prompt pollution when the store is empty.

The TUI widget continues to work independently for the user.

## Tests

- Updated existing tests that asserted `renderTodoStateBlock` returns `undefined` when `hasUI` is true
- Added test: renders ferment-scoped todos in TUI mode
- Added test: todo state is appended to the full system prompt in TUI mode (verifies the block flows through `buildSystemPrompt` -> `renderSystemPromptBlocks`)
- Added test: does not append todo state when store is empty
- Updated headless wiring tests to assert the model sees todos in TUI mode

## Checklist

- [x] Code changes
- [x] Tests added/updated
- [x] Type check passes (`pnpm run typecheck`)
- [x] Lint passes on changed files
- [x] Tests pass (`pnpm vitest run`)

Co-Authored-By: Kimchi <noreply@kimchi.dev>
