### PR TITLE
fix(clipboard-image): prevent clipboard polling on Wayland systems

### DIFF
--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -81,15 +81,21 @@ describe("clipboard-image extension", () => {
 		// Reset module-level state (clipboardHasImage) before each test.
 		// session_shutdown no longer clears it, so we drive a session_start with an
 		// empty-clipboard mock which causes checkClipboard to set clipboardHasImage=false.
+		const platform = process.platform
+		Object.defineProperty(process, "platform", { value: "darwin" })
 		mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
 		mockGetNativeClipboard.mockReturnValue({
 			clipboard: { hasImage: () => false, availableFormats: () => [] },
 			error: null,
 		})
-		const resetPi = makeMockPi()
-		clipboardImageExtension(resetPi)
-		;(resetPi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
-		;(resetPi._handlers.session_shutdown as () => void)()
+		try {
+			const resetPi = makeMockPi()
+			clipboardImageExtension(resetPi)
+			;(resetPi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+			;(resetPi._handlers.session_shutdown as () => void)()
+		} finally {
+			Object.defineProperty(process, "platform", { value: platform })
+		}
 		vi.clearAllMocks()
 		vi.useFakeTimers()
 	})

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -222,6 +222,27 @@ describe("clipboard-image extension", () => {
 
 		afterEach(() => {
 			Object.defineProperty(process, "platform", { value: realPlatform })
+			vi.unstubAllEnvs()
+		})
+
+		it("does not poll the clipboard on Linux", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			vi.stubEnv("WAYLAND_DISPLAY", "")
+			vi.stubEnv("DISPLAY", ":0")
+			const hasImage = vi.fn(() => false)
+			const availableFormats = vi.fn(() => [])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage, availableFormats },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+			vi.advanceTimersByTime(2000)
+
+			expect(availableFormats).not.toHaveBeenCalled()
+			expect(hasImage).not.toHaveBeenCalled()
 		})
 
 		it("shows hint when clipboard contains an image", () => {

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -77,30 +77,28 @@ function callInputHandler(pi: ExtensionAPI & { _handlers: Handlers }, event: { t
 }
 
 describe("clipboard-image extension", () => {
+	const realPlatform = process.platform
+
 	beforeEach(() => {
 		// Reset module-level state (clipboardHasImage) before each test.
 		// session_shutdown no longer clears it, so we drive a session_start with an
 		// empty-clipboard mock which causes checkClipboard to set clipboardHasImage=false.
-		const platform = process.platform
 		Object.defineProperty(process, "platform", { value: "darwin" })
 		mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
 		mockGetNativeClipboard.mockReturnValue({
 			clipboard: { hasImage: () => false, availableFormats: () => [] },
 			error: null,
 		})
-		try {
-			const resetPi = makeMockPi()
-			clipboardImageExtension(resetPi)
-			;(resetPi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
-			;(resetPi._handlers.session_shutdown as () => void)()
-		} finally {
-			Object.defineProperty(process, "platform", { value: platform })
-		}
+		const resetPi = makeMockPi()
+		clipboardImageExtension(resetPi)
+		;(resetPi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+		;(resetPi._handlers.session_shutdown as () => void)()
 		vi.clearAllMocks()
 		vi.useFakeTimers()
 	})
 
 	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: realPlatform })
 		vi.useRealTimers()
 	})
 
@@ -218,16 +216,12 @@ describe("clipboard-image extension", () => {
 	})
 
 	describe("proactive clipboard polling", () => {
-		const realPlatform = process.platform
-
 		beforeEach(() => {
 			vi.clearAllMocks()
 			mockGetAvailableModels.mockReturnValue([{ slug: "glm-4", input_modalities: ["text", "image"] }])
-			Object.defineProperty(process, "platform", { value: "darwin" })
 		})
 
 		afterEach(() => {
-			Object.defineProperty(process, "platform", { value: realPlatform })
 			vi.unstubAllEnvs()
 		})
 

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -225,7 +225,8 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		setImageCacheDir(dir)
 		clearAllImages()
 		updateIndicator()
-		// Polling the subprocess-based Linux backend can steal focus on Wayland.
+		// Linux clipboard detection shells out to wl-paste/xclip, so keep it on-demand.
+		// Polling wl-paste can create transient surfaces that steal focus on Wayland.
 		if (process.platform === "linux") return
 		checkClipboard()
 		clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -225,6 +225,8 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		setImageCacheDir(dir)
 		clearAllImages()
 		updateIndicator()
+		// Polling the subprocess-based Linux backend can steal focus on Wayland.
+		if (process.platform === "linux") return
 		checkClipboard()
 		clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
 	})

--- a/tests/e2e/tui/clipboard-wayland-idle.test.ts
+++ b/tests/e2e/tui/clipboard-wayland-idle.test.ts
@@ -25,7 +25,6 @@ testOnLinux("does not invoke wl-paste while idle on Wayland", async ({ terminal 
 					chmodSync(helperPath, 0o755)
 				}
 				return {
-					data: { logPath },
 					env: {
 						DISPLAY: "",
 						PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
@@ -36,7 +35,7 @@ testOnLinux("does not invoke wl-paste while idle on Wayland", async ({ terminal 
 		},
 		async (fixture, trace) => {
 			await new Promise((resolve) => setTimeout(resolve, 2200))
-			const { logPath } = fixture.seedResult as { logPath: string }
+			const logPath = join(fixture.homeDir, "clipboard-helper.log")
 			expect(readFileSync(logPath, "utf8")).toBe("")
 			trace.step("no background clipboard helper invocation after two polling intervals")
 		},

--- a/tests/e2e/tui/clipboard-wayland-idle.test.ts
+++ b/tests/e2e/tui/clipboard-wayland-idle.test.ts
@@ -1,0 +1,44 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { delimiter, join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const testOnLinux = process.platform === "linux" ? test : test.skip
+
+testOnLinux("does not invoke wl-paste while idle on Wayland", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "clipboard-wayland-idle",
+			responses: [],
+			seedHome(homeDir) {
+				const binDir = join(homeDir, "bin")
+				const logPath = join(homeDir, "clipboard-helper.log")
+				mkdirSync(binDir)
+				writeFileSync(logPath, "")
+				const shim = `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\n`
+				for (const helper of ["wl-paste", "xclip"]) {
+					const helperPath = join(binDir, helper)
+					writeFileSync(helperPath, shim)
+					chmodSync(helperPath, 0o755)
+				}
+				return {
+					data: { logPath },
+					env: {
+						DISPLAY: "",
+						PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+						WAYLAND_DISPLAY: "wayland-test",
+					},
+				}
+			},
+		},
+		async (fixture, trace) => {
+			await new Promise((resolve) => setTimeout(resolve, 2200))
+			const { logPath } = fixture.seedResult as { logPath: string }
+			expect(readFileSync(logPath, "utf8")).toBe("")
+			trace.step("no background clipboard helper invocation after two polling intervals")
+		},
+	)
+})


### PR DESCRIPTION
## Linked issue

Closes #824
<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Linux clipboard detection uses external helpers (`wl-paste` on Wayland and `xclip` on X11). Kimchi previously invoked those helpers every second while idle to update the clipboard-image hint. On Wayland, each `wl-paste` invocation can create a transient surface that steals focus from the active window.

This change keeps Linux clipboard access on-demand instead of polling in the background. Pasting an image with `Ctrl+V` still reads and attaches it normally; proactive clipboard hints remain unchanged on macOS and Windows.

The regression coverage includes a unit test for the Linux guard and a Linux TUI E2E scenario that runs the built CLI with recording `wl-paste` and `xclip` shims, leaves Kimchi idle, and verifies neither helper is invoked.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
