### PR TITLE
fix: stale post-compaction state in model-switch guards

### DIFF
--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -1,5 +1,5 @@
 import type { ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
-import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../ferment/types.js"
 import { getCompactionEnabled } from "../settings-watcher.js"
@@ -7,7 +7,10 @@ import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { clearActiveFermentId, setActive as setActiveFerment } from "./ferment/state.js"
 import modelGuardExtension, {
 	__resetImagesDetectedForTest,
+	__setLatestMessagesForTest,
 	estimateTokens,
+	getLatestMessages,
+	getLatestMessagesTimestamp,
 	hasImages,
 	markImagesAsStripped,
 	resolveContextTokens,
@@ -15,6 +18,7 @@ import modelGuardExtension, {
 	stripImages,
 	truncateMessages,
 } from "./model-guard.js"
+import modelSwitchExtension, { __resetModelSwitchStateForTest } from "./model-switch.js"
 
 // Mock the settings-watcher so the /settings Auto-compact toggle can be
 // controlled per test without touching the real settings files.
@@ -23,6 +27,11 @@ vi.mock("../settings-watcher.js", () => ({
 }))
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+// Production compaction-trigger value: the final pre-compaction assistant's
+// usage.totalTokens at the moment auto-compaction fired. Named fixture so the
+// summary's tokensBefore, kept-tail usage, and expectations cannot diverge.
+const COMPACTION_TRIGGER_TOKENS = 270_274
 
 function makeUser(text: string, extraContent?: (TextContent | ImageContent)[]): UserMessage {
 	const base: TextContent[] = [{ type: "text", text }]
@@ -63,6 +72,37 @@ function makeToolResult(text: string): ToolResultMessage {
 		isError: false,
 		timestamp: 0,
 	}
+}
+
+/** Mirrors the upstream compaction summary message shape (messages.js). */
+function makeCompactionSummary(summary: string, tokensBefore: number, timestamp: number) {
+	return {
+		role: "compactionSummary" as const,
+		summary,
+		tokensBefore,
+		timestamp,
+	}
+}
+
+/**
+ * Mirrors a real post-turn-end-compaction context: the final pre-compaction
+ * assistant response is kept in the tail with its stale pre-compaction
+ * usage.totalTokens, spliced after the compaction summary by buildContextEntries.
+ */
+function makePostCompactionMessages(opts: {
+	summaryTimestamp: number
+	keptAssistantTokens: number
+	keptAssistantTimestamp: number
+	tailText?: string
+}) {
+	return [
+		makeCompactionSummary("Summary of prior conversation.", opts.keptAssistantTokens, opts.summaryTimestamp),
+		{
+			...makeAssistant(opts.keptAssistantTokens),
+			timestamp: opts.keptAssistantTimestamp,
+		},
+		makeUser(opts.tailText ?? "continue"),
+	] as ContextEvent["messages"]
 }
 
 function makeImageBlock(): ImageContent {
@@ -130,6 +170,45 @@ describe("estimateTokens", () => {
 		// Should count chars, not usage.totalTokens
 		expect(estimateTokens(msgs)).toBe(1)
 	})
+
+	describe("compaction-summary boundary", () => {
+		it("ignores stale pre-compaction assistant usage kept after a summary", () => {
+			// Exact real-world shape after turn-end auto-compaction: the final
+			// pre-compaction assistant response is kept in the tail with
+			// usage.totalTokens = 270_274 (the trigger for compaction).
+			// The estimator must NOT use it as baseline.
+			const msgs = makePostCompactionMessages({
+				summaryTimestamp: 1_000,
+				keptAssistantTokens: COMPACTION_TRIGGER_TOKENS,
+				keptAssistantTimestamp: 900,
+			})
+			const tokens = estimateTokens(msgs)
+			// Summary text (30 chars) + assistant content (2 chars) + user (8 chars)
+			// → ceil(30/4) + 1 + 2 = 11; definitely NOT 270_274
+			expect(tokens).toBeLessThan(100)
+			expect(tokens).toBeGreaterThan(0)
+		})
+
+		it("trusts assistant usage generated after the summary (fresh post-compaction baseline)", () => {
+			const msgs = [
+				makeCompactionSummary("Summary.", COMPACTION_TRIGGER_TOKENS, 1_000),
+				{ ...makeAssistant(20_000), timestamp: 1_100 },
+				makeUser("hello"),
+			] as ContextEvent["messages"]
+			// Fresh baseline 20_000 + increment ceil(5/4)=2 → 20_002
+			expect(estimateTokens(msgs)).toBe(20_002)
+		})
+
+		it("sums only content from the summary onward when no fresh assistant exists", () => {
+			const msgs = [
+				makeUser("x".repeat(10_000)), // pre-compaction — must be ignored
+				makeCompactionSummary("Summary.", 50_000, 1_000),
+				makeUser("y".repeat(400)),
+			] as ContextEvent["messages"]
+			// ceil(8/4) + ceil(400/4) = 2 + 100 = 102
+			expect(estimateTokens(msgs)).toBe(102)
+		})
+	})
 })
 
 // ── resolveContextTokens ─────────────────────────────────────────────────────
@@ -182,6 +261,96 @@ describe("resolveContextTokens", () => {
 		const usage = undefined
 		const msgs: ContextEvent["messages"] = []
 		expect(resolveContextTokens(usage, msgs)).toBeNull()
+	})
+
+	describe("post-compaction", () => {
+		beforeEach(() => {
+			__resetImagesDetectedForTest()
+		})
+
+		it("uses the boundary-aware estimate when usage.tokens is null (upstream post-compaction contract)", () => {
+			// Upstream pi-coding-agent >= 0.84.1 reports tokens: null after
+			// compaction until a successful post-compaction assistant response
+			// exists, so the stale window relies solely on estimateTokens over
+			// refreshed messages.
+			__setLatestMessagesForTest([makeUser("hello world")])
+
+			const tokens = resolveContextTokens({ tokens: null }, getLatestMessages())
+			expect(tokens).toBe(3)
+		})
+
+		it("trusts non-null usage.tokens unconditionally (upstream contract)", () => {
+			// Once a post-compaction assistant response exists, upstream reports
+			// fresh usage — there is no stale-value window for non-null tokens.
+			expect(resolveContextTokens({ tokens: 5_000 }, [makeUser("hi")])).toBe(5_000)
+		})
+
+		it("resolves the real post-compaction size over refreshed messages carrying a stale kept-tail baseline", () => {
+			// Mirrors the production bug: refreshed latestMessages contains a
+			// kept-tail assistant carrying the full pre-compaction
+			// usage.totalTokens. resolveContextTokens must still resolve the small
+			// post-compaction estimate via estimateTokens (usage.tokens is null
+			// in the stale window per the upstream contract).
+			const postCompact = makePostCompactionMessages({
+				summaryTimestamp: Date.now(),
+				keptAssistantTokens: COMPACTION_TRIGGER_TOKENS,
+				keptAssistantTimestamp: 0,
+			})
+			__setLatestMessagesForTest(postCompact)
+
+			const tokens = resolveContextTokens({ tokens: null }, getLatestMessages())
+			expect(tokens).not.toBeNull()
+			expect(tokens as number).toBeLessThan(100)
+		})
+
+		it("counts kept-tail assistant content (never its stale usage) so large retained responses are not undercounted", () => {
+			// A rejected stale baseline must still contribute its content.
+			// Undercounting would let the model-switch guard accept a context
+			// that exceeds the target model's window.
+			const bigTail = "x".repeat(40_000)
+			const msgs = [
+				makeCompactionSummary("Summary.", COMPACTION_TRIGGER_TOKENS, 1_000),
+				{
+					...makeAssistant(COMPACTION_TRIGGER_TOKENS),
+					content: [{ type: "text" as const, text: bigTail }],
+					timestamp: 900,
+				},
+				makeUser("continue"),
+			] as ContextEvent["messages"]
+			// Summary ("Summary." = 8 chars → 2) + tail content (40,000/4 = 10_000;
+			// the stale 270_274 usage baseline is NOT trusted) + user (8 chars → 2)
+			// = 10_004
+			expect(estimateTokens(msgs)).toBe(10_004)
+		})
+
+		it("counts kept-tail assistant thinking and toolCall arguments (via Pi's estimator)", () => {
+			// Stale-kept assistant content includes thinking/toolCall blocks — a
+			// retained `write` call with a huge payload must NOT estimate as 0.
+			// Delegated to Pi's public per-message estimator, which counts text,
+			// thinking, and toolCall name + serialized arguments (usage ignored).
+			const thinkingText = "t".repeat(4_000)
+			const args = { path: "/tmp/f", content: "w".repeat(8_000) }
+			const msgs = [
+				makeCompactionSummary("Summary.", COMPACTION_TRIGGER_TOKENS, 1_000),
+				{
+					...makeAssistant(COMPACTION_TRIGGER_TOKENS),
+					content: [
+						{ type: "thinking" as const, thinking: thinkingText },
+						{
+							type: "toolCall" as const,
+							id: "call-1",
+							name: "write",
+							arguments: args,
+						},
+					],
+					timestamp: 900,
+				},
+			] as ContextEvent["messages"]
+			// Old behavior: 2 (summary only — thinking/toolCall counted as 0).
+			const assistantTokens = Math.ceil((thinkingText.length + "write".length + JSON.stringify(args).length) / 4)
+			expect(assistantTokens).toBeGreaterThan(1_000)
+			expect(estimateTokens(msgs)).toBe(2 + assistantTokens)
+		})
 	})
 })
 
@@ -423,7 +592,7 @@ function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContex
 		hasUI: false,
 		cwd: "/tmp",
 		ui: {} as ExtensionContext["ui"],
-		sessionManager: {} as ExtensionContext["sessionManager"],
+		sessionManager: { getBranch: () => [] } as unknown as ExtensionContext["sessionManager"],
 		modelRegistry: {} as ExtensionContext["modelRegistry"],
 		isIdle: () => true,
 		signal: undefined,
@@ -959,5 +1128,535 @@ describe("markImagesAsStripped", () => {
 		// After reset, triggering context with images should detect them again
 		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
 		expect(sessionHasImages()).toBe(true)
+	})
+})
+
+// ── session_compact state refresh ─────────────────────────────────────────────
+
+describe("session_compact state refresh", () => {
+	beforeEach(() => {
+		__resetImagesDetectedForTest()
+	})
+
+	// Build real SessionEntry[] simulating a post-compaction session.
+	// The real buildSessionContext will emit the summary as a text-only message.
+	function makeCompactedEntries(summary: string): SessionEntry[] {
+		return [
+			{
+				type: "compaction",
+				id: "compaction-1",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				summary,
+				firstKeptEntryId: "msg-1",
+				tokensBefore: 50_000,
+			},
+			{
+				type: "message",
+				id: "msg-1",
+				parentId: "compaction-1",
+				timestamp: new Date().toISOString(),
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Continue after compaction." }],
+					timestamp: 0,
+				},
+			},
+		]
+	}
+
+	it("refreshes latestMessages from post-compaction session", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+
+		// Simulate pre-compaction context with large messages
+		const bigMessages: ContextEvent["messages"] = [makeAssistant(50_000), makeUser("x".repeat(200_000))]
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+		})
+		await trigger("context", { messages: bigMessages }, ctx)
+		expect(getLatestMessages()).toBe(bigMessages)
+		expect(getLatestMessagesTimestamp()).toBeGreaterThan(0)
+
+		// Simulate compaction: buildSessionContext resolves real entries into
+		// text-only summary + kept messages (much smaller than bigMessages).
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => makeCompactedEntries("Summary of previous conversation."),
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 50_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// latestMessages should now reflect post-compaction state (not bigMessages)
+		expect(getLatestMessages()).not.toBe(bigMessages)
+		expect(hasImages(getLatestMessages())).toBe(false)
+		expect(getLatestMessagesTimestamp()).toBeGreaterThan(0)
+	})
+
+	it("clears imagesDetected when post-compaction messages have no images", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+
+		// Pre-compaction: session has images
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+		})
+		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
+		expect(sessionHasImages()).toBe(true)
+
+		// Compaction replaces session with text-only summary
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => makeCompactedEntries("Summary of previous conversation."),
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 1_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// Images should no longer be detected — compaction summary is text-only
+		expect(sessionHasImages()).toBe(false)
+	})
+
+	it("resets imagesStripped flag after compaction", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+
+		// Pre-compaction: session has images, mark them stripped
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+		})
+		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
+		markImagesAsStripped()
+		expect(sessionHasImages()).toBe(false) // stripped
+
+		// Compaction replaces session with text-only summary
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => makeCompactedEntries("Summary."),
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 1_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// imagesStripped should be reset; with no images in post-compaction messages,
+		// sessionHasImages() should be false
+		expect(sessionHasImages()).toBe(false)
+	})
+
+	it("preserves strip state when images survive compaction in the kept tail", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+
+		// Pre-compaction: session has images, user stripped them
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+		})
+		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
+		markImagesAsStripped()
+		expect(sessionHasImages()).toBe(false)
+
+		// Compaction keeps a recent tail entry that still contains an image.
+		// Resetting strip state here would undo /strip-images for an image that
+		// remains in the active context (pmateusz PR #1020 review).
+		const keptImageEntries: SessionEntry[] = [
+			{
+				type: "compaction",
+				id: "compaction-1",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				summary: "Summary.",
+				firstKeptEntryId: "msg-1",
+				tokensBefore: 50_000,
+			},
+			{
+				type: "message",
+				id: "msg-1",
+				parentId: "compaction-1",
+				timestamp: new Date().toISOString(),
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "kept tail" }, makeImageBlock()],
+					timestamp: 0,
+				},
+			},
+		]
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => keptImageEntries,
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 1_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// Images survived → imagesDetected refreshed to true, but imagesStripped
+		// must stay set so sessionHasImages() remains false.
+		expect(sessionHasImages()).toBe(false)
+	})
+
+	it("emits a diagnostic warning when the state refresh throws", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+
+			// getBranch that throws — refresh fails, should warn but not throw
+			const compactCtx = makeMockCtx({
+				sessionManager: {
+					getBranch: () => {
+						throw new Error("boom")
+					},
+				} as unknown as ExtensionContext["sessionManager"],
+			})
+
+			await expect(
+				trigger(
+					"session_compact",
+					{
+						type: "session_compact",
+						compactionEntry: { tokensBefore: 1_000 },
+						fromExtension: false,
+						reason: "threshold",
+						willRetry: false,
+					},
+					compactCtx,
+				),
+			).resolves.toBeUndefined()
+
+			// Should emit a diagnostic warning
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("session_compact state refresh failed"),
+				expect.anything(),
+			)
+		} finally {
+			warn.mockRestore()
+		}
+	})
+})
+
+// ── integration: session_compact → model_select ────────────────────────────────
+//
+// These tests wire both modelGuardExtension and modelSwitchExtension on the
+// same pi instance, then fire context → session_compact → model_select.
+// They verify end-to-end that the session_compact handler refreshes the
+// cached state that model_select guards read. Without the fix, these tests
+// fail because session_compact doesn't refresh latestMessages/imagesDetected.
+//
+// These tests use the REAL buildSessionContext from upstream — no mock.
+// Post-compaction messages are produced by constructing real SessionEntry[]
+// with a compaction entry and letting buildSessionContext resolve them.
+
+describe("session_compact → model_select integration", () => {
+	beforeEach(() => {
+		__resetImagesDetectedForTest()
+		__resetModelSwitchStateForTest()
+	})
+
+	// A pi that supports both on() (for extensions) and registerTool (for model-switch)
+	function makeSharedPI() {
+		const handlers = new Map<string, Set<(data: unknown, ctx: ExtensionContext) => unknown>>()
+		const setModel = vi.fn(async () => true)
+		const pi = {
+			on(event: string, handler: (data: unknown, ctx: ExtensionContext) => unknown) {
+				if (!handlers.has(event)) handlers.set(event, new Set())
+				handlers.get(event)?.add(handler)
+			},
+			registerTool: vi.fn(),
+			registerCommand: vi.fn(),
+			setModel,
+		} as unknown as ExtensionAPI
+		const trigger = async (event: string, data: unknown, ctx: ExtensionContext) => {
+			const set = handlers.get(event)
+			if (set) for (const h of set) await h(data, ctx)
+		}
+		return { pi, trigger, setModel }
+	}
+
+	// Build real SessionEntry[] simulating a post-compaction session:
+	// [compaction(summary, firstKeptEntryId) → kept message → new message]
+	// buildSessionContext will walk from the leaf to root, find the compaction
+	// entry, emit the summary as a text-only message, then the kept messages.
+	function makeCompactedEntries(summary: string): SessionEntry[] {
+		return [
+			{
+				type: "compaction",
+				id: "compaction-1",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				summary,
+				firstKeptEntryId: "msg-1",
+				tokensBefore: 175_000,
+			},
+			{
+				type: "message",
+				id: "msg-1",
+				parentId: "compaction-1",
+				timestamp: new Date().toISOString(),
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Continue after compaction." }],
+					timestamp: 0,
+				},
+			},
+		]
+	}
+
+	it("allows switch to smaller-context model after compaction refreshes latestMessages", async () => {
+		const { pi, trigger, setModel } = makeSharedPI()
+		modelGuardExtension(pi)
+		modelSwitchExtension(pi)
+
+		// Pre-compaction: fire context with large messages (125k tokens estimated)
+		const bigMessages: ContextEvent["messages"] = [
+			makeAssistant(50_000),
+			...Array.from({ length: 50 }, () => makeUser("x".repeat(10_000))),
+		]
+		// 50 * ceil(10000/4) = 125_000; + 50_000 baseline from assistant = 175_000
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+			getContextUsage: () => ({ tokens: null, contextWindow: 200_000, percent: null }),
+		})
+		await trigger("context", { messages: bigMessages }, ctx)
+
+		// Fire session_compact — the handler calls the real buildSessionContext
+		// with the entries from ctx.sessionManager.getBranch().
+		const compactEntries = makeCompactedEntries("Summary of previous conversation.")
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => compactEntries,
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 175_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// Verify state was refreshed — latestMessages should now be the small
+		// post-compaction messages produced by the real buildSessionContext.
+		const refreshed = getLatestMessages()
+		expect(refreshed).not.toBe(bigMessages)
+		expect(refreshed.length).toBeLessThan(bigMessages.length)
+		// The real buildSessionContext produces a compaction summary message + kept messages
+		expect(hasImages(refreshed)).toBe(false)
+
+		// Now model_select to a 100k model should succeed (post-compaction tokens are tiny)
+		await trigger(
+			"model_select",
+			{
+				type: "model_select",
+				model: { id: "minimax-m2.7", provider: "kimchi-dev", input: ["text"], contextWindow: 100_000 },
+				previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+				source: "set",
+			},
+			makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+				getContextUsage: () => ({ tokens: null, contextWindow: 200_000, percent: null }),
+				sessionManager: { getSessionId: () => "test-session" } as unknown as ExtensionContext["sessionManager"],
+				ui: { notify: vi.fn() } as unknown as ExtensionContext["ui"],
+			}),
+		)
+
+		// setModel should NOT have been called for revert (switch accepted)
+		expect(setModel).not.toHaveBeenCalledWith(expect.objectContaining({ id: "kimi-k2.6" }))
+	})
+
+	it("allows switch to non-vision model after compaction clears imagesDetected", async () => {
+		const { pi, trigger, setModel } = makeSharedPI()
+		modelGuardExtension(pi)
+		modelSwitchExtension(pi)
+
+		// Pre-compaction: fire context with images
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+			getContextUsage: () => ({ tokens: 1_000, contextWindow: 200_000, percent: 1 }),
+		})
+		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
+		expect(sessionHasImages()).toBe(true)
+
+		// Fire session_compact — the real buildSessionContext produces text-only
+		// messages from the compaction entry (summary is text, no images).
+		const compactEntries = makeCompactedEntries("Summary of previous conversation with images.")
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => compactEntries,
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 1_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+
+		// Verify imagesDetected was cleared — compaction summary is text-only
+		expect(sessionHasImages()).toBe(false)
+
+		// Now model_select to a non-vision model should succeed
+		await trigger(
+			"model_select",
+			{
+				type: "model_select",
+				model: { id: "minimax-m2.7", provider: "kimchi-dev", input: ["text"], contextWindow: 100_000 },
+				previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+				source: "set",
+			},
+			makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+				getContextUsage: () => ({ tokens: 1_000, contextWindow: 200_000, percent: 1 }),
+				sessionManager: { getSessionId: () => "test-session" } as unknown as ExtensionContext["sessionManager"],
+				ui: { notify: vi.fn() } as unknown as ExtensionContext["ui"],
+			}),
+		)
+
+		// setModel should NOT have been called for revert (switch accepted)
+		expect(setModel).not.toHaveBeenCalledWith(expect.objectContaining({ id: "kimi-k2.6" }))
+	})
+
+	it("allows vision to non-vision switch via set_model tool after compaction refreshes guard state", async () => {
+		// Regression for the reported Gap-2 tool path: after compaction, executing
+		// the set_model tool must not reject a non-vision target based on
+		// pre-compaction images — session_compact refreshed imagesDetected.
+		const { pi, trigger, setModel } = makeSharedPI()
+		modelGuardExtension(pi)
+		modelSwitchExtension(pi)
+		const tool = (pi.registerTool as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+			name: string
+			execute: (
+				toolCallId: string,
+				params: { model: string },
+				signal: AbortSignal | undefined,
+				onUpdate: unknown,
+				ctx: unknown,
+			) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
+		}
+		expect(tool.name).toBe("set_model")
+
+		// Pre-compaction: session has images
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text", "image"], contextWindow: 200_000 } as ExtensionContext["model"],
+			getContextUsage: () => ({ tokens: 1_000, contextWindow: 200_000, percent: 1 }),
+		})
+		await trigger("context", { messages: [makeUser("look", [makeImageBlock()])] }, ctx)
+		expect(sessionHasImages()).toBe(true)
+
+		// Compaction — text-only post state
+		const compactCtx = makeMockCtx({
+			sessionManager: {
+				getBranch: () => makeCompactedEntries("Summary of previous conversation with images."),
+			} as unknown as ExtensionContext["sessionManager"],
+		})
+		await trigger(
+			"session_compact",
+			{
+				type: "session_compact",
+				compactionEntry: { tokensBefore: 1_000 },
+				fromExtension: false,
+				reason: "threshold",
+				willRetry: false,
+			},
+			compactCtx,
+		)
+		expect(sessionHasImages()).toBe(false)
+
+		// Agent-driven path: execute the set_model tool directly
+		const result = await tool.execute(
+			"call-1",
+			{ model: "kimchi-dev/minimax-m2.7" },
+			undefined,
+			undefined,
+			makeMockCtx({
+				model: {
+					id: "kimi-k2.6",
+					provider: "kimchi-dev",
+					input: ["text", "image"],
+					contextWindow: 200_000,
+				} as ExtensionContext["model"],
+				modelRegistry: {
+					getAvailable: () => [
+						{
+							id: "kimi-k2.6",
+							provider: "kimchi-dev",
+							name: "Kimi K2.6",
+							input: ["text", "image"],
+							contextWindow: 200_000,
+						},
+						{
+							id: "minimax-m2.7",
+							provider: "kimchi-dev",
+							name: "MiniMax M2.7",
+							input: ["text"],
+							contextWindow: 100_000,
+						},
+					],
+					find: (_p: string, id: string) =>
+						id === "minimax-m2.7"
+							? {
+									id: "minimax-m2.7",
+									provider: "kimchi-dev",
+									name: "MiniMax M2.7",
+									input: ["text"],
+									contextWindow: 100_000,
+								}
+							: undefined,
+				} as unknown as ExtensionContext["modelRegistry"],
+				getContextUsage: () => ({ tokens: null, contextWindow: 200_000, percent: null }),
+				sessionManager: { getSessionId: () => "test-session" } as unknown as ExtensionContext["sessionManager"],
+			}),
+		)
+
+		expect(setModel).toHaveBeenCalledTimes(1)
+		expect(result.content[0].text).toContain("Switched to model kimchi-dev/minimax-m2.7")
 	})
 })

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -1,5 +1,11 @@
 import type { AssistantMessage, ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
-import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import {
+	buildSessionContext,
+	type ContextEvent,
+	type ExtensionAPI,
+	type ExtensionContext,
+	estimateTokens as estimatePiMessageTokens,
+} from "@earendil-works/pi-coding-agent"
 import { getCompactionEnabled } from "../settings-watcher.js"
 import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { hasActiveFerment } from "./ferment/state.js"
@@ -31,6 +37,10 @@ export function resolveContextTokens(
 ): number | null {
 	if (messages.length === 0) return usage?.tokens ?? null
 
+	// Upstream pi-coding-agent (>= 0.84.1) reports tokens: null after compaction
+	// until a successful post-compaction assistant response exists, so a non-null
+	// value is trustworthy. The null fallback below is compaction-boundary aware
+	// (see estimateTokens).
 	if (usage?.tokens == null) return estimateTokens(messages)
 
 	const lastAssistantUsage = findLastAssistantUsage(messages)
@@ -145,10 +155,86 @@ export const __resetImagesDetectedForTest = resetSessionState
 /**
  * Rough token estimation: 4 chars per token for text, images counted separately.
  * Accumulates from assistant message usage when available for higher accuracy.
+ *
+ * Compaction-aware: when a compactionSummary message is present, kept tail
+ * messages (entries before the compaction point, spliced after the summary by
+ * buildContextEntries) still carry PRE-COMPACTION usage.totalTokens — e.g. the
+ * final turn-end response reports the full ~270k pre-compaction context. Using
+ * such a baseline reproduces the "stale 270k" rejection. We only trust an
+ * assistant usage baseline when the assistant's timestamp is AFTER the
+ * compaction summary's timestamp (i.e. it was generated on the compacted
+ * context); otherwise we sum content from the summary onward.
  */
 export function estimateTokens(messages: ContextEvent["messages"]): number {
-	const lastAssistantUsage = findLastAssistantUsage(messages)
-	return (lastAssistantUsage?.totalTokens ?? 0) + estimateTokensAfter(messages, lastAssistantUsage?.index ?? -1)
+	// Latest compaction boundary, if any. Kept-tail messages (entries kept from
+	// before the compaction, spliced after the summary by buildContextEntries)
+	// still carry PRE-COMPACTION usage.totalTokens — e.g. the final turn-end
+	// response reports the full ~270k pre-compaction context. Such stale
+	// baselines reproduce the "stale 270k" rejection, so an assistant usage
+	// baseline is only trusted when the assistant's timestamp is AFTER the
+	// latest compaction summary's timestamp.
+	const boundary = compactionBoundary(messages)
+	if (!boundary) {
+		const lastAssistantUsage = findLastAssistantUsage(messages)
+		return (lastAssistantUsage?.totalTokens ?? 0) + estimateTokensAfter(messages, lastAssistantUsage?.index ?? -1)
+	}
+
+	// Boundary present: only a post-summary assistant is a usable baseline.
+	for (let i = messages.length - 1; i > boundary.index; i--) {
+		const msg = messages[i]
+		if (msg.role !== "assistant" || !("usage" in msg) || typeof msg.usage?.totalTokens !== "number") continue
+		const ts = (msg as { timestamp?: unknown }).timestamp
+		if (typeof ts !== "number" || ts <= boundary.timestamp) continue // stale kept-tail baseline
+		return msg.usage.totalTokens + estimateTokensAfter(messages, i)
+	}
+
+	// No usable baseline: sum content from the summary onward (the summary's
+	// own text included). Content is always counted — NEVER the stale usage of
+	// kept-tail assistants — so large retained responses are not undercounted
+	// (an undercount would let the guard accept a context that is too large
+	// for the target model).
+	let tokens = 0
+	for (let i = boundary.index; i < messages.length; i++) tokens += estimateMessageContentTokens(messages[i])
+	return tokens
+}
+
+/** Index and timestamp of the most recent compactionSummary message, if present. */
+function compactionBoundary(messages: ContextEvent["messages"]): { index: number; timestamp: number } | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i] as { role: string; timestamp?: unknown }
+		if (msg.role === "compactionSummary") {
+			return { index: i, timestamp: typeof msg.timestamp === "number" ? msg.timestamp : 0 }
+		}
+	}
+	return undefined
+}
+
+/**
+ * Content-only estimate for a single message. Usage metadata is NEVER read —
+ * safe for kept-tail assistants with stale pre-compaction usage (see
+ * estimateTokens).
+ *
+ * Image-capable roles (user/toolResult/custom) keep Kimchi's policy of 4 chars
+ * per token for text and 1000 tokens per image. All other roles (assistant
+ * text/thinking/toolCall arguments, summaries, bash executions) go through
+ * Pi's public per-message estimator, which also ignores usage and counts the
+ * full content — assistant messages contain no image blocks, so the image
+ * policy is unaffected.
+ */
+function estimateMessageContentTokens(msg: ContextEvent["messages"][number]): number {
+	if (msg.role === "user" || msg.role === "toolResult" || msg.role === "custom") {
+		if (!("content" in msg)) return 0
+		const content = (msg as ContentMessage).content
+		if (typeof content === "string") return Math.ceil(content.length / 4)
+		if (!Array.isArray(content)) return 0
+		let tokens = 0
+		for (const block of content) {
+			if (block.type === "text") tokens += Math.ceil(block.text.length / 4)
+			else if (block.type === "image") tokens += 1000
+		}
+		return tokens
+	}
+	return estimatePiMessageTokens(msg as Parameters<typeof estimatePiMessageTokens>[0])
 }
 
 /**
@@ -280,7 +366,32 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 	// captured in the turn_end handler. The session_compact event fires
 	// afterwards with a fresh ctx, so we notify from there instead of from
 	// the stale onComplete/onError closures.
-	_pi.on("session_compact", (event, ctx: ExtensionContext) => {
+	_pi.on("session_compact", async (event, ctx: ExtensionContext) => {
+		// Refresh cached state so model-switch guards see post-compaction reality
+		// immediately, rather than waiting for the next context event (which only
+		// fires on the next LLM call). Without this, latestMessages still holds
+		// pre-compaction messages (inflated token count) and imagesDetected stays
+		// true even though the compaction summary is text-only.
+		try {
+			const branch = await Promise.resolve(ctx.sessionManager.getBranch())
+			const postCompactMessages = buildSessionContext(branch).messages
+			latestMessages = postCompactMessages
+			latestMessagesTimestamp = Date.now()
+			// Reset strip state only when no images survived compaction — Pi keeps a
+			// recent tail after the summary and images in it remain in the active
+			// context, so an unconditional reset would undo /strip-images for
+			// images that are still present.
+			imagesDetected = hasImages(postCompactMessages)
+			if (!imagesDetected) {
+				imagesStripped = false
+				imageDescriptions.clear()
+			}
+		} catch (err) {
+			// If we can't refresh (e.g. sessionManager not fully available),
+			// the next context event will correct the state.
+			console.warn("[model-guard] session_compact state refresh failed:", err)
+		}
+
 		// Only consume the flag for compactions triggered by this guard's
 		// ctx.compact() call — not for /compact or threshold-triggered ones.
 		if (!pendingMidTurnCompaction || !event.fromExtension) return
@@ -300,7 +411,6 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 		// Store reference to latest messages for /strip-images command
 		latestMessages = messages
 		latestMessagesTimestamp = Date.now()
-
 		// Always scan for images in the current context.
 		// If new images appear after a previous strip, reset the stripped flag
 		// so the guards re-engage for the fresh images.

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -27,6 +27,11 @@ type RegisteredTool = {
 	) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
 }
 
+// Production compaction-trigger value: the final pre-compaction assistant's
+// usage.totalTokens at the moment turn-end auto-compaction fired. Named fixture
+// so the summary's tokensBefore and kept-tail usage cannot diverge.
+const COMPACTION_TRIGGER_TOKENS = 270_274
+
 type ModelEntry = { id: string; provider: string; name: string; input?: ("text" | "image")[]; contextWindow?: number }
 
 interface Harness {
@@ -794,6 +799,125 @@ describe("modelSwitchExtension", () => {
 
 				expect(h.setModel).toHaveBeenCalledTimes(1)
 				expect(textOf(result)).toBe("Switched to model kimchi-dev/kimi-k2.6 (Kimi K2.6)")
+			})
+		})
+
+		describe("post-compaction model switch", () => {
+			beforeEach(() => {
+				__resetImagesDetectedForTest()
+				__resetModelSwitchStateForTest()
+			})
+
+			it("allows switch to smaller model after compaction reduced context", async () => {
+				// Reproduces the exact production bug: turn-end auto-compaction fires,
+				// and the kept tail (spliced after the summary by buildContextEntries)
+				// includes the final pre-compaction assistant response with
+				// usage.totalTokens = 270_274. Upstream getContextUsage() reports
+				// tokens: null in this window (Pi >= 0.84.1), so the guard falls back
+				// to the local estimate — which must reject the stale kept-tail
+				// baseline and resolve the real post-compaction size instead.
+				__setLatestMessagesForTest([
+					{
+						role: "compactionSummary" as const,
+						summary: "Summary of prior conversation.",
+						tokensBefore: COMPACTION_TRIGGER_TOKENS,
+						timestamp: 1_000,
+					},
+					{
+						role: "assistant" as const,
+						content: [{ type: "text" as const, text: "done" }],
+						usage: {
+							input: COMPACTION_TRIGGER_TOKENS,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: COMPACTION_TRIGGER_TOKENS,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						api: "openai-responses" as const,
+						provider: "kimchi-dev",
+						stopReason: "stop" as const,
+						model: "kimi-k2.6",
+						timestamp: 900,
+					},
+					{ role: "user" as const, content: [{ type: "text" as const, text: "continue" }], timestamp: 0 as const },
+				])
+
+				// Self-contained mock — no dependency on createHarness/find/getAvailable
+				const setModel = vi.fn(async () => true)
+				let registered: RegisteredTool | undefined
+				const pi = {
+					on: vi.fn(),
+					registerTool: (t: RegisteredTool) => {
+						registered = t
+					},
+					setModel,
+					registerCommand: vi.fn(),
+				} as unknown as ExtensionAPI
+				modelSwitchExtension(pi)
+				if (!registered) throw new Error("set_model not registered")
+				const ctx = createContext({
+					modelRegistry: {
+						find: (_p: string, id: string) => MODELS.find((m) => m.id === id),
+						getAvailable: () => MODELS,
+					} as unknown as ModelRegistry,
+					getContextUsage: () => ({ tokens: null }),
+					model: { id: "nemotron-3-ultra-fp4", provider: "kimchi-dev", input: ["text", "image"] },
+				})
+				const result = await registered.execute("test", { model: "kimchi-dev/kimi-k2.6" }, undefined, undefined, ctx)
+
+				// Should switch successfully — post-compaction content estimate (~15 tokens)
+				// fits well within the 190k safe window of the 200k model.
+				expect(setModel).toHaveBeenCalledTimes(1)
+				expect(textOf(result)).toContain("Switched to model")
+				expect(textOf(result)).not.toContain("Switch rejected")
+				expect(textOf(result)).not.toContain("270274")
+			})
+
+			it("still rejects when post-compaction context still exceeds target", async () => {
+				// Even after compaction, the compacted context might still be too large.
+				// With usage.tokens null (upstream post-compaction contract) the guard
+				// should fire using the local estimate.
+				// Large post-compaction messages: 30 messages × 2000 chars → ~15,000 tokens
+				__setLatestMessagesForTest(
+					Array.from({ length: 30 }, () => ({
+						role: "user" as const,
+						content: [{ type: "text" as const, text: "x".repeat(2000) }],
+						timestamp: 0 as const,
+					})),
+				)
+
+				// Self-contained mock — return kimi with a small context window.
+				const smallKimi = { ...MODELS[0], contextWindow: 10_000 }
+				const setModel = vi.fn(async () => true)
+				let registered: RegisteredTool | undefined
+				const pi = {
+					on: vi.fn(),
+					registerTool: (t: RegisteredTool) => {
+						registered = t
+					},
+					setModel,
+					registerCommand: vi.fn(),
+				} as unknown as ExtensionAPI
+				modelSwitchExtension(pi)
+				if (!registered) throw new Error("set_model not registered")
+				const ctx = createContext({
+					modelRegistry: {
+						find: (_p: string, id: string) => (id === "kimi-k2.6" ? smallKimi : MODELS.find((m) => m.id === id)),
+						getAvailable: () => [
+							...MODELS.filter((m) => !(m.id === "kimi-k2.6" && m.provider === "kimchi-dev")),
+							smallKimi,
+						],
+					} as unknown as ModelRegistry,
+					getContextUsage: () => ({ tokens: null }),
+					model: { id: "nemotron-3-ultra-fp4", provider: "kimchi-dev", input: ["text", "image"] },
+				})
+				const result = await registered.execute("test", { model: "kimchi-dev/kimi-k2.6" }, undefined, undefined, ctx)
+
+				// Should reject — local estimate (15,000) exceeds safe window (9,500)
+				expect(setModel).not.toHaveBeenCalled()
+				expect(textOf(result)).toContain("Switch rejected")
+				expect(textOf(result)).toContain("Use /compact")
 			})
 		})
 	})


### PR DESCRIPTION
# Fix stale post-compaction state in model-switch guards

## Summary

After `/compact`, the model-switch guards (`set_model` tool and interactive model
selection) kept reading pre-compaction state for an entire window: cached messages
(`latestMessages`) still reflected the old conversation (inflated token estimate,
phantom images) until the next `context` event fired on the next LLM call. This PR
refreshes guard state immediately on `session_compact` and makes `estimateTokens()`
compaction-boundary aware.

## User impact

Fixed two failure modes right after compaction:

1. **Vision → non-vision model switch rejected.** The guard still saw pre-compaction
   image messages and blocked the switch, even though the compacted context was
   text-only.
2. **Smaller context window switch rejected.** The guard compared the pre-compaction
   token count (e.g. ~270k) against the new model's window and blocked the switch,
   even though the compacted summary plus tail fit comfortably.

Users can switch models immediately after `/compact` without sending an extra
message first.

## Design

Reworked on top of #1025 (baseline + trailing-message token resolution) and
upstream's post-compaction `getContextUsage()` contract (Pi ≥ 0.84.1,
earendil-works/pi@7eb969d — `tokens: null` after compaction until a successful
post-compaction assistant response exists; any non-null value is trustworthy by
contract).

- `src/extensions/model-guard.ts`
  - The `session_compact` handler refreshes `latestMessages` and image-detection
    state from `buildSessionContext(sessionManager.getBranch())`, so both the
    `set_model` tool and the `model_select` handler see post-compaction reality
    immediately instead of waiting for the next LLM call. Emits a diagnostic
    warning if the refresh fails.
  - `estimateTokens()` is compaction-boundary aware: an assistant `usage.totalTokens`
    baseline is trusted only when its timestamp is after the latest compaction
    summary's timestamp. Kept-tail assistants with pre-compaction usage fall back
    to **content counting** (never zero) so large retained responses are not
    undercounted.
  - `/strip-images` state is preserved when compaction's kept tail still contains
    images; it is only reset when the post-compaction context is fully text.

## Review-driven changes vs the previous revision

- Dropped the `contextInvalidatedByCompaction` flag and its clearing heuristic —
  redundant with upstream's deliberate `tokens: null` null-window contract.
- Strip-state reset is now conditional on the post-compaction context being
  image-free (kept-tail images survive compaction; unconditional reset undid
  `/strip-images` work).
- Kept-tail assistants rejected as usage baselines now contribute their content
  tokens, closing an undercount that could accept too-small target windows.
- Post-compaction `resolveContextTokens` trusts non-null `usage.tokens`
  unconditionally (upstream contract).

## Changes

- `src/extensions/model-guard.ts`
- `src/extensions/model-guard.test.ts`
- `src/extensions/model-switch.test.ts`

## Verification

- Unit/integration: `pnpm run test src/extensions/model-switch.test.ts
  src/extensions/model-guard.test.ts` (122 tests — includes end-to-end
  `context → session_compact → model_select`/`set_model` tests through the real
  upstream `buildSessionContext`, the kept-tail undercount regression test, and
  strip-state preservation on kept-tail images)
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean

Closes #<!-- TODO: link the tracking issue -->
