### PR TITLE
feat(acp): per-turn usage reporting and live context window updates

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1152,7 +1152,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect((usageUpdates[0].update as { used: number; size: number }).size).toBe(200_000)
 	})
 
-	it("falls back to getSessionStats total when getContextUsage tokens is null", async () => {
+	it("does not emit usage_update when getContextUsage tokens is null (post-compaction)", async () => {
 		const { conn, updates } = makeRecordingConn()
 		const localFake = new FakeAgentSession("session-usage-fallback")
 		localFake.model = { provider: "test", id: "m", name: "M", input: ["text"], contextWindow: 128_000 }
@@ -1181,9 +1181,8 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		const usageUpdates = updates.filter(
 			(u) => (u.update as { sessionUpdate?: string }).sessionUpdate === "usage_update",
 		)
-		expect(usageUpdates).toHaveLength(1)
-		expect((usageUpdates[0].update as { used: number; size: number }).used).toBe(10_000)
-		expect((usageUpdates[0].update as { used: number; size: number }).size).toBe(128_000)
+		// Per the issue doc: skip when tokens is null — no fallback to getSessionStats.
+		expect(usageUpdates).toHaveLength(0)
 	})
 
 	it("does not emit usage_update when size is unavailable (no contextWindow)", async () => {
@@ -1744,25 +1743,32 @@ describe("KimchiAcpAgent usage reporting", () => {
 
 		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
 
-		// Streaming chunks arrived, but no usage_update and no per-turn usage —
-		// no assistant message_end with usage ever fired.
+		// Streaming chunks arrived, but no per-turn usage — no assistant
+		// message_end with usage ever fired, so PromptResponse.usage is
+		// undefined. The final emitUsageUpdate at turn end still fires because
+		// contextUsage is set; that's the expected behavior.
 		expect(updates.some((u) => u.update.sessionUpdate === "agent_message_chunk")).toBe(true)
-		expect(usageUpdates()).toHaveLength(0)
 		expect(result.usage).toBeUndefined()
 	})
 
 	it("omits PromptResponse.usage when the turn is cancelled before any assistant message", async () => {
+		let cancelSeen = false
 		fake.promptImpl = async () => {
-			await delay(10)
+			// Wait until cancel() runs so the turn context is marked cancelled
+			// before promptImpl resolves.
+			while (!cancelSeen) await delay(5)
+		}
+		fake.abortImpl = async () => {
+			cancelSeen = true
 		}
 
 		const pending = agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+		await delay(10)
 		await agent.cancel({ sessionId })
 		const result = await pending
 
 		expect(result.stopReason).toBe("cancelled")
 		expect(result.usage).toBeUndefined()
-		expect(usageUpdates()).toHaveLength(0)
 	})
 })
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1598,9 +1598,9 @@ describe("KimchiAcpAgent usage reporting", () => {
 	const usageUpdates = () => updates.filter((u) => u.update.sessionUpdate === "usage_update")
 
 	// Builds the assistant message_end event pi-mono emits after an LLM
-	// response. `reasoning` is modelled as an untyped extra because pi-ai's
-	// Usage type (0.78.x) doesn't declare it yet — the server folds it in
-	// defensively when a provider reports it.
+	// response. totalTokens is computed the way providers do (pi-ai 0.84
+	// Usage docs): input + output + cacheRead + cacheWrite, where `reasoning`
+	// is a subset of `output` and must never be re-added.
 	function assistantUsageEvent(usage: {
 		input: number
 		output: number
@@ -1608,25 +1608,27 @@ describe("KimchiAcpAgent usage reporting", () => {
 		cacheWrite?: number
 		reasoning?: number
 	}): AgentSessionEvent {
-		const { reasoning, ...rest } = usage
-		const message = {
+		const cacheRead = usage.cacheRead ?? 0
+		const cacheWrite = usage.cacheWrite ?? 0
+		const message: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text: "reply" }],
 			api: "anthropic-messages",
 			provider: "anthropic",
 			model: "claude",
 			usage: {
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
+				input: usage.input,
+				output: usage.output,
+				cacheRead,
+				cacheWrite,
+				...(usage.reasoning !== undefined ? { reasoning: usage.reasoning } : {}),
+				totalTokens: usage.input + usage.output + cacheRead + cacheWrite,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				...rest,
-				...(reasoning !== undefined ? { reasoning } : {}),
 			},
 			stopReason: "stop",
 			timestamp: 0,
 		}
-		return { type: "message_end", message } as unknown as AgentSessionEvent
+		return { type: "message_end", message }
 	}
 
 	it("sums pi-ai usage across chained assistant messages into PromptResponse.usage", async () => {
@@ -1647,7 +1649,9 @@ describe("KimchiAcpAgent usage reporting", () => {
 			cachedReadTokens: 7,
 			cachedWriteTokens: 4,
 			thoughtTokens: 10,
-			totalTokens: 201,
+			// msg1: 100+20+5+3=128, msg2: 50+10+2+1=63 — reasoning (7, 3) is a
+			// subset of output and must not be double-counted.
+			totalTokens: 191,
 		})
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1668,7 +1668,7 @@ describe("KimchiAcpAgent usage reporting", () => {
 		expect(result.usage).not.toHaveProperty("thoughtTokens")
 	})
 
-	it("emits a usage_update sessionUpdate with size/used at turn end", async () => {
+	it("emits usage_update with size/used on assistant message_end and again at turn end", async () => {
 		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
@@ -1679,11 +1679,34 @@ describe("KimchiAcpAgent usage reporting", () => {
 		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
 
 		const usage = usageUpdates()
-		expect(usage).toHaveLength(1)
+		// One live update on the assistant message_end, one final update at
+		// finalizeTurn — both reflect the same getContextUsage() snapshot here.
+		expect(usage).toHaveLength(2)
 		expect(usage[0].sessionId).toBe(sessionId)
-		expect(usage[0].update).toMatchObject({ sessionUpdate: "usage_update", size: 200000, used: 1234 })
+		expect(usage[1].sessionId).toBe(sessionId)
+		for (const u of usage) {
+			expect(u.update).toMatchObject({ sessionUpdate: "usage_update", size: 200000, used: 1234 })
+		}
 		// PromptResponse.usage is independent of the context-window estimate.
 		expect(result.usage?.inputTokens).toBe(100)
+	})
+
+	it("refreshes the context indicator after each chained assistant message", async () => {
+		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20, cacheRead: 5, cacheWrite: 3 }))
+			// Second chain step (e.g. agent.continue after a tool call).
+			fake.emit(assistantUsageEvent({ input: 50, output: 10, cacheRead: 2, cacheWrite: 1 }))
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		// One usage_update per assistant message_end (2), plus the final
+		// turn-end emission — the indicator follows the turn live instead of
+		// updating only once at the end.
+		expect(usageUpdates()).toHaveLength(3)
 	})
 
 	it("skips usage_update when getContextUsage returns undefined", async () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1668,7 +1668,7 @@ describe("KimchiAcpAgent usage reporting", () => {
 		expect(result.usage).not.toHaveProperty("thoughtTokens")
 	})
 
-	it("emits a usage_update sessionUpdate with size/used on assistant message_end", async () => {
+	it("emits a usage_update sessionUpdate with size/used at turn end", async () => {
 		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
@@ -1743,12 +1743,13 @@ describe("KimchiAcpAgent usage reporting", () => {
 
 		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
 
-		// Streaming chunks arrived, but no per-turn usage — no assistant
-		// message_end with usage ever fired, so PromptResponse.usage is
-		// undefined. The final emitUsageUpdate at turn end still fires because
-		// contextUsage is set; that's the expected behavior.
+		// Streaming chunks arrived, but no assistant message_end with usage
+		// ever fired, so PromptResponse.usage is undefined. Exactly one
+		// usage_update fires — the final emitUsageUpdate at turn end
+		// (contextUsage is set); none in response to the deltas themselves.
 		expect(updates.some((u) => u.update.sessionUpdate === "agent_message_chunk")).toBe(true)
 		expect(result.usage).toBeUndefined()
+		expect(usageUpdates()).toHaveLength(1)
 	})
 
 	it("omits PromptResponse.usage when the turn is cancelled before any assistant message", async () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1568,6 +1568,200 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 	})
 })
 
+// Usage reporting (issue #03): the ACP server accumulates pi-ai Usage across
+// pi-mono's chained prompt/continue calls — each chain step emits its own
+// assistant message_end with its own usage object — folds the sum into the
+// (experimental) PromptResponse.usage, and pairs assistant message_end
+// events with usage_update sessionUpdates mapped from
+// session.getContextUsage(). Both pieces are gated: PromptResponse.usage is
+// omitted when the turn collected no usage, and usage_update is skipped when
+// the estimate is undefined or its token count is null (post-compaction).
+describe("KimchiAcpAgent usage reporting", () => {
+	let fake: FakeAgentSession
+	let agent: KimchiAcpAgent
+	let sessionId: string
+	let updates: SessionNotification[]
+
+	beforeEach(async () => {
+		fake = new FakeAgentSession("session-usage")
+		const { conn, updates: rec } = makeRecordingConn()
+		updates = rec
+		agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(fake),
+		})
+		const res = await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+		sessionId = res.sessionId
+	})
+
+	const usageUpdates = () => updates.filter((u) => u.update.sessionUpdate === "usage_update")
+
+	// Builds the assistant message_end event pi-mono emits after an LLM
+	// response. `reasoning` is modelled as an untyped extra because pi-ai's
+	// Usage type (0.78.x) doesn't declare it yet — the server folds it in
+	// defensively when a provider reports it.
+	function assistantUsageEvent(usage: {
+		input: number
+		output: number
+		cacheRead?: number
+		cacheWrite?: number
+		reasoning?: number
+	}): AgentSessionEvent {
+		const { reasoning, ...rest } = usage
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "reply" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude",
+			usage: {
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				...rest,
+				...(reasoning !== undefined ? { reasoning } : {}),
+			},
+			stopReason: "stop",
+			timestamp: 0,
+		}
+		return { type: "message_end", message } as unknown as AgentSessionEvent
+	}
+
+	it("sums pi-ai usage across chained assistant messages into PromptResponse.usage", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20, cacheRead: 5, cacheWrite: 3, reasoning: 7 }))
+			// Second chain step (e.g. agent.continue after a tool call or follow-up).
+			fake.emit(assistantUsageEvent({ input: 50, output: 10, cacheRead: 2, cacheWrite: 1, reasoning: 3 }))
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		expect(result.stopReason).toBe("end_turn")
+		expect(result.usage).toEqual({
+			inputTokens: 150,
+			outputTokens: 30,
+			cachedReadTokens: 7,
+			cachedWriteTokens: 4,
+			thoughtTokens: 10,
+			totalTokens: 201,
+		})
+	})
+
+	it("omits thoughtTokens when no provider reported a reasoning count", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20 }))
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		expect(result.usage?.inputTokens).toBe(100)
+		expect(result.usage?.outputTokens).toBe(20)
+		expect(result.usage).not.toHaveProperty("thoughtTokens")
+	})
+
+	it("emits a usage_update sessionUpdate with size/used on assistant message_end", async () => {
+		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20 }))
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		const usage = usageUpdates()
+		expect(usage).toHaveLength(1)
+		expect(usage[0].sessionId).toBe(sessionId)
+		expect(usage[0].update).toMatchObject({ sessionUpdate: "usage_update", size: 200000, used: 1234 })
+		// PromptResponse.usage is independent of the context-window estimate.
+		expect(result.usage?.inputTokens).toBe(100)
+	})
+
+	it("skips usage_update when getContextUsage returns undefined", async () => {
+		fake.contextUsage = undefined
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20 }))
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		expect(usageUpdates()).toHaveLength(0)
+		// Per-turn summing must not depend on the context-window estimate.
+		expect(result.usage?.inputTokens).toBe(100)
+	})
+
+	it("skips usage_update when the context estimate has null tokens (post-compaction)", async () => {
+		fake.contextUsage = { tokens: null, contextWindow: 200000, percent: null }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20 }))
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		expect(usageUpdates()).toHaveLength(0)
+	})
+
+	it("never emits usage_update during streaming (message_update deltas)", async () => {
+		fake.contextUsage = { tokens: 500, contextWindow: 200000, percent: 0.25 }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "streaming ",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit({
+				type: "message_update",
+				assistantMessageEvent: {
+					type: "text_delta",
+					delta: "text",
+					contentIndex: 0,
+					partial: {} as unknown as AssistantMessage,
+				},
+				message: {} as unknown as AssistantMessage,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		// Streaming chunks arrived, but no usage_update and no per-turn usage —
+		// no assistant message_end with usage ever fired.
+		expect(updates.some((u) => u.update.sessionUpdate === "agent_message_chunk")).toBe(true)
+		expect(usageUpdates()).toHaveLength(0)
+		expect(result.usage).toBeUndefined()
+	})
+
+	it("omits PromptResponse.usage when the turn is cancelled before any assistant message", async () => {
+		fake.promptImpl = async () => {
+			await delay(10)
+		}
+
+		const pending = agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+		await agent.cancel({ sessionId })
+		const result = await pending
+
+		expect(result.stopReason).toBe("cancelled")
+		expect(result.usage).toBeUndefined()
+		expect(usageUpdates()).toHaveLength(0)
+	})
+})
+
 // ACP ContentChunk contract (src/modes/acp/server.ts onSessionEvent):
 // "All chunks belonging to the same message share the same messageId.
 // A change in messageId indicates a new message has started." pi-mono

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -176,13 +176,24 @@ type TurnUsage = {
 	cacheRead: number
 	cacheWrite: number
 	reasoning: number
+	/** Sum of the provider-computed usage.totalTokens across the chain. */
+	total: number
 	/** true once any provider actually reported a reasoning/thought count. */
 	sawReasoning: boolean
 	messages: number
 }
 
 function emptyTurnUsage(): TurnUsage {
-	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0, sawReasoning: false, messages: 0 }
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		reasoning: 0,
+		total: 0,
+		sawReasoning: false,
+		messages: 0,
+	}
 }
 
 type TurnContext = {
@@ -1138,21 +1149,20 @@ export class KimchiAcpAgent implements Agent {
 					turn.usage.output += usage.output
 					turn.usage.cacheRead += usage.cacheRead
 					turn.usage.cacheWrite += usage.cacheWrite
-					// pi-ai's Usage (0.78.x) has no `reasoning` field, but some
-					// providers report one ahead of the type — fold it in defensively
-					// so thoughtTokens is populated as soon as the pinned pi-ai
-					// exposes it.
-					const reasoning = (usage as { reasoning?: unknown }).reasoning
-					if (typeof reasoning === "number" && Number.isFinite(reasoning)) {
-						turn.usage.reasoning += reasoning
+					turn.usage.total += usage.totalTokens
+					// reasoning is a SUBSET of output (pi-ai 0.84 Usage docs) — summed
+					// separately for thoughtTokens only, never re-added to totals.
+					if (typeof usage.reasoning === "number") {
+						turn.usage.reasoning += usage.reasoning
 						turn.usage.sawReasoning = true
 					}
 					turn.usage.messages++
+					// The assistant message_end is the turn event that carries
+					// usage; pair it with a live context-window usage_update. Never
+					// emitted from message_update — streaming deltas must not spam
+					// usage.
+					this.sendUsageUpdate(sessionId, entry)
 				}
-				// The assistant message_end is the turn event that carries usage;
-				// pair it with a live context-window usage_update. Never emitted
-				// from message_update — streaming deltas must not spam usage.
-				this.sendUsageUpdate(sessionId, entry)
 				return
 			}
 			case "tool_execution_start": {
@@ -1606,7 +1616,7 @@ export class KimchiAcpAgent implements Agent {
 					cachedReadTokens: u.cacheRead,
 					cachedWriteTokens: u.cacheWrite,
 					...(u.sawReasoning ? { thoughtTokens: u.reasoning } : {}),
-					totalTokens: u.input + u.output + u.cacheRead + u.cacheWrite + u.reasoning,
+					totalTokens: u.total,
 				}
 			}
 			turn.resolve(response)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1160,11 +1160,6 @@ export class KimchiAcpAgent implements Agent {
 						turn.usage.sawReasoning = true
 					}
 					turn.usage.messages++
-					// The assistant message_end is the turn event that carries
-					// usage; pair it with a live context-window usage_update. Never
-					// emitted from message_update — streaming deltas must not spam
-					// usage.
-					this.sendUsageUpdate(sessionId, entry)
 				}
 				return
 			}
@@ -1490,35 +1485,6 @@ export class KimchiAcpAgent implements Agent {
 		flushText()
 	}
 
-	/**
-	 * Emits a usage_update sessionUpdate mapped from
-	 * `session.getContextUsage()` → ACP UsageUpdate { size, used }. Skipped
-	 * when the session reports no estimate (undefined) or an unknown token
-	 * count (tokens: null, e.g. right after compaction) — ACP requires both
-	 * fields, so there is no null-safe emission.
-	 */
-	private sendUsageUpdate(sessionId: string, entry: SessionRecord): void {
-		// getContextUsage runs inside the synchronous event-emitter path; a
-		// throw here would abort turn processing, so swallow-and-log instead.
-		let ctx: ReturnType<AgentSession["getContextUsage"]>
-		try {
-			ctx = entry.session.getContextUsage()
-		} catch (err) {
-			process.stderr.write(`acp getContextUsage failed: ${String(err)}\n`)
-			return
-		}
-		// tokens is typed number|null, but at runtime a provider edge can also
-		// surface undefined or NaN — ACP requires a real `used`, so skip all three.
-		if (!ctx || typeof ctx.tokens !== "number" || !Number.isFinite(ctx.tokens)) return
-		this.send({
-			sessionId,
-			update: {
-				sessionUpdate: "usage_update",
-				size: ctx.contextWindow,
-				used: ctx.tokens,
-			},
-		})
-	}
 	private send(params: SessionNotification): void {
 		// Fire-and-forget is safe here because the ACP SDK chains every outbound
 		// message onto a shared writeQueue Promise (see @agentclientprotocol/sdk
@@ -1595,15 +1561,16 @@ export class KimchiAcpAgent implements Agent {
 	private emitUsageUpdate(entry: SessionRecord): void {
 		const session = entry.session
 		const ctx = session.getContextUsage()
-		const used = ctx?.tokens ?? session.getSessionStats().tokens.total
-		const size = session.model?.contextWindow ?? ctx?.contextWindow
-		if (used == null || !size) return
+		// Per the issue doc: skip when getContextUsage() returns undefined or
+		// tokens is null (e.g. right after compaction). ACP requires both `used`
+		// and `size`, so there is no null-safe emission.
+		if (!ctx || ctx.tokens === null) return
 		this.send({
 			sessionId: session.sessionId,
 			update: {
 				sessionUpdate: "usage_update",
-				used,
-				size,
+				used: ctx.tokens,
+				size: ctx.contextWindow,
 			},
 		})
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1160,6 +1160,11 @@ export class KimchiAcpAgent implements Agent {
 						turn.usage.sawReasoning = true
 					}
 					turn.usage.messages++
+					// Live context-window refresh: a message_end carrying usage means
+					// the session's estimate just moved. Emit here (subject to
+					// emitUsageUpdate's undefined/null skip) so clients track the
+					// context window across chained steps, not just at turn end.
+					this.emitUsageUpdate(entry)
 				}
 				return
 			}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -160,6 +160,31 @@ export interface RunAcpOptions {
 	mcpServerManager?: McpServerManager
 }
 
+/**
+ * Per-turn usage accumulator. pi-mono chains multiple agent.prompt /
+ * agent.continue calls per turn, each producing an AssistantMessage with its
+ * own pi-ai `usage`; ACP's (v1/experimental) PromptResponse.usage expects a
+ * single summary, so message_end events fold their usage into this record and
+ * finalizeTurn emits the summed totals. `messages` counts the assistant
+ * usage records folded in — it gates the optional PromptResponse.usage field
+ * (omitted when no usage data was collected, e.g. a cancel before the first
+ * message).
+ */
+type TurnUsage = {
+	input: number
+	output: number
+	cacheRead: number
+	cacheWrite: number
+	reasoning: number
+	/** true once any provider actually reported a reasoning/thought count. */
+	sawReasoning: boolean
+	messages: number
+}
+
+function emptyTurnUsage(): TurnUsage {
+	return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0, sawReasoning: false, messages: 0 }
+}
+
 type TurnContext = {
 	cancelled: boolean
 	hiddenToolCallIds: Set<string>
@@ -182,6 +207,7 @@ type TurnContext = {
 	 * event resolves add-vs-modify from preWriteContents.
 	 */
 	pendingFileChanges: Map<string, PendingFileChange[]>
+	usage: TurnUsage
 	resolve: (res: PromptResponse) => void
 	reject: (err: unknown) => void
 }
@@ -884,6 +910,7 @@ export class KimchiAcpAgent implements Agent {
 			lastStreamedContent: new Map(),
 			preWriteContents: new Map(),
 			pendingFileChanges: new Map(),
+			usage: emptyTurnUsage(),
 			resolve: turnResolve,
 			reject: turnReject,
 		}
@@ -1099,6 +1126,33 @@ export class KimchiAcpAgent implements Agent {
 					return
 				}
 
+				return
+			}
+			case "message_end": {
+				if (!turn) return
+				const msg = event.message
+				if (msg.role !== "assistant") return
+				const usage = msg.usage
+				if (usage) {
+					turn.usage.input += usage.input
+					turn.usage.output += usage.output
+					turn.usage.cacheRead += usage.cacheRead
+					turn.usage.cacheWrite += usage.cacheWrite
+					// pi-ai's Usage (0.78.x) has no `reasoning` field, but some
+					// providers report one ahead of the type — fold it in defensively
+					// so thoughtTokens is populated as soon as the pinned pi-ai
+					// exposes it.
+					const reasoning = (usage as { reasoning?: unknown }).reasoning
+					if (typeof reasoning === "number" && Number.isFinite(reasoning)) {
+						turn.usage.reasoning += reasoning
+						turn.usage.sawReasoning = true
+					}
+					turn.usage.messages++
+				}
+				// The assistant message_end is the turn event that carries usage;
+				// pair it with a live context-window usage_update. Never emitted
+				// from message_update — streaming deltas must not spam usage.
+				this.sendUsageUpdate(sessionId, entry)
 				return
 			}
 			case "tool_execution_start": {
@@ -1423,6 +1477,25 @@ export class KimchiAcpAgent implements Agent {
 		flushText()
 	}
 
+	/**
+	 * Emits a usage_update sessionUpdate mapped from
+	 * `session.getContextUsage()` → ACP UsageUpdate { size, used }. Skipped
+	 * when the session reports no estimate (undefined) or an unknown token
+	 * count (tokens: null, e.g. right after compaction) — ACP requires both
+	 * fields, so there is no null-safe emission.
+	 */
+	private sendUsageUpdate(sessionId: string, entry: SessionRecord): void {
+		const ctx = entry.session.getContextUsage()
+		if (!ctx || ctx.tokens === null) return
+		this.send({
+			sessionId,
+			update: {
+				sessionUpdate: "usage_update",
+				size: ctx.contextWindow,
+				used: ctx.tokens,
+			},
+		})
+	}
 	private send(params: SessionNotification): void {
 		// Fire-and-forget is safe here because the ACP SDK chains every outbound
 		// message onto a shared writeQueue Promise (see @agentclientprotocol/sdk
@@ -1519,7 +1592,24 @@ export class KimchiAcpAgent implements Agent {
 		try {
 			this.emitUsageUpdate(entry)
 		} finally {
-			turn.resolve({ stopReason })
+			const response: PromptResponse = { stopReason }
+			// usage is v1/experimental-only on PromptResponse (v2 drops it in favor
+			// of usage_update session events) and is omitted when the turn produced
+			// no usage data (e.g. cancelled before the first assistant message).
+			// totalTokens is emitted because the pinned ACP SDK's experimental Usage
+			// type marks it required, even though the ticket's v1 field table drops it.
+			if (turn.usage.messages > 0) {
+				const u = turn.usage
+				response.usage = {
+					inputTokens: u.input,
+					outputTokens: u.output,
+					cachedReadTokens: u.cacheRead,
+					cachedWriteTokens: u.cacheWrite,
+					...(u.sawReasoning ? { thoughtTokens: u.reasoning } : {}),
+					totalTokens: u.input + u.output + u.cacheRead + u.cacheWrite + u.reasoning,
+				}
+			}
+			turn.resolve(response)
 		}
 	}
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1145,14 +1145,17 @@ export class KimchiAcpAgent implements Agent {
 				if (msg.role !== "assistant") return
 				const usage = msg.usage
 				if (usage) {
-					turn.usage.input += usage.input
-					turn.usage.output += usage.output
-					turn.usage.cacheRead += usage.cacheRead
-					turn.usage.cacheWrite += usage.cacheWrite
-					turn.usage.total += usage.totalTokens
+					// `|| 0` guards against providers emitting undefined/NaN for a
+					// field the type declares required — one bad message must not
+					// poison the whole turn's totals.
+					turn.usage.input += usage.input || 0
+					turn.usage.output += usage.output || 0
+					turn.usage.cacheRead += usage.cacheRead || 0
+					turn.usage.cacheWrite += usage.cacheWrite || 0
+					turn.usage.total += usage.totalTokens || 0
 					// reasoning is a SUBSET of output (pi-ai 0.84 Usage docs) — summed
 					// separately for thoughtTokens only, never re-added to totals.
-					if (typeof usage.reasoning === "number") {
+					if (typeof usage.reasoning === "number" && Number.isFinite(usage.reasoning)) {
 						turn.usage.reasoning += usage.reasoning
 						turn.usage.sawReasoning = true
 					}
@@ -1495,8 +1498,18 @@ export class KimchiAcpAgent implements Agent {
 	 * fields, so there is no null-safe emission.
 	 */
 	private sendUsageUpdate(sessionId: string, entry: SessionRecord): void {
-		const ctx = entry.session.getContextUsage()
-		if (!ctx || ctx.tokens === null) return
+		// getContextUsage runs inside the synchronous event-emitter path; a
+		// throw here would abort turn processing, so swallow-and-log instead.
+		let ctx: ReturnType<AgentSession["getContextUsage"]>
+		try {
+			ctx = entry.session.getContextUsage()
+		} catch (err) {
+			process.stderr.write(`acp getContextUsage failed: ${String(err)}\n`)
+			return
+		}
+		// tokens is typed number|null, but at runtime a provider edge can also
+		// surface undefined or NaN — ACP requires a real `used`, so skip all three.
+		if (!ctx || typeof ctx.tokens !== "number" || !Number.isFinite(ctx.tokens)) return
 		this.send({
 			sessionId,
 			update: {


### PR DESCRIPTION
## Linked issue

Closes #1038

## What does this PR do?

Implements ticket #03 — Usage Reporting in Kimchi ACP. The ACP server accumulates pi-ai `Usage` across the turn chain and emits per-turn totals in `PromptResponse.usage` (v1). Emits `usage_update` sessionUpdates mapped from `session.getContextUsage()` on `message_end` events. Skips emission when context usage is unavailable or during streaming. Hardened against provider edge cases (NaN, undefined tokens, missing fields).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
