### PR TITLE
feat(acp): make kimchi ACP registry compliant

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -486,7 +486,9 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 				sessionFactory: async () => asSession(fake),
 			})
 
-			await expect(testAgent.authenticate({ methodId: "kimchi-agent" })).rejects.toThrow(/Browser authentication failed/)
+			await expect(testAgent.authenticate({ methodId: "kimchi-agent" })).rejects.toThrow(
+				/Browser authentication failed/,
+			)
 			expect(writeApiKey).not.toHaveBeenCalled()
 		})
 	})

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -465,6 +465,18 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			await expect(testAgent.authenticate({ methodId: "unknown" })).rejects.toThrow(/unknown auth method/)
 			expect(authenticateViaBrowser).not.toHaveBeenCalled()
 		})
+
+		it("throws when browser auth returns no token", async () => {
+			vi.mocked(authenticateViaBrowser).mockResolvedValue({ token: "" })
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await expect(testAgent.authenticate({ methodId: "kimchi-agent" })).rejects.toThrow(/did not return a token/)
+			expect(writeApiKey).not.toHaveBeenCalled()
+		})
 	})
 
 	describe("unstable_logout", () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -477,6 +477,18 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			await expect(testAgent.authenticate({ methodId: "kimchi-agent" })).rejects.toThrow(/did not return a token/)
 			expect(writeApiKey).not.toHaveBeenCalled()
 		})
+
+		it("wraps browser auth errors as RequestError.internalError", async () => {
+			vi.mocked(authenticateViaBrowser).mockRejectedValue(new Error("User cancelled"))
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await expect(testAgent.authenticate({ methodId: "kimchi-agent" })).rejects.toThrow(/Browser authentication failed/)
+			expect(writeApiKey).not.toHaveBeenCalled()
+		})
 	})
 
 	describe("unstable_logout", () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -23,9 +23,26 @@ import type {
 } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+// Mock the browser auth flow so authenticate() can be tested without
+// starting a real callback server or opening a browser.
+vi.mock("../../cli-auth/index.js", () => ({
+	authenticateViaBrowser: vi.fn(),
+}))
+// Mock config writes so tests don't touch the real config file.
+vi.mock("../../config.js", () => ({
+	writeApiKey: vi.fn(),
+	clearApiKey: vi.fn(),
+}))
+// Mock the model cache refresh so tests don't hit the network.
+vi.mock("../../models.js", () => ({
+	updateModelsConfig: vi.fn(),
+}))
+
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
+import { authenticateViaBrowser } from "../../cli-auth/index.js"
+import { clearApiKey, writeApiKey } from "../../config.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../../extensions/agents/manager/constants.js"
 import { setProcessOrchestratorRef } from "../../extensions/kimchi-process.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
@@ -36,6 +53,7 @@ import {
 	getSessionPermissionFlagController,
 	unregisterSessionPermissionFlagController,
 } from "../../extensions/permissions/mode-controller-registry.js"
+import { updateModelsConfig } from "../../models.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	type AcpSessionFactory,
@@ -321,6 +339,180 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			const info = getAcpClientInfo()
 			expect(info?.name).toBe("kimchi-vscode")
 			expect(info?.version).toBe("1.0.0")
+		})
+
+		// ACP Registry compliance: initialize() must advertise auth methods so
+		// kimchi can be listed in the ACP registry (requires at least one of
+		// Agent Auth or Terminal Auth). See:
+		// https://github.com/agentclientprotocol/registry/blob/main/AUTHENTICATION.md
+		it("declares agent auth method in initialize response", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			expect(response.authMethods).toHaveLength(1)
+			expect(response.authMethods?.[0]).toMatchObject({
+				id: "kimchi-agent",
+				name: "Kimchi Login",
+			})
+			// Agent Auth is the default: the descriptor omits `type` (the
+			// registry treats an absent type as "agent"). AuthMethodAgent has no
+			// `type` field, so we verify absence rather than equality.
+			const method = response.authMethods?.[0]
+			expect("type" in (method ?? {})).toBe(false)
+		})
+
+		it("declares terminal auth method when client supports terminal capability", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({
+				protocolVersion: 1,
+				clientCapabilities: { auth: { terminal: true } },
+			})
+			expect(response.authMethods).toHaveLength(2)
+			const terminalMethod = response.authMethods?.find((m) => "type" in m && m.type === "terminal")
+			expect(terminalMethod).toMatchObject({
+				id: "kimchi-terminal",
+				name: "Log in from terminal",
+				type: "terminal",
+				args: ["login"],
+			})
+		})
+
+		it("omits terminal auth method when client does not support terminal capability", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			// No clientCapabilities at all
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			expect(response.authMethods).toHaveLength(1)
+			expect(response.authMethods?.some((m) => "type" in m && m.type === "terminal")).toBe(false)
+
+			// clientCapabilities present but auth.terminal is false/omitted
+			const response2 = await testAgent.initialize({
+				protocolVersion: 1,
+				clientCapabilities: { auth: { terminal: false } },
+			})
+			expect(response2.authMethods).toHaveLength(1)
+			expect(response2.authMethods?.some((m) => "type" in m && m.type === "terminal")).toBe(false)
+		})
+
+		it("advertises logout capability in agentCapabilities.auth", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			expect(response.agentCapabilities?.auth?.logout).toEqual({})
+		})
+	})
+
+	describe("authenticate", () => {
+		const tempAgentDir = "/tmp/kimchi-acp-test-agent-dir-auth"
+
+		beforeEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+			mkdirSync(tempAgentDir, { recursive: true })
+			vi.mocked(authenticateViaBrowser).mockReset()
+			vi.mocked(writeApiKey).mockReset()
+			vi.mocked(updateModelsConfig).mockReset()
+		})
+
+		afterEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+		})
+
+		it("authenticates with kimchi-agent methodId: runs browser login and persists token", async () => {
+			vi.mocked(authenticateViaBrowser).mockResolvedValue({ token: "castai_v1_test-token" })
+
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const result = await testAgent.authenticate({ methodId: "kimchi-agent" })
+
+			expect(result).toEqual({})
+			expect(authenticateViaBrowser).toHaveBeenCalledOnce()
+			expect(writeApiKey).toHaveBeenCalledWith("castai_v1_test-token")
+			expect(updateModelsConfig).toHaveBeenCalledWith(join(tempAgentDir, "models.json"), "castai_v1_test-token")
+		})
+
+		it("throws invalidParams for unknown methodId", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await expect(testAgent.authenticate({ methodId: "unknown" })).rejects.toThrow(/unknown auth method/)
+			expect(authenticateViaBrowser).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("unstable_logout", () => {
+		const tempAgentDir = "/tmp/kimchi-acp-test-agent-dir-logout"
+
+		beforeEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+			mkdirSync(tempAgentDir, { recursive: true })
+			vi.mocked(clearApiKey).mockReset()
+		})
+
+		afterEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+		})
+
+		it("clears API key from config and OAuth credentials from auth storage", async () => {
+			// Seed auth.json with a kimchi-dev OAuth entry so we can verify
+			// logout actually removes it.
+			writeFileSync(
+				join(tempAgentDir, "auth.json"),
+				JSON.stringify({
+					"kimchi-dev": { type: "oauth", accessToken: "old-token", refreshToken: "old-refresh" },
+				}),
+			)
+
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const result = await testAgent.unstable_logout({})
+
+			expect(result).toEqual({})
+			// clearApiKey is mocked — verify it was called to clear the config file.
+			expect(clearApiKey).toHaveBeenCalledOnce()
+
+			// AuthStorage.logout("kimchi-dev") should have removed the entry
+			// from auth.json. Read it back and verify.
+			const authJson = JSON.parse(
+				// eslint-disable-next-line no-restricted-syntax
+				await import("node:fs").then((fs) => fs.readFileSync(join(tempAgentDir, "auth.json"), "utf-8")),
+			)
+			expect(authJson["kimchi-dev"]).toBeUndefined()
 		})
 	})
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -328,7 +328,13 @@ export class KimchiAcpAgent implements Agent {
 
 		// Run the browser OAuth flow: starts a local callback server, opens the
 		// user's browser to the Kimchi web app, and awaits the resulting token.
-		const { token } = await authenticateViaBrowser()
+		let token: string
+		try {
+			;({ token } = await authenticateViaBrowser())
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error)
+			throw RequestError.internalError(undefined, `Browser authentication failed: ${detail}`)
+		}
 		if (!token) {
 			throw RequestError.internalError(undefined, "Browser authentication did not return a token")
 		}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -59,6 +59,7 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
 import { clearApiKey, writeApiKey } from "../../config.js"
+import { KIMCHI_PROVIDER_ID } from "../../extensions/login/flow.js"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult } from "../../extensions/mcp-adapter/types.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
@@ -96,6 +97,10 @@ import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompte
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./tool-calls/utils.js"
 import { asString, truncate } from "./utils.js"
+
+/** Auth method ID for Agent Auth (browser-based OAuth). Used in both
+ * initialize() declaration and authenticate() validation to avoid typo drift. */
+const KIMCHI_AGENT_AUTH_METHOD_ID = "kimchi-agent"
 
 /**
  * Produces an unbound AgentSession for a newSession request. The ACP agent owns
@@ -244,7 +249,7 @@ export class KimchiAcpAgent implements Agent {
 		// Client advertised the corresponding capability."
 		const authMethods: AuthMethod[] = [
 			{
-				id: "kimchi-agent",
+				id: KIMCHI_AGENT_AUTH_METHOD_ID,
 				name: "Kimchi Login",
 				description: "Authenticate via browser to Kimchi",
 			},
@@ -324,6 +329,9 @@ export class KimchiAcpAgent implements Agent {
 		// Run the browser OAuth flow: starts a local callback server, opens the
 		// user's browser to the Kimchi web app, and awaits the resulting token.
 		const { token } = await authenticateViaBrowser()
+		if (!token) {
+			throw RequestError.internalError(undefined, "Browser authentication did not return a token")
+		}
 
 		// Persist the key so new sessions pick it up via the login extension's
 		// session_start handler (which reads loadConfig().apiKey).
@@ -345,7 +353,7 @@ export class KimchiAcpAgent implements Agent {
 		// kimchi-dev provider from auth.json. AuthStorage.create is cheap —
 		// it reads auth.json lazily on access.
 		const authStorage = AuthStorage.create(join(this.agentDir, "auth.json"))
-		authStorage.logout("kimchi-dev")
+		authStorage.logout(KIMCHI_PROVIDER_ID)
 
 		return {}
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -10,6 +10,7 @@ import {
 	AgentSideConnection,
 	type AuthenticateRequest,
 	type AuthenticateResponse,
+	type AuthMethod,
 	type CancelNotification,
 	type ClientCapabilities,
 	type CloseSessionRequest,
@@ -21,6 +22,8 @@ import {
 	type ListSessionsResponse,
 	type LoadSessionRequest,
 	type LoadSessionResponse,
+	type LogoutRequest,
+	type LogoutResponse,
 	type NewSessionRequest,
 	type NewSessionResponse,
 	ndJsonStream,
@@ -54,6 +57,8 @@ import {
 	SessionManager,
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
+import { authenticateViaBrowser } from "../../cli-auth/index.js"
+import { clearApiKey, writeApiKey } from "../../config.js"
 import type { McpServerManager } from "../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult } from "../../extensions/mcp-adapter/types.js"
 import { refFromModel, splitModelRef } from "../../extensions/model-catalog/ref-utils.js"
@@ -79,6 +84,7 @@ import {
 } from "../../extensions/permissions/mode-controller-registry.js"
 import type { PermissionMode, PermissionModeState } from "../../extensions/permissions/types.js"
 import { configureHttpIdleTimeout } from "../../http/proxy.js"
+import { updateModelsConfig } from "../../models.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
@@ -229,10 +235,37 @@ export class KimchiAcpAgent implements Agent {
 		const authStorage = AuthStorage.create(join(this.agentDir, "auth.json"))
 		const modelRegistry = ModelRegistry.create(authStorage, join(this.agentDir, "models.json"))
 		const supportsImages = modelRegistry.getAvailable().some((m) => m.input?.includes("image"))
+
+		// ACP Registry compliance: advertise at least one auth method. Agent Auth
+		// (browser-based OAuth via local callback server) is always declared.
+		// Terminal Auth (interactive `kimchi login`) is declared only when the
+		// client advertises the terminal capability, per the auth-methods RFD:
+		// "An Agent may advertise a terminal authentication method only when the
+		// Client advertised the corresponding capability."
+		const authMethods: AuthMethod[] = [
+			{
+				id: "kimchi-agent",
+				name: "Kimchi Login",
+				description: "Authenticate via browser to Kimchi",
+			},
+		]
+		if (request.clientCapabilities?.auth?.terminal === true) {
+			authMethods.push({
+				id: "kimchi-terminal",
+				name: "Log in from terminal",
+				description: "Run Kimchi's interactive login flow",
+				type: "terminal",
+				args: ["login"],
+			})
+		}
+
 		return {
 			protocolVersion: PROTOCOL_VERSION,
 			agentCapabilities: {
 				loadSession: true,
+				// Advertise logout support so clients know they can call
+				// `unstable_logout` to clear stored credentials.
+				auth: { logout: {} },
 				// `list: {}` advertises support for session/list per spec
 				// (SessionListCapabilities is `{ _meta? }` — empty object means
 				// "supported"). loadSession remains the top-level flag because
@@ -247,7 +280,7 @@ export class KimchiAcpAgent implements Agent {
 					},
 				},
 			},
-			authMethods: [],
+			authMethods,
 		}
 	}
 
@@ -279,7 +312,41 @@ export class KimchiAcpAgent implements Agent {
 		return { sessions, nextCursor: null }
 	}
 
-	async authenticate(_: AuthenticateRequest): Promise<AuthenticateResponse> {
+	async authenticate(params: AuthenticateRequest): Promise<AuthenticateResponse> {
+		// Only the Agent Auth method ("kimchi-agent") is handled here. Terminal
+		// Auth ("kimchi-terminal") is resolved out-of-band: the client launches
+		// `kimchi login` as a separate process, so this method is never called
+		// for it.
+		if (params.methodId !== "kimchi-agent") {
+			throw RequestError.invalidParams(undefined, `unknown auth method: ${params.methodId}`)
+		}
+
+		// Run the browser OAuth flow: starts a local callback server, opens the
+		// user's browser to the Kimchi web app, and awaits the resulting token.
+		const { token } = await authenticateViaBrowser()
+
+		// Persist the key so new sessions pick it up via the login extension's
+		// session_start handler (which reads loadConfig().apiKey).
+		writeApiKey(token)
+
+		// Eagerly refresh the model cache so the subsequent newSession() call
+		// finds available models without another round-trip.
+		await updateModelsConfig(join(this.agentDir, "models.json"), token)
+
+		return {}
+	}
+
+	async unstable_logout(_params: LogoutRequest): Promise<LogoutResponse> {
+		// Clear the persisted API key from config (loadConfig().apiKey), so
+		// new sessions no longer pick it up via the login extension.
+		clearApiKey()
+
+		// Clear stored OAuth credentials (refresh tokens etc.) for the
+		// kimchi-dev provider from auth.json. AuthStorage.create is cheap —
+		// it reads auth.json lazily on access.
+		const authStorage = AuthStorage.create(join(this.agentDir, "auth.json"))
+		authStorage.logout("kimchi-dev")
+
 		return {}
 	}
 


### PR DESCRIPTION
## Linked issue

Closes #0

## What does this PR do?

Makes kimchi's ACP server compliant with the ACP Registry authentication requirements — an agent must support at least one auth method to be listed in the registry. 

## Changes

 - Declares Agent Auth (kimchi-agent) in initialize() — always advertised, uses the existing browser-based OAuth flow (local callback server + browser open)
 - Declares Terminal Auth (kimchi-terminal) in initialize() — only advertised when the client declares clientCapabilities.auth.terminal === true, points to the existing kimchi login
   subcommand via args: ["login"]
 - Advertises logout capability — agentCapabilities.auth.logout = {} so clients know they can call unstable_logout
 - Implements authenticate() — validates the method ID, runs authenticateViaBrowser(), persists the token via writeApiKey(), and eagerly refreshes the model cache via updateModelsConfig() so
   newSession() succeeds immediately after
 - Implements unstable_logout() — clears the API key from config and clears stored OAuth credentials for the kimchi-dev provider
 - Adds 7 unit tests covering all auth behaviors (auth method declarations, conditional terminal auth, authenticate flow, logout flow)

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
