### PR TITLE
feat(acp): add _kimchi.dev/steering extension method

### DIFF
--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -8,8 +8,8 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 //
 // Direction:
 // - pi_* methods are agent→client (the agent calls conn.extMethod on the client).
-// - probe_mcp_server and set_session_title are client→agent inbound (the
-//   agent's extMethod() handler receives them).
+// - probe_mcp_server, set_session_title, and steering are client→agent
+//   inbound (the agent's extMethod() handler receives them).
 //
 // Capability advertising: every entry here is exposed in
 // `_meta["kimchi.dev"][<key>] === true` so clients can discover the methods
@@ -18,6 +18,7 @@ export const AVAILABLE_EXT_METHODS = {
 	pi_editor: `_${CAPABILITIES_KEY}/pi_editor`,
 	probe_mcp_server: `_${CAPABILITIES_KEY}/probe_mcp_server`,
 	set_session_title: `_${CAPABILITIES_KEY}/set_session_title`,
+	steering: `_${CAPABILITIES_KEY}/steering`,
 } as const
 
 export const AVAILABLE_EXT_NOTIFICATIONS = {

--- a/src/modes/acp/ext-methods/steering.test.ts
+++ b/src/modes/acp/ext-methods/steering.test.ts
@@ -23,6 +23,7 @@ class FakeAgentSession {
 	}
 	setSessionName = vi.fn()
 	steer = vi.fn(async (_text: string) => {})
+	clearQueue = vi.fn(() => ({ steering: [] as string[], followUp: [] as string[] }))
 	extensionRunner = { emit: async () => {} }
 	getToolDefinition = vi.fn((_name: string) => undefined)
 	getContextUsage = () => undefined
@@ -58,9 +59,10 @@ class FakeAgentSession {
 	finishTurn(): void {
 		this.promptResolve?.()
 	}
-	async abort(): Promise<void> {
-		this.finishTurn()
-	}
+	// abort() deliberately does NOT finish the turn: real pi-mono has a window
+	// between cancel and turn teardown where entry.turn is still defined but
+	// already cancelled — tests use finishTurn() to end it explicitly.
+	async abort(): Promise<void> {}
 	dispose(): void {
 		this.finishTurn()
 		this.disposed = true
@@ -132,6 +134,34 @@ describe("KimchiAcpAgent extMethod steering", () => {
 
 		expect(result).toEqual({ status: "promptRequired" })
 		expect(session.steer).not.toHaveBeenCalled()
+	})
+
+	// cancel() marks the turn cancelled and drains the queue, but entry.turn
+	// stays defined until the prompt settles. A steer landing in that window
+	// must not re-queue text that would leak into the next prompt().
+	it("returns promptRequired when steering arrives after cancel but before the turn settles", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		await agent.cancel({ sessionId: "sess-1" })
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+			sessionId: "sess-1",
+			prompt: "too late",
+		})
+		expect(result).toEqual({ status: "promptRequired" })
+		expect(session.steer).not.toHaveBeenCalled()
+
+		session.finishTurn()
+		expect(await promptPromise).toEqual({ stopReason: "cancelled" })
 	})
 
 	it("maps pi's extension-command steer() error to invalidParams instead of swallowing it", async () => {

--- a/src/modes/acp/ext-methods/steering.test.ts
+++ b/src/modes/acp/ext-methods/steering.test.ts
@@ -1,0 +1,238 @@
+import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
+import type { AgentSession, ResourceLoader } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { AVAILABLE_EXT_METHODS } from "../capabilities.js"
+import { type AcpSessionFactory, KimchiAcpAgent } from "../server.js"
+
+class FakeAgentSession {
+	sessionId: string
+	disposed = false
+	model = { provider: "test", id: "test-model" }
+	modelRegistry = {
+		getAvailable: () => [{ provider: "test", id: "test-model", name: "Test" }],
+		find: (provider: string, id: string) =>
+			this.modelRegistry.getAvailable().find((m) => m.provider === provider && m.id === id),
+	}
+	sessionManager = {
+		getBranch: () => [],
+		getSessionId: () => this.sessionId,
+		getEntries: () => [],
+		getSessionDir: () => "/tmp",
+		getCwd: () => "/tmp",
+		appendCustomEntry: () => "entry-id",
+	}
+	setSessionName = vi.fn()
+	steer = vi.fn(async (_text: string) => {})
+	extensionRunner = { emit: async () => {} }
+	getToolDefinition = vi.fn((_name: string) => undefined)
+	getContextUsage = () => undefined
+	resourceLoader = {
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getExtensions: () => ({ extensions: [], errors: [], runtime: undefined }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => undefined,
+		getSystemPromptSource: () => undefined,
+		getAppendSystemPrompt: () => [],
+		getAppendSystemPromptSources: () => [],
+		extendResources: () => {},
+		reload: async () => {},
+	} as unknown as ResourceLoader
+
+	// Tests control when (or whether) the turn finishes to exercise the
+	// active-turn / race paths.
+	private promptResolve: (() => void) | undefined
+
+	constructor(sessionId: string) {
+		this.sessionId = sessionId
+	}
+
+	subscribe = () => () => {}
+	async bindExtensions(): Promise<void> {}
+	prompt(): Promise<void> {
+		return new Promise<void>((resolve) => {
+			this.promptResolve = resolve
+		})
+	}
+	finishTurn(): void {
+		this.promptResolve?.()
+	}
+	async abort(): Promise<void> {
+		this.finishTurn()
+	}
+	dispose(): void {
+		this.finishTurn()
+		this.disposed = true
+	}
+}
+
+function asSession(fake: FakeAgentSession): AgentSession {
+	return fake as unknown as AgentSession
+}
+
+function makeConn(): AgentSideConnection {
+	return {
+		sessionUpdate: async (_p: SessionNotification) => {},
+		extNotification: vi.fn(),
+		extMethod: vi.fn(),
+		requestPermission: vi.fn(),
+		unstable_createElicitation: vi.fn(),
+		closed: Promise.resolve(),
+	} as unknown as AgentSideConnection
+}
+
+function makeAgent(session: FakeAgentSession) {
+	const sessionFactory: AcpSessionFactory = async () => asSession(session)
+	return new KimchiAcpAgent(makeConn(), {
+		extensionFactories: [],
+		agentDir: "/tmp/fake-agent-dir",
+		sessionFactory,
+	})
+}
+
+describe("KimchiAcpAgent extMethod steering", () => {
+	it("queues the steering message via session.steer and returns injected when a turn is active", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		// entry.turn is set synchronously in prompt(), but the call above is async
+		// — flush the queue so the turn context exists before steering arrives.
+		await Promise.resolve()
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+			sessionId: "sess-1",
+			prompt: "actually, do it differently",
+		})
+
+		expect(result).toEqual({ status: "injected" })
+		expect(session.steer).toHaveBeenCalledTimes(1)
+		expect(session.steer).toHaveBeenCalledWith("actually, do it differently")
+
+		session.finishTurn()
+		expect(await promptPromise).toEqual({ stopReason: "end_turn" })
+	})
+
+	it("returns promptRequired instead of throwing when no turn is in progress", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+			sessionId: "sess-1",
+			prompt: "hello",
+		})
+
+		expect(result).toEqual({ status: "promptRequired" })
+		expect(session.steer).not.toHaveBeenCalled()
+	})
+
+	it("maps pi's extension-command steer() error to invalidParams instead of swallowing it", async () => {
+		const session = new FakeAgentSession("sess-1")
+		session.steer.mockRejectedValueOnce(
+			new Error('Extension command "/plan" cannot be queued. Use prompt() or execute the command when not streaming.'),
+		)
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, { sessionId: "sess-1", prompt: "/plan refine" }),
+		).rejects.toMatchObject({ code: -32602 })
+
+		session.finishTurn()
+		await promptPromise
+	})
+
+	it("does not relabel unexpected steer() errors as promptRequired", async () => {
+		const session = new FakeAgentSession("sess-1")
+		session.steer.mockRejectedValueOnce(new Error("boom"))
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, { sessionId: "sess-1", prompt: "nudge" }),
+		).rejects.toThrow("boom")
+
+		session.finishTurn()
+		await promptPromise
+	})
+
+	it("throws methodNotFound for unknown extension methods", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(agent.extMethod("_kimchi.dev/unknown", {})).rejects.toMatchObject({ code: -32601 })
+	})
+
+	it("throws invalidParams when sessionId is missing", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.steering, { prompt: "hello" })).rejects.toMatchObject({
+			code: -32602,
+			message: "Invalid params: sessionId is required and must be a non-empty string",
+		})
+	})
+
+	it("throws invalidParams when prompt is missing or empty", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		await expect(agent.extMethod(AVAILABLE_EXT_METHODS.steering, { sessionId: "sess-1" })).rejects.toMatchObject({
+			code: -32602,
+			message: "Invalid params: prompt is required and must be a non-empty string",
+		})
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, { sessionId: "sess-1", prompt: "" }),
+		).rejects.toMatchObject({
+			code: -32602,
+			message: "Invalid params: prompt is required and must be a non-empty string",
+		})
+	})
+
+	it("throws invalidParams for an unknown sessionId", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, { sessionId: "sess-2", prompt: "hello" }),
+		).rejects.toMatchObject({ code: -32602, message: "Invalid params: unknown sessionId sess-2" })
+		expect(session.steer).not.toHaveBeenCalled()
+	})
+
+	it("advertises steering in the vendor-namespaced initialize response _meta", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		const response = await agent.initialize({ protocolVersion: 1 })
+		const meta = response.agentCapabilities?._meta as Record<string, unknown> | undefined
+		const vendor = meta?.["kimchi.dev"] as Record<string, boolean> | undefined
+		expect(vendor?.steering).toBe(true)
+		expect(meta?.steering).toBeUndefined()
+	})
+})

--- a/src/modes/acp/ext-methods/steering.ts
+++ b/src/modes/acp/ext-methods/steering.ts
@@ -15,8 +15,9 @@ export type SteeringResponse = {
 /**
  * Lookup result for the session targeted by a steering request.
  * `turnActive` mirrors the ACP agent's turn bookkeeping
- * (SessionRecord.turn !== undefined) so this handler doesn't need to reach
- * into the agent's private turn state.
+ * (SessionRecord.turn defined AND not cancelled — a cancelled turn's queue
+ * has already been drained and must not accept new steers) so this handler
+ * doesn't need to reach into the agent's private turn state.
  */
 export type SteeringTarget = {
 	session: AgentSession

--- a/src/modes/acp/ext-methods/steering.ts
+++ b/src/modes/acp/ext-methods/steering.ts
@@ -1,0 +1,81 @@
+// ACP extension method handler for steering a running turn.
+//
+// Wire name: `_kimchi.dev/steering` — the vendor-namespaced name from the
+// kimchi-native-chat ticket (#06), advertised via _meta["kimchi.dev"].steering.
+
+import { RequestError } from "@agentclientprotocol/sdk"
+import type { AgentSession } from "@earendil-works/pi-coding-agent"
+
+export type SteeringStatus = "injected" | "promptRequired"
+
+export type SteeringResponse = {
+	status: SteeringStatus
+}
+
+/**
+ * Lookup result for the session targeted by a steering request.
+ * `turnActive` mirrors the ACP agent's turn bookkeeping
+ * (SessionRecord.turn !== undefined) so this handler doesn't need to reach
+ * into the agent's private turn state.
+ */
+export type SteeringTarget = {
+	session: AgentSession
+	turnActive: boolean
+}
+
+function respond(status: SteeringStatus): SteeringResponse {
+	return { status }
+}
+
+/**
+ * Steering handler for `_kimchi.dev/steering`.
+ *
+ * Queues a steering message into a running turn via pi's AgentSession.steer(),
+ * which delivers it after the current assistant turn finishes executing its
+ * tool calls — before the next LLM call. Returns status "injected" when the
+ * message was queued, or "promptRequired" when no turn is in progress (this
+ * handler must never start a new turn).
+ *
+ * Error handling is deliberately narrow, matched against pi-mono 0.84.1's
+ * actual steer() failure surface: steer() only throws when the text is an
+ * extension command ("Extension command ... cannot be queued") — a caller
+ * input error mapped to invalidParams. There is no idle-race throw in this
+ * pi version (_queueSteer never rejects), so no catch-all: unexpected errors
+ * propagate to the client as JSON-RPC internal errors rather than being
+ * silently relabeled promptRequired.
+ */
+export async function handleSteering(
+	getTarget: (sessionId: string) => SteeringTarget | undefined,
+	params: Record<string, unknown>,
+): Promise<SteeringResponse> {
+	const sessionId = params.sessionId
+	if (typeof sessionId !== "string" || sessionId.length === 0) {
+		throw RequestError.invalidParams(undefined, "sessionId is required and must be a non-empty string")
+	}
+
+	const prompt = params.prompt
+	if (typeof prompt !== "string" || prompt.length === 0) {
+		throw RequestError.invalidParams(undefined, "prompt is required and must be a non-empty string")
+	}
+
+	const target = getTarget(sessionId)
+	if (!target) {
+		throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
+	}
+
+	if (!target.turnActive) {
+		return respond("promptRequired")
+	}
+
+	try {
+		await target.session.steer(prompt)
+		return respond("injected")
+	} catch (err) {
+		// Extension commands can't be queued; that's a caller input problem,
+		// not a race. Everything else is genuinely unexpected — let it surface.
+		if (err instanceof Error && err.message.includes("cannot be queued")) {
+			throw RequestError.invalidParams(undefined, err.message)
+		}
+		throw err
+	}
+}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -148,6 +148,8 @@ class FakeAgentSession {
 	private listeners = new Set<AgentSessionEventListener>()
 	disposed = false
 	aborted = false
+	clearQueueCalls = 0
+	clearQueueReturn = { steering: [] as string[], followUp: [] as string[] }
 	model: FakeModel | undefined = {
 		provider: "test",
 		id: "test-model",
@@ -264,6 +266,11 @@ class FakeAgentSession {
 	async abort(): Promise<void> {
 		this.aborted = true
 		await this.abortImpl()
+	}
+
+	clearQueue(): { steering: string[]; followUp: string[] } {
+		this.clearQueueCalls++
+		return this.clearQueueReturn
 	}
 
 	async bindExtensions(bindings: unknown): Promise<void> {
@@ -884,6 +891,31 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		const result = await promptP
 		expect(result.stopReason).toBe("cancelled")
 		expect(fake.aborted).toBe(true)
+	})
+
+	// cancel() must drain the steer/follow-up queue so queued text doesn't
+	// leak into the next prompt — mirrors the TUI's Escape → clearAllQueues().
+	it("drains the steer queue when cancel arrives mid-turn", async () => {
+		let cancelSeen = false
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			while (!cancelSeen) await delay(5)
+			fake.emit(agentEnd())
+		}
+		fake.abortImpl = async () => {
+			cancelSeen = true
+		}
+
+		const promptP = agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "run forever" }],
+		})
+		await delay(10)
+		await agent.cancel({ sessionId })
+
+		await promptP
+		expect(fake.aborted).toBe(true)
+		expect(fake.clearQueueCalls).toBe(1)
 	})
 
 	// If session.prompt throws (pre-turn validation, config error, etc.), the

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -97,6 +97,7 @@ import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { handleSetSessionTitle } from "./ext-methods/set-session-title.js"
+import { handleSteering } from "./ext-methods/steering.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
 import { AcpPlanTracker, type ActivePlan } from "./plans.js"
 import {
@@ -995,6 +996,12 @@ export class KimchiAcpAgent implements Agent {
 			}
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
+			case AVAILABLE_EXT_METHODS.steering:
+				return handleSteering((sessionId) => {
+					const entry = this.sessions.get(sessionId)
+					if (!entry) return undefined
+					return { session: entry.session, turnActive: entry.turn !== undefined }
+				}, params)
 			default:
 				throw RequestError.methodNotFound(method)
 		}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -986,6 +986,9 @@ export class KimchiAcpAgent implements Agent {
 		if (!entry) return
 		if (entry.turn) entry.turn.cancelled = true
 		await entry.session.abort()
+		// Drain the steer/follow-up queue so queued text doesn't leak into the
+		// next prompt. Mirrors the TUI's Escape → clearAllQueues() behaviour.
+		entry.session.clearQueue()
 	}
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -1000,7 +1003,11 @@ export class KimchiAcpAgent implements Agent {
 				return handleSteering((sessionId) => {
 					const entry = this.sessions.get(sessionId)
 					if (!entry) return undefined
-					return { session: entry.session, turnActive: entry.turn !== undefined }
+					// A cancelled turn stays defined until the prompt settles, but
+					// cancel() has already drained its queue — a steer landing in this
+					// window must not re-queue text that would leak into the next prompt.
+					const turnActive = entry.turn !== undefined && !entry.turn.cancelled
+					return { session: entry.session, turnActive }
 				}, params)
 			default:
 				throw RequestError.methodNotFound(method)


### PR DESCRIPTION
## Linked issue

Closes #1037

## What does this PR do?

Implements ticket #06 — Steering via ACP Extension. Kimchi implements the `_kimchi.dev/steering` ACP extension method, allowing any ACP client to inject guidance into a running Kimchi turn.

The handler is routed only under the vendor-namespaced `_kimchi.dev/steering` method and advertises the capability as `agentCapabilities._meta["kimchi.dev"].steering === true` — the same namespace as the existing ext methods (`probe_mcp_server`, `set_session_title`). Consumer-specific wire contracts (method aliases, alternate capability shapes) belong in consuming clients, not in kimchi.

The handler queues the steering text via pi's `AgentSession.steer()`, which delivers it after the current assistant turn's tool calls finish, before the next LLM call. It returns `{ status: "injected" }` when queued and `{ status: "promptRequired" }` when no turn is in progress — it never starts a new turn. `steer()` input errors for extension commands map to JSON-RPC `invalidParams`; unexpected errors propagate.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
