### PR TITLE
feat(model-guard): improve token resolution by incorporating appended message usage

### DIFF
--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -141,6 +141,17 @@ describe("resolveContextTokens", () => {
 		expect(resolveContextTokens(usage, msgs)).toBe(42_000)
 	})
 
+	it("returns usage.tokens when messages are empty", () => {
+		expect(resolveContextTokens({ tokens: 42_000 }, [])).toBe(42_000)
+	})
+
+	it("adds messages appended after the provider-reported usage", () => {
+		const usage = { tokens: 200_000 }
+		const msgs: ContextEvent["messages"] = [makeAssistant(200_000), makeToolResult("x".repeat(300_000))]
+
+		expect(resolveContextTokens(usage, msgs)).toBe(275_000)
+	})
+
 	it("falls back to estimateTokens(messages) when usage.tokens is null", () => {
 		const usage = { tokens: null }
 		// 30 msgs × 2000 chars each → ceil(2000/4)=500 tokens each → 15,000 total
@@ -483,6 +494,24 @@ describe("modelGuardExtension handler", () => {
 		const msgs: ContextEvent["messages"] = Array.from({ length: 30 }, () => makeUser("x".repeat(2000)))
 		const result = await trigger("context", { messages: msgs }, ctx)
 		expect(result).toBeUndefined()
+	})
+
+	it("truncates when appended tool output pushes the current payload over the hard limit", async () => {
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const ctx = makeMockCtx({
+			model: { id: "claude", input: ["text"], contextWindow: 10_000 } as ExtensionContext["model"],
+			getContextUsage: () => ({ tokens: 9_600, contextWindow: 10_000, percent: 96 }),
+		})
+		const msgs: ContextEvent["messages"] = [
+			...Array.from({ length: 20 }, () => makeUser("x".repeat(2000))),
+			makeAssistant(9_600),
+			makeToolResult("x".repeat(4000)),
+		]
+
+		const result = (await trigger("context", { messages: msgs }, ctx)) as { messages: ContextEvent["messages"] }
+		expect(result).toBeDefined()
+		expect(result.messages.length).toBeLessThan(msgs.length)
 	})
 
 	it("truncates when usage.tokens exceeds the hard context window limit", async () => {

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -152,6 +152,18 @@ describe("resolveContextTokens", () => {
 		expect(resolveContextTokens(usage, msgs)).toBe(275_000)
 	})
 
+	it("recognizes zero-token assistant usage before appended messages", () => {
+		const msgs: ContextEvent["messages"] = [makeAssistant(0), makeToolResult("x".repeat(400))]
+
+		expect(resolveContextTokens({ tokens: 0 }, msgs)).toBe(100)
+	})
+
+	it("adds the appended suffix to a refreshed provider baseline", () => {
+		const msgs: ContextEvent["messages"] = [makeAssistant(200), makeToolResult("x".repeat(400))]
+
+		expect(resolveContextTokens({ tokens: 50 }, msgs)).toBe(150)
+	})
+
 	it("falls back to estimateTokens(messages) when usage.tokens is null", () => {
 		const usage = { tokens: null }
 		// 30 msgs × 2000 chars each → ceil(2000/4)=500 tokens each → 15,000 total

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -19,18 +19,37 @@ export function contextFitsModel(tokens: number, contextWindow: number): boolean
 
 /**
  * Returns the best available token count for the current context.
- * Prefers the upstream getContextUsage().tokens (provider-accurate);
- * falls back to the local estimateTokens() heuristic when upstream
- * returns null (e.g. post-compaction, pre-first-response, fresh session).
+ * Uses upstream getContextUsage().tokens as the provider-accurate baseline,
+ * then estimates messages appended after that provider response. Falls back
+ * to the local estimateTokens() heuristic when upstream returns null
+ * (e.g. post-compaction, pre-first-response, fresh session).
  * Returns null when no data is available at all.
  */
 export function resolveContextTokens(
 	usage: { tokens: number | null } | undefined,
 	messages: ContextEvent["messages"],
 ): number | null {
-	if (usage?.tokens != null) return usage.tokens
-	if (messages.length === 0) return null
-	return estimateTokens(messages)
+	if (messages.length === 0) return usage?.tokens ?? null
+
+	const estimatedTokens = estimateTokens(messages)
+	if (usage?.tokens == null) return estimatedTokens
+
+	const lastAssistantUsage = findLastAssistantUsage(messages)
+	if (!lastAssistantUsage) return usage.tokens
+
+	return usage.tokens + estimatedTokens - lastAssistantUsage.totalTokens
+}
+
+function findLastAssistantUsage(
+	messages: ContextEvent["messages"],
+): { index: number; totalTokens: number } | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]
+		if (message.role === "assistant" && "usage" in message && message.usage?.totalTokens) {
+			return { index: i, totalTokens: message.usage.totalTokens }
+		}
+	}
+	return undefined
 }
 
 /** Module-level flag tracking whether the current session contains image blocks. */
@@ -123,21 +142,10 @@ export const __resetImagesDetectedForTest = resetSessionState
  * Accumulates from assistant message usage when available for higher accuracy.
  */
 export function estimateTokens(messages: ContextEvent["messages"]): number {
-	let lastAssistantIdx = -1
-	for (let i = messages.length - 1; i >= 0; i--) {
-		const msg = messages[i]
-		if (msg.role === "assistant" && "usage" in msg && msg.usage?.totalTokens) {
-			lastAssistantIdx = i
-			break
-		}
-	}
+	const lastAssistantUsage = findLastAssistantUsage(messages)
+	const lastAssistantIdx = lastAssistantUsage?.index ?? -1
 
-	let tokens = 0
-
-	if (lastAssistantIdx >= 0) {
-		const lastAssistant = messages[lastAssistantIdx]
-		tokens = (lastAssistant as AssistantMessage).usage?.totalTokens ?? 0
-	}
+	let tokens = lastAssistantUsage?.totalTokens ?? 0
 
 	for (let i = lastAssistantIdx >= 0 ? lastAssistantIdx + 1 : 0; i < messages.length; i++) {
 		const msg = messages[i]

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -31,13 +31,12 @@ export function resolveContextTokens(
 ): number | null {
 	if (messages.length === 0) return usage?.tokens ?? null
 
-	const estimatedTokens = estimateTokens(messages)
-	if (usage?.tokens == null) return estimatedTokens
+	if (usage?.tokens == null) return estimateTokens(messages)
 
 	const lastAssistantUsage = findLastAssistantUsage(messages)
 	if (!lastAssistantUsage) return usage.tokens
 
-	return usage.tokens + estimatedTokens - lastAssistantUsage.totalTokens
+	return usage.tokens + estimateTokensAfter(messages, lastAssistantUsage.index)
 }
 
 function findLastAssistantUsage(
@@ -45,11 +44,17 @@ function findLastAssistantUsage(
 ): { index: number; totalTokens: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i]
-		if (message.role === "assistant" && "usage" in message && message.usage?.totalTokens) {
+		if (message.role === "assistant" && "usage" in message && typeof message.usage?.totalTokens === "number") {
 			return { index: i, totalTokens: message.usage.totalTokens }
 		}
 	}
 	return undefined
+}
+
+function estimateTokensAfter(messages: ContextEvent["messages"], index: number): number {
+	let tokens = 0
+	for (let i = index + 1; i < messages.length; i++) tokens += estimateMessageTokens(messages[i])
+	return tokens
 }
 
 /** Module-level flag tracking whether the current session contains image blocks. */
@@ -143,28 +148,7 @@ export const __resetImagesDetectedForTest = resetSessionState
  */
 export function estimateTokens(messages: ContextEvent["messages"]): number {
 	const lastAssistantUsage = findLastAssistantUsage(messages)
-	const lastAssistantIdx = lastAssistantUsage?.index ?? -1
-
-	let tokens = lastAssistantUsage?.totalTokens ?? 0
-
-	for (let i = lastAssistantIdx >= 0 ? lastAssistantIdx + 1 : 0; i < messages.length; i++) {
-		const msg = messages[i]
-		if (msg.role === "assistant" && "usage" in msg && msg.usage?.totalTokens) continue
-		if (!("content" in msg)) continue
-		const content = (msg as ContentMessage).content
-		if (typeof content === "string") {
-			tokens += Math.ceil(content.length / 4)
-		} else if (Array.isArray(content)) {
-			for (const block of content) {
-				if (block.type === "text") {
-					tokens += Math.ceil(block.text.length / 4)
-				} else if (block.type === "image") {
-					tokens += 1000
-				}
-			}
-		}
-	}
-	return tokens
+	return (lastAssistantUsage?.totalTokens ?? 0) + estimateTokensAfter(messages, lastAssistantUsage?.index ?? -1)
 }
 
 /**
@@ -242,7 +226,7 @@ const TRUNCATE_NOTICE = "⚠️ Context truncated to fit model context window.\n
  * Returns the original reference when nothing is truncated.
  */
 export function estimateMessageTokens(msg: ContextEvent["messages"][number]): number {
-	if (msg.role === "assistant" && "usage" in msg && msg.usage?.totalTokens) {
+	if (msg.role === "assistant" && "usage" in msg && typeof msg.usage?.totalTokens === "number") {
 		return msg.usage.totalTokens
 	}
 	if (!("content" in msg)) return 0


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The harness previously checked only the token count from the last completed model request. If a tool then returned more output, that new content was not included, so the next request could be larger than the model's context window.

For example:

```text
Previous request: 250k tokens
New tool output: +30k tokens
Actual next request: 280k tokens
Old guard still saw: 250k tokens
```

This change adds newly appended messages and tool output to the previous provider-reported token count. If the complete request is too large, the existing model guard shortens the old context before sending it.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
