### PR TITLE
fix(bash-background): exit watcher defers to in-flight bash_control; safe shutdown drain

### DIFF
--- a/src/extensions/bash-background/bash-control-extension.test.ts
+++ b/src/extensions/bash-background/bash-control-extension.test.ts
@@ -10,7 +10,7 @@
  * Exercises the full event wiring in bashControlExtension(pi) against a
  * fake ExtensionAPI + controllable fake registry.
  */
-import type { ExtensionAPI, ExtensionContext, ToolCallEventResult } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, InputSource, ToolCallEventResult } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it } from "vitest"
 import bashControlExtension, {
 	BASH_BACKGROUND_EXIT_MESSAGE_TYPE,
@@ -150,8 +150,37 @@ async function fireToolCall(pi: ExtensionAPI, toolName: string): Promise<ToolCal
 	return result
 }
 
-async function fireInput(pi: ExtensionAPI, source: "user" | "extension" = "user"): Promise<void> {
+async function fireInput(pi: ExtensionAPI, source: InputSource = "interactive"): Promise<void> {
 	await (pi as unknown as FakePi).emit("input", { source, text: "hi" })
+}
+
+async function fireToolExecutionStart(
+	pi: ExtensionAPI,
+	toolCallId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): Promise<void> {
+	await (pi as unknown as FakePi).emit("tool_execution_start", {
+		type: "tool_execution_start",
+		toolCallId,
+		toolName,
+		args,
+	})
+}
+
+async function fireToolExecutionEnd(
+	pi: ExtensionAPI,
+	toolCallId: string,
+	toolName: string,
+	isError = false,
+): Promise<void> {
+	await (pi as unknown as FakePi).emit("tool_execution_end", {
+		type: "tool_execution_end",
+		toolCallId,
+		toolName,
+		result: {},
+		isError,
+	})
 }
 
 async function fireShutdown(pi: ExtensionAPI): Promise<void> {
@@ -394,7 +423,7 @@ describe("bashControlExtension — gate via tool_call hard blocks", () => {
 		const pi = makeFakePi()
 		await startGatedSession(pi, registry, "h1")
 
-		await fireInput(pi, "user")
+		await fireInput(pi)
 		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
 
 		registry.resolveExit("h1", 0)
@@ -504,6 +533,132 @@ describe("bashControlExtension — gate via tool_call hard blocks", () => {
 			details: { handle: "h1", exited: true, exitCode: null, action: "stop" },
 		})
 		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
+	})
+})
+
+describe("bashControlExtension — exit watcher vs bash_control ownership", () => {
+	it("no natural-exit steer when a bash_control stop settles the process before its tool_result", async () => {
+		const registry = makeFakeRegistry()
+		const pi = makeFakePi()
+		await startGatedSession(pi, registry, "h1")
+
+		await fireToolExecutionStart(pi, "c2", "bash_control", { handle: "h1", action: "stop" })
+		// kill() settles the process before bash_control can emit its result;
+		// the watcher's promise reaction runs first and must defer to the
+		// in-flight control call instead of steering.
+		registry.resolveExit("h1", null)
+		await flush()
+		expect(messages(pi)).toHaveLength(0)
+
+		await fireToolResult(pi, {
+			type: "tool_result",
+			toolName: "bash_control",
+			toolCallId: "c2",
+			input: { handle: "h1", action: "stop" },
+			content: [{ type: "text", text: "final output" }],
+			isError: false,
+			details: { handle: "h1", exited: true, exitCode: null, action: "stop" },
+		})
+		await fireToolExecutionEnd(pi, "c2", "bash_control")
+
+		expect(messages(pi)).toHaveLength(0)
+		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
+	})
+
+	it("no natural-exit steer when bash_control continue observes the exit mid-flight", async () => {
+		const registry = makeFakeRegistry()
+		const pi = makeFakePi()
+		await startGatedSession(pi, registry, "h1")
+
+		await fireToolExecutionStart(pi, "c2", "bash_control", { handle: "h1", action: "continue" })
+		registry.resolveExit("h1", 0)
+		await flush()
+		expect(messages(pi)).toHaveLength(0)
+
+		await fireToolResult(pi, {
+			type: "tool_result",
+			toolName: "bash_control",
+			toolCallId: "c2",
+			input: { handle: "h1", action: "continue" },
+			content: [{ type: "text", text: "done" }],
+			isError: false,
+			details: { handle: "h1", exited: true, exitCode: 0, action: "continue" },
+		})
+		await fireToolExecutionEnd(pi, "c2", "bash_control")
+
+		expect(messages(pi)).toHaveLength(0)
+		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
+	})
+
+	it("a claimed exit is released silently at tool_execution_end when the control call throws (throwIfTerminal)", async () => {
+		const registry = makeFakeRegistry()
+		const pi = makeFakePi()
+		await startGatedSession(pi, registry, "h1")
+
+		await fireToolExecutionStart(pi, "c2", "bash_control", { handle: "h1", action: "continue" })
+		registry.resolveExit("h1", 1)
+		await flush()
+		expect(messages(pi)).toHaveLength(0)
+
+		// throwIfTerminal threw inside execute — no resolved tool_result with
+		// details, only an error execution end. Release the handle without
+		// steering: the thrown error result already carried the outcome.
+		await fireToolExecutionEnd(pi, "c2", "bash_control", true)
+
+		expect(messages(pi)).toHaveLength(0)
+		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
+	})
+
+	it("an unattended exit on one handle still steers while a control call owns another", async () => {
+		const registry = makeFakeRegistry()
+		const pi = makeFakePi()
+		await startGatedSession(pi, registry, "h1")
+		await fireToolResult(pi, checkinResult("h2"))
+
+		await fireToolExecutionStart(pi, "c2", "bash_control", { handle: "h1", action: "continue" })
+		// h2 exits with no control call on it — unattended, steer expected.
+		registry.resolveExit("h2", 0)
+		await flush()
+
+		expect(messages(pi)).toHaveLength(1)
+		expect(messages(pi)[0]?.content[0]?.text).toContain("h2")
+		// Gate stays closed: h1 still pending under the in-flight call.
+		expect((await fireToolCall(pi, "read"))?.block).toBe(true)
+
+		// h1 then exits mid-flight — claimed, no steer.
+		registry.resolveExit("h1", 0)
+		await flush()
+		await fireToolResult(pi, {
+			type: "tool_result",
+			toolName: "bash_control",
+			toolCallId: "c2",
+			input: { handle: "h1", action: "continue" },
+			content: [{ type: "text", text: "done" }],
+			isError: false,
+			details: { handle: "h1", exited: true, exitCode: 0, action: "continue" },
+		})
+		await fireToolExecutionEnd(pi, "c2", "bash_control")
+
+		expect(messages(pi)).toHaveLength(1)
+		expect((await fireToolCall(pi, "read"))?.block).toBe(false)
+	})
+
+	it("a registry unpublished before the watcher fires (shutdown drain) cannot steer", async () => {
+		const registry = makeFakeRegistry()
+		const pi = makeFakePi()
+		let activeRegistry = registry as unknown as ProcessRegistry | undefined
+		bashControlExtension(pi, { getRegistry: () => activeRegistry })
+		await fireSessionStart(pi)
+		await fireToolResult(pi, checkinResult("h1"))
+
+		// Shutdown unpublishes the session registry, THEN the drain kills
+		// pending processes and settles the watcher promise.
+		activeRegistry = undefined
+		registry.resolveExit("h1", null)
+		await flush()
+
+		expect(messages(pi)).toHaveLength(0)
+		await fireShutdown(pi)
 	})
 })
 

--- a/src/extensions/bash-background/bash-control-extension.ts
+++ b/src/extensions/bash-background/bash-control-extension.ts
@@ -42,6 +42,16 @@
  *    `bash_control` uses `throwIfTerminal` (throws on non-zero exit /
  *    deadline) and may never produce a resolved tool_result — the exit
  *    watcher covers that path too.
+ *  - Ownership: an exit that settles while a `bash_control` call on the same
+ *    handle is in flight (tracked via `tool_execution_start/end`) is NOT an
+ *    unattended exit — the control call's own result is the authoritative
+ *    notification, so the watcher claims it silently. If that call then
+ *    throws before emitting a resolved result, `tool_execution_end`
+ *    releases the handle without steering.
+ *  - The watcher also captures the registry it subscribed to and bails when
+ *    the accessor no longer returns it (session shutdown unpublishes the
+ *    registry before draining it, so teardown never steers a closing
+ *    session).
  *
  * Safety net: user `input` clears the pending set so a stuck gate can't lock
  * the agent out when a human takes over.
@@ -98,13 +108,32 @@ export default function bashControlExtension(pi: ExtensionAPI, options?: BashCon
 	// set is non-empty. Per-session: rebuilt on session_start (this factory
 	// runs once per session, but resume/fork re-enters session_start).
 	let pendingHandles = new Set<string>()
+	// bash_control executions currently in flight: toolCallId -> handle.
+	// Used so the exit watcher can distinguish an unattended natural exit
+	// (steer) from an exit an active control call is about to report (its
+	// own result is authoritative — steering would be stale).
+	let activeControlCalls = new Map<string, string>()
+	// Exits claimed by an in-flight control call: handle -> toolCallId.
+	// tool_execution_end releases these silently when the control call
+	// finished without emitting a resolved result (throwIfTerminal path).
+	let claimedExits = new Map<string, string>()
 	let disposed = false
 
 	pi.on("session_start", () => {
 		pendingHandles = new Set()
+		activeControlCalls = new Map()
+		claimedExits = new Map()
 		disposed = false
 		pi.registerTool(createBashControlToolDefinition())
 	})
+
+	/** toolCallId of the in-flight bash_control call for `handle`, if any. */
+	function controlCallFor(handle: string): string | undefined {
+		for (const [callId, h] of activeControlCalls) {
+			if (h === handle) return callId
+		}
+		return undefined
+	}
 
 	/** Watch a pending handle for natural process exit and release the gate. */
 	function armExitWatcher(handle: string): void {
@@ -114,9 +143,24 @@ export default function bashControlExtension(pi: ExtensionAPI, options?: BashCon
 			.whenExited(handle)
 			.then(({ exitCode }) => {
 				if (disposed) return
+				// The registry this watcher subscribed to was unpublished
+				// (shutdown drains it, or a replacement session installed a new
+				// one) — never steer into a closing/stale session.
+				if (getRegistry() !== registry) return
 				// Already resolved via bash_control or the input safety net —
 				// bash_control's own result carried the final state, so no notice.
 				if (!pendingHandles.has(handle)) return
+				// An in-flight bash_control call owns this exit: its promise
+				// settles before the call emits its result (kill/exit settles
+				// execPromise first, so watcher reactions run first), and without
+				// this guard we'd queue a stale "call bash_control" steer about a
+				// handle the call is about to resolve. Claim it silently; the
+				// tool_result / tool_execution_end paths do the bookkeeping.
+				const ownerCallId = controlCallFor(handle)
+				if (ownerCallId) {
+					claimedExits.set(handle, ownerCallId)
+					return
+				}
 				pendingHandles.delete(handle)
 				const codeText = exitCode !== null ? ` (exit code ${exitCode})` : ""
 				const stillPending = pendingHandles.size
@@ -160,10 +204,34 @@ export default function bashControlExtension(pi: ExtensionAPI, options?: BashCon
 		// Explicit resolution (stop, or continue that observed the exit):
 		// the handle no longer pends. Deleting an unlisted handle is a no-op
 		// (e.g. bash_control's graceful "unknown handle" error result).
-		if (details.exited) pendingHandles.delete(details.handle)
+		if (details.exited) {
+			pendingHandles.delete(details.handle)
+			claimedExits.delete(details.handle)
+		}
 		// checkin:false + exited:false is ambiguous (transient error that
 		// never observed the process state) — keep the gate closed rather
 		// than risk opening it while the process still runs.
+	})
+
+	pi.on("tool_execution_start", (event) => {
+		if (event.toolName !== BASH_CONTROL_TOOL_NAME) return
+		const args = (event.args ?? undefined) as Record<string, unknown> | undefined
+		if (!args || typeof args !== "object") return
+		if (typeof args.handle === "string") activeControlCalls.set(event.toolCallId, args.handle)
+	})
+
+	pi.on("tool_execution_end", (event) => {
+		const handle = activeControlCalls.get(event.toolCallId)
+		if (handle === undefined) return
+		activeControlCalls.delete(event.toolCallId)
+		// This call claimed the exit (watcher deferred to it) but no resolved
+		// tool_result released the handle — the throwIfTerminal path, where
+		// the call removes the registry entry and throws. Its error result
+		// still carried the outcome to the model, so release silently.
+		if (claimedExits.get(handle) === event.toolCallId) {
+			claimedExits.delete(handle)
+			pendingHandles.delete(handle)
+		}
 	})
 
 	pi.on("tool_call", (event) => {
@@ -181,11 +249,14 @@ export default function bashControlExtension(pi: ExtensionAPI, options?: BashCon
 	// under their registry deadlines; bash_control still resolves them normally.
 	pi.on("input", (event) => {
 		if (event.source === "extension") return
-		if (pendingHandles.size > 0) pendingHandles.clear()
+		pendingHandles.clear()
+		claimedExits.clear()
 	})
 
 	pi.on("session_shutdown", () => {
 		disposed = true
 		pendingHandles.clear()
+		activeControlCalls.clear()
+		claimedExits.clear()
 	})
 }

--- a/src/extensions/bash-background/index.test.ts
+++ b/src/extensions/bash-background/index.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression test for shutdown drain ordering (post-merge review on #988).
+ *
+ * bashBackgroundExtension is registered before bashControlExtension in
+ * src/cli.ts, and shutdown handlers run in registration order. Draining the
+ * registry kills pending processes, which settles their `whenExited`
+ * promises — if the registry were still published at that point, the
+ * control extension's exit watcher could emit an "exited on its own"
+ * steer into the closing session. The extension must UNPUBLISH the
+ * session registry before awaiting the drain.
+ */
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it } from "vitest"
+import bashBackgroundExtension from "./index.js"
+import type { ProcessRegistry } from "./process-registry.js"
+import { getSessionRegistry, setSessionRegistry } from "./session-registry.js"
+
+type AnyHandler = (event: unknown, ctx: ExtensionContext) => unknown
+
+function makeFakePi(): ExtensionAPI & { emit(event: string, payload: unknown, ctx?: unknown): Promise<void> } {
+	const handlers = new Map<string, AnyHandler[]>()
+	const fake = {
+		handlers,
+		on(event: string, handler: AnyHandler) {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		},
+		registerTool(_tool: { name: string }) {},
+		async emit(event: string, payload: unknown, ctx?: unknown) {
+			for (const h of handlers.get(event) ?? []) {
+				await h(payload, ctx as ExtensionContext)
+			}
+		},
+	}
+	return fake as unknown as ExtensionAPI & {
+		emit(event: string, payload: unknown, ctx?: unknown): Promise<void>
+	}
+}
+
+describe("bashBackgroundExtension — shutdown drain ordering", () => {
+	afterEach(() => {
+		// The session registry is a module singleton — never leak it.
+		setSessionRegistry(undefined)
+	})
+
+	it("unpublishes the session registry before awaiting the drain", async () => {
+		const pi = makeFakePi()
+		bashBackgroundExtension(pi)
+		await pi.emit("session_start", {}, { cwd: "/tmp" })
+		expect(getSessionRegistry()).toBeDefined()
+
+		// Swap in a sentinel that records what the accessor returns while the
+		// drain is in progress.
+		const observed: { publishedDuringDrain: ProcessRegistry | undefined | "unset" } = {
+			publishedDuringDrain: "unset",
+		}
+		const sentinel = {
+			async shutdown(): Promise<void> {
+				observed.publishedDuringDrain = getSessionRegistry()
+			},
+		} as unknown as ProcessRegistry
+		setSessionRegistry(sentinel)
+
+		await pi.emit("session_shutdown", {})
+
+		expect(observed.publishedDuringDrain).toBeUndefined()
+		expect(getSessionRegistry()).toBeUndefined()
+	})
+
+	it("session_start installs a fresh registry that callers can resolve", async () => {
+		const pi = makeFakePi()
+		bashBackgroundExtension(pi)
+
+		await pi.emit("session_start", {}, { cwd: "/tmp" })
+		const first = getSessionRegistry()
+		expect(first).toBeDefined()
+
+		await pi.emit("session_shutdown", {})
+		expect(getSessionRegistry()).toBeUndefined()
+	})
+})

--- a/src/extensions/bash-background/index.ts
+++ b/src/extensions/bash-background/index.ts
@@ -64,8 +64,12 @@ export function bashBackgroundExtension(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", async (_event: SessionShutdownEvent) => {
 		const registry = getSessionRegistry()
 		if (registry) {
-			await registry.shutdown()
+			// Unpublish BEFORE draining: shutdown() kills pending processes,
+			// which settles their whenExited promises — and a still-published
+			// registry would let bashControlExtension's exit watcher emit an
+			// "exited on its own" steer into the closing session.
 			setSessionRegistry(undefined)
+			await registry.shutdown()
 		}
 	})
 }


### PR DESCRIPTION
## Linked issue

Addresses three post-merge review comments on #988 (comments [#discussion-3747813201](https://github.com/getkimchi/kimchi/pull/988#discussion_r3747813201), [#discussion-3747813209](https://github.com/getkimchi/kimchi/pull/988#discussion_r3747813209), [#discussion-3747813215](https://github.com/getkimchi/kimchi/pull/988#discussion_r3747813215)).

## What does this PR do?

Follow-up fixes to the `bash_control` gate's exit watcher, from post-merge review:

1. **⚠️ Correctness — watcher raced an active `bash_control` call.** On `stop` (or `continue` observing an exit), `registry.kill()` / process exit settles `execPromise` *before* the tool emits its result. Watcher promise reactions (registered at the checkin) run first, so the watcher treated the exit as unattended and queued a stale *"exited on its own; call bash_control"* steer for a handle the control call was about to resolve. In-flight `bash_control` calls are now tracked via `tool_execution_start`/`tool_execution_end`; the watcher claims such exits silently, and `tool_execution_end` releases the handle when the call finished without a resolved result (the `throwIfTerminal` throw path). Reproduced as a failing test per the reviewer's scenario, now passing.

2. **⚠️ Lifecycle — shutdown could emit the same misleading steer.** `bashBackgroundExtension` (registered first in `cli.ts`) awaited `registry.shutdown()` before `bashControlExtension` could set `disposed`, so kill-settled watchers fired into the closing session. The background extension now **unpublishes the session registry before awaiting the drain**, and the watcher captures the registry it subscribed to and bails when `getRegistry()` no longer returns it — teardown never steers a closing (or replacement) session regardless of handler ordering.

3. **🧪 Test accuracy — `"user"` is not an upstream `InputSource`.** `fireInput` now imports `InputSource` from the SDK and defaults to `"interactive"`, keeping the safety-net tests aligned with the real event contract.

### Tests

6 new tests (stop-race / continue-race / throw-path silent release / multi-handle ownership isolation / unpublished-registry bail / two drain-ordering regressions for `index.ts`). Suite: 71 passed across `bash-background/` (25 extension + 2 index + existing tool/registry tests).

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test` — full suite green on base commit; `bash-background/` 71/71 on this branch)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed (extension header docs describe the ownership + shutdown ordering)