### PR TITLE
fix(mcp): release OAuth callback port

### DIFF
--- a/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
@@ -27,12 +27,13 @@ async function sendCallback(port: number, path: string, state: string, code: str
 	expect(response.ok).toBe(true)
 }
 
-async function loadAuthFlowForPort(port: number) {
+async function loadAuthFlowForPort(port: number, options: { connectGate?: Promise<void> } = {}) {
 	const authDir = mkdtempSync(join(tmpdir(), "kimchi-mcp-oauth-test-"))
 	vi.resetModules()
 	vi.stubEnv("MCP_OAUTH_CALLBACK_PORT", String(port))
 	vi.stubEnv("MCP_OAUTH_DIR", authDir)
 	const openBrowser = vi.fn(async () => {})
+	const connectStarted = vi.fn()
 	vi.doMock("open", () => ({ default: openBrowser }))
 
 	vi.doMock("@modelcontextprotocol/sdk/client/auth.js", () => {
@@ -64,6 +65,8 @@ async function loadAuthFlowForPort(port: number) {
 
 		class Client {
 			async connect(transport: { authProvider?: { redirectToAuthorization?: (url: URL) => void | Promise<void> } }) {
+				connectStarted()
+				await options.connectGate
 				await transport.authProvider?.redirectToAuthorization?.(new URL("https://auth.example.test/authorize"))
 				throw new UnauthorizedError("authorization required")
 			}
@@ -81,7 +84,7 @@ async function loadAuthFlowForPort(port: number) {
 		import("./mcp-oauth-provider.js"),
 	])
 
-	return { authDir, authStore, callbackServer, flow, oauthProvider, openBrowser }
+	return { authDir, authStore, callbackServer, connectStarted, flow, oauthProvider, openBrowser }
 }
 
 afterEach(() => {
@@ -155,6 +158,39 @@ describe("MCP OAuth callback lifecycle", () => {
 			expect(callbackServer.isCallbackServerRunning()).toBe(false)
 		} finally {
 			await flow.shutdownOAuth()
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+
+	it("cancels authentication when shutdown follows callback server startup", async () => {
+		const port = await getFreePort()
+		let resumeConnect = () => {}
+		const connectGate = new Promise<void>((resolve) => {
+			resumeConnect = resolve
+		})
+		const { authDir, callbackServer, connectStarted, flow } = await loadAuthFlowForPort(port, { connectGate })
+		const authenticating = flow.authenticate("rovo", "https://rovo.example.test/mcp")
+
+		try {
+			await vi.waitFor(() => expect(connectStarted).toHaveBeenCalledOnce())
+			expect(callbackServer.isCallbackServerRunning()).toBe(true)
+
+			await flow.shutdownOAuth()
+			resumeConnect()
+
+			const outcome = await Promise.race([
+				authenticating.then(
+					() => "authenticated",
+					(error: unknown) => (error instanceof Error ? error.message : String(error)),
+				),
+				new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 1_000)),
+			])
+			expect(outcome).toBe("OAuth callback server stopped")
+			expect(callbackServer.isCallbackServerRunning()).toBe(false)
+		} finally {
+			resumeConnect()
+			await flow.shutdownOAuth()
+			await authenticating.catch(() => {})
 			rmSync(authDir, { recursive: true, force: true })
 		}
 	})

--- a/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { createServer } from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+async function getFreePort(): Promise<number> {
+	const server = createServer()
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+	const address = server.address()
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+	if (!address || typeof address === "string") throw new Error("Could not allocate a local test port")
+	return address.port
+}
+
+async function expectPortCanBind(port: number): Promise<void> {
+	const server = createServer()
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject)
+		server.listen(port, "127.0.0.1", resolve)
+	})
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+}
+
+async function sendCallback(port: number, path: string, state: string, code: string): Promise<void> {
+	const response = await fetch(`http://127.0.0.1:${port}${path}?code=${code}&state=${state}`)
+	expect(response.ok).toBe(true)
+}
+
+async function loadAuthFlowForPort(port: number) {
+	const authDir = mkdtempSync(join(tmpdir(), "kimchi-mcp-oauth-test-"))
+	vi.resetModules()
+	vi.stubEnv("MCP_OAUTH_CALLBACK_PORT", String(port))
+	vi.stubEnv("MCP_OAUTH_DIR", authDir)
+	const openBrowser = vi.fn(async () => {})
+	vi.doMock("open", () => ({ default: openBrowser }))
+
+	vi.doMock("@modelcontextprotocol/sdk/client/auth.js", () => {
+		class UnauthorizedError extends Error {}
+		return { UnauthorizedError }
+	})
+
+	vi.doMock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
+		class StreamableHTTPClientTransport {
+			readonly authProvider?: { redirectToAuthorization?: (url: URL) => void | Promise<void> }
+
+			constructor(
+				_url: URL,
+				options?: { authProvider?: { redirectToAuthorization?: (url: URL) => void | Promise<void> } },
+			) {
+				this.authProvider = options?.authProvider
+			}
+
+			async finishAuth(): Promise<void> {}
+
+			async close(): Promise<void> {}
+		}
+
+		return { StreamableHTTPClientTransport }
+	})
+
+	vi.doMock("@modelcontextprotocol/sdk/client/index.js", async () => {
+		const { UnauthorizedError } = await import("@modelcontextprotocol/sdk/client/auth.js")
+
+		class Client {
+			async connect(transport: { authProvider?: { redirectToAuthorization?: (url: URL) => void | Promise<void> } }) {
+				await transport.authProvider?.redirectToAuthorization?.(new URL("https://auth.example.test/authorize"))
+				throw new UnauthorizedError("authorization required")
+			}
+
+			async close(): Promise<void> {}
+		}
+
+		return { Client }
+	})
+
+	const [flow, callbackServer, authStore, oauthProvider] = await Promise.all([
+		import("./mcp-auth-flow.js"),
+		import("./mcp-callback-server.js"),
+		import("./mcp-auth.js"),
+		import("./mcp-oauth-provider.js"),
+	])
+
+	return { authDir, authStore, callbackServer, flow, oauthProvider, openBrowser }
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+	vi.doUnmock("@modelcontextprotocol/sdk/client/auth.js")
+	vi.doUnmock("@modelcontextprotocol/sdk/client/index.js")
+	vi.doUnmock("@modelcontextprotocol/sdk/client/streamableHttp.js")
+	vi.doUnmock("open")
+})
+
+describe("MCP OAuth callback lifecycle", () => {
+	it("does not bind the callback port during idle initialization", async () => {
+		const port = await getFreePort()
+		const { authDir, callbackServer, flow } = await loadAuthFlowForPort(port)
+
+		try {
+			await flow.initializeOAuth()
+
+			await expectPortCanBind(port)
+			expect(callbackServer.isCallbackServerRunning()).toBe(false)
+		} finally {
+			await flow.shutdownOAuth()
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+
+	it("shares one callback listener across concurrent authentications and releases it after the last one", async () => {
+		const port = await getFreePort()
+		const { authDir, authStore, callbackServer, flow, oauthProvider, openBrowser } = await loadAuthFlowForPort(port)
+
+		try {
+			const first = flow.authenticate("first", "https://first.example.test/mcp")
+			const second = flow.authenticate("second", "https://second.example.test/mcp")
+			await vi.waitFor(() => expect(openBrowser).toHaveBeenCalledTimes(2))
+
+			const firstState = await authStore.getOAuthState("first")
+			if (!firstState) throw new Error("Missing first OAuth state")
+			await sendCallback(port, oauthProvider.OAUTH_CALLBACK_PATH, firstState, "first-code")
+			await expect(first).resolves.toBe("authenticated")
+			expect(callbackServer.isCallbackServerRunning()).toBe(true)
+
+			const secondState = await authStore.getOAuthState("second")
+			if (!secondState) throw new Error("Missing second OAuth state")
+			await sendCallback(port, oauthProvider.OAUTH_CALLBACK_PATH, secondState, "second-code")
+			await expect(second).resolves.toBe("authenticated")
+			expect(callbackServer.isCallbackServerRunning()).toBe(false)
+			await expectPortCanBind(port)
+		} finally {
+			await flow.shutdownOAuth()
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+
+	it("waits for an in-progress close before starting a new authentication", async () => {
+		const port = await getFreePort()
+		const { authDir, authStore, callbackServer, flow, oauthProvider, openBrowser } = await loadAuthFlowForPort(port)
+
+		try {
+			await callbackServer.ensureCallbackServer({ strictPort: true })
+			const stopping = callbackServer.stopCallbackServer()
+			const authenticating = flow.authenticate("rovo", "https://rovo.example.test/mcp")
+
+			await stopping
+			await vi.waitFor(() => expect(openBrowser).toHaveBeenCalledOnce())
+			expect(callbackServer.isCallbackServerRunning()).toBe(true)
+
+			const state = await authStore.getOAuthState("rovo")
+			if (!state) throw new Error("Missing Rovo OAuth state")
+			await sendCallback(port, oauthProvider.OAUTH_CALLBACK_PATH, state, "rovo-code")
+			await expect(authenticating).resolves.toBe("authenticated")
+			expect(callbackServer.isCallbackServerRunning()).toBe(false)
+		} finally {
+			await flow.shutdownOAuth()
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+
+	it("releases callback ownership when the browser cannot open", async () => {
+		const port = await getFreePort()
+		const { authDir, callbackServer, flow, openBrowser } = await loadAuthFlowForPort(port)
+		openBrowser.mockRejectedValueOnce(new Error("browser unavailable"))
+
+		try {
+			await expect(flow.authenticate("rovo", "https://rovo.example.test/mcp")).rejects.toThrow("Could not open browser")
+			expect(callbackServer.isCallbackServerRunning()).toBe(false)
+			await expectPortCanBind(port)
+		} finally {
+			await flow.shutdownOAuth()
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+})

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -37,6 +37,12 @@ const pendingTransports = new Map<string, StreamableHTTPClientTransport>()
 // Deduplicate concurrent authenticate() calls per server.
 const pendingAuthentications = new Map<string, Promise<AuthStatus>>()
 
+async function stopCallbackServerIfIdle(): Promise<void> {
+	if (pendingTransports.size === 0 && pendingAuthentications.size === 0) {
+		await stopCallbackServer()
+	}
+}
+
 /**
  * Generate a cryptographically secure random state parameter.
  */
@@ -139,6 +145,7 @@ export async function startAuth(
 		// If we get here, we're already authenticated
 		await client.close().catch(() => {})
 		await transport.close().catch(() => {})
+		await stopCallbackServerIfIdle()
 		return { authorizationUrl: "", transport }
 	} catch (error) {
 		if (error instanceof UnauthorizedError && capturedUrl) {
@@ -149,6 +156,7 @@ export async function startAuth(
 		}
 		await client.close().catch(() => {})
 		await transport.close().catch(() => {})
+		await stopCallbackServerIfIdle()
 		throw error
 	}
 }
@@ -169,6 +177,7 @@ export async function completeAuth(serverName: string, authorizationCode: string
 	} finally {
 		pendingTransports.delete(serverName)
 		await transport.close().catch(() => {})
+		await stopCallbackServerIfIdle()
 	}
 }
 
@@ -212,16 +221,18 @@ export async function authenticate(
 		// Register the callback BEFORE opening the browser
 		const callbackPromise = waitForCallback(oauthState)
 
-		// Open browser
-		console.log(`MCP Auth: Opening browser for ${serverName}`)
 		try {
-			await open(authorizationUrl)
-		} catch (error) {
-			console.warn(`MCP Auth: Failed to open browser for ${serverName}`, { error })
-			throw new Error(`Could not open browser. Please open this URL manually: ${authorizationUrl}`, { cause: error })
-		}
+			// Open browser
+			console.log(`MCP Auth: Opening browser for ${serverName}`)
+			try {
+				await open(authorizationUrl)
+			} catch (error) {
+				console.warn(`MCP Auth: Failed to open browser for ${serverName}`, { error })
+				throw new Error(`Could not open browser. Please open this URL manually: ${authorizationUrl}`, {
+					cause: error,
+				})
+			}
 
-		try {
 			// Wait for callback
 			const code = await callbackPromise
 
@@ -237,6 +248,7 @@ export async function authenticate(
 			return await completeAuth(serverName, code)
 		} catch (error) {
 			cancelPendingCallback(oauthState)
+			await callbackPromise.catch(() => {})
 			const pendingTransport = pendingTransports.get(serverName)
 			if (pendingTransport) {
 				pendingTransports.delete(serverName)
@@ -254,6 +266,7 @@ export async function authenticate(
 		if (pendingAuthentications.get(serverName) === operation) {
 			pendingAuthentications.delete(serverName)
 		}
+		await stopCallbackServerIfIdle()
 	}
 }
 
@@ -373,6 +386,7 @@ export async function removeAuth(serverName: string): Promise<void> {
 		pendingTransports.delete(serverName)
 		await pendingTransport.close().catch(() => {})
 	}
+	await stopCallbackServerIfIdle()
 	clearAllCredentials(serverName)
 	await clearOAuthState(serverName)
 	console.log(`MCP Auth: Removed credentials for ${serverName}`)
@@ -399,11 +413,9 @@ export function supportsOAuth(definition: ServerEntry): boolean {
 
 /**
  * Initialize the OAuth system on startup.
- * Starts the callback server if there are any OAuth servers configured.
+ * OAuth callback binding is lazy and starts from startAuth() only.
  */
-export async function initializeOAuth(): Promise<void> {
-	await ensureCallbackServer()
-}
+export async function initializeOAuth(): Promise<void> {}
 
 /**
  * Shutdown the OAuth system.

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -19,12 +19,7 @@ import {
 	type StoredTokens,
 	updateOAuthState,
 } from "./mcp-auth.js"
-import {
-	cancelPendingCallback,
-	ensureCallbackServer,
-	stopCallbackServer,
-	waitForCallback,
-} from "./mcp-callback-server.js"
+import { cancelPendingCallback, prepareCallback, stopCallbackServer } from "./mcp-callback-server.js"
 import { type McpOAuthConfig, McpOAuthProvider } from "./mcp-oauth-provider.js"
 import type { ServerEntry } from "./types.js"
 
@@ -81,7 +76,12 @@ export async function startAuth(
 	serverName: string,
 	serverUrl: string,
 	definition?: ServerEntry,
-): Promise<{ authorizationUrl: string; transport: StreamableHTTPClientTransport }> {
+): Promise<{
+	authorizationUrl: string
+	transport: StreamableHTTPClientTransport
+	oauthState?: string
+	callbackPromise?: Promise<string>
+}> {
 	const config = definition ? extractOAuthConfig(definition) : {}
 
 	if (config.grantType === "client_credentials") {
@@ -107,19 +107,7 @@ export async function startAuth(
 		}
 	}
 
-	// Start the callback server with strict port binding. The redirect URI
-	// is tied to the port — if the port changes between registrations, the
-	// OAuth server rejects the callback with "redirect_uri not registered".
-	// Always use the default port (19876) so dynamic client registration
-	// stays consistent across attempts.
-	await ensureCallbackServer({ strictPort: true })
-
-	// Generate and store OAuth state BEFORE creating the provider.
-	// The SDK calls provider.state() (not saveState) to read the state when
-	// constructing the authorization URL — it expects the state to already
-	// be stored. We generate it here so it's available when the SDK needs it.
 	const oauthState = generateState()
-	await updateOAuthState(serverName, oauthState)
 
 	// Create the auth provider
 	let capturedUrl: URL | undefined
@@ -138,21 +126,37 @@ export async function startAuth(
 		name: "pi-mcp",
 		version: "3.0.0",
 	})
+	let callbackPromise: Promise<string> | undefined
 
 	// Try to connect - this triggers the OAuth flow
 	try {
+		// Start the callback server and register ownership in one serialized operation.
+		// This prevents shutdown from closing the listener between those two steps.
+		const preparedCallback = await prepareCallback(oauthState, { strictPort: true })
+		callbackPromise = preparedCallback.callbackPromise
+		void callbackPromise.catch(() => {})
+
+		// The SDK reads the stored state while constructing the authorization URL.
+		await updateOAuthState(serverName, oauthState)
+
 		await client.connect(transport)
 		// If we get here, we're already authenticated
+		cancelPendingCallback(oauthState)
+		await callbackPromise.catch(() => {})
 		await client.close().catch(() => {})
 		await transport.close().catch(() => {})
 		await stopCallbackServerIfIdle()
 		return { authorizationUrl: "", transport }
 	} catch (error) {
-		if (error instanceof UnauthorizedError && capturedUrl) {
+		if (error instanceof UnauthorizedError && capturedUrl && callbackPromise) {
 			await client.close().catch(() => {})
 			// Store transport for later finishAuth
 			pendingTransports.set(serverName, transport)
-			return { authorizationUrl: capturedUrl.toString(), transport }
+			return { authorizationUrl: capturedUrl.toString(), transport, oauthState, callbackPromise }
+		}
+		if (callbackPromise) {
+			cancelPendingCallback(oauthState)
+			await callbackPromise.catch(() => {})
 		}
 		await client.close().catch(() => {})
 		await transport.close().catch(() => {})
@@ -201,27 +205,18 @@ export async function authenticate(
 
 	const operation = (async (): Promise<AuthStatus> => {
 		// Start auth flow
-		const { authorizationUrl } = await startAuth(serverName, serverUrl, definition)
+		const { authorizationUrl, callbackPromise, oauthState } = await startAuth(serverName, serverUrl, definition)
 
 		// If no auth URL needed, already authenticated
 		if (!authorizationUrl) {
 			return "authenticated"
 		}
 
-		// Read the OAuth state stored by startAuth() (line ~107) and/or
-		// by the SDK via provider.saveState() during client.connect().
-		// At least one of these paths always saves state before we reach
-		// here — startAuth() pre-generates it, and provider.state()
-		// auto-generates if missing — so this is always defined.
-		const oauthState = await getOAuthState(serverName)
-		if (!oauthState) {
-			throw new Error("OAuth state was not saved during startAuth")
-		}
-
-		// Register the callback BEFORE opening the browser
-		const callbackPromise = waitForCallback(oauthState)
-
 		try {
+			if (!oauthState || !callbackPromise) {
+				throw new Error("OAuth callback was not registered during startAuth")
+			}
+
 			// Open browser
 			console.log(`MCP Auth: Opening browser for ${serverName}`)
 			try {
@@ -247,8 +242,10 @@ export async function authenticate(
 			// Complete the auth
 			return await completeAuth(serverName, code)
 		} catch (error) {
-			cancelPendingCallback(oauthState)
-			await callbackPromise.catch(() => {})
+			if (oauthState) {
+				cancelPendingCallback(oauthState)
+			}
+			await callbackPromise?.catch(() => {})
 			const pendingTransport = pendingTransports.get(serverName)
 			if (pendingTransport) {
 				pendingTransports.delete(serverName)

--- a/src/extensions/mcp-adapter/mcp-callback-server.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.ts
@@ -227,6 +227,19 @@ export function ensureCallbackServer(options: EnsureCallbackServerOptions = {}):
 	return serializeServerLifecycle(() => ensureCallbackServerLocked(options))
 }
 
+export async function prepareCallback(
+	oauthState: string,
+	options: EnsureCallbackServerOptions = {},
+): Promise<{ callbackPromise: Promise<string> }> {
+	let callbackPromise: Promise<string> | undefined
+	await serializeServerLifecycle(async () => {
+		await ensureCallbackServerLocked(options)
+		callbackPromise = waitForCallback(oauthState)
+	})
+	if (!callbackPromise) throw new Error("OAuth callback registration failed")
+	return { callbackPromise }
+}
+
 /**
  * Wait for a callback with the given OAuth state.
  * Returns a promise that resolves with the authorization code.

--- a/src/extensions/mcp-adapter/mcp-callback-server.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.ts
@@ -65,6 +65,13 @@ interface PendingAuth {
 /** Server singleton state */
 let server: Server | undefined
 const pendingAuths = new Map<string, PendingAuth>()
+let serverLifecycle = Promise.resolve()
+
+function serializeServerLifecycle(operation: () => Promise<void>): Promise<void> {
+	const result = serverLifecycle.then(operation, operation)
+	serverLifecycle = result.catch(() => {})
+	return result
+}
 
 /** Timeout for callback completion (5 minutes) */
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
@@ -150,7 +157,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
  * If strictPort is true, requires binding on the configured callback port.
  * If strictPort is false, scans forward for an available local port.
  */
-export async function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
+async function ensureCallbackServerLocked(options: EnsureCallbackServerOptions): Promise<void> {
 	const configuredPort = getConfiguredOAuthCallbackPort()
 	const strictPort = options.strictPort === true
 
@@ -163,7 +170,7 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
 			)
 		}
 
-		await stopCallbackServer()
+		await stopCallbackServerLocked()
 	}
 
 	const preferredPort = configuredPort
@@ -216,6 +223,10 @@ export async function ensureCallbackServer(options: EnsureCallbackServerOptions 
 	)
 }
 
+export function ensureCallbackServer(options: EnsureCallbackServerOptions = {}): Promise<void> {
+	return serializeServerLifecycle(() => ensureCallbackServerLocked(options))
+}
+
 /**
  * Wait for a callback with the given OAuth state.
  * Returns a promise that resolves with the authorization code.
@@ -248,7 +259,7 @@ export function cancelPendingCallback(oauthState: string): void {
 /**
  * Stop the callback server and reject all pending authorizations.
  */
-export async function stopCallbackServer(): Promise<void> {
+async function stopCallbackServerLocked(): Promise<void> {
 	if (server) {
 		await new Promise<void>((resolve) => {
 			server?.close(() => {
@@ -269,6 +280,10 @@ export async function stopCallbackServer(): Promise<void> {
 			pending.reject(new Error("OAuth callback server stopped"))
 		}
 	}, 0)
+}
+
+export function stopCallbackServer(): Promise<void> {
+	return serializeServerLifecycle(stopCallbackServerLocked)
 }
 
 /**

--- a/tests/smoke/mcp-oauth-callback.test.ts
+++ b/tests/smoke/mcp-oauth-callback.test.ts
@@ -1,37 +1,71 @@
-import { createServer } from "node:http"
-import { describe, it } from "vitest"
+import { createServer, type Server } from "node:http"
+import { describe, expect, it } from "vitest"
 import { spawnInteractive } from "./harness.js"
 
-async function getFreePort(): Promise<number> {
-	const server = createServer()
-	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
-	const address = server.address()
-	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
-	if (!address || typeof address === "string") throw new Error("Could not allocate a local test port")
-	return address.port
+// Occupy the complete pre-fix fallback range so eager startup fails deterministically.
+const LEGACY_CALLBACK_PORT_SCAN_ATTEMPTS = 25
+
+async function closeServers(servers: Server[]): Promise<void> {
+	await Promise.all(
+		servers
+			.filter((server) => server.listening)
+			.map(
+				(server) =>
+					new Promise<void>((resolve, reject) => {
+						server.close((error) => (error ? reject(error) : resolve()))
+					}),
+			),
+	)
 }
 
-async function expectPortCanBind(port: number): Promise<void> {
-	const server = createServer()
-	await new Promise<void>((resolve, reject) => {
-		server.once("error", reject)
-		server.listen(port, "127.0.0.1", resolve)
-	})
-	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+async function reserveCallbackPortRange(): Promise<{ port: number; release: () => Promise<void> }> {
+	for (let attempt = 0; attempt < 10; attempt++) {
+		const servers: Server[] = []
+		try {
+			const first = createServer()
+			await new Promise<void>((resolve, reject) => {
+				first.once("error", reject)
+				first.listen(0, "127.0.0.1", resolve)
+			})
+			servers.push(first)
+
+			const address = first.address()
+			if (!address || typeof address === "string" || address.port > 65_535 - (LEGACY_CALLBACK_PORT_SCAN_ATTEMPTS - 1)) {
+				await closeServers(servers)
+				continue
+			}
+
+			for (let offset = 1; offset < LEGACY_CALLBACK_PORT_SCAN_ATTEMPTS; offset++) {
+				const server = createServer()
+				await new Promise<void>((resolve, reject) => {
+					server.once("error", reject)
+					server.listen(address.port + offset, "127.0.0.1", resolve)
+				})
+				servers.push(server)
+			}
+
+			return { port: address.port, release: () => closeServers(servers) }
+		} catch {
+			await closeServers(servers)
+		}
+	}
+
+	throw new Error("Could not reserve an OAuth callback port range")
 }
 
 describe("MCP OAuth callback smoke test", () => {
-	it("an idle harness leaves the callback port available to another process", { timeout: 20_000 }, async () => {
-		const port = await getFreePort()
-		const session = spawnInteractive({ extraEnv: { MCP_OAUTH_CALLBACK_PORT: String(port) } })
+	it("an idle harness does not initialize the OAuth callback server", { timeout: 20_000 }, async () => {
+		const reservation = await reserveCallbackPortRange()
+		const session = spawnInteractive({ extraEnv: { MCP_OAUTH_CALLBACK_PORT: String(reservation.port) } })
 
 		try {
 			await session.waitFor((output) => output.length > 0, 10_000)
 			session.write("\r")
 			await session.waitFor((output) => output.includes("ask anything or type / for commands"), 10_000)
-			await expectPortCanBind(port)
+			expect(session.output()).not.toContain("MCP OAuth initialization failed")
 		} finally {
 			await session.kill()
+			await reservation.release()
 		}
 	})
 })

--- a/tests/smoke/mcp-oauth-callback.test.ts
+++ b/tests/smoke/mcp-oauth-callback.test.ts
@@ -1,0 +1,37 @@
+import { createServer } from "node:http"
+import { describe, it } from "vitest"
+import { spawnInteractive } from "./harness.js"
+
+async function getFreePort(): Promise<number> {
+	const server = createServer()
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+	const address = server.address()
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+	if (!address || typeof address === "string") throw new Error("Could not allocate a local test port")
+	return address.port
+}
+
+async function expectPortCanBind(port: number): Promise<void> {
+	const server = createServer()
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject)
+		server.listen(port, "127.0.0.1", resolve)
+	})
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+}
+
+describe("MCP OAuth callback smoke test", () => {
+	it("an idle harness leaves the callback port available to another process", { timeout: 20_000 }, async () => {
+		const port = await getFreePort()
+		const session = spawnInteractive({ extraEnv: { MCP_OAUTH_CALLBACK_PORT: String(port) } })
+
+		try {
+			await session.waitFor((output) => output.length > 0, 10_000)
+			session.write("\r")
+			await session.waitFor((output) => output.includes("ask anything or type / for commands"), 10_000)
+			await expectPortCanBind(port)
+		} finally {
+			await session.kill()
+		}
+	})
+})


### PR DESCRIPTION
## What was wrong

Every harness eagerly bound the fixed MCP OAuth callback port and kept it open, so another harness could not authenticate pre-registered servers such as Rovo that require the exact redirect URI. Concurrent authentication and browser-open failures could also leave the listener in a bad state.

## Fix

Bind the callback server only while authentication needs it, serialize listener start/stop operations, release the port after the last authentication settles, and clean up failed browser launches.

## Validation

- `pnpm exec vitest run src/extensions/mcp-adapter` — 11 files, 128 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
