### PR TITLE
fix(rtk-rewrite): pass through all package managers in compound commands

### DIFF
--- a/src/extensions/rtk-rewrite.test.ts
+++ b/src/extensions/rtk-rewrite.test.ts
@@ -52,8 +52,17 @@ describe("isRtkPassthrough", () => {
 		"cd '/tmp/project with spaces' && npm install",
 		"git status || bunx tsx script.ts",
 		"(pnpm run lint)",
+		"$(pnpm run lint)",
+		"echo $(pnpm run lint)",
+		"cat <(pnpm run lint)",
+		"{ pnpm run lint; }",
+		"if true; then pnpm test; fi",
+		"echo ready\npnpm test",
 		// leading environment assignments still invoke pnpm directly
 		"CI=1 pnpm test",
+		// Parse failures bypass the optional RTK optimization rather than risk
+		// changing the command's semantics.
+		"git status ${BROKEN",
 	])("returns true for %s", (cmd) => {
 		expect(isRtkPassthrough(cmd)).toBe(true)
 	})
@@ -63,6 +72,7 @@ describe("isRtkPassthrough", () => {
 		"cargo test",
 		"echo pnpm run lint", // pnpm not at start
 		'echo "cd /tmp && pnpm exec vitest --version"',
+		"echo '$(pnpm test)'", // single-quoted command substitution is literal text
 		"echo ready && echo pnpm exec vitest --version",
 		"bash -c 'pnpm exec vitest --version'",
 	])("returns false for %s", (cmd) => {

--- a/src/extensions/rtk-rewrite.test.ts
+++ b/src/extensions/rtk-rewrite.test.ts
@@ -5,11 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import {
 	_resetRtkState,
 	detectRtk,
-	getBashCommandForDisplay,
 	isRtkPassthrough,
 	rewritePreparedBashCommand,
 	rewriteWithRtk,
-	rtkSpawnHook,
 } from "./rtk-rewrite.js"
 
 // ---------------------------------------------------------------------------
@@ -18,7 +16,7 @@ import {
 
 describe("isRtkPassthrough", () => {
 	it.each([
-		// explicit `run` forms
+		// package-manager scripts
 		"pnpm run lint",
 		"npm run lint",
 		"yarn run build",
@@ -26,10 +24,17 @@ describe("isRtkPassthrough", () => {
 		"pnpm run lint --fix",
 		"npm run lint:fix",
 		"  pnpm run lint", // leading whitespace
-		// npx / bunx
+		// package-manager built-ins
+		"npm install",
+		"npm ci",
+		"yarn install",
+		"yarn add react",
+		"bun install",
+		"bun add react",
+		// package launchers
 		"npx eslint .",
 		"bunx tsx script.ts",
-		// all pnpm commands — scripts AND built-ins — are passed through
+		// all pnpm commands are passed through
 		"pnpm lint",
 		"pnpm build",
 		"pnpm typecheck",
@@ -42,6 +47,13 @@ describe("isRtkPassthrough", () => {
 		"pnpm update",
 		"pnpm remove lodash",
 		"pnpm exec eslint .",
+		// package-manager commands in compound shell expressions
+		"cd /tmp && pnpm exec vitest --version",
+		"cd '/tmp/project with spaces' && npm install",
+		"git status || bunx tsx script.ts",
+		"(pnpm run lint)",
+		// leading environment assignments still invoke pnpm directly
+		"CI=1 pnpm test",
 	])("returns true for %s", (cmd) => {
 		expect(isRtkPassthrough(cmd)).toBe(true)
 	})
@@ -49,8 +61,10 @@ describe("isRtkPassthrough", () => {
 	it.each([
 		"git status",
 		"cargo test",
-		"npm install", // npm without `run` is not passed through
 		"echo pnpm run lint", // pnpm not at start
+		'echo "cd /tmp && pnpm exec vitest --version"',
+		"echo ready && echo pnpm exec vitest --version",
+		"bash -c 'pnpm exec vitest --version'",
 	])("returns false for %s", (cmd) => {
 		expect(isRtkPassthrough(cmd)).toBe(false)
 	})
@@ -204,13 +218,17 @@ describe("rewriteWithRtk", () => {
 		expect(rewriteWithRtk("git status")).toBe("rtk git status")
 	})
 
-	it("does not call rtk for package-manager script invocations", async () => {
+	it("does not call rtk for package-manager or launcher invocations", async () => {
 		seedRtkAvailable()
 		await detectRtk()
 
 		expect(rewriteWithRtk("pnpm run lint")).toBe("pnpm run lint")
-		expect(rewriteWithRtk("npm run build")).toBe("npm run build")
+		expect(rewriteWithRtk("npm install")).toBe("npm install")
+		expect(rewriteWithRtk("cd /tmp && npm install")).toBe("cd /tmp && npm install")
+		expect(rewriteWithRtk("yarn add react")).toBe("yarn add react")
+		expect(rewriteWithRtk("bun install")).toBe("bun install")
 		expect(rewriteWithRtk("npx eslint .")).toBe("npx eslint .")
+		expect(rewriteWithRtk("cd /tmp && pnpm exec vitest --version")).toBe("cd /tmp && pnpm exec vitest --version")
 		expect(mockExecFileSync).not.toHaveBeenCalled()
 	})
 
@@ -264,58 +282,5 @@ describe("rewriteWithRtk", () => {
 			return "rtk git log --oneline -10 && echo done\n"
 		})
 		rewriteWithRtk("git log --oneline -10 && echo done")
-	})
-})
-
-describe("rtkSpawnHook", () => {
-	let tmpRtkRoot: string | undefined
-	let previousKimchiDir: string | undefined
-	let previousHome: string | undefined
-
-	beforeEach(() => {
-		_resetRtkState()
-		previousKimchiDir = process.env.KIMCHI_CODING_AGENT_DIR
-		previousHome = process.env.HOME
-		tmpRtkRoot = mkdtempSync(join(tmpdir(), "kimchi-rtk-spawn-test-"))
-		process.env.KIMCHI_CODING_AGENT_DIR = tmpRtkRoot
-		process.env.HOME = tmpRtkRoot
-		mockExecFileSync.mockReset()
-		mockExecFile.mockReset()
-	})
-
-	afterEach(() => {
-		if (tmpRtkRoot) rmSync(tmpRtkRoot, { recursive: true, force: true })
-		tmpRtkRoot = undefined
-		if (previousKimchiDir === undefined) delete process.env.KIMCHI_CODING_AGENT_DIR
-		else process.env.KIMCHI_CODING_AGENT_DIR = previousKimchiDir
-		if (previousHome === undefined) delete process.env.HOME
-		else process.env.HOME = previousHome
-	})
-
-	it("rewrites the command in a BashSpawnContext", async () => {
-		// Seed rtk as available.
-		mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
-			cb(null, "rtk 0.40.0\n", "")
-		})
-		await detectRtk()
-
-		mockExecFileSync.mockReturnValueOnce("rtk git status\n")
-		const ctx = { command: "git status", cwd: "/tmp", env: process.env }
-		const result = rtkSpawnHook(ctx)
-		expect(result.command).toBe("rtk git status")
-		expect(result.cwd).toBe("/tmp")
-		expect(getBashCommandForDisplay("git status")).toBe("rtk git status")
-	})
-
-	it("returns the original context when command is unchanged", async () => {
-		mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
-			cb(null, "rtk 0.40.0\n", "")
-		})
-		await detectRtk()
-
-		mockExecFileSync.mockReturnValueOnce("echo hello\n")
-		const ctx = { command: "echo hello", cwd: "/tmp", env: process.env }
-		const result = rtkSpawnHook(ctx)
-		expect(result).toBe(ctx) // Same reference — no copy.
 	})
 })

--- a/src/extensions/rtk-rewrite.test.ts
+++ b/src/extensions/rtk-rewrite.test.ts
@@ -58,6 +58,8 @@ describe("isRtkPassthrough", () => {
 		"{ pnpm run lint; }",
 		"if true; then pnpm test; fi",
 		"echo ready\npnpm test",
+		"# run tests\npnpm test",
+		"  # run tests\npnpm test",
 		// leading environment assignments still invoke pnpm directly
 		"CI=1 pnpm test",
 		// Parse failures bypass the optional RTK optimization rather than risk

--- a/src/extensions/rtk-rewrite.ts
+++ b/src/extensions/rtk-rewrite.ts
@@ -1,11 +1,7 @@
 import { execFile, execFileSync } from "node:child_process"
 import { existsSync } from "node:fs"
-import {
-	type BashOperations,
-	type BashSpawnContext,
-	createLocalBashOperations,
-	type ExtensionAPI,
-} from "@earendil-works/pi-coding-agent"
+import { type BashOperations, createLocalBashOperations, type ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { parse as parseShell } from "shell-quote"
 import { applyEnabledBashHooks } from "../resources/bash-hooks.js"
 import { globalRtkLinkPath, managedRtkPath } from "../resources/rtk-install.js"
 import { isResourceEnabled } from "../resources/store.js"
@@ -64,34 +60,67 @@ export function detectRtk(): Promise<boolean> {
 }
 
 /**
- * Package-manager script invocations that RTK must not rewrite.
+ * Package-manager invocations that RTK must not rewrite.
  *
  * RTK hijacks subcommand names that collide with its own — the most painful
  * example is `pnpm lint` / `pnpm run lint` → `rtk lint` (its own ESLint
  * wrapper), which breaks projects that use Biome or other linters.
  *
- * Rather than maintaining an allowlist of pnpm built-ins, we passthrough
- * ALL `pnpm …` commands.  RTK's token-compression benefit on pnpm subcommands
- * is negligible compared to the risk of future subcommand name collisions.
- * Other package managers (`npm run`, `yarn run`, `bun run`) are also
- * passed through because they may invoke arbitrary user-defined scripts.
+ * Rather than maintaining an allowlist of package-manager built-ins, we pass
+ * through every invocation of the supported package managers and launchers.
+ * RTK's token-compression benefit on these commands is negligible compared to
+ * the risk of current or future subcommand collisions.
  */
-const RTK_PASSTHROUGH_RE = /^\s*(pnpm|npm\s+run|yarn\s+run|bun\s+run)\b|^\s*(npx|bunx)\s/
+const RTK_PASSTHROUGH_COMMANDS = new Set(["pnpm", "npm", "yarn", "bun", "npx", "bunx"])
+
+// Common shell separators that begin another executable command. shell-quote
+// keeps quoted operators inside string tokens, avoiding substring matches such
+// as `echo "pnpm test"`. This deliberately is not a complete Bash parser.
+const COMMAND_SEPARATORS = new Set(["||", "&&", "|&", "&", ";", "|"])
+const LEADING_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
+
+function segmentInvokesPassthroughCommand(tokens: string[]): boolean {
+	let commandIndex = 0
+	while (commandIndex < tokens.length && LEADING_ASSIGNMENT_RE.test(tokens[commandIndex] ?? "")) commandIndex++
+
+	const command = tokens[commandIndex]
+	if (command === undefined) return false
+	return RTK_PASSTHROUGH_COMMANDS.has(command)
+}
 
 /**
  * Returns true for commands that must bypass RTK rewriting entirely.
  */
 export function isRtkPassthrough(command: string): boolean {
-	return RTK_PASSTHROUGH_RE.test(command)
+	try {
+		const entries = parseShell(command)
+		let segment: string[] = []
+
+		for (const entry of entries) {
+			if (typeof entry === "string") {
+				segment.push(entry)
+				continue
+			}
+
+			if ("op" in entry && COMMAND_SEPARATORS.has(entry.op)) {
+				if (segmentInvokesPassthroughCommand(segment)) return true
+				segment = []
+			}
+		}
+
+		return segmentInvokesPassthroughCommand(segment)
+	} catch {
+		return false
+	}
 }
 
 /**
  * Synchronously ask `rtk rewrite` to compress / rewrite a command string.
- * Used as a pi-mono BashSpawnHook (which must be synchronous).
+ * Used by the synchronous `tool_call` extension event before Bash execution.
  *
  * Returns the original command unchanged when:
  *   - rtk is not available or hooks.rtk-rewrite is disabled
- *   - the command is a package-manager script invocation (passthrough)
+ *   - the command invokes a passthrough package manager or launcher
  *   - rtk returns empty output or the same string
  *   - the subprocess times out or fails to spawn
  */
@@ -126,17 +155,6 @@ const rewriteCache = new Map<string, string>()
 export function getBashCommandForDisplay(command: string | undefined): string | undefined {
 	if (!command) return command
 	return rewriteCache.get(command) ?? command
-}
-
-/**
- * BashSpawnHook for pi-mono's createBashToolDefinition.
- * Rewrites the command through `rtk rewrite` before the shell spawns.
- * Caches the result so renderCall can display it without a subprocess.
- */
-export function rtkSpawnHook(context: BashSpawnContext): BashSpawnContext {
-	const rewritten = rewriteWithRtk(context.command)
-	rewriteCache.set(context.command, rewritten)
-	return rewritten !== context.command ? { ...context, command: rewritten } : context
 }
 
 /** Reset cached detection state (for tests). */

--- a/src/extensions/rtk-rewrite.ts
+++ b/src/extensions/rtk-rewrite.ts
@@ -82,6 +82,7 @@ const RTK_PASSTHROUGH_COMMANDS = new Set(["pnpm", "npm", "yarn", "bun", "npx", "
 const COMMAND_SEPARATORS = new Set(["||", "&&", "|&", "&", ";", "|", "(", "<("])
 const LEADING_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
 const COMMAND_PREFIXES = new Set(["!", "{", "if", "then", "elif", "else", "while", "until", "do", "time"])
+const FULL_LINE_COMMENT_RE = /^[\t ]*#[^\r\n]*(?:\r?\n|$)/gm
 
 function segmentInvokesPassthroughCommand(tokens: string[]): boolean {
 	let commandIndex = 0
@@ -102,10 +103,10 @@ function segmentInvokesPassthroughCommand(tokens: string[]): boolean {
  */
 export function isRtkPassthrough(command: string): boolean {
 	try {
-		// shell-quote treats newlines as whitespace rather than command
-		// boundaries. Normalize them to semicolons; semicolons inside quotes
-		// remain string content, while escaped newlines remain escaped.
-		const entries = parseShell(command.replace(/\r?\n/g, ";"))
+		// shell-quote treats a comment as extending to the end of its input and
+		// newlines as whitespace. Remove full-line comments before normalizing
+		// newlines so a following command is still parsed as its own segment.
+		const entries = parseShell(command.replace(FULL_LINE_COMMENT_RE, "").replace(/\r?\n/g, ";"))
 		let segment: string[] = []
 
 		for (const entry of entries) {

--- a/src/extensions/rtk-rewrite.ts
+++ b/src/extensions/rtk-rewrite.ts
@@ -73,15 +73,24 @@ export function detectRtk(): Promise<boolean> {
  */
 const RTK_PASSTHROUGH_COMMANDS = new Set(["pnpm", "npm", "yarn", "bun", "npx", "bunx"])
 
-// Common shell separators that begin another executable command. shell-quote
+// Shell operators that begin another executable command context. shell-quote
 // keeps quoted operators inside string tokens, avoiding substring matches such
-// as `echo "pnpm test"`. This deliberately is not a complete Bash parser.
-const COMMAND_SEPARATORS = new Set(["||", "&&", "|&", "&", ";", "|"])
+// as `echo "pnpm test"`. Opening subshell/process-substitution operators are
+// included so nested commands such as `$(pnpm test)` and `<(pnpm test)` are
+// checked independently from their outer command. Quoted source passed to a
+// nested shell, such as `bash -c 'pnpm test'`, remains outside this policy.
+const COMMAND_SEPARATORS = new Set(["||", "&&", "|&", "&", ";", "|", "(", "<("])
 const LEADING_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
+const COMMAND_PREFIXES = new Set(["!", "{", "if", "then", "elif", "else", "while", "until", "do", "time"])
 
 function segmentInvokesPassthroughCommand(tokens: string[]): boolean {
 	let commandIndex = 0
-	while (commandIndex < tokens.length && LEADING_ASSIGNMENT_RE.test(tokens[commandIndex] ?? "")) commandIndex++
+	while (commandIndex < tokens.length) {
+		const token = tokens[commandIndex]
+		if (token === undefined) return false
+		if (!LEADING_ASSIGNMENT_RE.test(token) && !COMMAND_PREFIXES.has(token)) break
+		commandIndex++
+	}
 
 	const command = tokens[commandIndex]
 	if (command === undefined) return false
@@ -93,7 +102,10 @@ function segmentInvokesPassthroughCommand(tokens: string[]): boolean {
  */
 export function isRtkPassthrough(command: string): boolean {
 	try {
-		const entries = parseShell(command)
+		// shell-quote treats newlines as whitespace rather than command
+		// boundaries. Normalize them to semicolons; semicolons inside quotes
+		// remain string content, while escaped newlines remain escaped.
+		const entries = parseShell(command.replace(/\r?\n/g, ";"))
 		let segment: string[] = []
 
 		for (const entry of entries) {
@@ -110,7 +122,10 @@ export function isRtkPassthrough(command: string): boolean {
 
 		return segmentInvokesPassthroughCommand(segment)
 	} catch {
-		return false
+		// RTK is an optional optimization. If we cannot safely classify a shell
+		// command, preserve its original semantics instead of asking RTK to
+		// reinterpret malformed or unsupported syntax.
+		return true
 	}
 }
 


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The anchored regex only matched pnpm at string start, and for npm/yarn/bun only the `run` subcommand — so `cd /x && pnpm test` or `npm install` were sent to RTK and rewritten, breaking user-defined scripts and risking subcommand collisions (e.g. `pnpm lint` → `rtk lint`).

Parse with shell-quote and check the first real token of each separator-delimited segment (after VAR=value prefixes) against a flat passthrough set: pnpm, npm, yarn, bun, npx, bunx. Quoted operators stay inside string tokens, so `echo "a && pnpm x"` is still rewritten.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
