### PR TITLE
fix(provider): omit Pi completion token limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ With the metadata above, the orchestrator will use minimax for simple build chun
 
 Metadata can also be managed interactively via `/multi-model` → "Edit model metadata" — this is the only in-app path for configuring or overriding metadata, so model selection stays uninterrupted. Custom overrides can be reset to defaults from the same menu. Metadata for builtin models can be overridden the same way.
 
+#### Completion token limits
+
+Kimchi omits Pi's estimated `max_completion_tokens` and `max_tokens` fields from requests to managed Kimchi providers. The gateway determines how much output fits using the model's actual tokenizer; output-budget enforcement belongs at the gateway rather than in Pi's approximate client-side context calculation.
+
 ### Phase tracking
 
 Kimchi tags every LLM request with a `phase:{name}` label for usage analytics and cost attribution. The orchestrator sets the phase as work progresses and it is displayed in the status line.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,7 @@ import lspExtension from "./extensions/lsp.js"
 import mcpAdapterExtension from "./extensions/mcp-adapter/index.js"
 import modelGuardExtension from "./extensions/model-guard.js"
 import modelSwitchExtension from "./extensions/model-switch.js"
+import omitKimchiMaxTokensExtension from "./extensions/omit-kimchi-max-tokens.js"
 import { createSessionModeOnboardingForStartup } from "./extensions/onboarding/session-mode-startup.js"
 import { applyRoleAugmentation } from "./extensions/orchestration/model-roles.js"
 import orphanToolResultSanitizerExtension from "./extensions/orphan-tool-result-sanitizer.js"
@@ -625,6 +626,7 @@ try {
 			modelGuardExtension,
 			orphanToolResultRepairExtension,
 			orphanToolResultSanitizerExtension,
+			omitKimchiMaxTokensExtension,
 			piiRedactionExtension,
 			stripImagesExtension,
 			traceIdExtension,

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import omitKimchiMaxTokensExtension from "../../omit-kimchi-max-tokens.js"
 
 vi.mock("@earendil-works/pi-coding-agent", async () => {
 	return {
@@ -327,7 +328,7 @@ describe("runAgent — telemetry extension", () => {
 		vi.clearAllMocks()
 	})
 
-	it("passes telemetryExtension as extensionFactories to DefaultResourceLoader", async () => {
+	it("passes required Kimchi extensions to DefaultResourceLoader", async () => {
 		const session = makeFakeSession({})
 		mockCreateAgentSession.mockResolvedValue({
 			session: session as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
@@ -344,7 +345,8 @@ describe("runAgent — telemetry extension", () => {
 		const ctorArg = mockDefaultResourceLoader.mock.calls[0]?.[0]
 		expect(ctorArg).toHaveProperty("extensionFactories")
 		expect(Array.isArray(ctorArg?.extensionFactories)).toBe(true)
-		expect(ctorArg?.extensionFactories).toHaveLength(3)
+		expect(ctorArg?.extensionFactories).toHaveLength(4)
+		expect(ctorArg?.extensionFactories).toContain(omitKimchiMaxTokensExtension)
 		expect(mockReadTelemetryConfig).toHaveBeenCalled()
 		expect(mockTelemetryExtension).toHaveBeenCalledWith(mockReadTelemetryConfig.mock.results[0]?.value)
 	})
@@ -417,8 +419,8 @@ describe("runAgent — telemetry extension", () => {
 
 		const linkedLoaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0]
 		const ordinaryLoaderOptions = mockDefaultResourceLoader.mock.calls[1]?.[0]
-		expect(linkedLoaderOptions?.extensionFactories).toHaveLength(4)
-		expect(ordinaryLoaderOptions?.extensionFactories).toHaveLength(3)
+		expect(linkedLoaderOptions?.extensionFactories).toHaveLength(5)
+		expect(ordinaryLoaderOptions?.extensionFactories).toHaveLength(4)
 		expect(linkedSession.setActiveToolsByName).toHaveBeenCalledWith(["submit_agent_report"])
 		expect(ordinarySession.setActiveToolsByName).toHaveBeenCalledWith([])
 	})
@@ -434,7 +436,7 @@ describe("runAgent — telemetry extension", () => {
 			abortSpy,
 			emitUsage: false,
 			promptAction: async (emit) => {
-				const factory = mockDefaultResourceLoader.mock.calls[0]?.[0]?.extensionFactories?.[3]
+				const factory = mockDefaultResourceLoader.mock.calls[0]?.[0]?.extensionFactories?.[4]
 				const registerTool = vi.fn()
 				runInlineExtension(factory, { registerTool } as unknown as ExtensionAPI)
 				const tool = registerTool.mock.calls[0]?.[0]

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -21,6 +21,7 @@ import { runAsAgentWorker } from "../../agent-worker-context.js"
 import bashDefaultTimeoutExtension, { createSubagentBashClampExtension } from "../../bash-default-timeout.js"
 import { FERMENT_TOOL_NAMES } from "../../ferment/tool-names.js"
 import infrastructureBreakerExtension from "../../infrastructure-breaker.js"
+import omitKimchiMaxTokensExtension from "../../omit-kimchi-max-tokens.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import { ModelRegistry } from "../../orchestration/model-registry/index.js"
 import type { Phase } from "../../orchestration/model-registry/types.js"
@@ -472,6 +473,7 @@ ${skillLines}`
 		telemetryExtension(readTelemetryConfig()),
 		bashExtension,
 		infrastructureBreakerExtension,
+		omitKimchiMaxTokensExtension,
 	]
 	if (options.workerReport) {
 		extensionFactories.push(createWorkerReportExtension(options.workerReport))

--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -8,12 +8,20 @@ import {
 	type JudgeApiResult,
 	type JudgeJourneyGradeInput,
 	type JudgePhaseInput,
+	judgeApiCall,
 	judgeJourneyGrade,
 	judgeJourneyGradeViaSubagent,
 	judgePhaseGrade,
 	judgePhaseGradeViaSubagent,
 } from "./judge.js"
 import { captureJudgeContext } from "./state.js"
+
+const completeMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@earendil-works/pi-ai/compat", async () => {
+	const actual = await vi.importActual<typeof import("@earendil-works/pi-ai/compat")>("@earendil-works/pi-ai/compat")
+	return { ...actual, complete: (...args: unknown[]) => completeMock(...args) }
+})
 
 describe("isGrade", () => {
 	it("accepts the five valid letters", () => {
@@ -914,5 +922,38 @@ describe("describeJudgeModel", () => {
 	it("falls back to the captured session model in multi-model mode when the role does not resolve", () => {
 		captureJudgeContext(sessionModel, { find: () => undefined } as unknown as ModelRegistry, true)
 		expect(describeJudgeModel()).toBe("kimchi-dev/glm-5.2-fp8")
+	})
+})
+
+describe("judgeApiCall", () => {
+	afterEach(() => {
+		completeMock.mockReset()
+		captureJudgeContext(undefined, undefined, false)
+	})
+
+	it("omits Pi defaults but preserves an explicit Kimchi judge token limit", async () => {
+		const model = {
+			provider: "kimchi-dev",
+			id: "judge-x",
+			api: "openai-completions",
+		} as unknown as Model<Api>
+		const registry = {
+			getApiKeyAndHeaders: vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key", headers: {} }),
+		} as unknown as ModelRegistry
+		const requests: Array<{ maxTokens?: number; onPayload?: (payload: unknown) => unknown }> = []
+		completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
+			requests.push(options as (typeof requests)[number])
+			return { content: [{ type: "text", text: "ok" }], stopReason: "stop" }
+		})
+		captureJudgeContext(model, registry, false)
+
+		await judgeApiCall("system", "user")
+		await judgeApiCall("system", "user", 100)
+
+		expect(requests[0].onPayload?.({ max_completion_tokens: 100, max_tokens: 100, messages: [] })).toEqual({
+			messages: [],
+		})
+		expect(requests[1]).toMatchObject({ maxTokens: 100 })
+		expect(requests[1].onPayload).toBeUndefined()
 	})
 })

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -23,6 +23,7 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import { complete } from "@earendil-works/pi-ai/compat"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import type { CharterClauseVerdict, FermentCharter, Grade } from "../../ferment/types.js"
+import { omitKimchiMaxTokensFromPayload } from "../omit-kimchi-max-tokens.js"
 import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
 import { renderCharterFull } from "./charter.js"
 import { getJudgeModel, getJudgeModelRegistry, isJudgeMultiModelEnabled } from "./state.js"
@@ -88,7 +89,9 @@ export async function judgeApiCall(systemPrompt: string, userMsg: string, maxTok
 				apiKey: auth.apiKey,
 				headers: auth.headers,
 				signal: AbortSignal.timeout(45_000),
-				...(maxTokens === undefined ? {} : { maxTokens }),
+				...(maxTokens === undefined
+					? { onPayload: (payload: unknown) => omitKimchiMaxTokensFromPayload(payload, model.provider) }
+					: { maxTokens }),
 			},
 		)
 

--- a/src/extensions/omit-kimchi-max-tokens.test.ts
+++ b/src/extensions/omit-kimchi-max-tokens.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { Model } from "@earendil-works/pi-ai"
+import { streamSimple } from "@earendil-works/pi-ai/compat"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { updateModelsConfig } from "../models.js"
+import { createExtensionApi } from "./__mocks__/extension-api.js"
+import omitKimchiMaxTokensExtension, { omitKimchiMaxTokens } from "./omit-kimchi-max-tokens.js"
+
+const KIMI_METADATA = {
+	slug: "kimi-k2.7",
+	display_name: "Kimi K2.7",
+	provider: "ai-enabler",
+	reasoning: true,
+	input_modalities: ["text"],
+	is_serverless: true,
+	limits: { context_window: 262_144, max_output_tokens: 262_144 },
+}
+
+function openAIStreamResponse(): Response {
+	const chunk = {
+		id: "completion",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "kimi-k2.7",
+		choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+	}
+	return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	})
+}
+
+describe("Kimchi max token request invariant", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-max-tokens-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => Response.json({ models: [KIMI_METADATA] })),
+		)
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+		vi.restoreAllMocks()
+	})
+
+	it("registers the request transform", () => {
+		const { api, getHandler } = createExtensionApi()
+		omitKimchiMaxTokensExtension(api)
+		expect(getHandler("before_provider_request")).toBe(omitKimchiMaxTokens)
+	})
+
+	it.each([
+		["max_completion_tokens", undefined],
+		["max_tokens", { maxTokensField: "max_tokens" as const }],
+	])("omits Pi's %s field from the outgoing Kimi request", async (_field, compat) => {
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const provider = config.providers["kimchi-dev"]
+		const model: Model<"openai-completions"> = {
+			...provider.models[0],
+			provider: "kimchi-dev",
+			api: "openai-completions",
+			baseUrl: provider.baseUrl,
+			...(compat && { compat }),
+		}
+		let sentPayload: Record<string, unknown> | undefined
+		const requestFetch: typeof fetch = async (_input, init) => {
+			sentPayload = JSON.parse(String(init?.body))
+			return openAIStreamResponse()
+		}
+
+		await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "incident regression", timestamp: Date.now() }] },
+			{
+				apiKey: "test",
+				fetch: requestFetch,
+				onPayload: (payload) => omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model }),
+			},
+		).result()
+
+		expect(sentPayload).toBeDefined()
+		expect(sentPayload).not.toHaveProperty("max_completion_tokens")
+		expect(sentPayload).not.toHaveProperty("max_tokens")
+	})
+
+	it.each([
+		"kimchi-dev/anthropic",
+		"kimchi-experimental",
+	])("omits token limits for the managed %s provider", (provider) => {
+		const result = omitKimchiMaxTokens(
+			{ type: "before_provider_request", payload: { max_completion_tokens: 10, max_tokens: 10 } },
+			{ model: { provider } },
+		)
+		expect(result).toEqual({})
+	})
+
+	it("leaves non-Kimchi provider payloads unchanged", () => {
+		const payload = { max_completion_tokens: 10, messages: [] }
+		expect(omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model: { provider: "openai" } })).toBe(
+			undefined,
+		)
+		expect(payload).toEqual({ max_completion_tokens: 10, messages: [] })
+	})
+})

--- a/src/extensions/omit-kimchi-max-tokens.ts
+++ b/src/extensions/omit-kimchi-max-tokens.ts
@@ -1,0 +1,30 @@
+import type { BeforeProviderRequestEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+
+function isKimchiProvider(provider: string): boolean {
+	return provider === "kimchi-dev" || provider.startsWith("kimchi-dev/") || provider === "kimchi-experimental"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function omitKimchiMaxTokensFromPayload(payload: unknown, provider: string): unknown {
+	if (!isKimchiProvider(provider) || !isRecord(payload)) return payload
+	if (!("max_completion_tokens" in payload) && !("max_tokens" in payload)) return payload
+
+	const { max_completion_tokens: _maxCompletionTokens, max_tokens: _maxTokens, ...rest } = payload
+	return rest
+}
+
+export function omitKimchiMaxTokens(
+	event: BeforeProviderRequestEvent,
+	ctx: { model?: Pick<NonNullable<ExtensionContext["model"]>, "provider"> },
+): unknown {
+	if (!ctx.model) return
+	const payload = omitKimchiMaxTokensFromPayload(event.payload, ctx.model.provider)
+	return payload === event.payload ? undefined : payload
+}
+
+export default function omitKimchiMaxTokensExtension(pi: ExtensionAPI) {
+	pi.on("before_provider_request", omitKimchiMaxTokens)
+}

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -18,8 +18,8 @@ vi.mock("@earendil-works/pi-ai/compat", async () => {
 	}
 })
 
-function fakeModel(id = "test-model"): Model<Api> {
-	return { provider: "openai", id, api: "openai-completions" } as Model<Api>
+function fakeModel(id = "test-model", provider = "openai"): Model<Api> {
+	return { provider, id, api: "openai-completions" } as Model<Api>
 }
 
 function fakeRegistry(
@@ -66,6 +66,23 @@ describe("classifyToolCall", () => {
 		expect(result.riskScore).toBe("low")
 		expect(result.ok).toBe(true)
 		expect(completeMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("keeps classifier tags while omitting Pi token limits for Kimchi", async () => {
+		let sentPayload: unknown
+		completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
+			const { onPayload } = options as { onPayload: (payload: unknown) => unknown }
+			sentPayload = onPayload({ max_completion_tokens: 100, max_tokens: 100, tags: ["existing"] })
+			return fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' })
+		})
+
+		await classifyToolCall(
+			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID, "kimchi-dev")]),
+			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
+			{ timeoutMs: 5000 },
+		)
+
+		expect(sentPayload).toEqual({ tags: ["source:classifier", "existing"] })
 	})
 
 	it("retries up to 3 times on abort before giving up", async () => {

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai"
 import { complete } from "@earendil-works/pi-ai/compat"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { omitKimchiMaxTokensFromPayload } from "../omit-kimchi-max-tokens.js"
 import classifierSystemPrompt from "./prompts/classifier-system-prompt.js"
 import type { ClassifierResult, ClassifierVerdict, RiskScore } from "./types.js"
 
@@ -107,7 +108,7 @@ async function runClassifier(
 						const existing = Array.isArray(p.tags) ? (p.tags as string[]) : []
 						p.tags = [CLASSIFIER_REQUEST_TAG, ...existing]
 					}
-					return payload
+					return omitKimchiMaxTokensFromPayload(payload, model.provider)
 				},
 			},
 		)

--- a/src/extensions/strip-images.test.ts
+++ b/src/extensions/strip-images.test.ts
@@ -1,16 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 // All mock functions must be vi.hoisted
-const { mockNotify, mockRegisterCommand } = vi.hoisted(() => ({
+const { completeMock, mockNotify, mockRegisterCommand } = vi.hoisted(() => ({
+	completeMock: vi.fn(),
 	mockNotify: vi.fn(),
 	mockRegisterCommand: vi.fn(),
 }))
 
+vi.mock("@earendil-works/pi-ai/compat", async () => {
+	const actual = await vi.importActual<typeof import("@earendil-works/pi-ai/compat")>("@earendil-works/pi-ai/compat")
+	return { ...actual, complete: (...args: unknown[]) => completeMock(...args) }
+})
+
 // Mock the ExtensionAPI interface
 const createMockCtx = (overrides: Record<string, unknown> = {}) => ({
-	model: overrides.model ?? { id: "test-model", input: ["text", "image"] },
+	model: overrides.model ?? { provider: "kimchi-dev", id: "test-model", input: ["text", "image"] },
 	modelRegistry: overrides.modelRegistry ?? {
-		getAvailable: () => [{ id: "vision-model", input: ["text", "image"] }],
+		getAvailable: () => [{ provider: "kimchi-dev", id: "vision-model", input: ["text", "image"] }],
 		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key", headers: {} }),
 	},
 	ui: { notify: mockNotify },
@@ -42,7 +48,7 @@ vi.mock("./model-guard.js", async () => {
 	}
 })
 
-import { markImagesAsStripped, sessionHasImages } from "./model-guard.js"
+import { getLatestMessages, markImagesAsStripped, sessionHasImages } from "./model-guard.js"
 // Import the extension after mocks are set up
 import stripImagesExtension from "./strip-images.js"
 
@@ -51,6 +57,7 @@ describe("strip-images extension", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
+		completeMock.mockReset()
 		mockNotify.mockClear()
 		mockRegisterCommand.mockClear()
 		markImagesAsStripped()
@@ -112,6 +119,24 @@ describe("strip-images extension", () => {
 			await handler([], ctx)
 
 			expect(mockNotify).toHaveBeenCalledWith(expect.stringContaining("no API key available"), "error")
+		})
+
+		it("preserves the explicit image-analysis token limit", async () => {
+			let sentOptions: unknown
+			vi.mocked(getLatestMessages).mockReturnValue([
+				{ role: "user", content: [{ type: "image", data: "image-data", mimeType: "image/png" }] },
+			] as never)
+			completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
+				sentOptions = options
+				return { content: [{ type: "text", text: "description" }], stopReason: "stop" }
+			})
+			stripImagesExtension(mockPi as never)
+
+			const handler = mockPi.getHandler("strip-images") as (args: string[], ctx: unknown) => Promise<void>
+			await handler([], createMockCtx())
+
+			expect(sentOptions).toMatchObject({ maxTokens: 200 })
+			expect(sentOptions).not.toHaveProperty("onPayload")
 		})
 	})
 })


### PR DESCRIPTION
## What changed

Replays the exact final patch from #1003 onto current `master` after that stacked PR was accidentally squash-merged into `chore/pi-0.84.1-upgrade`.

Stops Pi's approximate completion-token limit from being sent to Kimchi's OpenAI-compatible API, including auxiliary model calls. Explicit user token limits and non-Kimchi providers remain unchanged.

## Why

PR #1005 was squash-merged into `master`, so the original stacked ancestry no longer matched `master`. Merging #1003 into its old base branch left GitHub showing the whole stack as a large diff. This replacement branch starts at the #1005 squash commit and replays only #1003's final squash commit.

The recovered diff is 11 files with 252 additions and 13 deletions.

## Impact

Kimchi's gateway receives no approximate Pi completion cap and can apply the exact model/context limit. Other providers and explicit token limits keep their existing behavior.

## Validation

- `pnpm run check`
- 157 focused tests across the five affected test files
- `pnpm run build:binary`
- `pnpm run test:smoke`: 13 passed, 12 environment-gated skipped
- Full unit suite: 8,089 passed, 4 skipped; the same 4 pre-existing `system-prompt-stability.test.ts` failures currently present on `master`
- `git diff --check getkimchi/master...HEAD`

Replaces #1003. No matching issue was found, so this draft intentionally does not claim to close an unrelated issue.
