### PR TITLE
e2e: fix flaky billing-warnings test and make TUI/ACP fixtures hermetic

### DIFF
--- a/tests/e2e/acp/support/acp-fixture.ts
+++ b/tests/e2e/acp/support/acp-fixture.ts
@@ -307,6 +307,12 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 				PI_PACKAGE_DIR: PACKAGE_DIR,
 				KIMCHI_DISABLE_BUILTIN_PROVIDERS: "1",
 				PI_SKIP_VERSION_CHECK: "1",
+				// Disable startup network hooks (self-update probe and RTK
+				// auto-install) so the session boots without background HTTP or
+				// synchronous tar/exec work. Keeps the ACP e2e hermetic and
+				// deterministic.
+				KIMCHI_NO_UPDATE_CHECK: "1",
+				KIMCHI_RTK_AUTO_INSTALL: "0",
 			},
 			cwd: workDir,
 		})

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { waitForText } from "./support/assertions.js"
+import { INPUT_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -183,7 +183,17 @@ test("shows caller budget in the footer and command, then refreshes a budget war
 			await waitForText(terminal, "Credits: $18.40", { full: true })
 			await waitForText(terminal, "Budget: 13.73% ($274.59/$2k)", { full: true })
 
-			terminal.submit("/budget")
+			// Write + submit separately — one-shot `terminal.submit("/budget\r")`
+			// can garble the command. An incomplete terminal escape sequence that
+			// is still in flight can coalesce with the `/budget\r` bytes in a
+			// single pty read, so the leading `/` is consumed as part of that
+			// sequence and the editor receives `udget` instead of the command.
+			// Typing the command, confirming it echoed, then pressing Enter on
+			// its own keeps the two apart. Same workaround as the theme-selector
+			// tests.
+			terminal.write("/budget")
+			await waitForText(terminal, "/budget", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
 			await waitForText(terminal, "Budget  Jul 1–Aug 1 UTC", { full: true })
 			await waitForText(terminal, "Personal", { full: true })
 			await waitForText(terminal, "Organization per-user hard", { full: true })

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -183,14 +183,10 @@ test("shows caller budget in the footer and command, then refreshes a budget war
 			await waitForText(terminal, "Credits: $18.40", { full: true })
 			await waitForText(terminal, "Budget: 13.73% ($274.59/$2k)", { full: true })
 
-			// Write + submit separately — one-shot `terminal.submit("/budget\r")`
-			// can garble the command. An incomplete terminal escape sequence that
-			// is still in flight can coalesce with the `/budget\r` bytes in a
-			// single pty read, so the leading `/` is consumed as part of that
-			// sequence and the editor receives `udget` instead of the command.
-			// Typing the command, confirming it echoed, then pressing Enter on
-			// its own keeps the two apart. Same workaround as the theme-selector
-			// tests.
+			// Type the command and wait for it to echo, then press Enter on its own.
+			// A one-shot submit can drop the command's leading `/`, which appears to
+			// happen when the Enter bytes merge with the command text in one pty read.
+			// Same approach as the theme-selector and todo-overlay tests.
 			terminal.write("/budget")
 			await waitForText(terminal, "/budget", { timeoutMs: INPUT_TIMEOUT_MS })
 			terminal.submit("")

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -205,6 +205,12 @@ export function launchKimchi(
 			`HOME=${sh(fixture.homeDir)}`,
 			`PI_PACKAGE_DIR=${sh(PACKAGE_DIR)}`,
 			"KIMCHI_PERMISSIONS=yolo",
+			// Disable startup network hooks (self-update probe and RTK
+			// auto-install) so the session boots without background HTTP or
+			// synchronous tar/exec work. Keeps the TUI e2e hermetic and its
+			// timing deterministic.
+			"KIMCHI_NO_UPDATE_CHECK=1",
+			"KIMCHI_RTK_AUTO_INSTALL=0",
 			...((fixture.ollama ? [`OLLAMA_HOST=${sh(fixture.ollama.baseUrl)}`] : []) as string[]),
 			...envEntries,
 			"TERM=xterm-256color",


### PR DESCRIPTION
## TL;DR
Fix a flaky TUI end-to-end test (billing-warnings) where the `/budget` command was sometimes dropped so the budget panel never rendered, and make the TUI and ACP test fixtures hermetic so tests do not depend on startup network calls.

## Requirements
- The billing-warnings test must submit `/budget` reliably and still assert the panel shows the expected budget breakdown and the warning transition.
- End-to-end tests should not perform startup network calls to external services.
- No change to product behavior. The two settings used by the fixtures already exist and keep their normal defaults outside the tests.

## Changes
- Type the command and wait for it to echo before pressing Enter, so the Enter keystroke does not coalesce with the command text and drop its leading character. This matches the existing approach used by the theme selector and todo overlay tests.
- Disable the startup update check and the startup RTK auto-install in the TUI and ACP test fixtures.

Closes #1010
