### PR TITLE
fix(teleport): sync themes directory contents in harness config rsync

### DIFF
--- a/src/extensions/teleport/provisioning/harness-config.test.ts
+++ b/src/extensions/teleport/provisioning/harness-config.test.ts
@@ -82,6 +82,9 @@ describe("provisionHarnessConfig", () => {
 
 describe("HARNESS_CONFIG_ALLOWLIST", () => {
 	it("contains exactly the synced harness config entries", () => {
-		expect([...HARNESS_CONFIG_ALLOWLIST]).toEqual(["settings.json", "keybindings.json", "themes", "models.json"])
+		// Directory entries must keep their trailing slash: in --files-from
+		// mode a bare `themes` syncs as an empty dir (still exit 0) on both
+		// GNU rsync and macOS openrsync.
+		expect([...HARNESS_CONFIG_ALLOWLIST]).toEqual(["settings.json", "keybindings.json", "themes/", "models.json"])
 	})
 })

--- a/src/extensions/teleport/provisioning/harness-config.ts
+++ b/src/extensions/teleport/provisioning/harness-config.ts
@@ -12,7 +12,12 @@ import { formatRsyncFailure, runRsync } from "./rsync-runner.js"
 export const HARNESS_CONFIG_ALLOWLIST: readonly string[] = [
 	"settings.json",
 	"keybindings.json",
-	"themes",
+	// Trailing slash is load-bearing: in --files-from mode, a bare `themes`
+	// entry transfers as an EMPTY directory while rsync still exits 0 —
+	// the remote gets no theme files at all and the session falls back
+	// with "Failed to load theme". Verified on GNU rsync 3.5 (Linux) and
+	// macOS openrsync — both need `themes/` to recurse.
+	"themes/",
 	"models.json",
 ]
 


### PR DESCRIPTION
The harness-config allowlist listed "themes" without a trailing slash. In --files-from mode, both GNU rsync (3.5, Linux) and macOS openrsync transfer a bare directory entry as an empty dir while still exiting 0, so the sandbox ended up with only its own seeded bundled themes and any custom theme selected in settings.json failed to load remotely ("Failed to load theme ... Fell back to dark theme").


## Linked issue

Closes #1026


## What does this PR do?


Give the entry its trailing slash ("themes/") so --files-from recurses on both rsync flavors. Update the allowlist regression test and document the cross-flavor behavior.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed