### PR TITLE
e2e: make TUI and ACP test fixtures hermetic

### DIFF
--- a/tests/e2e/acp/support/acp-fixture.ts
+++ b/tests/e2e/acp/support/acp-fixture.ts
@@ -307,6 +307,12 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 				PI_PACKAGE_DIR: PACKAGE_DIR,
 				KIMCHI_DISABLE_BUILTIN_PROVIDERS: "1",
 				PI_SKIP_VERSION_CHECK: "1",
+				// Disable startup network hooks (self-update probe and RTK
+				// auto-install) so the session boots without background HTTP or
+				// synchronous tar/exec work. Keeps the ACP e2e hermetic and
+				// deterministic.
+				KIMCHI_NO_UPDATE_CHECK: "1",
+				KIMCHI_RTK_AUTO_INSTALL: "0",
 			},
 			cwd: workDir,
 		})

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -205,6 +205,12 @@ export function launchKimchi(
 			`HOME=${sh(fixture.homeDir)}`,
 			`PI_PACKAGE_DIR=${sh(PACKAGE_DIR)}`,
 			"KIMCHI_PERMISSIONS=yolo",
+			// Disable startup network hooks (self-update probe and RTK
+			// auto-install) so the session boots without background HTTP or
+			// synchronous tar/exec work. Keeps the TUI e2e hermetic and its
+			// timing deterministic.
+			"KIMCHI_NO_UPDATE_CHECK=1",
+			"KIMCHI_RTK_AUTO_INSTALL=0",
 			...((fixture.ollama ? [`OLLAMA_HOST=${sh(fixture.ollama.baseUrl)}`] : []) as string[]),
 			...envEntries,
 			"TERM=xterm-256color",


### PR DESCRIPTION
## TL;DR
Make the TUI and ACP end-to-end test fixtures hermetic by disabling two startup network calls when launching the test binary. This removes an external dependency from the tests and reduces timing-related flakiness.

## Requirements
- End-to-end tests should not perform startup network calls to external services.
- No change to product behavior. Both settings already exist and keep their normal defaults outside the tests.

## Changes
- Disable the startup update check and the startup RTK auto-install in the TUI and ACP test fixtures.
