### PR TITLE
feat(teleport): compaction hint before teleport for long sessions

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -14,12 +14,14 @@ import {
 	readGitToken,
 	readHideTips,
 	readTelemetryConfig,
+	readTeleportCompactHintEnabled,
 	upgradeLegacyRetrySettings,
 	writeApiKey,
 	writeDeviceId,
 	writeGitToken,
 	writeHideTips,
 	writeSessionModeWizardSeenAt,
+	writeTeleportCompactHintEnabled,
 } from "./config.js"
 
 describe("loadConfig", () => {
@@ -663,6 +665,63 @@ describe("readGitToken / writeGitToken", () => {
 	})
 })
 
+describe("readTeleportCompactHintEnabled / writeTeleportCompactHintEnabled", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("defaults to enabled when config file does not exist", () => {
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(true)
+	})
+
+	it("defaults to enabled when the teleport.compactHint section is missing", () => {
+		writeFileSync(configPath, JSON.stringify({ apiKey: "key" }))
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(true)
+	})
+
+	it("defaults to enabled when config file is corrupt", () => {
+		writeFileSync(configPath, "{ not json")
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(true)
+	})
+
+	it("defaults to enabled when enabled is not a boolean", () => {
+		writeFileSync(configPath, JSON.stringify({ teleport: { compactHint: { enabled: "no" } } }))
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(true)
+	})
+
+	it("reads a stored false", () => {
+		writeFileSync(configPath, JSON.stringify({ teleport: { compactHint: { enabled: false } } }))
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(false)
+	})
+
+	it("round-trips write then read", () => {
+		writeTeleportCompactHintEnabled(false, configPath)
+		expect(readTeleportCompactHintEnabled(configPath)).toBe(false)
+	})
+
+	it("preserves sibling keys when writing", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				apiKey: "key",
+				teleport: { otherSetting: true, compactHint: { futureField: 1 } },
+			}),
+		)
+		writeTeleportCompactHintEnabled(false, configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+		expect(raw.apiKey).toBe("key")
+		expect(raw.teleport.otherSetting).toBe(true)
+		expect(raw.teleport.compactHint).toEqual({ futureField: 1, enabled: false })
+	})
+})
 describe("buildSkillPathOptions", () => {
 	let tempDir: string
 	let originalCwd: string

--- a/src/config.ts
+++ b/src/config.ts
@@ -709,6 +709,46 @@ export function clearApiKey(configPath?: string): void {
 	)
 }
 
+export const TELEPORT_COMPACT_HINT_ENABLED_DEFAULT = true
+
+/**
+ * Whether the pre-teleport compaction hint is enabled (`teleport.compactHint.enabled`
+ * in the config file).
+ * Missing/invalid values or unreadable/corrupt files fall back to enabled.
+ */
+export function readTeleportCompactHintEnabled(configPath?: string): boolean {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	try {
+		const raw = readFileSync(path, "utf-8")
+		const parsed = JSON.parse(raw)
+		const enabled = parsed?.teleport?.compactHint?.enabled
+		return typeof enabled === "boolean" ? enabled : TELEPORT_COMPACT_HINT_ENABLED_DEFAULT
+	} catch {
+		return TELEPORT_COMPACT_HINT_ENABLED_DEFAULT
+	}
+}
+
+/**
+ * Set `teleport.compactHint.enabled` in the config file, preserving sibling
+ * keys in the compactHint section, the teleport section, and the file.
+ */
+export function writeTeleportCompactHintEnabled(enabled: boolean, configPath?: string): void {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	updateConfigFile(path, (raw) => {
+		const teleport =
+			raw.teleport && typeof raw.teleport === "object" && !Array.isArray(raw.teleport)
+				? { ...(raw.teleport as Record<string, unknown>) }
+				: {}
+		const compactHint =
+			teleport.compactHint && typeof teleport.compactHint === "object" && !Array.isArray(teleport.compactHint)
+				? { ...(teleport.compactHint as Record<string, unknown>) }
+				: {}
+		compactHint.enabled = enabled
+		teleport.compactHint = compactHint
+		raw.teleport = teleport
+	})
+}
+
 /**
  * Read a stored git token for a specific host from the global config.
  * Tokens are stored under `gitTokens.<host>` (e.g. `gitTokens["github.com"]`).

--- a/src/extensions/teleport/commands/args.test.ts
+++ b/src/extensions/teleport/commands/args.test.ts
@@ -48,6 +48,10 @@ describe("parseTeleportArgs", () => {
 		expect(parseTeleportArgs("--no-git-token")).toEqual({ noGitToken: true })
 	})
 
+	it("reads --no-compact-hint as a boolean", () => {
+		expect(parseTeleportArgs("--no-compact-hint")).toEqual({ noCompactHint: true })
+	})
+
 	it("rejects --no-shallow (removed in favor of worker-side clone)", () => {
 		expect(() => parseTeleportArgs("--no-shallow")).toThrow(/Unknown flag/)
 	})

--- a/src/extensions/teleport/commands/args.ts
+++ b/src/extensions/teleport/commands/args.ts
@@ -6,17 +6,19 @@ export interface TeleportArgs {
 	gitRepo?: string
 	branch?: string
 	noGitToken?: boolean
+	noCompactHint?: boolean
 	skipSession?: boolean
 }
 
 const SESSION_NAME_RE = /^[A-Za-z0-9\-_]+$/
 
 const FLAGS_WITH_VALUE = new Set(["--workspace", "--git-repo", "--branch"])
-const BOOLEAN_FLAGS = new Set(["--no-git-token", "--skip-session"])
+const BOOLEAN_FLAGS = new Set(["--no-git-token", "--no-compact-hint", "--skip-session"])
 
 /**
  * Parse `/teleport [name] [--workspace ID] [--git-repo URL] [--branch B]
- *                  [--allow-dirty] [--force] [--no-git-token] [--skip-session]`.
+ *                  [--allow-dirty] [--force] [--no-git-token] [--no-compact-hint]
+ *                  [--skip-session]`.
  *
  * A malformed input (a `--flag=` with no key, a stray `--`) throws so the
  * command surfaces a clear refusal.
@@ -65,6 +67,10 @@ export function parseTeleportArgs(raw: string): TeleportArgs {
 			}
 			if (flag === "--no-git-token") {
 				args.noGitToken = true
+				continue
+			}
+			if (flag === "--no-compact-hint") {
+				args.noCompactHint = true
 				continue
 			}
 			if (flag === "--skip-session") {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -697,8 +697,8 @@ describe("runTeleport", () => {
 	})
 
 	describe("compaction hint gate", () => {
-		// 25 messages > the production lookback of 20, so a fresh fixture is
-		// hint-eligible (suppression would otherwise kick in).
+		// 25 messages > the production lookback of 20, exercising the real
+		// lookback path (a never-compacted session hints at any count).
 		function writeSessionJsonl(timestamp: Date, messageCount = 25): string {
 			const sessionFile = join(tempDir, "session.jsonl")
 			const entry = {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -25,6 +25,7 @@ const {
 	provisionGitIdentityMock,
 	provisionGitCredentialMock,
 	provisionHarnessConfigMock,
+	readTeleportCompactHintEnabledMock,
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	waitReadyMock: vi.fn(),
@@ -54,6 +55,7 @@ const {
 	provisionGitIdentityMock: vi.fn(),
 	provisionGitCredentialMock: vi.fn(),
 	provisionHarnessConfigMock: vi.fn(),
+	readTeleportCompactHintEnabledMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
@@ -78,6 +80,7 @@ vi.mock("../../../config.js", () => ({
 	writeGitToken: writeGitTokenMock,
 	readTeleportHelpSeenAt: readTeleportHelpSeenAtMock,
 	writeTeleportHelpSeenAt: writeTeleportHelpSeenAtMock,
+	readTeleportCompactHintEnabled: readTeleportCompactHintEnabledMock,
 }))
 vi.mock("../provisioning/git-provision.js", () => ({
 	provisionGitIdentity: provisionGitIdentityMock,
@@ -201,6 +204,7 @@ beforeEach(() => {
 	provisionGitIdentityMock.mockReset().mockResolvedValue(undefined)
 	provisionGitCredentialMock.mockReset().mockResolvedValue(undefined)
 	provisionHarnessConfigMock.mockReset().mockResolvedValue({ ok: true })
+	readTeleportCompactHintEnabledMock.mockReset().mockReturnValue(true)
 })
 
 afterEach(() => {
@@ -683,6 +687,111 @@ describe("runTeleport", () => {
 			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
 
 			expect(createSessionMock.mock.calls[0][3]).toMatchObject({ sessionFile: undefined })
+		})
+	})
+
+	describe("compaction hint gate", () => {
+		// 25 messages > the production lookback of 20, so a fresh fixture is
+		// hint-eligible (suppression would otherwise kick in).
+		function writeSessionJsonl(timestamp: Date, messageCount = 25): string {
+			const sessionFile = join(tempDir, "session.jsonl")
+			const entry = {
+				type: "message",
+				timestamp: timestamp.toISOString(),
+				message: { role: "user", content: [{ type: "text", text: "hello" }] },
+			}
+			writeFileSync(sessionFile, `${Array.from({ length: messageCount }, () => JSON.stringify(entry)).join("\n")}\n`)
+			return sessionFile
+		}
+
+		function usageOf(tokens: number | null) {
+			return () => ({ tokens, contextWindow: 200_000, percent: tokens === null ? null : tokens / 2000 })
+		}
+
+		beforeEach(() => {
+			readTeleportCompactHintEnabledMock.mockReset().mockReturnValue(true)
+		})
+
+		// Above/below the production threshold (TELEPORT_COMPACT_HINT_DEFAULTS),
+		// which the gate now uses directly.
+		const BIG_TOKENS = 300_000
+		const SMALL_TOKENS = 100_000
+
+		it("refuses a big, recently active session before any network call", async () => {
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx, ui } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await expect(
+				runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx),
+			).rejects.toBeInstanceOf(TeleportRefusal)
+			expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("--no-compact-hint"), "error")
+			// The gate runs before workspace resolution — no network, no progress UI.
+			expect(authMock).not.toHaveBeenCalled()
+			expect(listWorkspacesMock).not.toHaveBeenCalled()
+			expect(progressInstances).toHaveLength(0)
+		})
+
+		it("proceeds for a big, fresh session when --no-compact-hint is passed", async () => {
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111 --no-compact-hint", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds for a big, fresh session when the config disables the hint", async () => {
+			readTeleportCompactHintEnabledMock.mockReturnValue(false)
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds for a small session", async () => {
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx } = makeCtx({ sessionFile, getContextUsage: usageOf(SMALL_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds for a big but stale (2h old) session", async () => {
+			const sessionFile = writeSessionJsonl(new Date(Date.now() - 2 * 60 * 60_000))
+			const { ctx } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds when context usage reports tokens null (post-compaction unknown), even for a big fresh file", async () => {
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx } = makeCtx({ sessionFile, getContextUsage: usageOf(null) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds silently when getContextUsage is unavailable (hint is non-critical)", async () => {
+			const sessionFile = writeSessionJsonl(new Date())
+			const { ctx } = makeCtx({ sessionFile })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+		})
+
+		it("proceeds when no session file is available", async () => {
+			const { ctx } = makeCtx({ getContextUsage: usageOf(BIG_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
 		})
 	})
 })

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -110,7 +110,13 @@ vi.mock("../ui/progress.js", () => ({
 
 import type { TeleportContext } from "../types.js"
 import { TeleportRefusal } from "./errors.js"
-import { runTeleport, SESSION_CREATE_TIMEOUT_MS } from "./teleport.js"
+import {
+	readSessionTail,
+	runTeleport,
+	SESSION_CREATE_TIMEOUT_MS,
+	SESSION_TAIL_BYTES,
+	SESSION_WIDEN_MAX_BYTES,
+} from "./teleport.js"
 
 const CREDS = {
 	connectToken: "tok-1",
@@ -793,5 +799,80 @@ describe("runTeleport", () => {
 
 			expect(authMock).toHaveBeenCalledOnce()
 		})
+
+		/**
+		 * 25 fresh head messages (enough to hint if the whole file is evaluated),
+		 * followed by one giant message line of `padBytes` that swallows the tail
+		 * slice — the tail evaluation sees only a fragment of that line and can't
+		 * decide, forcing the widen-to-whole-file fallback.
+		 */
+		function writeGiantSessionJsonl(padBytes: number): string {
+			const sessionFile = join(tempDir, "session.jsonl")
+			const timestamp = new Date().toISOString()
+			const head = Array.from({ length: 25 }, () =>
+				JSON.stringify({
+					type: "message",
+					timestamp,
+					message: { role: "user", content: [{ type: "text", text: "hello" }] },
+				}),
+			)
+			const giant = JSON.stringify({
+				type: "message",
+				timestamp,
+				message: { role: "assistant", content: [{ type: "text", text: "x".repeat(padBytes) }] },
+			})
+			writeFileSync(sessionFile, `${[...head, giant].join("\n")}\n`)
+			return sessionFile
+		}
+
+		it("skips the hint silently when an undecidable session file exceeds the widen cap", async () => {
+			// The tail slice lies entirely inside the giant line, so the tail
+			// evaluation can't decide — and at over SESSION_WIDEN_MAX_BYTES the
+			// whole-file fallback is refused: the non-critical hint is skipped.
+			const sessionFile = writeGiantSessionJsonl(SESSION_WIDEN_MAX_BYTES + 1024)
+			const { ctx, ui } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx)
+
+			expect(authMock).toHaveBeenCalledOnce()
+			expect(ui.notify).not.toHaveBeenCalledWith(expect.stringContaining("--no-compact-hint"), "error")
+		})
+
+		it("widens an undecidable file under the cap and still refuses a big fresh session", async () => {
+			const sessionFile = writeGiantSessionJsonl(1024 * 1024)
+			const { ctx, ui } = makeCtx({ sessionFile, getContextUsage: usageOf(BIG_TOKENS) })
+
+			await expect(
+				runTeleport("mysession --workspace 11111111-1111-4111-8111-111111111111", ctx),
+			).rejects.toBeInstanceOf(TeleportRefusal)
+			expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("--no-compact-hint"), "error")
+		})
+	})
+})
+
+describe("readSessionTail", () => {
+	it("reads a file that fits the tail budget whole and marks it as such", async () => {
+		const sessionFile = join(tempDir, "small.jsonl")
+		const content = '{"type":"message","message":{"role":"user"}}\n{"type":"compaction"}\n'
+		writeFileSync(sessionFile, content)
+
+		const info = await readSessionTail(sessionFile)
+
+		expect(info.tail).toBe(content)
+		expect(info.tailIsWholeFile).toBe(true)
+		expect(info.fileSizeBytes).toBe(Buffer.byteLength(content))
+		expect(info.fileMtimeMs).toBeGreaterThan(0)
+	})
+
+	it("reads exactly the last SESSION_TAIL_BYTES when the file is larger", async () => {
+		const sessionFile = join(tempDir, "large.jsonl")
+		const body = "x".repeat(SESSION_TAIL_BYTES + 1000)
+		writeFileSync(sessionFile, body)
+
+		const info = await readSessionTail(sessionFile)
+
+		expect(info.tailIsWholeFile).toBe(false)
+		expect(info.tail).toBe("x".repeat(SESSION_TAIL_BYTES))
+		expect(info.fileSizeBytes).toBe(SESSION_TAIL_BYTES + 1000)
 	})
 })

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -1,4 +1,5 @@
-import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs"
+import { existsSync } from "node:fs"
+import { open, readFile, stat } from "node:fs/promises"
 import { platform } from "node:os"
 import { basename, dirname } from "node:path"
 import {
@@ -71,7 +72,7 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 	}
 
 	runPreflight(ctx, args)
-	maybeRefuseTeleportForLongSession(ctx, args)
+	await maybeRefuseTeleportForLongSession(ctx, args)
 
 	// Show an inline status line message while we resolve the workspace — the
 	// progress overlay can't open until we know which workspace to attach
@@ -429,7 +430,10 @@ async function resolveGitToken(
  * the evaluator scans backward with early-exit, so a widening re-read to the
  * whole file only happens when the tail genuinely can't decide.
  */
-function maybeRefuseTeleportForLongSession(ctx: TeleportContext, args: ReturnType<typeof parseTeleportArgs>): void {
+async function maybeRefuseTeleportForLongSession(
+	ctx: TeleportContext,
+	args: ReturnType<typeof parseTeleportArgs>,
+): Promise<void> {
 	if (args.skipSession || args.noCompactHint) return
 	const config = { ...TELEPORT_COMPACT_HINT_DEFAULTS, enabled: readTeleportCompactHintEnabled(ctx.configPath) }
 	if (!config.enabled) return
@@ -438,29 +442,33 @@ function maybeRefuseTeleportForLongSession(ctx: TeleportContext, args: ReturnTyp
 	const sessionFile = ctx.sessionFile
 	if (!sessionFile || !existsSync(sessionFile)) return
 
-	let tail: string
-	let tailIsWholeFile: boolean
-	let fileMtimeMs: number
+	let tailInfo: Awaited<ReturnType<typeof readSessionTail>>
 	try {
-		;({ tail, tailIsWholeFile, fileMtimeMs } = readSessionTail(sessionFile))
+		tailInfo = await readSessionTail(sessionFile)
 	} catch {
 		return
 	}
+	const { tail, tailIsWholeFile, tailStartsMidLine, fileMtimeMs } = tailInfo
 	let evaluation = evaluateCompactHint({
 		sessionTail: tail,
 		tailIsWholeFile,
+		tailStartsMidLine,
 		estimatedTokens: tokens,
 		now: Date.now(),
 		config,
 		fallbackTimestampMs: fileMtimeMs,
 	})
 	if (!evaluation.decided) {
+		// Cap the widening re-read: the hint is a non-critical nudge, so loading
+		// a pathologically large session file (blocking memory + event loop)
+		// just to decide suppression is not worth it — skip the hint instead.
+		if (tailInfo.fileSizeBytes > SESSION_WIDEN_MAX_BYTES) return
 		// The tail slice ran out before either stop condition (e.g. fewer than
 		// the lookback window of very large messages, compaction just beyond
 		// the slice). Widen to the whole file and decide.
 		try {
 			evaluation = evaluateCompactHint({
-				sessionTail: readFileSync(sessionFile, "utf-8"),
+				sessionTail: await readFile(sessionFile, "utf-8"),
 				tailIsWholeFile: true,
 				estimatedTokens: tokens,
 				now: Date.now(),
@@ -486,20 +494,54 @@ function maybeRefuseTeleportForLongSession(ctx: TeleportContext, args: ReturnTyp
  */
 const SESSION_TAIL_BYTES = 512 * 1024
 
+/**
+ * Maximum file size for the widen-to-whole-file fallback. Sessions over the
+ * hint threshold are usually a few MB; anything far beyond this is too large
+ * to justify a full synchronous-within-the-gate load for a non-critical hint.
+ */
+const SESSION_WIDEN_MAX_BYTES = 64 * 1024 * 1024
+
+interface SessionTail {
+	tail: string
+	tailIsWholeFile: boolean
+	/**
+	 * True when the tail slice begins mid-entry (the byte before the slice is
+	 * not a newline): the first line of `tail` is a partial entry and must be
+	 * skipped by the evaluator. False when the slice happens to start exactly
+	 * at a line boundary, in which case the first line is a complete entry.
+	 */
+	tailStartsMidLine: boolean
+	fileMtimeMs: number
+	fileSizeBytes: number
+}
+
 /** Read the last SESSION_TAIL_BYTES of the session file as UTF-8 (whole file when smaller). */
-function readSessionTail(path: string): { tail: string; tailIsWholeFile: boolean; fileMtimeMs: number } {
-	const stat = statSync(path)
-	const size = stat.size
+async function readSessionTail(path: string): Promise<SessionTail> {
+	const { size, mtimeMs } = await stat(path)
 	if (size <= SESSION_TAIL_BYTES) {
-		return { tail: readFileSync(path, "utf-8"), tailIsWholeFile: true, fileMtimeMs: stat.mtimeMs }
+		return {
+			tail: await readFile(path, "utf-8"),
+			tailIsWholeFile: true,
+			tailStartsMidLine: false,
+			fileMtimeMs: mtimeMs,
+			fileSizeBytes: size,
+		}
 	}
-	const fd = openSync(path, "r")
+	const handle = await open(path, "r")
 	try {
-		const buffer = Buffer.alloc(SESSION_TAIL_BYTES)
-		readSync(fd, buffer, 0, SESSION_TAIL_BYTES, size - SESSION_TAIL_BYTES)
-		return { tail: buffer.toString("utf-8"), tailIsWholeFile: false, fileMtimeMs: stat.mtimeMs }
+		// Read one extra byte BEFORE the slice to know whether the slice starts
+		// mid-line or exactly at a line boundary.
+		const buffer = Buffer.alloc(SESSION_TAIL_BYTES + 1)
+		const { bytesRead } = await handle.read(buffer, 0, buffer.length, size - SESSION_TAIL_BYTES - 1)
+		return {
+			tail: buffer.subarray(1, bytesRead).toString("utf-8"),
+			tailIsWholeFile: false,
+			tailStartsMidLine: buffer[0] !== 0x0a,
+			fileMtimeMs: mtimeMs,
+			fileSizeBytes: size,
+		}
 	} finally {
-		closeSync(fd)
+		await handle.close()
 	}
 }
 

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -442,17 +442,16 @@ async function maybeRefuseTeleportForLongSession(
 	const sessionFile = ctx.sessionFile
 	if (!sessionFile || !existsSync(sessionFile)) return
 
-	let tailInfo: Awaited<ReturnType<typeof readSessionTail>>
+	let tailInfo: SessionTail
 	try {
 		tailInfo = await readSessionTail(sessionFile)
 	} catch {
 		return
 	}
-	const { tail, tailIsWholeFile, tailStartsMidLine, fileMtimeMs } = tailInfo
+	const { tail, tailIsWholeFile, fileMtimeMs } = tailInfo
 	let evaluation = evaluateCompactHint({
 		sessionTail: tail,
 		tailIsWholeFile,
-		tailStartsMidLine,
 		estimatedTokens: tokens,
 		now: Date.now(),
 		config,
@@ -460,8 +459,8 @@ async function maybeRefuseTeleportForLongSession(
 	})
 	if (!evaluation.decided) {
 		// Cap the widening re-read: the hint is a non-critical nudge, so loading
-		// a pathologically large session file (blocking memory + event loop)
-		// just to decide suppression is not worth it — skip the hint instead.
+		// a pathologically large session file fully into memory just to decide
+		// suppression is not worth it — skip the hint instead.
 		if (tailInfo.fileSizeBytes > SESSION_WIDEN_MAX_BYTES) return
 		// The tail slice ran out before either stop condition (e.g. fewer than
 		// the lookback window of very large messages, compaction just beyond
@@ -492,51 +491,41 @@ async function maybeRefuseTeleportForLongSession(
  * well beyond the lookback window; pathological single messages bigger than
  * this simply trigger the widen-to-whole-file path.
  */
-const SESSION_TAIL_BYTES = 512 * 1024
+export const SESSION_TAIL_BYTES = 512 * 1024
 
 /**
- * Maximum file size for the widen-to-whole-file fallback. Sessions over the
- * hint threshold are usually a few MB; anything far beyond this is too large
- * to justify a full synchronous-within-the-gate load for a non-critical hint.
+ * Maximum file size for the widen-to-whole-file fallback. Real sessions over
+ * the hint threshold are a few MB at most, so 6MB covers them with headroom;
+ * anything beyond is too large to justify loading fully into memory for a
+ * non-critical hint.
  */
-const SESSION_WIDEN_MAX_BYTES = 64 * 1024 * 1024
+export const SESSION_WIDEN_MAX_BYTES = 6 * 1024 * 1024
 
 interface SessionTail {
 	tail: string
 	tailIsWholeFile: boolean
-	/**
-	 * True when the tail slice begins mid-entry (the byte before the slice is
-	 * not a newline): the first line of `tail` is a partial entry and must be
-	 * skipped by the evaluator. False when the slice happens to start exactly
-	 * at a line boundary, in which case the first line is a complete entry.
-	 */
-	tailStartsMidLine: boolean
 	fileMtimeMs: number
 	fileSizeBytes: number
 }
 
 /** Read the last SESSION_TAIL_BYTES of the session file as UTF-8 (whole file when smaller). */
-async function readSessionTail(path: string): Promise<SessionTail> {
+export async function readSessionTail(path: string): Promise<SessionTail> {
 	const { size, mtimeMs } = await stat(path)
 	if (size <= SESSION_TAIL_BYTES) {
 		return {
 			tail: await readFile(path, "utf-8"),
 			tailIsWholeFile: true,
-			tailStartsMidLine: false,
 			fileMtimeMs: mtimeMs,
 			fileSizeBytes: size,
 		}
 	}
 	const handle = await open(path, "r")
 	try {
-		// Read one extra byte BEFORE the slice to know whether the slice starts
-		// mid-line or exactly at a line boundary.
-		const buffer = Buffer.alloc(SESSION_TAIL_BYTES + 1)
-		const { bytesRead } = await handle.read(buffer, 0, buffer.length, size - SESSION_TAIL_BYTES - 1)
+		const buffer = Buffer.alloc(SESSION_TAIL_BYTES)
+		const { bytesRead } = await handle.read(buffer, 0, buffer.length, size - SESSION_TAIL_BYTES)
 		return {
-			tail: buffer.subarray(1, bytesRead).toString("utf-8"),
+			tail: buffer.subarray(0, bytesRead).toString("utf-8"),
 			tailIsWholeFile: false,
-			tailStartsMidLine: buffer[0] !== 0x0a,
 			fileMtimeMs: mtimeMs,
 			fileSizeBytes: size,
 		}

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -1,7 +1,13 @@
-import { existsSync } from "node:fs"
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs"
 import { platform } from "node:os"
 import { basename, dirname } from "node:path"
-import { readGitToken, readTeleportHelpSeenAt, writeGitToken, writeTeleportHelpSeenAt } from "../../../config.js"
+import {
+	readGitToken,
+	readTeleportCompactHintEnabled,
+	readTeleportHelpSeenAt,
+	writeGitToken,
+	writeTeleportHelpSeenAt,
+} from "../../../config.js"
 import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
 import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
@@ -11,6 +17,7 @@ import { createSession, listSessions } from "../../../sandbox/worker/sessions.js
 import type { CreateSessionRequest, Session } from "../../../sandbox/worker/types.js"
 import { createTabsOverlay } from "../overlay/overlay-component.js"
 import { generateSessionName } from "../overlay/tab-manager.js"
+import { evaluateCompactHint, TELEPORT_COMPACT_HINT_DEFAULTS } from "../preflight/compaction-hint.js"
 import { getGitHeadSha, gitWorkingTreeDirty, isGitRepo } from "../preflight/git.js"
 import { runPreflight } from "../preflight/index.js"
 import { SIZE_REFUSE_BYTES, SIZE_WARN_BYTES } from "../preflight/workspace-size.js"
@@ -64,6 +71,7 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 	}
 
 	runPreflight(ctx, args)
+	maybeRefuseTeleportForLongSession(ctx, args)
 
 	// Show an inline status line message while we resolve the workspace — the
 	// progress overlay can't open until we know which workspace to attach
@@ -402,6 +410,101 @@ async function resolveGitToken(
 		}
 	}
 	return result.token
+}
+
+/**
+ * v1 compaction-hint gate (companion to the --force/--allow-dirty preflight
+ * refuses). When the session about to be uploaded is large AND was recently
+ * active, the local prompt cache is likely still warm, so compacting locally
+ * first is cheaper than letting the remote re-read the whole history cold —
+ * refusing with an actionable message saves the difference. A stale session
+ * inverts the economics (compaction would itself be a cold read), so
+ * freshness gates the hint inside evaluateCompactHint.
+ *
+ * Sizing comes from the harness's live context usage (provider-backed). The
+ * hint is non-critical, so anything that makes the number unavailable is a
+ * silent skip: no live session stats (RPC mode, no model), tokens === null
+ * right after compaction, or no session file. The session file is only read
+ * once the session is known to be over the threshold — and only its tail:
+ * the evaluator scans backward with early-exit, so a widening re-read to the
+ * whole file only happens when the tail genuinely can't decide.
+ */
+function maybeRefuseTeleportForLongSession(ctx: TeleportContext, args: ReturnType<typeof parseTeleportArgs>): void {
+	if (args.skipSession || args.noCompactHint) return
+	const config = { ...TELEPORT_COMPACT_HINT_DEFAULTS, enabled: readTeleportCompactHintEnabled(ctx.configPath) }
+	if (!config.enabled) return
+	const tokens = ctx.getContextUsage?.()?.tokens
+	if (tokens === undefined || tokens === null || tokens <= config.tokenThreshold) return
+	const sessionFile = ctx.sessionFile
+	if (!sessionFile || !existsSync(sessionFile)) return
+
+	let tail: string
+	let tailIsWholeFile: boolean
+	let fileMtimeMs: number
+	try {
+		;({ tail, tailIsWholeFile, fileMtimeMs } = readSessionTail(sessionFile))
+	} catch {
+		return
+	}
+	let evaluation = evaluateCompactHint({
+		sessionTail: tail,
+		tailIsWholeFile,
+		estimatedTokens: tokens,
+		now: Date.now(),
+		config,
+		fallbackTimestampMs: fileMtimeMs,
+	})
+	if (!evaluation.decided) {
+		// The tail slice ran out before either stop condition (e.g. fewer than
+		// the lookback window of very large messages, compaction just beyond
+		// the slice). Widen to the whole file and decide.
+		try {
+			evaluation = evaluateCompactHint({
+				sessionTail: readFileSync(sessionFile, "utf-8"),
+				tailIsWholeFile: true,
+				estimatedTokens: tokens,
+				now: Date.now(),
+				config,
+				fallbackTimestampMs: fileMtimeMs,
+			})
+		} catch {
+			return
+		}
+	}
+	const { shouldHint, estimatedTokens } = evaluation
+	if (!shouldHint) return
+	refuse(
+		ctx,
+		`Long session history (~${formatTokenCount(estimatedTokens)} tokens) — consider /compact prior to teleport (or --no-compact-hint to skip).`,
+	)
+}
+
+/**
+ * Size of the tail slice read first. 512KB holds dozens of typical entries,
+ * well beyond the lookback window; pathological single messages bigger than
+ * this simply trigger the widen-to-whole-file path.
+ */
+const SESSION_TAIL_BYTES = 512 * 1024
+
+/** Read the last SESSION_TAIL_BYTES of the session file as UTF-8 (whole file when smaller). */
+function readSessionTail(path: string): { tail: string; tailIsWholeFile: boolean; fileMtimeMs: number } {
+	const stat = statSync(path)
+	const size = stat.size
+	if (size <= SESSION_TAIL_BYTES) {
+		return { tail: readFileSync(path, "utf-8"), tailIsWholeFile: true, fileMtimeMs: stat.mtimeMs }
+	}
+	const fd = openSync(path, "r")
+	try {
+		const buffer = Buffer.alloc(SESSION_TAIL_BYTES)
+		readSync(fd, buffer, 0, SESSION_TAIL_BYTES, size - SESSION_TAIL_BYTES)
+		return { tail: buffer.toString("utf-8"), tailIsWholeFile: false, fileMtimeMs: stat.mtimeMs }
+	} finally {
+		closeSync(fd)
+	}
+}
+
+function formatTokenCount(tokens: number): string {
+	return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : String(tokens)
 }
 
 /**

--- a/src/extensions/teleport/index.ts
+++ b/src/extensions/teleport/index.ts
@@ -26,6 +26,7 @@ function makeHandler(run: CommandFn) {
 			signal: ctx.signal,
 			ui: ctx.ui,
 			sessionFile: ctx.sessionManager.getSessionFile(),
+			getContextUsage: () => ctx.getContextUsage(),
 		}
 		try {
 			await run(args, tctx)

--- a/src/extensions/teleport/preflight/compaction-hint.test.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.test.ts
@@ -200,34 +200,6 @@ describe("evaluateCompactHint", () => {
 			expect(result.shouldHint).toBe(false)
 		})
 
-		it("counts the first line of a tail that starts exactly at a line boundary (tailStartsMidLine: false)", () => {
-			// The slice begins at a real line boundary, so the first line is a
-			// complete entry: a compaction marker there must still suppress, and
-			// message counting must include it.
-			const result = evaluateCompactHint({
-				sessionTail: [COMPACTION, ...manyMessages(2)].join("\n"),
-				tailIsWholeFile: false,
-				tailStartsMidLine: false,
-				estimatedTokens: BIG_TOKENS,
-				now: NOW,
-				config: makeConfig(),
-			})
-			expect(result.decided).toBe(true)
-			expect(result.shouldHint).toBe(false)
-			expect(result.messagesSinceLastCompaction).toBe(2)
-		})
-
-		it("still skips the first line of a boundary-start tail by default (conservative)", () => {
-			const result = evaluateCompactHint({
-				sessionTail: [COMPACTION, ...manyMessages(2)].join("\n"),
-				tailIsWholeFile: false,
-				estimatedTokens: BIG_TOKENS,
-				now: NOW,
-				config: makeConfig(),
-			})
-			expect(result.decided).toBe(false)
-		})
-
 		it("skips the first line of an incomplete tail (may be a fragment)", () => {
 			// First line is a malformed fragment of a real entry; only the second
 			// complete line should be parsed.

--- a/src/extensions/teleport/preflight/compaction-hint.test.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest"
+import { evaluateCompactHint, type TeleportCompactHintConfig } from "./compaction-hint.js"
+
+/** Small lookback so fixtures stay tiny; production default is 20. */
+function makeConfig(overrides: Partial<TeleportCompactHintConfig> = {}): TeleportCompactHintConfig {
+	return {
+		enabled: true,
+		tokenThreshold: 1000,
+		freshnessWindowMinutes: 60,
+		compactionLookbackMessages: 3,
+		...overrides,
+	}
+}
+
+function messageEntry(timestamp?: string | number, messageTimestamp?: string | number): string {
+	const entry: Record<string, unknown> = {
+		type: "message",
+		message: { role: "user", content: [{ type: "text", text: "hello" }] },
+	}
+	if (timestamp !== undefined) entry.timestamp = timestamp
+	if (messageTimestamp !== undefined) (entry.message as Record<string, unknown>).timestamp = messageTimestamp
+	return JSON.stringify(entry)
+}
+
+const COMPACTION = JSON.stringify({ type: "compaction", timestamp: "2025-01-01T00:00:00Z" })
+const NOW = new Date("2025-06-01T12:00:00Z").getTime()
+const FRESH_ISO = new Date(NOW - 10 * 60_000).toISOString()
+const STALE_ISO = new Date(NOW - 120 * 60_000).toISOString()
+const BIG_TOKENS = 50_000
+const SMALL_TOKENS = 100
+
+/** Convenience: whole-file evaluation with sane defaults. */
+function evaluate(sessionLines: string[], overrides: Partial<Parameters<typeof evaluateCompactHint>[0]> = {}) {
+	return evaluateCompactHint({
+		sessionTail: sessionLines.join("\n"),
+		tailIsWholeFile: true,
+		estimatedTokens: BIG_TOKENS,
+		now: NOW,
+		config: makeConfig(),
+		...overrides,
+	})
+}
+
+function manyMessages(n: number, timestamp: string | number = FRESH_ISO): string[] {
+	return Array.from({ length: n }, () => messageEntry(timestamp))
+}
+
+function untimed(n: number): string[] {
+	return Array.from({ length: n }, () => messageEntry())
+}
+
+describe("evaluateCompactHint", () => {
+	it("does not hint when the session is below the token threshold, even when fresh with many messages", () => {
+		const result = evaluate(manyMessages(10), { estimatedTokens: SMALL_TOKENS })
+		expect(result.shouldHint).toBe(false)
+		expect(result.decided).toBe(true)
+	})
+
+	it("hints when over threshold, fresh, and more messages than the lookback window", () => {
+		const result = evaluate(manyMessages(4))
+		expect(result.shouldHint).toBe(true)
+		expect(result.messagesSinceLastCompaction).toBe(4)
+		expect(result.lastActivityAt).toBe(new Date(FRESH_ISO).getTime())
+	})
+
+	it("does not hint when over threshold but stale", () => {
+		const result = evaluate(manyMessages(10, STALE_ISO))
+		expect(result.shouldHint).toBe(false)
+		expect(result.lastActivityAt).toBe(new Date(STALE_ISO).getTime())
+	})
+
+	it("does not hint when the config is disabled", () => {
+		const result = evaluate(manyMessages(10), { config: makeConfig({ enabled: false }) })
+		expect(result.shouldHint).toBe(false)
+	})
+
+	it("suppresses when a compaction marker is within the lookback window, even when big and fresh", () => {
+		const result = evaluate([COMPACTION, ...manyMessages(2)])
+		expect(result.shouldHint).toBe(false)
+		expect(result.messagesSinceLastCompaction).toBe(2)
+		expect(result.decided).toBe(true)
+	})
+
+	it("hints again once enough messages follow the compaction (session made new progress)", () => {
+		const result = evaluate([COMPACTION, ...manyMessages(4)])
+		expect(result.shouldHint).toBe(true)
+		expect(result.messagesSinceLastCompaction).toBe(4)
+	})
+
+	it("counts only messages after the LAST compaction marker", () => {
+		const result = evaluate([COMPACTION, ...manyMessages(5), COMPACTION, ...manyMessages(1)])
+		expect(result.shouldHint).toBe(false)
+		expect(result.messagesSinceLastCompaction).toBe(1)
+	})
+
+	it("a compaction marker without a timestamp still suppresses (position is what matters)", () => {
+		const untimed = JSON.stringify({ type: "compaction" })
+		const result = evaluate([untimed, messageEntry(FRESH_ISO)])
+		expect(result.shouldHint).toBe(false)
+		expect(result.messagesSinceLastCompaction).toBe(1)
+	})
+
+	it("boundary: exactly the lookback window of messages since compaction does not hint; one more does", () => {
+		expect(evaluate([COMPACTION, ...manyMessages(3)]).shouldHint).toBe(false)
+		expect(evaluate([COMPACTION, ...manyMessages(4)]).shouldHint).toBe(true)
+	})
+
+	it("ignores malformed lines (non-JSON, JSON non-objects, entries without message) without throwing", () => {
+		const session = [
+			"not json at all",
+			JSON.stringify([1, 2, 3]),
+			JSON.stringify("just a string"),
+			JSON.stringify(null),
+			JSON.stringify({ type: "custom", foo: "bar" }),
+			...manyMessages(4),
+		]
+		const result = evaluate(session)
+		expect(result.shouldHint).toBe(true)
+	})
+
+	it("falls back to fallbackTimestampMs when no entry has a parseable timestamp (fresh)", () => {
+		const fallback = NOW - 5 * 60_000
+		const result = evaluate(untimed(5), { fallbackTimestampMs: fallback })
+		expect(result.shouldHint).toBe(true)
+		expect(result.lastActivityAt).toBe(fallback)
+	})
+
+	it("falls back to fallbackTimestampMs when no entry has a parseable timestamp (stale)", () => {
+		const fallback = NOW - 120 * 60_000
+		const result = evaluate(untimed(5), { fallbackTimestampMs: fallback })
+		expect(result.shouldHint).toBe(false)
+		expect(result.lastActivityAt).toBe(fallback)
+	})
+
+	it("does not hint when no timestamp and no fallback are known (liveness unknown)", () => {
+		const result = evaluate(untimed(5))
+		expect(result.shouldHint).toBe(false)
+		expect(result.lastActivityAt).toBeUndefined()
+	})
+
+	it("parses ISO string and numeric-ms timestamps; uses message.timestamp when top-level is missing", () => {
+		const numericFresh = NOW - 10 * 60_000
+		// Append-ordered: the LAST entry's timestamp is the most recent activity.
+		const result = evaluate([messageEntry(numericFresh), messageEntry(undefined, FRESH_ISO)])
+		expect(result.shouldHint).toBe(false) // only 2 messages since no compaction, below window
+		expect(result.lastActivityAt).toBe(new Date(FRESH_ISO).getTime())
+	})
+
+	it("treats small numeric timestamps as seconds and converts to ms", () => {
+		const secondsEpoch = Math.floor((NOW - 10 * 60_000) / 1000)
+		const result = evaluate([...manyMessages(1), messageEntry(secondsEpoch)], {
+			config: makeConfig({ compactionLookbackMessages: 1 }),
+		})
+		expect(result.shouldHint).toBe(true)
+		expect(result.lastActivityAt).toBe(secondsEpoch * 1000)
+	})
+
+	it("returns shouldHint false but decided true for an empty session", () => {
+		const result = evaluate([])
+		expect(result.shouldHint).toBe(false)
+		expect(result.decided).toBe(true)
+		expect(result.messagesSinceLastCompaction).toBe(0)
+	})
+
+	describe("tail slices (progressive widening)", () => {
+		it("decides from a tail slice when a compaction marker is found there", () => {
+			const result = evaluateCompactHint({
+				sessionTail: ["...older entries...", COMPACTION, messageEntry(FRESH_ISO)].join("\n"),
+				tailIsWholeFile: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.decided).toBe(true)
+			expect(result.shouldHint).toBe(false)
+		})
+
+		it("decides from a tail slice when more than the lookback window of messages is counted", () => {
+			// 5 lines: the first is treated as a fragment and skipped, leaving 4 > 3.
+			const result = evaluateCompactHint({
+				sessionTail: manyMessages(5).join("\n"),
+				tailIsWholeFile: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.decided).toBe(true)
+			expect(result.shouldHint).toBe(true)
+		})
+
+		it("reports undecided when a partial tail runs out before any stop condition", () => {
+			const result = evaluateCompactHint({
+				sessionTail: messageEntry(FRESH_ISO),
+				tailIsWholeFile: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.decided).toBe(false)
+			expect(result.shouldHint).toBe(false)
+		})
+
+		it("skips the first line of an incomplete tail (may be a fragment)", () => {
+			// First line is a malformed fragment of a real entry; only the second
+			// complete line should be parsed.
+			const fragment = '{"type":"messag'
+			const result = evaluateCompactHint({
+				sessionTail: `${fragment}\n${messageEntry(FRESH_ISO)}`,
+				tailIsWholeFile: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.messagesSinceLastCompaction).toBe(1)
+			expect(result.decided).toBe(false)
+		})
+	})
+})

--- a/src/extensions/teleport/preflight/compaction-hint.test.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.test.ts
@@ -87,6 +87,17 @@ describe("evaluateCompactHint", () => {
 		expect(result.messagesSinceLastCompaction).toBe(4)
 	})
 
+	it("hints for a never-compacted session with fewer messages than the lookback window (few big messages still compact well)", () => {
+		// No compaction marker anywhere → nothing to loop on. A small message
+		// count must not suppress: large tool results can push a handful of
+		// messages well past the token threshold, and compaction would still
+		// summarize most of them (keepRecentTokens is token-, not count-based).
+		const result = evaluate(manyMessages(2))
+		expect(result.decided).toBe(true)
+		expect(result.shouldHint).toBe(true)
+		expect(result.messagesSinceLastCompaction).toBe(2)
+	})
+
 	it("counts only messages after the LAST compaction marker", () => {
 		const result = evaluate([COMPACTION, ...manyMessages(5), COMPACTION, ...manyMessages(1)])
 		expect(result.shouldHint).toBe(false)
@@ -142,7 +153,7 @@ describe("evaluateCompactHint", () => {
 		const numericFresh = NOW - 10 * 60_000
 		// Append-ordered: the LAST entry's timestamp is the most recent activity.
 		const result = evaluate([messageEntry(numericFresh), messageEntry(undefined, FRESH_ISO)])
-		expect(result.shouldHint).toBe(false) // only 2 messages since no compaction, below window
+		expect(result.shouldHint).toBe(true) // fresh + over threshold; no compaction marker to suppress
 		expect(result.lastActivityAt).toBe(new Date(FRESH_ISO).getTime())
 	})
 

--- a/src/extensions/teleport/preflight/compaction-hint.test.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.test.ts
@@ -200,6 +200,34 @@ describe("evaluateCompactHint", () => {
 			expect(result.shouldHint).toBe(false)
 		})
 
+		it("counts the first line of a tail that starts exactly at a line boundary (tailStartsMidLine: false)", () => {
+			// The slice begins at a real line boundary, so the first line is a
+			// complete entry: a compaction marker there must still suppress, and
+			// message counting must include it.
+			const result = evaluateCompactHint({
+				sessionTail: [COMPACTION, ...manyMessages(2)].join("\n"),
+				tailIsWholeFile: false,
+				tailStartsMidLine: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.decided).toBe(true)
+			expect(result.shouldHint).toBe(false)
+			expect(result.messagesSinceLastCompaction).toBe(2)
+		})
+
+		it("still skips the first line of a boundary-start tail by default (conservative)", () => {
+			const result = evaluateCompactHint({
+				sessionTail: [COMPACTION, ...manyMessages(2)].join("\n"),
+				tailIsWholeFile: false,
+				estimatedTokens: BIG_TOKENS,
+				now: NOW,
+				config: makeConfig(),
+			})
+			expect(result.decided).toBe(false)
+		})
+
 		it("skips the first line of an incomplete tail (may be a fragment)", () => {
 			// First line is a malformed fragment of a real entry; only the second
 			// complete line should be parsed.

--- a/src/extensions/teleport/preflight/compaction-hint.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.ts
@@ -77,13 +77,6 @@ export interface EvaluateCompactHintInput {
 	sessionTail: string
 	/** True when sessionTail covers the file from its start, making an exhausted scan's message count exact. */
 	tailIsWholeFile: boolean
-	/**
-	 * True when the tail slice begins mid-line, making its first line a
-	 * fragment that must be skipped. Defaults to true for non-whole-file
-	 * slices; the caller should pass false explicitly when it knows the slice
-	 * starts exactly at a line boundary, so a valid first entry isn't dropped.
-	 */
-	tailStartsMidLine?: boolean
 	/** Live token count for the session (e.g. ctx.getContextUsage().tokens). */
 	estimatedTokens: number
 	now: number
@@ -152,11 +145,10 @@ export function evaluateCompactHint(input: EvaluateCompactHintInput): CompactHin
 	})
 
 	const lines = input.sessionTail.split("\n")
-	// A tail that doesn't start at offset 0 may begin mid-line; a leading
-	// fragment is not a complete entry, so skip it — but only when the caller
-	// confirms the slice truly begins mid-line.
+	// A tail that doesn't start at offset 0 may begin mid-line; the first
+	// fragment is not a complete entry, so skip it.
 	let startIdx = 0
-	if (!input.tailIsWholeFile && (input.tailStartsMidLine ?? true)) startIdx = 1
+	if (!input.tailIsWholeFile) startIdx = 1
 
 	let lastActivityAt: number | undefined
 	let messagesSinceLastCompaction = 0

--- a/src/extensions/teleport/preflight/compaction-hint.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.ts
@@ -187,15 +187,16 @@ export function evaluateCompactHint(input: EvaluateCompactHintInput): CompactHin
 
 	// Reached only once recent-compaction suppression has been ruled out: apply
 	// the remaining gates (enabled, threshold, liveness) and build the result.
+	// Message count plays no role here — the backward scan above already
+	// implements "few messages since the last compaction" via the marker, and
+	// for a never-compacted session a low count must NOT suppress: big tool
+	// results can push a handful of messages past the threshold, and
+	// compaction keeps recent TOKENS, not recent messages, so it still helps.
 	function evaluateUnsuppressed(activity: number | undefined, count: number): CompactHintEvaluation {
 		const lastActivity = activity ?? input.fallbackTimestampMs
 		const livenessWindowMs = input.config.freshnessWindowMinutes * 60_000
 		const live = lastActivity !== undefined && input.now - lastActivity <= livenessWindowMs
-		const shouldHint =
-			input.config.enabled &&
-			input.estimatedTokens > input.config.tokenThreshold &&
-			live &&
-			count > input.config.compactionLookbackMessages
+		const shouldHint = input.config.enabled && input.estimatedTokens > input.config.tokenThreshold && live
 		return result(true, shouldHint, lastActivity, count)
 	}
 }

--- a/src/extensions/teleport/preflight/compaction-hint.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.ts
@@ -77,6 +77,13 @@ export interface EvaluateCompactHintInput {
 	sessionTail: string
 	/** True when sessionTail covers the file from its start, making an exhausted scan's message count exact. */
 	tailIsWholeFile: boolean
+	/**
+	 * True when the tail slice begins mid-line, making its first line a
+	 * fragment that must be skipped. Defaults to true for non-whole-file
+	 * slices; the caller should pass false explicitly when it knows the slice
+	 * starts exactly at a line boundary, so a valid first entry isn't dropped.
+	 */
+	tailStartsMidLine?: boolean
 	/** Live token count for the session (e.g. ctx.getContextUsage().tokens). */
 	estimatedTokens: number
 	now: number
@@ -145,10 +152,11 @@ export function evaluateCompactHint(input: EvaluateCompactHintInput): CompactHin
 	})
 
 	const lines = input.sessionTail.split("\n")
-	// A tail that doesn't start at offset 0 may begin mid-line; the first
-	// fragment is not a complete entry, so skip it.
+	// A tail that doesn't start at offset 0 may begin mid-line; a leading
+	// fragment is not a complete entry, so skip it — but only when the caller
+	// confirms the slice truly begins mid-line.
 	let startIdx = 0
-	if (!input.tailIsWholeFile) startIdx = 1
+	if (!input.tailIsWholeFile && (input.tailStartsMidLine ?? true)) startIdx = 1
 
 	let lastActivityAt: number | undefined
 	let messagesSinceLastCompaction = 0

--- a/src/extensions/teleport/preflight/compaction-hint.ts
+++ b/src/extensions/teleport/preflight/compaction-hint.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure evaluator for the teleport pre-compact hint.
+ *
+ * High-level idea: when /teleport is about to upload a large session that was
+ * recently active, compacting locally first is cheaper than letting the
+ * remote re-read the full history cold (the local prompt cache is likely
+ * still warm). For a stale session the economics flip — local compaction
+ * would itself be a cold read — so liveness gates the hint on top of the
+ * size threshold.
+ *
+ * Loop protection: suppress the hint when a compaction marker appears in the
+ * session's recent tail (`compactionLookbackMessages`). Few messages since
+ * the last compaction means compacting again would mostly re-keep what's
+ * already there — re-hinting would just loop.
+ *
+ * The session JSONL is append-ordered, so the evaluator scans BACKWARD and
+ * stops as soon as the suppression question is decided: at the first
+ * compaction marker, once more than `compactionLookbackMessages` messages
+ * have been counted without one, or at the start of the data. The caller
+ * passes a tail slice of the file; if `tailIsWholeFile` is false and the
+ * slice runs out before a stop condition, `decided` is false and the caller
+ * should widen (e.g. re-read the whole file) and evaluate again.
+ *
+ * Sizing is the caller's job: the gate passes the harness's live context
+ * usage (provider-backed). This evaluator only scans for liveness and
+ * compaction markers — the hint is a non-critical nudge, so it is skipped
+ * entirely when no live token count exists.
+ */
+
+/**
+ * The hint's tuned parameters — implementation constants, deliberately NOT
+ * user settings: tokenThreshold tracks the upload cost curve,
+ * freshnessWindowMinutes tracks provider prompt-cache TTL, and
+ * compactionLookbackMessages tracks compaction's keepRecentTokens (20K tokens
+ * ≈ ~20 typical messages). The user's only knob is master on/off, read from
+ * config and passed in via `enabled`.
+ */
+export interface TeleportCompactHintConfig {
+	enabled: boolean
+	/** Hint only fires above this session size (context tokens). */
+	tokenThreshold: number
+	/** Hint only fires when the session was active within this many minutes —
+	 *  a proxy for "prompt cache plausibly still warm"; outside it, compaction
+	 *  is itself cold and the economics invert. */
+	freshnessWindowMinutes: number
+	/** Suppress the hint when a compaction marker appears within the last N
+	 *  messages — few messages since the last compaction means compacting
+	 *  again would mostly re-keep what's already there. */
+	compactionLookbackMessages: number
+}
+
+export const TELEPORT_COMPACT_HINT_DEFAULTS: TeleportCompactHintConfig = {
+	enabled: true,
+	tokenThreshold: 200_000,
+	freshnessWindowMinutes: 60,
+	compactionLookbackMessages: 20,
+}
+
+export interface CompactHintEvaluation {
+	shouldHint: boolean
+	/**
+	 * False when the supplied tail ran out before either stop condition —
+	 * suppression is unresolved and the caller should re-evaluate on a wider
+	 * slice. shouldHint is always false in that case.
+	 */
+	decided: boolean
+	/** The caller-supplied token count, echoed for message formatting. */
+	estimatedTokens: number
+	/** ms epoch of last session activity (newest timestamp seen while scanning back), if known. */
+	lastActivityAt: number | undefined
+	/** Message entries between the end of the tail and the most recent compaction marker (capped at the window + 1). */
+	messagesSinceLastCompaction: number
+}
+
+export interface EvaluateCompactHintInput {
+	/** A tail slice of the session JSONL (see tailIsWholeFile). May start mid-line; the first partial line is ignored internally. */
+	sessionTail: string
+	/** True when sessionTail covers the file from its start, making an exhausted scan's message count exact. */
+	tailIsWholeFile: boolean
+	/** Live token count for the session (e.g. ctx.getContextUsage().tokens). */
+	estimatedTokens: number
+	now: number
+	config: TeleportCompactHintConfig
+	/** Fallback timestamp (e.g. session file mtime) when no entry carries a parseable timestamp. */
+	fallbackTimestampMs?: number
+}
+
+/** Parse a timestamp that may be ms epoch, seconds epoch (< 1e11), or a Date.parse-able string. */
+function parseTimestamp(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value < 1e11 ? value * 1000 : value
+	}
+	if (typeof value === "string") {
+		const parsed = Date.parse(value)
+		return Number.isNaN(parsed) ? undefined : parsed
+	}
+	return undefined
+}
+
+/** The pieces of a session-JSONL entry the hint cares about. */
+interface ParsedEntry {
+	/** ms epoch timestamp from entry.timestamp (or message.timestamp), if parseable. */
+	timestampMs: number | undefined
+	isCompaction: boolean
+	isMessage: boolean
+}
+
+/** Parse one session-JSONL line into the fields the hint needs; undefined for malformed/non-object lines. */
+function parseEntryLine(line: string): ParsedEntry | undefined {
+	if (!line.trim()) return undefined
+	let entry: unknown
+	try {
+		entry = JSON.parse(line)
+	} catch {
+		return undefined
+	}
+	if (entry === null || typeof entry !== "object") return undefined
+	const record = entry as Record<string, unknown>
+
+	const rawMessage =
+		record.message !== null && typeof record.message === "object"
+			? (record.message as Record<string, unknown>)
+			: undefined
+	const timestampMs =
+		parseTimestamp(record.timestamp) ?? (rawMessage ? parseTimestamp(rawMessage.timestamp) : undefined)
+	// A message entry is one that embeds a message object with a role — the unit
+	// the lookback window counts (mirrors what compaction counts).
+	const isMessage = rawMessage !== undefined && typeof rawMessage.role === "string"
+
+	return { timestampMs, isCompaction: record.type === "compaction", isMessage }
+}
+
+export function evaluateCompactHint(input: EvaluateCompactHintInput): CompactHintEvaluation {
+	const result = (
+		decided: boolean,
+		shouldHint: boolean,
+		lastActivityAt: number | undefined,
+		messagesSinceLastCompaction: number,
+	): CompactHintEvaluation => ({
+		decided,
+		shouldHint: decided && shouldHint,
+		estimatedTokens: input.estimatedTokens,
+		lastActivityAt,
+		messagesSinceLastCompaction,
+	})
+
+	const lines = input.sessionTail.split("\n")
+	// A tail that doesn't start at offset 0 may begin mid-line; the first
+	// fragment is not a complete entry, so skip it.
+	let startIdx = 0
+	if (!input.tailIsWholeFile) startIdx = 1
+
+	let lastActivityAt: number | undefined
+	let messagesSinceLastCompaction = 0
+	const lookback = input.config.compactionLookbackMessages
+
+	for (let i = lines.length - 1; i >= startIdx; i--) {
+		const entry = parseEntryLine(lines[i])
+		if (!entry) continue
+
+		// The file is append-ordered, so the first parseable timestamp walking
+		// back is the most recent activity — stop tracking after that.
+		if (entry.timestampMs !== undefined && lastActivityAt === undefined) {
+			lastActivityAt = entry.timestampMs
+		}
+
+		if (entry.isCompaction) {
+			// Marker found with few messages after it → suppressed.
+			return result(true, false, lastActivityAt, messagesSinceLastCompaction)
+		}
+		if (entry.isMessage) {
+			messagesSinceLastCompaction++
+			if (messagesSinceLastCompaction > lookback) {
+				// Any compaction further back is older than the window → no
+				// suppression; the count is a floor, not exact — enough.
+				return evaluateUnsuppressed(lastActivityAt, messagesSinceLastCompaction)
+			}
+		}
+	}
+	// Tail exhausted before a stop condition: exact only if this was the whole
+	// file (no compaction seen anywhere → count is every message).
+	if (!input.tailIsWholeFile) {
+		return result(false, false, lastActivityAt, messagesSinceLastCompaction)
+	}
+
+	return evaluateUnsuppressed(lastActivityAt, messagesSinceLastCompaction)
+
+	// Reached only once recent-compaction suppression has been ruled out: apply
+	// the remaining gates (enabled, threshold, liveness) and build the result.
+	function evaluateUnsuppressed(activity: number | undefined, count: number): CompactHintEvaluation {
+		const lastActivity = activity ?? input.fallbackTimestampMs
+		const livenessWindowMs = input.config.freshnessWindowMinutes * 60_000
+		const live = lastActivity !== undefined && input.now - lastActivity <= livenessWindowMs
+		const shouldHint =
+			input.config.enabled &&
+			input.estimatedTokens > input.config.tokenThreshold &&
+			live &&
+			count > input.config.compactionLookbackMessages
+		return result(true, shouldHint, lastActivity, count)
+	}
+}

--- a/src/extensions/teleport/types.ts
+++ b/src/extensions/teleport/types.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
+import type { ContextUsage, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
 
 export const STATUS_KEY = "teleport"
 
@@ -11,4 +11,9 @@ export interface TeleportContext {
 	ui: ExtensionCommandContext["ui"]
 	/** Path to the local harness session.jsonl, if a session is active. */
 	sessionFile?: string
+	/**
+	 * Live context-usage probe for the active session (same data as the footer).
+	 * `tokens` is null right after compaction, until the next LLM response.
+	 */
+	getContextUsage?: () => ContextUsage | undefined
 }


### PR DESCRIPTION
## What

Refuses `/teleport` when the session is large (~200K+ tokens) and recently active, suggesting `/compact` first — the local prompt cache is likely still warm, making local compaction cheaper than a cold remote re-read.

## Why

After teleport, the system prompt likely changes due to different environment essentially invalidating KV cache - to avoid having user pay 2x for the session, propose compaction before teleport to limit the cost of first turn after teleport.

## Changes

- **New:** `compaction-hint.ts` — pure evaluator that scans the session tail backward with early-exit. Gates on size, freshness, and a compaction-marker lookback window to avoid re-hint loops.
- **New:** `compaction-hint.test.ts` — 20 unit tests covering threshold, freshness, lookback suppression, and edge cases.
- **Modified:** `teleport.ts` — gate runs before any network call; `--no-compact-hint` skips it.
- **Modified:** `config.ts` — `teleport.compactHint.enabled` config toggle (defaults to enabled).
- **Modified:** `args.ts` — `--no-compact-hint` flag parsing.
- **Modified:** `types.ts` — `getContextUsage` on `TeleportContext`.

## Testing

- 20 unit tests for the pure evaluator.
- 7 integration tests in `teleport.test.ts` covering: refusal before network, `--no-compact-hint` bypass, config disable, small session, stale session, null tokens, missing context usage.

## Stack

Part of a stacked PR:
- **#985** (bottom) — `feat(teleport): environment handoff note`
- **This PR** (top) — compaction hint, targets the branch below

Closes #987