### PR TITLE
ci: run master-checks on merge_group so the queue can gate merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  merge_group:
 
 jobs:
   pr-checks:
@@ -56,7 +57,11 @@ jobs:
     # a PR based on a stale base ref can pass `pr-checks` and only fail at the
     # post-merge `master-checks` step, leaving master red until a follow-up
     # lands (see #657 for the original incident).
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    # It also runs on merge_group events as the merge queue's required
+    # validation build ("CI / master-checks"): checkout@v4 resolves to the
+    # queued merge branch (base + queued PRs), so the queue validates exactly
+    # the tree that would land on master before squashing.
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -67,15 +72,21 @@ jobs:
       #   pull_request       → group = "ci-pr-master-checks-<head_ref>"
       #                        e.g. PR from "fix/foo"  →  "ci-pr-master-checks-fix/foo"
       #                        (one slot per PR; cancels only that PR's stale runs)
+      #   merge_group        → group = "ci-mq-<run_id>"
+      #                        (merge-queue validation builds. github.head_ref
+      #                        is empty on merge_group events, and each queued
+      #                        build needs its own slot — a shared group with
+      #                        cancel-in-progress would make successive queue
+      #                        builds cancel each other)
       #
       # Why not a single "ci-master" group across both events? It would make
       # concurrent PRs cancel each other and let master pushes cancel
       # in-flight PR runs.
       #
-      # `&&`/`||` short-circuit in GitHub Actions expressions, so the
-      # `format(...)` on the right side is only evaluated on pull_request
-      # events (where `github.head_ref` is defined; it's empty for push).
-      group: ${{ github.event_name == 'push' && 'ci-master' || format('ci-pr-master-checks-{0}', github.head_ref) }}
+      # `&&`/`||` short-circuit (and `&&` binds tighter than `||`) in GitHub
+      # Actions expressions, so each `format(...)` branch is only evaluated
+      # for its own event (github.head_ref is only defined on pull_request).
+      group: ${{ github.event_name == 'push' && 'ci-master' || github.event_name == 'merge_group' && format('ci-mq-{0}', github.run_id) || format('ci-pr-master-checks-{0}', github.head_ref) }}
       cancel-in-progress: true
 
     steps:


### PR DESCRIPTION
## Linked issue

Closes #1022

## What does this PR do?

Master has a merge queue turned on, but it was set up without any required checks — so "Merge when ready" merged PRs after a 5-minute wait, no matter what CI said. That's the root cause of the recent incident where master stayed broken for ~23 hours: one PR merged with outdated green checks and broke the prompt-stability tests (#996), and another merged 3 minutes after its checks failed (#1004).

This PR makes CI run on the queue's test builds, which is the missing piece GitHub needs before we can make the queue actually check CI:

- The CI workflow now also runs when the merge queue creates a test merge (GitHub calls this a `merge_group` event). The code under test is exactly what master would look like after merging, so a PR can no longer slip through with outdated test results.
- The `master-checks` job (the one that mirrors what runs on master after merging) runs on those queue builds. Each queue build gets its own concurrency slot, so successive builds don't cancel each other.
- Nothing else changes. Regular PR checks work exactly as before.

This PR only makes CI *run* on queue builds. It doesn't enforce anything by itself — enforcement is a separate repo-settings step (below) that must happen **after** this is merged, in the order listed, otherwise merging breaks.

## How to turn on enforcement (after this PR merges)

1. **Test it.** Put a small, harmless PR into the merge queue. Check the Actions tab for a CI run triggered by `merge_group` and confirm `master-checks` runs and passes. If it doesn't show up, stop here — nothing is enforced yet, so no harm is done, but don't continue.
2. **Enforce it (needs repo admin).** Settings → Rules → Rulesets → "Master" → turn on "Require status checks to pass before merging" and add the check `CI / master-checks`. ⚠️ Do this **only** after step 1 shows the queue CI run exists. Otherwise every queued PR waits 60 minutes and gets rejected — no one can merge until the setting is removed again.
3. **Verify it.** Queue a PR with a deliberately failing test. It must be rejected from the queue instead of merging. (Delete the test PRs afterwards.)
4. **Tell the team.** Merges now take ~5–10 minutes longer while the queue's CI runs. If a PR's merged result fails tests, the queue refuses it — that's the gate working, not a bug.
5. **Undo if anything misbehaves.** Remove the required check from the same ruleset settings page and everything behaves exactly like before.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA (authored by Kimchi agent under user direction)
- [x] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`) — N/A: workflow-only change; validated by YAML parse + this PR's own CI
- [ ] Lint passes (`pnpm run check`) — N/A: workflow-only change
- [x] Documentation updated if behavior changed — N/A (no product behavior change)
