### PR TITLE
feat(teleport): environment handoff note for resumed sessions

### DIFF
--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -630,7 +630,8 @@ describe("runTeleport", () => {
 
 		it("appends a [Teleport] handoff note as a user message to the uploaded session", async () => {
 			const sessionFile = join(tempDir, "session.jsonl")
-			writeFileSync(sessionFile, '{"type":"session"}\n')
+			const originalContent = '{"type":"session"}\n'
+			writeFileSync(sessionFile, originalContent)
 			const { ctx } = makeCtx({ sessionFile })
 
 			// Read the uploaded file contents inside the createSession mock — the
@@ -643,12 +644,14 @@ describe("runTeleport", () => {
 
 			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
 
+			// Original session file is never mutated by the upload.
+			expect(readFileSync(sessionFile, "utf8")).toBe(originalContent)
+
 			// Original content survives the copy…
-			expect(capturedUpload).toContain('{"type":"session"}')
+			expect(capturedUpload).toContain(originalContent.trimEnd())
 			// …and the handoff note got appended as a parseable user-message entry,
 			// so the resumed remote agent sees the environment change in context
 			// (and the user sees it in the transcript).
-			expect(capturedUpload).toContain("[Teleport] Environment handoff")
 			const noteLine = capturedUpload.split("\n").find((l) => l.includes("[Teleport]"))
 			expect(noteLine).toBeDefined()
 			const parsed = JSON.parse(noteLine!)

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
@@ -611,7 +611,7 @@ describe("runTeleport", () => {
 	})
 
 	describe("session upload", () => {
-		it("uploads the local session file when one is present", async () => {
+		it("uploads an annotated temp copy of the session file and deletes it afterwards", async () => {
 			const sessionFile = join(tempDir, "session.jsonl")
 			writeFileSync(sessionFile, '{"type":"session"}\n')
 			const { ctx } = makeCtx({ sessionFile })
@@ -619,7 +619,41 @@ describe("runTeleport", () => {
 			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
 
 			expect(createSessionMock).toHaveBeenCalledOnce()
-			expect(createSessionMock.mock.calls[0][3]).toMatchObject({ sessionFile })
+			const { sessionFile: uploaded } = createSessionMock.mock.calls[0][3]
+			// The uploaded file is an annotated copy of the original — not the
+			// original path — and the copy is cleaned up after upload.
+			expect(uploaded).not.toBe(sessionFile)
+			// The temp copy is removed again once the upload finished — otherwise
+			// session JSONLs would pile up in the OS temp dir.
+			expect(existsSync(uploaded)).toBe(false)
+		})
+
+		it("appends a [Teleport] handoff note as a user message to the uploaded session", async () => {
+			const sessionFile = join(tempDir, "session.jsonl")
+			writeFileSync(sessionFile, '{"type":"session"}\n')
+			const { ctx } = makeCtx({ sessionFile })
+
+			// Read the uploaded file contents inside the createSession mock — the
+			// temp copy is deleted right after upload, so we must capture it here.
+			let capturedUpload = ""
+			createSessionMock.mockImplementationOnce(async (_client, _name, _req, opts) => {
+				capturedUpload = readFileSync(opts.sessionFile, "utf8")
+				return { name: "mysession" }
+			})
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			// Original content survives the copy…
+			expect(capturedUpload).toContain('{"type":"session"}')
+			// …and the handoff note got appended as a parseable user-message entry,
+			// so the resumed remote agent sees the environment change in context
+			// (and the user sees it in the transcript).
+			expect(capturedUpload).toContain("[Teleport] Environment handoff")
+			const noteLine = capturedUpload.split("\n").find((l) => l.includes("[Teleport]"))
+			expect(noteLine).toBeDefined()
+			const parsed = JSON.parse(noteLine!)
+			expect(parsed.message.role).toBe("user")
+			expect(parsed.message.content[0].text).toContain("Environment handoff")
 		})
 
 		it("--skip-session opts out even when a local session file exists", async () => {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -653,8 +653,8 @@ describe("runTeleport", () => {
 			// so the resumed remote agent sees the environment change in context
 			// (and the user sees it in the transcript).
 			const noteLine = capturedUpload.split("\n").find((l) => l.includes("[Teleport]"))
-			expect(noteLine).toBeDefined()
-			const parsed = JSON.parse(noteLine!)
+			if (noteLine === undefined) throw new Error("handoff note line missing from uploaded JSONL")
+			const parsed = JSON.parse(noteLine)
 			expect(parsed.message.role).toBe("user")
 			expect(parsed.message.content[0].text).toContain("Environment handoff")
 		})

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -11,20 +11,16 @@ import { createSession, listSessions } from "../../../sandbox/worker/sessions.js
 import type { CreateSessionRequest, Session } from "../../../sandbox/worker/types.js"
 import { createTabsOverlay } from "../overlay/overlay-component.js"
 import { generateSessionName } from "../overlay/tab-manager.js"
-import { isGitRepo } from "../preflight/git.js"
+import { getGitHeadSha, gitWorkingTreeDirty, isGitRepo } from "../preflight/git.js"
 import { runPreflight } from "../preflight/index.js"
 import { SIZE_REFUSE_BYTES, SIZE_WARN_BYTES } from "../preflight/workspace-size.js"
 import { SANDBOX_USER } from "../provisioning/constants.js"
 import { sumIncludeListBytes } from "../provisioning/estimate-bytes.js"
 import { provisionGitCredential, provisionGitIdentity } from "../provisioning/git-provision.js"
+import { buildHandoffNote, copySessionFileAndAddHandoffNote, removeTempDir } from "../provisioning/handoff-note.js"
 import { provisionHarnessConfig } from "../provisioning/harness-config.js"
 import { buildIncludeList } from "../provisioning/include-list.js"
 import { deriveSandboxDest, deriveSandboxDestFromRepoUrl, repoBasename } from "../provisioning/paths.js"
-import {
-	buildHandoffNote,
-	copySessionFileAndAddHandoffNote,
-	removeTempDir,
-} from "../provisioning/handoff-note.js"
 import { formatRsyncFailure, runRsync } from "../provisioning/rsync-runner.js"
 import { STATUS_KEY, type TeleportContext } from "../types.js"
 import { formatBytes } from "../ui/format-bytes.js"
@@ -292,14 +288,24 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 		let sessionFileToUpload: string | undefined
 		let sessionFileWithHandoffNote: string | undefined
 		if (!args.skipSession && ctx.sessionFile && existsSync(ctx.sessionFile)) {
+			// Git anchor for the note (HEAD sha + tree dirtiness): one-time
+			// provenance facts about where the history was generated.
+			const gitAnchor = isGitRepo(ctx.cwd)
+				? { headSha: getGitHeadSha(ctx.cwd), dirty: gitWorkingTreeDirty(ctx.cwd) }
+				: undefined
 			const note = buildHandoffNote({
 				fromPlatform: platform(),
 				fromCwd: ctx.cwd,
 				toCwd: sessionCwd,
+				git: gitAnchor,
 				workspace: args.gitRepo
 					? { kind: "git-clone", repo: args.gitRepo, branch: args.branch }
 					: shouldRsyncWorkspace
-						? { kind: "rsync", fileCount: filesFrom.length, bytes: estimatedUploadBytes }
+						? {
+								kind: "rsync",
+								fileCount: filesFrom.length,
+								syncedDotKimchi: filesFrom.some((f) => f === ".kimchi" || f.startsWith(".kimchi/")),
+							}
 						: { kind: "none" },
 				gitIdentityProvisioned: Boolean(localGitConfig.name || localGitConfig.email),
 				gitCredential: gitHost && gitToken ? { host: gitHost } : undefined,

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs"
-import { basename } from "node:path"
+import { platform } from "node:os"
+import { basename, dirname } from "node:path"
 import { readGitToken, readTeleportHelpSeenAt, writeGitToken, writeTeleportHelpSeenAt } from "../../../config.js"
 import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
@@ -19,6 +20,11 @@ import { provisionGitCredential, provisionGitIdentity } from "../provisioning/gi
 import { provisionHarnessConfig } from "../provisioning/harness-config.js"
 import { buildIncludeList } from "../provisioning/include-list.js"
 import { deriveSandboxDest, deriveSandboxDestFromRepoUrl, repoBasename } from "../provisioning/paths.js"
+import {
+	buildHandoffNote,
+	copySessionFileAndAddHandoffNote,
+	removeTempDir,
+} from "../provisioning/handoff-note.js"
 import { formatRsyncFailure, runRsync } from "../provisioning/rsync-runner.js"
 import { STATUS_KEY, type TeleportContext } from "../types.js"
 import { formatBytes } from "../ui/format-bytes.js"
@@ -278,8 +284,29 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 			: shouldRsyncWorkspace
 				? deriveSandboxDest(ctx.cwd)
 				: undefined
-		const sessionFileToUpload =
-			!args.skipSession && ctx.sessionFile && existsSync(ctx.sessionFile) ? ctx.sessionFile : undefined
+		// Upload an annotated copy of the local session file: append a handoff
+		// note (visible in the remote transcript) explaining the environment
+		// change, provisioning provenance, and any heuristics (rsync include
+		// list / fresh clone) so the resumed agent doesn't trust stale paths
+		// or artifacts. The user's local session file is never mutated.
+		let sessionFileToUpload: string | undefined
+		let sessionFileWithHandoffNote: string | undefined
+		if (!args.skipSession && ctx.sessionFile && existsSync(ctx.sessionFile)) {
+			const note = buildHandoffNote({
+				fromPlatform: platform(),
+				fromCwd: ctx.cwd,
+				toCwd: sessionCwd,
+				workspace: args.gitRepo
+					? { kind: "git-clone", repo: args.gitRepo, branch: args.branch }
+					: shouldRsyncWorkspace
+						? { kind: "rsync", fileCount: filesFrom.length, bytes: estimatedUploadBytes }
+						: { kind: "none" },
+				gitIdentityProvisioned: Boolean(localGitConfig.name || localGitConfig.email),
+				gitCredential: gitHost && gitToken ? { host: gitHost } : undefined,
+			})
+			sessionFileWithHandoffNote = copySessionFileAndAddHandoffNote(ctx.sessionFile, note)
+			sessionFileToUpload = sessionFileWithHandoffNote ?? ctx.sessionFile
+		}
 		const req: CreateSessionRequest = { agentMode: "PTY", cwd: sessionCwd }
 		if (args.gitRepo) {
 			req.details = {
@@ -299,6 +326,8 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 		} catch (err) {
 			if (signal.aborted) throw err
 			refuse(ctx, `Could not create session: ${err instanceof Error ? err.message : String(err)}`)
+		} finally {
+			if (sessionFileWithHandoffNote) removeTempDir(dirname(sessionFileWithHandoffNote))
 		}
 		progress.complete("Session ready")
 

--- a/src/extensions/teleport/preflight/git.test.ts
+++ b/src/extensions/teleport/preflight/git.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
-import { type GitPreflightOptions, getGitRemoteUrl, gitWorkingTreeDirty, isGitRepo } from "./git.js"
+import { type GitPreflightOptions, getGitHeadSha, getGitRemoteUrl, gitWorkingTreeDirty, isGitRepo } from "./git.js"
 
 type MockExec = NonNullable<GitPreflightOptions["execFile"]>
 
@@ -90,5 +90,26 @@ describe("getGitRemoteUrl", () => {
 		getGitRemoteUrl("/work/dir", { execFile: exec })
 		expect(receivedFile).toBe("git")
 		expect(receivedArgs).toEqual(["-C", "/work/dir", "remote", "get-url", "origin"])
+	})
+})
+
+describe("getGitHeadSha", () => {
+	it("trims the trailing newline git appends to stdout", () => {
+		const exec = mockExec(() => "a1b2c3d\n")
+		expect(getGitHeadSha("/work/dir", { execFile: exec })).toBe("a1b2c3d")
+	})
+
+	it("returns undefined on failure", () => {
+		expect(getGitHeadSha("/fake", { execFile: mockExecThrowing() })).toBeUndefined()
+	})
+
+	it("invokes git with rev-parse --short HEAD", () => {
+		let receivedArgs: readonly string[] = []
+		const exec = mockExec((_file, args) => {
+			receivedArgs = args
+			return "a1b2c3d"
+		})
+		getGitHeadSha("/work/dir", { execFile: exec })
+		expect(receivedArgs).toEqual(["-C", "/work/dir", "rev-parse", "--short", "HEAD"])
 	})
 })

--- a/src/extensions/teleport/preflight/git.ts
+++ b/src/extensions/teleport/preflight/git.ts
@@ -25,9 +25,17 @@ export function gitWorkingTreeDirty(cwd: string, options?: GitPreflightOptions):
 }
 
 export function getGitRemoteUrl(cwd: string, options?: GitPreflightOptions): string | undefined {
+	return runGit(cwd, ["remote", "get-url", "origin"], options)
+}
+
+export function getGitHeadSha(cwd: string, options?: GitPreflightOptions): string | undefined {
+	return runGit(cwd, ["rev-parse", "--short", "HEAD"], options)
+}
+
+function runGit(cwd: string, args: string[], options?: GitPreflightOptions): string | undefined {
 	const execImpl = options?.execFile ?? execFileSync
 	try {
-		const stdout = execImpl("git", ["-C", cwd, "remote", "get-url", "origin"], {
+		const stdout = execImpl("git", ["-C", cwd, ...args], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],
 			timeout: 5_000,

--- a/src/extensions/teleport/provisioning/handoff-note.test.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.test.ts
@@ -26,13 +26,24 @@ describe("buildHandoffNote", () => {
 		gitCredential: { host: "github.com" },
 	}
 
-	it("describes the rsync heuristic with file count", () => {
-		const note = buildHandoffNote({ ...base, workspace: { kind: "rsync", fileCount: 42, bytes: 1024 } })
-		expect(note).toContain("rsync")
-		expect(note).toContain("42 files")
+	it("rsync: uncommitted changes carried, gitignored not; .kimchi synced when in the include list", () => {
+		const note = buildHandoffNote({
+			...base,
+			workspace: { kind: "rsync", fileCount: 42, syncedDotKimchi: true },
+		})
+		expect(note).toContain("rsync of the working tree (42 files)")
+		expect(note).toContain("uncommitted local changes were carried over")
 		expect(note).toContain("Gitignored content")
-		expect(note).toContain("darwin, cwd /home/dev/projects/demo")
-		expect(note).toContain("Current environment: Linux sandbox, cwd /home/sandbox/demo")
+		expect(note).toContain("(.kimchi/ — ferment plans & runtime, transient docs) was synced")
+	})
+
+	it("rsync: warns explicitly when .kimchi was not synced", () => {
+		const note = buildHandoffNote({
+			...base,
+			workspace: { kind: "rsync", fileCount: 10, syncedDotKimchi: false },
+		})
+		expect(note).toContain("(.kimchi/ — ferment plans & runtime, transient docs) was NOT synced")
+		expect(note).toContain("do not expect ferment state or prior working documents to exist here")
 	})
 
 	it("describes a fresh git clone and missing uncommitted changes", () => {
@@ -41,7 +52,40 @@ describe("buildHandoffNote", () => {
 			workspace: { kind: "git-clone", repo: "https://github.com/org/repo.git", branch: "main" },
 		})
 		expect(note).toContain("fresh git clone of https://github.com/org/repo.git (branch main)")
-		expect(note).toContain("uncommitted changes were NOT carried over")
+		expect(note).toContain("uncommitted changes and gitignored content were NOT carried over")
+	})
+
+	it("clone: appends the local HEAD anchor when available", () => {
+		const note = buildHandoffNote({
+			...base,
+			git: { headSha: "a1b2c3d", dirty: true },
+			workspace: { kind: "git-clone", repo: "https://github.com/org/repo.git" },
+		})
+		expect(note).toContain("local repo was at commit a1b2c3d")
+	})
+
+	it("includes the git anchor in the previous-environment line", () => {
+		const note = buildHandoffNote({
+			...base,
+			git: { headSha: "a1b2c3d", dirty: true },
+			workspace: { kind: "none" },
+		})
+		expect(note).toContain("darwin, cwd /home/dev/projects/demo (local repo at a1b2c3d, working tree dirty)")
+	})
+
+	it("shows only dirtiness when the sha is unavailable", () => {
+		const note = buildHandoffNote({
+			...base,
+			git: { dirty: true },
+			workspace: { kind: "none" },
+		})
+		expect(note).toContain("/home/dev/projects/demo (working tree dirty)")
+	})
+
+	it("omits the git anchor entirely outside git repos", () => {
+		const note = buildHandoffNote({ ...base, git: undefined, workspace: { kind: "none" } })
+		expect(note).not.toContain("local repo at")
+		expect(note).not.toContain("working tree dirty")
 	})
 
 	it("describes no-sync provisioning", () => {
@@ -64,6 +108,7 @@ describe("buildHandoffNote", () => {
 		const note = buildHandoffNote({ ...base, workspace: { kind: "none" } })
 		expect(note).toContain("command -v")
 		expect(note).toContain("package manager")
+		expect(note).toContain("History is not fully replayable here")
 	})
 })
 

--- a/src/extensions/teleport/provisioning/handoff-note.test.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.test.ts
@@ -152,25 +152,26 @@ describe("copySessionFileAndAddHandoffNote", () => {
 	})
 
 	it("writes an annotated copy without mutating the original", () => {
-		const original = msgEntry("u1", "root", userMsg("hello")) + "\n"
+		const original = `${msgEntry("u1", "root", userMsg("hello"))}\n`
 		const sessionFile = join(dir, "session.jsonl")
 		writeFileSync(sessionFile, original)
 
 		const copy = copySessionFileAndAddHandoffNote(sessionFile, "NOTE TEXT")
 		expect(copy).toBeDefined()
 		expect(copy).not.toBe(sessionFile)
+		if (!copy) throw new Error("expected copy to be defined")
 
 		// Original untouched.
 		expect(readFileSync(sessionFile, "utf8")).toBe(original)
 		// Copy contains original content plus the note.
-		const copyText = readFileSync(copy!, "utf8")
+		const copyText = readFileSync(copy, "utf8")
 		expect(copyText).toContain("hello")
 		expect(copyText).toContain("NOTE TEXT")
 
 		// The copy sits at the root of its own temp dir; removeTempDir on its
 		// parent fully cleans it up.
-		removeTempDir(dirname(copy!))
-		expect(existsSync(copy!)).toBe(false)
+		removeTempDir(dirname(copy))
+		expect(existsSync(copy)).toBe(false)
 	})
 
 	it("returns undefined for a missing file", () => {

--- a/src/extensions/teleport/provisioning/handoff-note.test.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.test.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+	addHandoffNoteToSessionJsonl,
+	buildHandoffNote,
+	copySessionFileAndAddHandoffNote,
+	removeTempDir,
+} from "./handoff-note.js"
+
+function msgEntry(id: string, parentId: string | null, message: Record<string, unknown>): string {
+	return JSON.stringify({ type: "message", id, parentId, timestamp: "2026-01-01T00:00:00.000Z", message })
+}
+
+function userMsg(content: string): Record<string, unknown> {
+	return { role: "user", content: [{ type: "text", text: content }], timestamp: 1 }
+}
+
+describe("buildHandoffNote", () => {
+	const base = {
+		fromPlatform: "darwin",
+		fromCwd: "/home/dev/projects/demo",
+		toCwd: "/home/sandbox/demo",
+		gitIdentityProvisioned: true,
+		gitCredential: { host: "github.com" },
+	}
+
+	it("describes the rsync heuristic with file count", () => {
+		const note = buildHandoffNote({ ...base, workspace: { kind: "rsync", fileCount: 42, bytes: 1024 } })
+		expect(note).toContain("rsync")
+		expect(note).toContain("42 files")
+		expect(note).toContain("Gitignored content")
+		expect(note).toContain("darwin, cwd /home/dev/projects/demo")
+		expect(note).toContain("Current environment: Linux sandbox, cwd /home/sandbox/demo")
+	})
+
+	it("describes a fresh git clone and missing uncommitted changes", () => {
+		const note = buildHandoffNote({
+			...base,
+			workspace: { kind: "git-clone", repo: "https://github.com/org/repo.git", branch: "main" },
+		})
+		expect(note).toContain("fresh git clone of https://github.com/org/repo.git (branch main)")
+		expect(note).toContain("uncommitted changes were NOT carried over")
+	})
+
+	it("describes no-sync provisioning", () => {
+		const note = buildHandoffNote({ ...base, workspace: { kind: "none" } })
+		expect(note).toContain("no workspace content was synced")
+	})
+
+	it("states git identity and credential status", () => {
+		const note = buildHandoffNote({
+			...base,
+			workspace: { kind: "none" },
+			gitIdentityProvisioned: false,
+			gitCredential: undefined,
+		})
+		expect(note).toContain("Git identity provisioned in sandbox: no")
+		expect(note).toContain("Git credential: not provisioned")
+	})
+
+	it("points the agent at concrete ways to check and install tools", () => {
+		const note = buildHandoffNote({ ...base, workspace: { kind: "none" } })
+		expect(note).toContain("command -v")
+		expect(note).toContain("package manager")
+	})
+})
+
+describe("addHandoffNoteToSessionJsonl", () => {
+	it("appends the note as a user message chained to the last entry", () => {
+		const src = [
+			JSON.stringify({ type: "session", version: 3, id: "root", timestamp: "t", cwd: "/x" }),
+			msgEntry("u1", "root", userMsg("hello")),
+			"",
+		].join("\n")
+
+		const out = addHandoffNoteToSessionJsonl(src, "NOTE TEXT")
+		const lines = out.split("\n")
+		// session header + original user msg + appended note + trailing empty line
+		expect(lines).toHaveLength(4)
+		expect(lines[0]).toContain('"type":"session"')
+		expect(lines[1]).toBe(src.split("\n")[1])
+		const note = JSON.parse(lines[2])
+		expect(note.type).toBe("message")
+		expect(note.parentId).toBe("u1")
+		expect(note.message.role).toBe("user")
+		expect(note.message.content[0].type).toBe("text")
+		expect(note.message.content[0].text).toBe("NOTE TEXT")
+		expect(out.endsWith("\n")).toBe(true)
+	})
+
+	it("preserves malformed lines verbatim", () => {
+		const src = ["not json {{{", msgEntry("u1", "root", userMsg("hi"))].join("\n")
+		const out = addHandoffNoteToSessionJsonl(src, "NOTE")
+		expect(out.split("\n")[0]).toBe("not json {{{")
+	})
+})
+
+describe("copySessionFileAndAddHandoffNote", () => {
+	let dir: string
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "handoff-test-"))
+	})
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("writes an annotated copy without mutating the original", () => {
+		const original = msgEntry("u1", "root", userMsg("hello")) + "\n"
+		const sessionFile = join(dir, "session.jsonl")
+		writeFileSync(sessionFile, original)
+
+		const copy = copySessionFileAndAddHandoffNote(sessionFile, "NOTE TEXT")
+		expect(copy).toBeDefined()
+		expect(copy).not.toBe(sessionFile)
+
+		// Original untouched.
+		expect(readFileSync(sessionFile, "utf8")).toBe(original)
+		// Copy contains original content plus the note.
+		const copyText = readFileSync(copy!, "utf8")
+		expect(copyText).toContain("hello")
+		expect(copyText).toContain("NOTE TEXT")
+
+		// The copy sits at the root of its own temp dir; removeTempDir on its
+		// parent fully cleans it up.
+		removeTempDir(dirname(copy!))
+		expect(existsSync(copy!)).toBe(false)
+	})
+
+	it("returns undefined for a missing file", () => {
+		expect(copySessionFileAndAddHandoffNote(join(dir, "nope.jsonl"), "NOTE")).toBeUndefined()
+	})
+})

--- a/src/extensions/teleport/provisioning/handoff-note.test.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.test.ts
@@ -29,12 +29,35 @@ describe("buildHandoffNote", () => {
 	it("rsync: uncommitted changes carried, gitignored not; .kimchi synced when in the include list", () => {
 		const note = buildHandoffNote({
 			...base,
+			git: { headSha: "a1b2c3d", dirty: true },
 			workspace: { kind: "rsync", fileCount: 42, syncedDotKimchi: true },
 		})
 		expect(note).toContain("rsync of the working tree (42 files)")
 		expect(note).toContain("uncommitted local changes were carried over")
 		expect(note).toContain("Gitignored content")
 		expect(note).toContain("(.kimchi/ — ferment plans & runtime, transient docs) was synced")
+	})
+
+	it("rsync: states the tree was clean instead of claiming carried-over changes", () => {
+		const note = buildHandoffNote({
+			...base,
+			git: { headSha: "a1b2c3d", dirty: false },
+			workspace: { kind: "rsync", fileCount: 42, syncedDotKimchi: true },
+		})
+		expect(note).toContain("rsync of the working tree (42 files)")
+		expect(note).toContain("the working tree was clean — no uncommitted changes existed to carry over")
+		expect(note).not.toContain("uncommitted local changes were carried over")
+	})
+
+	it("rsync: omits the carried-over claim when the local git state is unknown", () => {
+		const note = buildHandoffNote({
+			...base,
+			workspace: { kind: "rsync", fileCount: 42, syncedDotKimchi: true },
+		})
+		expect(note).toContain("rsync of the working tree (42 files)")
+		expect(note).not.toContain("uncommitted local changes were carried over")
+		expect(note).not.toContain("the working tree was clean")
+		expect(note).toContain("Gitignored content")
 	})
 
 	it("rsync: warns explicitly when .kimchi was not synced", () => {

--- a/src/extensions/teleport/provisioning/handoff-note.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.ts
@@ -1,0 +1,174 @@
+import { basename, join } from "node:path"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+
+/**
+ * Teleport environment-handoff note.
+ *
+ * When a local session file is uploaded to a remote sandbox, the conversation
+ * history still claims facts about the *local* environment (cwd, OS, artifacts
+ * produced by earlier commands). The remote agent can easily get confused when
+ * those files/tools do not exist. This module builds a transparency note and
+ * appends it to an annotated COPY of the session JSONL (the user's local
+ * session file is never mutated) so the resumed agent — and the user reading
+ * the transcript — sees exactly what happened: new environment, how the
+ * workspace was provisioned, and which heuristics were used.
+ *
+ */
+
+/**
+ * Write an annotated COPY of the session file to a temp dir: read the local
+ * session JSONL and save it with the handoff note appended. The user's local
+ * session file is never mutated.
+ *
+ * A real file is required because session upload is a multipart POST that
+ * streams from a path on disk (`createSession(..., { sessionFile: path })`);
+ * there is no in-memory upload variant.
+ *
+ * Returns the copy's path, or undefined on any failure (callers then fall
+ * back to uploading the original file). The copy sits at the root of its own
+ * temp dir — callers are responsible for calling removeTempDir(dirname(path))
+ * once the upload has finished.
+ */
+export function copySessionFileAndAddHandoffNote(sessionFile: string, note: string): string | undefined {
+	try {
+		const src = readFileSync(sessionFile, "utf8")
+		const annotated = addHandoffNoteToSessionJsonl(src, note)
+		const tempDir = mkdtempSync(join(tmpdir(), "kimchi-teleport-"))
+		const filePath = join(tempDir, basename(sessionFile))
+		writeFileSync(filePath, annotated, "utf8")
+		return filePath
+	} catch {
+		return undefined
+	}
+}
+
+/** Best-effort removal of the temp dir produced by copySessionFileAndAddHandoffNote. */
+export function removeTempDir(tempDir: string): void {
+	try {
+		rmSync(tempDir, { recursive: true, force: true })
+	} catch {
+		// best effort
+	}
+}
+
+export interface HandoffNoteInput {
+	/** OS of the machine the session was running on (e.g. "darwin"). */
+	fromPlatform: string
+	/** Local working directory the history was generated in. */
+	fromCwd: string
+	/** Working directory the remote session will start in, if known. */
+	toCwd?: string
+	/** How the remote workspace was bootstrapped. */
+	workspace:
+		| { kind: "git-clone"; repo: string; branch?: string }
+		| { kind: "rsync"; fileCount: number; bytes: number }
+		| { kind: "none" }
+	/** Whether a git identity (user.name/user.email) was pushed to the sandbox. */
+	gitIdentityProvisioned: boolean
+	/** Whether a git credential was provisioned. Contains ONLY the host — the
+	 *  token itself is a secret and must never reach the session history, so
+	 *  this type deliberately has no field for it. */
+	gitCredential?: { host: string }
+}
+
+export function buildHandoffNote(input: HandoffNoteInput): string {
+	const lines: string[] = [
+		"[Teleport] Environment handoff: this session was moved from a local machine to a remote sandbox.",
+		`The conversation history above was produced in the previous environment — paths, tools, and artifacts it references may not exist here.`,
+		``,
+		`Previous environment: ${input.fromPlatform}, cwd ${input.fromCwd}`,
+		`Current environment: Linux sandbox${input.toCwd ? `, cwd ${input.toCwd}` : ""}`,
+	]
+
+	switch (input.workspace.kind) {
+		case "git-clone":
+			lines.push(
+				"",
+				`Workspace provisioning: the remote workspace is a fresh git clone of ${input.workspace.repo}${input.workspace.branch ? ` (branch ${input.workspace.branch})` : ""}. Local uncommitted changes were NOT carried over.`,
+			)
+			break
+		case "rsync":
+			lines.push(
+				"",
+				`Workspace provisioning: the workspace was synced with rsync using a git-based include-list heuristic (${input.workspace.fileCount} files). Only git-tracked files and untracked non-ignored files were copied. Gitignored content such as dependencies (node_modules), build outputs, and local caches may be missing.`,
+			)
+			break
+		case "none":
+			lines.push(
+				"",
+				`Workspace provisioning: no workspace content was synced to the sandbox.`,
+			)
+			break
+	}
+
+	lines.push(
+		"",
+		// gitCredential carries only the host — never the token itself (secret).
+		`Git identity provisioned in sandbox: ${input.gitIdentityProvisioned ? "yes" : "no"}. Git credential: ${input.gitCredential ? `provisioned for ${input.gitCredential.host}` : "not provisioned"}.`,
+		"",
+		`Do not assume tools or file artifacts from the previous machine exist here — verify availability with \`command -v <tool>\` before relying on earlier results, and install missing tools via the sandbox's package manager if needed.`,
+	)
+
+	return lines.join("\n")
+}
+
+interface ParsedEntry {
+	type?: string
+	id?: string
+}
+
+function randomId(): string {
+	return (Math.random() * 0xffffffff + 0x100000000).toString(16).slice(-8)
+}
+
+function stringifyEntry(entry: Record<string, unknown>): string {
+	return JSON.stringify(entry)
+}
+
+/**
+ * Find the id of the last entry in a session JSONL line list, to chain
+ * parentId from. Scans from the end and stops at the last non-empty line:
+ * malformed trailing content returns null rather than being skipped past.
+ */
+function findLastMessageId(lines: string[]): string | null {
+	for (let i = lines.length - 1; i >= 0; i--) {
+		if (!lines[i]) continue
+		try {
+			const entry = JSON.parse(lines[i]) as ParsedEntry
+			if (entry && typeof entry.id === "string") return entry.id
+			return null
+		} catch {
+			return null
+		}
+	}
+	return null
+}
+
+/**
+ * Append a teleport transparency note (as a user message) to session JSONL.
+ * Malformed lines are preserved verbatim; the note is chained to the last
+ * entry via parentId.
+ */
+export function addHandoffNoteToSessionJsonl(sessionJsonl: string, note: string): string {
+	const lines = sessionJsonl.split("\n")
+	const now = Date.now()
+	const lastId = findLastMessageId(lines)
+
+	const noteLine = stringifyEntry({
+		type: "message",
+		id: randomId(),
+		parentId: lastId,
+		timestamp: new Date(now).toISOString(),
+		message: {
+			role: "user",
+			content: [{ type: "text", text: note }],
+			timestamp: now,
+		},
+	})
+
+	// Drop a trailing empty line (from a trailing newline) so the appended
+	// line stays properly delimited, then re-add the trailing newline.
+	const base = lines[lines.length - 1] === "" ? lines.slice(0, -1) : lines
+	return [...base, noteLine].join("\n") + "\n"
+}

--- a/src/extensions/teleport/provisioning/handoff-note.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.ts
@@ -185,5 +185,5 @@ export function addHandoffNoteToSessionJsonl(sessionJsonl: string, note: string)
 	// Drop a trailing empty line (from a trailing newline) so the appended
 	// line stays properly delimited, then re-add the trailing newline.
 	const base = lines[lines.length - 1] === "" ? lines.slice(0, -1) : lines
-	return [...base, noteLine].join("\n") + "\n"
+	return `${[...base, noteLine].join("\n")}\n`
 }

--- a/src/extensions/teleport/provisioning/handoff-note.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -38,7 +39,8 @@ export function copySessionFileAndAddHandoffNote(sessionFile: string, note: stri
 		const filePath = join(tempDir, basename(sessionFile))
 		writeFileSync(filePath, annotated, "utf8")
 		return filePath
-	} catch {
+	} catch (err) {
+		console.warn("Failed to create annotated session copy:", err)
 		return undefined
 	}
 }
@@ -132,7 +134,7 @@ interface ParsedEntry {
 }
 
 function randomId(): string {
-	return (Math.random() * 0xffffffff + 0x100000000).toString(16).slice(-8)
+	return randomUUID()
 }
 
 function stringifyEntry(entry: Record<string, unknown>): string {

--- a/src/extensions/teleport/provisioning/handoff-note.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.ts
@@ -1,6 +1,6 @@
-import { basename, join } from "node:path"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
 
 /**
  * Teleport environment-handoff note.
@@ -59,10 +59,12 @@ export interface HandoffNoteInput {
 	fromCwd: string
 	/** Working directory the remote session will start in, if known. */
 	toCwd?: string
+	/** Git anchor of the local repo at teleport time (undefined outside git repos). */
+	git?: { headSha?: string; dirty: boolean }
 	/** How the remote workspace was bootstrapped. */
 	workspace:
 		| { kind: "git-clone"; repo: string; branch?: string }
-		| { kind: "rsync"; fileCount: number; bytes: number }
+		| { kind: "rsync"; fileCount: number; syncedDotKimchi: boolean }
 		| { kind: "none" }
 	/** Whether a git identity (user.name/user.email) was pushed to the sandbox. */
 	gitIdentityProvisioned: boolean
@@ -73,32 +75,43 @@ export interface HandoffNoteInput {
 }
 
 export function buildHandoffNote(input: HandoffNoteInput): string {
+	let fromDescription = `Previous environment: ${input.fromPlatform}, cwd ${input.fromCwd}`
+	if (input.git) {
+		const parts: string[] = []
+		if (input.git.headSha) parts.push(`local repo at ${input.git.headSha}`)
+		if (input.git.dirty) parts.push("working tree dirty")
+		if (parts.length > 0) fromDescription += ` (${parts.join(", ")})`
+	}
+
 	const lines: string[] = [
 		"[Teleport] Environment handoff: this session was moved from a local machine to a remote sandbox.",
-		`The conversation history above was produced in the previous environment — paths, tools, and artifacts it references may not exist here.`,
-		``,
-		`Previous environment: ${input.fromPlatform}, cwd ${input.fromCwd}`,
+		"The conversation history above was produced in the previous environment — paths, tools, and artifacts it references may not exist here.",
+		"",
+		fromDescription,
 		`Current environment: Linux sandbox${input.toCwd ? `, cwd ${input.toCwd}` : ""}`,
 	]
 
 	switch (input.workspace.kind) {
-		case "git-clone":
+		case "git-clone": {
+			let line = `Workspace provisioning: fresh git clone of ${input.workspace.repo}${input.workspace.branch ? ` (branch ${input.workspace.branch})` : ""} — uncommitted changes and gitignored content were NOT carried over.`
+			if (input.git?.headSha) {
+				line += ` The local repo was at commit ${input.git.headSha}, so history references to newer local commits or files may not resolve.`
+			}
+			lines.push("", line)
+			break
+		}
+		case "rsync": {
+			const dotKimchi = input.workspace.syncedDotKimchi
+				? "The project working state (.kimchi/ — ferment plans & runtime, transient docs) was synced."
+				: "The project working state (.kimchi/ — ferment plans & runtime, transient docs) was NOT synced; do not expect ferment state or prior working documents to exist here."
 			lines.push(
 				"",
-				`Workspace provisioning: the remote workspace is a fresh git clone of ${input.workspace.repo}${input.workspace.branch ? ` (branch ${input.workspace.branch})` : ""}. Local uncommitted changes were NOT carried over.`,
+				`Workspace provisioning: rsync of the working tree (${input.workspace.fileCount} files) — uncommitted local changes were carried over. Gitignored content (dependencies such as node_modules, build outputs, caches) was NOT. ${dotKimchi}`,
 			)
 			break
-		case "rsync":
-			lines.push(
-				"",
-				`Workspace provisioning: the workspace was synced with rsync using a git-based include-list heuristic (${input.workspace.fileCount} files). Only git-tracked files and untracked non-ignored files were copied. Gitignored content such as dependencies (node_modules), build outputs, and local caches may be missing.`,
-			)
-			break
+		}
 		case "none":
-			lines.push(
-				"",
-				`Workspace provisioning: no workspace content was synced to the sandbox.`,
-			)
+			lines.push("", `Workspace provisioning: no workspace content was synced to the sandbox.`)
 			break
 	}
 
@@ -107,7 +120,7 @@ export function buildHandoffNote(input: HandoffNoteInput): string {
 		// gitCredential carries only the host — never the token itself (secret).
 		`Git identity provisioned in sandbox: ${input.gitIdentityProvisioned ? "yes" : "no"}. Git credential: ${input.gitCredential ? `provisioned for ${input.gitCredential.host}` : "not provisioned"}.`,
 		"",
-		`Do not assume tools or file artifacts from the previous machine exist here — verify availability with \`command -v <tool>\` before relying on earlier results, and install missing tools via the sandbox's package manager if needed.`,
+		`History is not fully replayable here: earlier turns may show tools, files, or authenticated commands from the previous machine that would fail now. Verify tool availability with \`command -v <tool>\` and install missing tools via the sandbox package manager before relying on earlier results.`,
 	)
 
 	return lines.join("\n")

--- a/src/extensions/teleport/provisioning/handoff-note.ts
+++ b/src/extensions/teleport/provisioning/handoff-note.ts
@@ -103,12 +103,23 @@ export function buildHandoffNote(input: HandoffNoteInput): string {
 			break
 		}
 		case "rsync": {
+			// The carried-over claim depends on what we actually know about the
+			// local tree: assert it only for a confirmed dirty tree, state
+			// cleanliness when confirmed clean, and stay silent when the local
+			// git state is unknown (no anchor) — claiming carry-over we can't
+			// verify mislabeled clean teleports.
+			const carriedOver =
+				input.git === undefined
+					? ""
+					: input.git.dirty
+						? "uncommitted local changes were carried over. "
+						: "the working tree was clean — no uncommitted changes existed to carry over. "
 			const dotKimchi = input.workspace.syncedDotKimchi
 				? "The project working state (.kimchi/ — ferment plans & runtime, transient docs) was synced."
 				: "The project working state (.kimchi/ — ferment plans & runtime, transient docs) was NOT synced; do not expect ferment state or prior working documents to exist here."
 			lines.push(
 				"",
-				`Workspace provisioning: rsync of the working tree (${input.workspace.fileCount} files) — uncommitted local changes were carried over. Gitignored content (dependencies such as node_modules, build outputs, caches) was NOT. ${dotKimchi}`,
+				`Workspace provisioning: rsync of the working tree (${input.workspace.fileCount} files) — ${carriedOver}Gitignored content (dependencies such as node_modules, build outputs, caches) was NOT. ${dotKimchi}`,
 			)
 			break
 		}


### PR DESCRIPTION
## What

Appends an environment handoff note to the session JSONL when teleporting, so the resumed remote agent sees the environment change in context (and the user sees it in the transcript).

## Why

When a session is teleported to a remote workspace, the resumed agent starts cold — it has no awareness that the environment changed. The handoff note bridges this gap by injecting a structured user-message entry into the uploaded session file, giving the agent context about the new environment without requiring a manual prompt.

## Changes

- **New:** `handoff-note.ts` — builds and appends the handoff note as a JSONL entry, preserving the original session file (writes to a copy).
- **New:** `handoff-note.test.ts` — full coverage of note generation, file copy, and immutability of the original.
- **Modified:** `teleport.ts` — wired handoff note into the teleport upload flow.
- **Modified:** `git.ts` — minor git preflight improvements.

## Testing

- Unit tests for handoff-note generation and file handling.
- Integration tests in `teleport.test.ts` verify the note appears in the uploaded JSONL and the original file is unmutated.

Closes #987