### PR TITLE
test(prompt-construction): context determinism and steer trigger boundaries

### DIFF
--- a/src/extensions/prompt-construction/system-prompt-stability.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.test.ts
@@ -17,7 +17,7 @@ import { buildPlanModeSupplementBlock } from "../permissions/index.js"
 import type { PermissionModeState } from "../permissions/types.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "../todos/constants.js"
 import { FERMENT_TODO_GUIDANCE } from "../todos/ferment-prompt-block.js"
-import todosExtension from "../todos/index.js"
+import todosExtension, { TODO_EARLY_NUDGE_THRESHOLD } from "../todos/index.js"
 import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
 import { createSystemPromptBlocks } from "./index.js"
 import { buildSystemPrompt, type EnvironmentInfo } from "./system-prompt.js"
@@ -611,12 +611,12 @@ describe("system prompt stability contract", () => {
 		 * threshold crossings on todo-less sessions may emit the early nudge. */
 
 		it("does not fire below the work-tool threshold", async () => {
-			for (let i = 0; i < 4; i++) await fireToolExecutionEnd("bash")
+			for (let i = 0; i < TODO_EARLY_NUDGE_THRESHOLD - 1; i++) await fireToolExecutionEnd("bash")
 			expect(earlyNudgeCalls()).toHaveLength(0)
 		})
 
 		it("fires exactly once when the threshold is crossed and never recurs", async () => {
-			for (let i = 0; i < 5; i++) await fireToolExecutionEnd("bash")
+			for (let i = 0; i < TODO_EARLY_NUDGE_THRESHOLD; i++) await fireToolExecutionEnd("bash")
 
 			const firstPass = earlyNudgeCalls()
 			expect(firstPass).toHaveLength(1)
@@ -632,19 +632,19 @@ describe("system prompt stability contract", () => {
 			applyWriteTodos({ todos: [{ content: "planned task", status: "pending" }] }, SESSION_ID)
 			applyWriteTodos({ todos: [] }, SESSION_ID)
 
-			for (let i = 0; i < 8; i++) await fireToolExecutionEnd("bash")
+			for (let i = 0; i < TODO_EARLY_NUDGE_THRESHOLD + 3; i++) await fireToolExecutionEnd("bash")
 			expect(earlyNudgeCalls()).toHaveLength(0)
 		})
 
 		it("does not count todo tool calls toward the threshold", async () => {
-			for (let i = 0; i < 3; i++) await fireToolExecutionEnd("bash")
+			for (let i = 0; i < TODO_EARLY_NUDGE_THRESHOLD - 2; i++) await fireToolExecutionEnd("bash")
 			for (let i = 0; i < 3; i++) await fireToolExecutionEnd("write_todos")
 			expect(earlyNudgeCalls()).toHaveLength(0)
 
 			await fireToolExecutionEnd("read")
 			expect(earlyNudgeCalls()).toHaveLength(0)
 
-			// Fourth work tool call plus this one reaches the threshold.
+			// Second-to-last work tool call plus this one reaches the threshold.
 			await fireToolExecutionEnd("read")
 			expect(earlyNudgeCalls()).toHaveLength(1)
 		})
@@ -679,7 +679,7 @@ describe("system prompt stability contract", () => {
 			setActive(undefined)
 			todosExtension(harness.pi)
 			wireBehaviours(harness.pi, [glabBehaviour], { resolverIO: stubResolverIO })
-			await harness.fire("session_start", { reason: "new", fork: false, resumed: false, version: "0" })
+			await harness.fire("session_start", { reason: "new" })
 		})
 
 		afterEach(async () => {

--- a/src/extensions/prompt-construction/system-prompt-stability.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.test.ts
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
 import { TriggerEngine } from "../behaviours/engine.js"
+import type { ResolverIO } from "../behaviours/session-context.js"
 import { tool } from "../behaviours/triggers.js"
 import type { TriggeredBehaviour } from "../behaviours/types.js"
+import { BEHAVIOUR_BODY_TYPE, wireBehaviours } from "../behaviours/wiring.js"
 import { emitFermentDomainEvent } from "../ferment/domain-events-emitter.js"
 import { buildFermentPromptBlock } from "../ferment/prompt-block.js"
 import { createDefaultFermentRuntime } from "../ferment/runtime.js"
@@ -13,6 +15,7 @@ import { setActive } from "../ferment/state.js"
 import { registerFermentTodoSync } from "../ferment/todo-sync.js"
 import { buildPlanModeSupplementBlock } from "../permissions/index.js"
 import type { PermissionModeState } from "../permissions/types.js"
+import { TODO_CUSTOM_ENTRY_TYPE } from "../todos/constants.js"
 import { FERMENT_TODO_GUIDANCE } from "../todos/ferment-prompt-block.js"
 import todosExtension from "../todos/index.js"
 import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
@@ -25,6 +28,8 @@ type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Pro
 type BeforeAgentStartResult = { systemPrompt?: string } | undefined
 
 type ContextResult = { messages?: Array<{ content?: unknown }> } | undefined
+
+type SendMessageCall = { message: unknown; options?: { deliverAs?: string } }
 
 const SESSION_ID = "system-prompt-stability-session"
 
@@ -93,6 +98,7 @@ interface TestHarness {
 	registerPlanningBlock(): void
 	buildFinalSystemPrompt(): Promise<string>
 	buildContextText(): Promise<string>
+	getSentMessages(): SendMessageCall[]
 }
 
 function createHarness(surface: WorkflowSurface): TestHarness {
@@ -179,6 +185,11 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		return extractTodoContextText(result)
 	}
 
+	function getSentMessages(): SendMessageCall[] {
+		const mock = pi.sendMessage as ReturnType<typeof vi.fn>
+		return mock.mock.calls.map(([message, options]) => ({ message, options }))
+	}
+
 	return {
 		surface,
 		ctx,
@@ -188,6 +199,7 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		registerPlanningBlock,
 		buildFinalSystemPrompt,
 		buildContextText,
+		getSentMessages,
 	}
 }
 
@@ -244,6 +256,70 @@ describe("system prompt stability contract", () => {
 					const contextAfterClear = await harness.buildContextText()
 					expect(promptAfterClear).toBe(promptBefore)
 					expect(contextAfterClear).toBe("")
+				})
+			})
+		}
+	})
+
+	describe("context message determinism", () => {
+		for (const surface of ["non-ferment", "ferment-interactive", "ferment-oneshot"] as WorkflowSurface[]) {
+			describe(`workflow: ${surface}`, () => {
+				let harness: TestHarness
+				let unsubscribeTodoSync: (() => void) | undefined
+
+				beforeEach(async () => {
+					harness = createHarness(surface)
+					__resetTodoStore()
+					setActive(surface === "non-ferment" ? undefined : makeFerment())
+					todosExtension(harness.pi)
+					harness.registerPlanningBlock()
+					unsubscribeTodoSync = registerFermentTodoSync(harness.pi, SESSION_ID)
+					await harness.fire("session_start", { reason: "new" })
+				})
+
+				afterEach(async () => {
+					await harness.fire("session_shutdown", {})
+					unsubscribeTodoSync?.()
+					unsubscribeTodoSync = undefined
+					setActive(undefined)
+					__resetTodoStore()
+				})
+
+				/* Prefix caching cares about the whole request, not just the system
+				 * prompt. The transient `context` message is the other channel that
+				 * volatile state flows through, so it must be *deterministic*: the
+				 * same state must render the same bytes on every call, and restoring
+				 * a prior state must restore the exact prior bytes. */
+
+				it("renders byte-identical context for identical state", async () => {
+					applyWriteTodos({ todos: [{ content: "determinism task", status: "pending" }] }, SESSION_ID)
+
+					const first = await harness.buildContextText()
+					const second = await harness.buildContextText()
+
+					expect(first).toContain("determinism task")
+					expect(second).toBe(first)
+				})
+
+				it("restores byte-identical context when todos are cleared back to baseline", async () => {
+					const baseline = await harness.buildContextText()
+
+					applyWriteTodos({ todos: [{ content: "clear task", status: "pending" }] }, SESSION_ID)
+					expect(await harness.buildContextText()).not.toBe(baseline)
+
+					applyWriteTodos({ todos: [] }, SESSION_ID)
+					expect(await harness.buildContextText()).toBe(baseline)
+				})
+
+				it("restores byte-identical context when a mutated list is restored to its prior contents", async () => {
+					applyWriteTodos({ todos: [{ id: 1, content: "restore task", status: "pending" }] }, SESSION_ID)
+					const baseline = await harness.buildContextText()
+
+					applyWriteTodos({ todos: [{ id: 1, content: "restore task mutated", status: "in_progress" }] }, SESSION_ID)
+					expect(await harness.buildContextText()).not.toBe(baseline)
+
+					applyWriteTodos({ todos: [{ id: 1, content: "restore task", status: "pending" }] }, SESSION_ID)
+					expect(await harness.buildContextText()).toBe(baseline)
 				})
 			})
 		}
@@ -410,6 +486,161 @@ describe("system prompt stability contract", () => {
 			// Full byte-identity restored: ferment activation leaves no residue in
 			// the prompt a cached prefix would see.
 			expect(await harness.buildFinalSystemPrompt()).toBe(promptBefore)
+		})
+	})
+
+	describe("todo early-nudge trigger boundary", () => {
+		let harness: TestHarness
+
+		beforeEach(async () => {
+			harness = createHarness("non-ferment")
+			__resetTodoStore()
+			setActive(undefined)
+			todosExtension(harness.pi)
+			await harness.fire("session_start", { reason: "new" })
+		})
+
+		afterEach(async () => {
+			await harness.fire("session_shutdown", {})
+			setActive(undefined)
+			__resetTodoStore()
+		})
+
+		async function fireToolExecutionEnd(toolName: string): Promise<void> {
+			await harness.fire("tool_execution_end", {
+				type: "tool_execution_end",
+				toolName,
+				toolCallId: `call-${toolName}`,
+				input: {},
+				isError: false,
+				result: { content: [], details: {} },
+			})
+		}
+
+		function earlyNudgeCalls(): SendMessageCall[] {
+			return harness.getSentMessages().filter((call) => {
+				const details = (call.message as { details?: { reason?: string } } | undefined)?.details
+				return call.options?.deliverAs === "steer" && details?.reason === "early_nudge"
+			})
+		}
+
+		/* Steer messages are transient injections into the current request's
+		 * prefix. Every steer that fires without its declared trigger is a cache
+		 * invalidation, so these tests pin the boundary: only work-tool-call
+		 * threshold crossings on todo-less sessions may emit the early nudge. */
+
+		it("does not fire below the work-tool threshold", async () => {
+			for (let i = 0; i < 4; i++) await fireToolExecutionEnd("bash")
+			expect(earlyNudgeCalls()).toHaveLength(0)
+		})
+
+		it("fires exactly once when the threshold is crossed and never recurs", async () => {
+			for (let i = 0; i < 5; i++) await fireToolExecutionEnd("bash")
+
+			const firstPass = earlyNudgeCalls()
+			expect(firstPass).toHaveLength(1)
+			expect((firstPass[0]?.message as { customType?: string }).customType).toBe(TODO_CUSTOM_ENTRY_TYPE)
+
+			// Further work tool calls must not emit another nudge — the prefix
+			// stabilises after the single steer.
+			for (let i = 0; i < 3; i++) await fireToolExecutionEnd("bash")
+			expect(earlyNudgeCalls()).toHaveLength(1)
+		})
+
+		it("never fires once the session has had a todo list", async () => {
+			applyWriteTodos({ todos: [{ content: "planned task", status: "pending" }] }, SESSION_ID)
+			applyWriteTodos({ todos: [] }, SESSION_ID)
+
+			for (let i = 0; i < 8; i++) await fireToolExecutionEnd("bash")
+			expect(earlyNudgeCalls()).toHaveLength(0)
+		})
+
+		it("does not count todo tool calls toward the threshold", async () => {
+			for (let i = 0; i < 3; i++) await fireToolExecutionEnd("bash")
+			for (let i = 0; i < 3; i++) await fireToolExecutionEnd("write_todos")
+			expect(earlyNudgeCalls()).toHaveLength(0)
+
+			await fireToolExecutionEnd("read")
+			expect(earlyNudgeCalls()).toHaveLength(0)
+
+			// Fourth work tool call plus this one reaches the threshold.
+			await fireToolExecutionEnd("read")
+			expect(earlyNudgeCalls()).toHaveLength(1)
+		})
+	})
+
+	describe("behaviours steer trigger boundary", () => {
+		/* Tool-triggered behaviour bodies are delivered as steer messages at
+		 * tool_result time (wiring.ts). Each steer injects a transient message
+		 * into the current request's prefix, so the boundary matters: a steer
+		 * must follow its declared trigger, and no unrelated state mutation may
+		 * flush or re-emit it. */
+		const glabBehaviour: TriggeredBehaviour = {
+			kind: "triggered",
+			name: "glab-cli",
+			description: "glab CLI guidance",
+			body: "Use glab for GitLab.",
+			triggers: { tool: tool("bash", (i) => String(i.command).startsWith("glab ")) },
+		}
+
+		const stubResolverIO: ResolverIO = {
+			hasCli: () => false,
+			readGitRemoteHost: () => undefined,
+			isGitRepo: () => false,
+			walkPaths: () => new Set<string>(),
+		}
+
+		let harness: TestHarness
+
+		beforeEach(async () => {
+			harness = createHarness("non-ferment")
+			__resetTodoStore()
+			setActive(undefined)
+			todosExtension(harness.pi)
+			wireBehaviours(harness.pi, [glabBehaviour], { resolverIO: stubResolverIO })
+			await harness.fire("session_start", { reason: "new", fork: false, resumed: false, version: "0" })
+		})
+
+		afterEach(async () => {
+			await harness.fire("session_shutdown", {})
+			setActive(undefined)
+			__resetTodoStore()
+		})
+
+		function behaviourSteers(): unknown[] {
+			return harness.getSentMessages().filter((call) => {
+				const message = call.message as { customType?: string } | undefined
+				return call.options?.deliverAs === "steer" && message?.customType === BEHAVIOUR_BODY_TYPE
+			})
+		}
+
+		it("emits no steer for non-matching tool calls or unrelated state mutations", async () => {
+			await harness.fire("turn_start", { turnIndex: 1 })
+			await harness.fire("tool_call", { toolName: "bash", input: { command: "curl https://x" } })
+			await harness.fire("tool_result", { toolName: "bash", input: { command: "curl https://x" } })
+
+			applyWriteTodos({ todos: [{ content: "unrelated task", status: "pending" }] }, SESSION_ID)
+			await harness.buildContextText()
+			await harness.fire("tool_result", { toolName: "bash", input: { command: "echo hi" } })
+
+			expect(behaviourSteers()).toHaveLength(0)
+		})
+
+		it("steers exactly once on the matching trigger and is not re-flushed by unrelated mutations", async () => {
+			await harness.fire("turn_start", { turnIndex: 1 })
+			await harness.fire("tool_call", { toolName: "bash", input: { command: "glab mr list" } })
+			await harness.fire("tool_result", { toolName: "bash", input: { command: "glab mr list" } })
+
+			const firstPass = behaviourSteers()
+			expect(firstPass).toHaveLength(1)
+			expect((firstPass[0] as { message?: { content?: string } })?.message?.content).toContain("Use glab for GitLab.")
+
+			// Unrelated volatile-state mutations must not re-emit the pending body.
+			applyWriteTodos({ todos: [{ content: "another task", status: "pending" }] }, SESSION_ID)
+			await harness.buildContextText()
+			await harness.fire("tool_result", { toolName: "bash", input: { command: "echo next" } })
+
+			expect(behaviourSteers()).toHaveLength(1)
 		})
 	})
 

--- a/src/extensions/prompt-construction/system-prompt-stability.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.test.ts
@@ -98,6 +98,7 @@ interface TestHarness {
 	registerPlanningBlock(): void
 	buildFinalSystemPrompt(): Promise<string>
 	buildContextText(): Promise<string>
+	buildModelVisiblePrefix(): Promise<string>
 	getSentMessages(): SendMessageCall[]
 }
 
@@ -185,6 +186,21 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		return extractTodoContextText(result)
 	}
 
+	/* The provider's cache key is the model-visible prefix of the whole
+	 * request: the system prompt plus the role/customType/content sequence of
+	 * injected transient messages. The projection deliberately strips
+	 * per-message timestamps — those are session metadata the model never
+	 * sees, so excluding them is correctness-preserving, not a codified
+	 * carve-out. */
+	async function buildModelVisiblePrefix(): Promise<string> {
+		const result = (await fire("context", { type: "context", messages: [] })) as ContextResult
+		const messages = (result?.messages ?? []).map((message) => {
+			const projected = message as { role?: string; customType?: string; content?: unknown }
+			return { role: projected.role, customType: projected.customType, content: projected.content }
+		})
+		return JSON.stringify({ systemPrompt: await buildFinalSystemPrompt(), messages })
+	}
+
 	function getSentMessages(): SendMessageCall[] {
 		const mock = pi.sendMessage as ReturnType<typeof vi.fn>
 		return mock.mock.calls.map(([message, options]) => ({ message, options }))
@@ -199,6 +215,7 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		registerPlanningBlock,
 		buildFinalSystemPrompt,
 		buildContextText,
+		buildModelVisiblePrefix,
 		getSentMessages,
 	}
 }
@@ -320,6 +337,70 @@ describe("system prompt stability contract", () => {
 
 					applyWriteTodos({ todos: [{ id: 1, content: "restore task", status: "pending" }] }, SESSION_ID)
 					expect(await harness.buildContextText()).toBe(baseline)
+				})
+			})
+		}
+	})
+
+	describe("multi-turn request prefix identity", () => {
+		for (const surface of ["non-ferment", "ferment-interactive", "ferment-oneshot"] as WorkflowSurface[]) {
+			describe(`workflow: ${surface}`, () => {
+				let harness: TestHarness
+				let unsubscribeTodoSync: (() => void) | undefined
+
+				beforeEach(async () => {
+					harness = createHarness(surface)
+					__resetTodoStore()
+					setActive(surface === "non-ferment" ? undefined : makeFerment())
+					todosExtension(harness.pi)
+					harness.registerPlanningBlock()
+					unsubscribeTodoSync = registerFermentTodoSync(harness.pi, SESSION_ID)
+					await harness.fire("session_start", { reason: "new" })
+				})
+
+				afterEach(async () => {
+					await harness.fire("session_shutdown", {})
+					unsubscribeTodoSync?.()
+					unsubscribeTodoSync = undefined
+					setActive(undefined)
+					__resetTodoStore()
+				})
+
+				/* A later turn in the same session reuses the provider's cached
+				 * prefix only if the whole model-visible prefix (system prompt +
+				 * transient context messages) is byte-identical. Restoring volatile
+				 * state must restore that combined prefix — this is the integration
+				 * guarantee that the per-channel suites prove separately. */
+
+				it("restores the full model-visible prefix when todo state returns to a prior snapshot", async () => {
+					applyWriteTodos({ todos: [{ id: 1, content: "prefix task", status: "pending" }] }, SESSION_ID)
+					const baseline = await harness.buildModelVisiblePrefix()
+
+					applyWriteTodos(
+						{
+							todos: [
+								{ id: 1, content: "prefix task", status: "completed" },
+								{ id: 2, content: "second task", status: "pending", note: "note" },
+							],
+						},
+						SESSION_ID,
+					)
+					const mutated = await harness.buildModelVisiblePrefix()
+					expect(mutated).not.toBe(baseline)
+
+					applyWriteTodos({ todos: [{ id: 1, content: "prefix task", status: "pending" }] }, SESSION_ID)
+					const restored = await harness.buildModelVisiblePrefix()
+					expect(restored).toBe(baseline)
+				})
+
+				it("keeps the full prefix byte-identical across consecutive turns with no state change", async () => {
+					applyWriteTodos(
+						{ todos: [{ id: 1, content: "steady task", status: "in_progress", note: "keep working" }] },
+						SESSION_ID,
+					)
+					const turnA = await harness.buildModelVisiblePrefix()
+					const turnB = await harness.buildModelVisiblePrefix()
+					expect(turnB).toBe(turnA)
 				})
 			})
 		}

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -78,7 +78,7 @@ function restoreTodoStoreFromSessionEntries(sessionManager: Pick<SessionManager,
 	)
 }
 
-const TODO_EARLY_NUDGE_THRESHOLD = 5
+export const TODO_EARLY_NUDGE_THRESHOLD = 5
 
 const TODO_EARLY_NUDGE_MESSAGE =
 	"You are working on a multi-step task without a todo list. Consider creating one to plan your approach — pair the create_todos call with your next work tool call in the same turn."


### PR DESCRIPTION
## Goal

Extend the cache-stability coverage from #993 beyond the system prompt to the two remaining prefix-cache invalidation vectors: transient `context` messages and steer messages delivered via `pi.sendMessage`.

Provider prefix caching is byte-level for the whole request — not just the system prompt. This PR pins the behaviour of the two transient channels that volatile extension state flows through, so a regression that changes their bytes or fires them off their declared triggers fails a test immediately.

## Coverage

| Area | Proven |
|---|---|
| context determinism — all workflows (non-ferment, ferment interactive/oneshot) | Identical state renders byte-identical context; clearing back to baseline restores the exact prior bytes; restoring a mutated list to its prior contents restores the exact prior bytes (ids included) |
| multi-turn request prefix identity — all workflows | Whole model-visible prefix (system prompt + role/customType/content of injected transient messages) restores byte-identical when state returns to a prior snapshot; consecutive turns with no state change are byte-identical. Timestamps are session metadata the model never sees and are deliberately stripped from the projection |
| todo early-nudge trigger boundary | Below-threshold sessions never steer; the threshold fires exactly once per session and never recurs; sessions that ever had a todo list never steer; todo tool calls do not count toward the threshold |
| behaviours steer trigger boundary | Non-matching tool calls never steer; unrelated volatile-state mutations (todo writes, context rebuilds) never flush or re-emit a behaviour body; the matching trigger steers exactly once |

## Changes

- `system-prompt-stability.test.ts`: four new `describe` suites (`context message determinism`, `multi-turn request prefix identity`, `todo early-nudge trigger boundary`, `behaviours steer trigger boundary`).
- New `getSentMessages()` and `buildModelVisiblePrefix()` accessors on the existing test harness so suites can assert on `pi.sendMessage` captures and the combined model-visible prefix without new mock wiring.

No production behavior changes. One export-only source change: `TODO_EARLY_NUDGE_THRESHOLD` is now exported from `todos/index.ts` so the boundary tests share the production constant instead of hard-coding the number.

## Limitations & out of scope

- **Full history replay** — the harness does not simulate persistent message history between turns; multi-turn identity covers the system prompt + transient injections, not a replayed history with assistant/tool entries.
- **Compaction trigger determinism** — compaction decisions and entry selection must depend only on token/turn counts, not volatile extension state. Separate work.
- **Tool-result `details` determinism** — same input + same state must render identical tool-result details. Separate work.

## Testing

- `npx vitest run src/extensions/prompt-construction/system-prompt-stability.test.ts` — 34 passed (9 context determinism, 6 multi-turn prefix identity, 4 early-nudge boundary, 2 steer boundary, 13 existing)
- `pnpm run test src/extensions/prompt-construction src/extensions/todos src/extensions/behaviours --run` — 404 passed
- `pnpm run test src/extensions/ferment --run` — 1118 passed
- `pnpm run typecheck`, `pnpm run lint` — clean

Closes #0
