### PR TITLE
feat: add macOS text editing shortcuts to prompt editor

### DIFF
--- a/src/components/editor.test.ts
+++ b/src/components/editor.test.ts
@@ -181,4 +181,137 @@ describe("PromptEditor", () => {
 			expect(lines[1].startsWith("❯ ")).toBe(true)
 		})
 	})
+
+	describe("handleInput — macOS Cmd (super) shortcuts", () => {
+		// Kitty protocol sequences for super-modified keys.
+		// Modifier value is bitmask+1; super=8, so modifier param = 9.
+		const SUPER_BACKSPACE = "\x1b[127;9u" // Kitty CSI-u: backspace + super
+		const SUPER_DELETE = "\x1b[3;9~" // Legacy func: delete + super
+		const SUPER_LEFT = "\x1b[1;9D" // Arrow: left + super
+		const SUPER_RIGHT = "\x1b[1;9C" // Arrow: right + super
+
+		it("super+backspace deletes to beginning of line", () => {
+			const { editor } = makeEditor()
+			editor.setText("hello world")
+			// setText places cursor at end; move it left 5 times to land at col 6
+			for (let i = 0; i < 5; i++) editor.handleInput("\x1b[D")
+			expect(editor.getCursor().col).toBe(6)
+
+			editor.handleInput(SUPER_BACKSPACE)
+
+			// Everything before the cursor ("hello ") should be deleted
+			expect(editor.getText()).toBe("world")
+			expect(editor.getCursor().col).toBe(0)
+		})
+
+		it("super+delete deletes to end of line", () => {
+			const { editor } = makeEditor()
+			editor.setText("hello world")
+			// Move cursor to position 5 (after "hello")
+			for (let i = 0; i < 6; i++) editor.handleInput("\x1b[D")
+			expect(editor.getCursor().col).toBe(5)
+
+			editor.handleInput(SUPER_DELETE)
+
+			// Everything from cursor to end (" world") should be deleted
+			expect(editor.getText()).toBe("hello")
+			expect(editor.getCursor().col).toBe(5)
+		})
+
+		it("super+left moves cursor to beginning of line", () => {
+			const { editor } = makeEditor()
+			editor.setText("hello world")
+			// Cursor starts at end (col 11)
+			expect(editor.getCursor().col).toBe(11)
+
+			editor.handleInput(SUPER_LEFT)
+
+			expect(editor.getCursor().col).toBe(0)
+			// Text is unchanged
+			expect(editor.getText()).toBe("hello world")
+		})
+
+		it("super+right moves cursor to end of line", () => {
+			const { editor } = makeEditor()
+			editor.setText("hello world")
+			// Move cursor to beginning first
+			for (let i = 0; i < 11; i++) editor.handleInput("\x1b[D")
+			expect(editor.getCursor().col).toBe(0)
+
+			editor.handleInput(SUPER_RIGHT)
+
+			expect(editor.getCursor().col).toBe(11)
+			// Text is unchanged
+			expect(editor.getText()).toBe("hello world")
+		})
+
+		it("does not interfere with regular key input", () => {
+			const { editor } = makeEditor()
+			editor.handleInput("a")
+			editor.handleInput("b")
+			editor.handleInput("c")
+			expect(editor.getText()).toBe("abc")
+		})
+
+		it("super+backspace on empty editor is a no-op", () => {
+			const { editor } = makeEditor()
+			editor.handleInput(SUPER_BACKSPACE)
+			expect(editor.getText()).toBe("")
+		})
+
+		it("super+delete at end of line is a no-op", () => {
+			const { editor } = makeEditor()
+			editor.setText("hello")
+			// Cursor is at end (col 5)
+			editor.handleInput(SUPER_DELETE)
+			expect(editor.getText()).toBe("hello")
+		})
+
+		describe("Ghostty cmd+backspace translation", () => {
+			// Ghostty translates cmd+backspace to alt+w (Kitty CSI-u with
+			// modifier 3 = alt). We intercept alt+w ONLY when TERM_PROGRAM
+			// is "ghostty" so real alt+w on other terminals is unaffected.
+			const GHOSTTY_ALT_W = "\x1b[119;3:1u" // Kitty CSI-u: 'w' + alt
+
+			beforeEach(() => {
+				process.env.TERM_PROGRAM = "ghostty"
+			})
+
+			afterEach(() => {
+				delete process.env.TERM_PROGRAM
+			})
+
+			it("Ghostty: alt+w (cmd+backspace) deletes to beginning of line", () => {
+				const { editor } = makeEditor()
+				editor.setText("hello world")
+				// Move cursor to col 6 (between "hello " and "world")
+				for (let i = 0; i < 5; i++) editor.handleInput("\x1b[D")
+				expect(editor.getCursor().col).toBe(6)
+
+				editor.handleInput(GHOSTTY_ALT_W)
+
+				expect(editor.getText()).toBe("world")
+				expect(editor.getCursor().col).toBe(0)
+			})
+
+			it("non-Ghostty: alt+w is NOT intercepted (passes through to editor)", () => {
+				process.env.TERM_PROGRAM = "iTerm.app"
+				const { editor } = makeEditor()
+				editor.setText("hello")
+				// Move cursor to col 2
+				for (let i = 0; i < 3; i++) editor.handleInput("\x1b[D")
+				expect(editor.getCursor().col).toBe(2)
+
+				editor.handleInput(GHOSTTY_ALT_W)
+
+				// alt+w is not a known keybinding, so it falls through to
+				// the editor's printable-char handler which inserts 'w'
+				// (the Kitty sequence decodes to 'w' with alt modifier, but
+				// since alt+w has no binding it gets treated as a character
+				// insertion by the editor's fallback).
+				// The key assertion: text is NOT deleted to line start.
+				expect(editor.getText()).not.toBe("llo")
+			})
+		})
+	})
 })

--- a/src/components/editor.ts
+++ b/src/components/editor.ts
@@ -1,7 +1,8 @@
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent"
 import { CustomEditor, type Theme } from "@earendil-works/pi-coding-agent"
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui"
-import { isKittyProtocolActive, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui"
+import { isKittyProtocolActive, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui"
+import { isNativeModifierPressed } from "@earendil-works/pi-tui/dist/native-modifiers.js"
 import { RST_FG } from "../ansi.js"
 
 const CHEVRON_WIDTH = 2
@@ -105,6 +106,56 @@ export class PromptEditor extends CustomEditor {
 			// Going through super avoids brittle prototype-chain jumps.
 			super.handleInput("\n")
 			return
+		}
+		// macOS-native text editing shortcuts using the Cmd (super) modifier.
+		//
+		// Terminals handle these inconsistently:
+		// - iTerm2/Kitty/WezTerm: send raw super-modified Kitty sequences
+		// - Ghostty: translates cmd+backspace→alt+w, cmd+left→ctrl+a,
+		//   cmd+right→ctrl+e; cmd+delete is swallowed entirely
+		// - Terminal.app: translates cmd+backspace→ctrl+u (already works)
+		//
+		// ctrl+a (cmd+left) and ctrl+e (cmd+right) already work via default
+		// keybindings. We intercept the remaining cases and re-emit the
+		// equivalent raw control sequences that the upstream Editor already
+		// handles via its default keybindings (ctrl+u, ctrl+k, home, end).
+		//
+		// This cannot be done via keybindings.json because user bindings
+		// REPLACE defaults rather than augmenting them.
+		const isGhostty = process.env.TERM_PROGRAM === "ghostty"
+		// For super+backspace: Ghostty translates to alt+w, so intercept that
+		// ONLY on Ghostty to avoid clobbering real alt+w on other terminals.
+		if (matchesKey(data, Key.super("backspace")) || (isGhostty && matchesKey(data, "alt+w"))) {
+			super.handleInput("\x15") // ctrl+u → deleteToLineStart
+			return
+		}
+		if (matchesKey(data, Key.super("delete"))) {
+			super.handleInput("\x0b") // ctrl+k → deleteToLineEnd
+			return
+		}
+		if (matchesKey(data, Key.super("left"))) {
+			super.handleInput("\x1b[H") // home → cursorLineStart
+			return
+		}
+		if (matchesKey(data, Key.super("right"))) {
+			super.handleInput("\x1b[F") // end → cursorLineEnd
+			return
+		}
+		// Ghostty strips the Option modifier from opt+backspace and opt+delete,
+		// sending plain DEL (\x7f) or plain delete (\x1b[3~) with no way to
+		// distinguish from a plain keypress via the byte stream alone. Use the
+		// native macOS modifier detection (same mechanism pi-tui uses for
+		// Terminal.app's Shift+Enter) to check if Option is physically pressed.
+		// Only works when pi runs on the same Mac as the terminal (not over SSH).
+		if (process.platform === "darwin") {
+			if (data === "\x7f" && isNativeModifierPressed("option")) {
+				super.handleInput("\x1b\x7f") // alt+backspace → deleteWordBackward
+				return
+			}
+			if (data === "\x1b[3~" && isNativeModifierPressed("option")) {
+				super.handleInput("\x1b[3;3~") // alt+delete → deleteWordForward
+				return
+			}
 		}
 		super.handleInput(data)
 	}


### PR DESCRIPTION
## Summary

Terminal-native macOS text editing shortcuts that use the **Cmd** and **Option** modifiers were previously ignored or broken in the prompt input fields. This adds support for the common editing shortcuts:

### Cmd (super) modifier shortcuts

| Shortcut | Action |
|----------|--------|
| Cmd+Backspace | Delete to beginning of line |
| Cmd+Delete | Delete to end of line (iTerm2/Kitty/WezTerm only — Ghostty swallows it) |
| Cmd+Left | Move cursor to beginning of line |
| Cmd+Right | Move cursor to end of line |

### Option modifier shortcuts (Ghostty fix)

| Shortcut | Action |
|----------|--------|
| Opt+Backspace | Delete previous word |
| Opt+Delete | Delete next word |

## Why

On macOS, these shortcuts are deeply ingrained muscle memory — they work in every native text field, Terminal.app, and most TUI apps. Their absence in the kimchi prompt input is a constant source of friction when editing prompts.

## How

Terminal handling of these shortcuts varies significantly. The implementation handles each terminal's quirks:

### iTerm2/Kitty/WezTerm
Send raw -modified Kitty keyboard protocol sequences. Intercepted via `matchesKey(data, Key.super(...))` and re-emitted as the equivalent raw control sequences the upstream Editor already handles via its default keybindings.

### Ghostty
- **cmd+backspace**: Ghostty translates to `alt+w` (Kitty CSI-u with alt modifier). Intercepted only when `TERM_PROGRAM === "ghostty"` to avoid clobbering real `alt+w` on other terminals.
- **cmd+left/cmd+right**: Ghostty translates to `ctrl+a`/`ctrl+e`, which already work via default keybindings — no interception needed.
- **cmd+delete**: Swallowed by Ghostty entirely — cannot be fixed in-app.
- **opt+backspace/opt+delete**: Ghostty strips the Option modifier entirely, sending plain DEL (`\x7f`). Fixed via native macOS modifier detection (`isNativeModifierPressed("option")`) — the same mechanism pi-tui uses for Terminal.app's Shift+Enter. Only works when pi runs on the same Mac as the terminal (not over SSH).

### Terminal.app
Translates `cmd+backspace`→`ctrl+u`, `cmd+left`→`home`, `cmd+right`→`end`, which already work via default keybindings.

## Why not keybindings.json?

User bindings in `~/.pi/agent/keybindings.json` **replace** the default keys for an action rather than augmenting them. Binding `super+backspace` to `tui.editor.deleteToLineStart` would lose the existing `ctrl+u` binding unless the user manually includes it. Intercepting in `handleInput` preserves all existing defaults while layering the macOS shortcuts on top — zero config, works out of the box.

## Test coverage

- [x] `super+backspace` deletes to beginning of line (Kitty protocol)
- [x] `super+delete` deletes to end of line (Kitty protocol)
- [x] `super+left` moves cursor to beginning of line (Kitty protocol)
- [x] `super+right` moves cursor to end of line (Kitty protocol)
- [x] Ghostty: `alt+w` (cmd+backspace translation) deletes to beginning of line
- [x] Non-Ghostty: `alt+w` is NOT intercepted (passes through to editor)
- [x] Regular key input is not affected
- [x] Edge cases: empty editor, cursor at end of line
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (7714 tests, 0 failures)
- [x] `pnpm run lint` passes (pre-commit hook)
- [x] Manually tested on Ghostty: all shortcuts work

## Checklist

- [x] Code changes
- [x] Unit tests added
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (7714 tests, 0 failures)
- [x] `pnpm run lint` passes (pre-commit hook)
- [x] Manually tested on Ghostty: cmd+backspace, opt+backspace, opt+delete, cmd+left, cmd+right all work