### PR TITLE
feat(acp): attach per-turn file-change diffs to tool_call_update

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -65,6 +65,7 @@ import {
 	type AcpSessionLoader,
 	assertSessionHasModel,
 	buildSessionModelState,
+	fileChangeToDiffContent,
 	initializeHeadlessTheme,
 	KimchiAcpAgent,
 	stripAnsi,
@@ -2996,6 +2997,272 @@ describe("KimchiAcpAgent tool execution stream", () => {
 				}),
 			}),
 		])
+	})
+})
+
+// Ticket #04 — Per-Turn Diffs. The edit and write tools carry the diff data in
+// their own arguments (edit: args.edits[]; write: args.content + pre-write file
+// content read at tool_execution_start). tool_execution_end for those tools
+// must attach ACP `diff` content blocks to the terminal tool_call_update — in
+// addition to the existing text/image content, never replacing it. Read-only
+// tools emit no diffs. Args only travel on tool_execution_start, so the server
+// captures FileChange data there and emits it at tool_execution_end.
+describe("KimchiAcpAgent per-turn diffs", () => {
+	let fake: FakeAgentSession
+	let agent: KimchiAcpAgent
+	let sessionId: string
+	let updates: SessionNotification[]
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = mkdtempSync(join(tmpdir(), "kimchi-acp-diff-"))
+		fake = new FakeAgentSession("session-diff", tmpDir)
+		const sessionFactory: AcpSessionFactory = async () => asSession(fake)
+		const rec = makeRecordingConn()
+		updates = rec.updates
+		agent = new KimchiAcpAgent(rec.conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory,
+		})
+		const res = await agent.newSession({ cwd: tmpDir, mcpServers: [] })
+		sessionId = res.sessionId
+	})
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true })
+	})
+
+	// Upstream toolCallIds are rewritten to session-unique ACP ids (kt.<tool>.N)
+	// on the wire; the pi id survives in _meta.piToolCallId — key off that.
+	const terminalContent = (piToolCallId: string): unknown[] => {
+		const terminal = updates.find(
+			(u) =>
+				u.update.sessionUpdate === "tool_call_update" &&
+				(u.update as { _meta?: { piToolCallId?: string } })._meta?.piToolCallId === piToolCallId &&
+				((u.update as { status?: string }).status === "completed" ||
+					(u.update as { status?: string }).status === "failed"),
+		)
+		expect(terminal).toBeDefined()
+		return (terminal?.update as { content: unknown[] }).content
+	}
+
+	it("emits one diff content block for an edit tool call with a single edit", async () => {
+		const target = join(tmpDir, "a.txt")
+		writeFileSync(target, "hello world")
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-edit-1",
+				toolName: "edit",
+				args: { path: target, edits: [{ oldText: "hello", newText: "goodbye" }] },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-edit-1",
+				toolName: "edit",
+				result: { content: [{ type: "text", text: "Edited a.txt" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		// Existing text content preserved; the diff block is additional content.
+		expect(terminalContent("tc-edit-1")).toEqual([
+			{ type: "content", content: { type: "text", text: "Edited a.txt" } },
+			{ type: "diff", path: target, oldText: "hello", newText: "goodbye" },
+		])
+	})
+
+	it("emits one diff content block per edit for an edit tool call with multiple edits", async () => {
+		const target = join(tmpDir, "multi.txt")
+		writeFileSync(target, "one two")
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-edit-2",
+				toolName: "edit",
+				args: {
+					path: target,
+					edits: [
+						{ oldText: "one", newText: "1" },
+						{ oldText: "two", newText: "2" },
+					],
+				},
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-edit-2",
+				toolName: "edit",
+				result: { content: [{ type: "text", text: "Edited multi.txt" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const content = terminalContent("tc-edit-2") as Array<{ type: string }>
+		const diffs = content.filter((b) => b.type === "diff")
+		expect(diffs).toEqual([
+			{ type: "diff", path: target, oldText: "one", newText: "1" },
+			{ type: "diff", path: target, oldText: "two", newText: "2" },
+		])
+		// Text content preserved alongside the diffs.
+		expect(content.some((b) => b.type === "content")).toBe(true)
+	})
+
+	// Relative path exercises the server-side cwd resolution for the pre-write
+	// read; the emitted diff path stays verbatim from args.path.
+	it("emits a diff with oldText null for a write tool call creating a new file", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-write-new",
+				toolName: "write",
+				args: { path: "brand-new.txt", content: "fresh content" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-write-new",
+				toolName: "write",
+				result: { content: [{ type: "text", text: "Wrote brand-new.txt" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const content = terminalContent("tc-write-new") as Array<{ type: string }>
+		const diffs = content.filter((b) => b.type === "diff")
+		expect(diffs).toEqual([{ type: "diff", path: "brand-new.txt", newText: "fresh content", oldText: null }])
+	})
+
+	// Overwrite: tool_execution_start must read the existing file into
+	// TurnContext.preWriteContents so the diff carries it as oldText.
+	it("emits a diff with the previous content as oldText for a write tool call overwriting a file", async () => {
+		const target = join(tmpDir, "existing.txt")
+		writeFileSync(target, "before content")
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-write-over",
+				toolName: "write",
+				args: { path: target, content: "after content" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-write-over",
+				toolName: "write",
+				result: { content: [{ type: "text", text: "Wrote existing.txt" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const content = terminalContent("tc-write-over") as Array<{ type: string }>
+		const diffs = content.filter((b) => b.type === "diff")
+		expect(diffs).toEqual([{ type: "diff", path: target, oldText: "before content", newText: "after content" }])
+	})
+
+	it("emits no diff content blocks for read-only tool calls", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			for (const [toolCallId, toolName, args] of [
+				["tc-bash", "bash", { command: "true" }],
+				["tc-read", "read", { path: join(tmpDir, "a.txt") }],
+				["tc-grep", "grep", { pattern: "foo" }],
+			] as const) {
+				fake.emit({ type: "tool_execution_start", toolCallId, toolName, args })
+				fake.emit({
+					type: "tool_execution_end",
+					toolCallId,
+					toolName,
+					result: { content: [{ type: "text", text: "ok" }] },
+					isError: false,
+				})
+			}
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		for (const toolCallId of ["tc-bash", "tc-read", "tc-grep"]) {
+			const content = terminalContent(toolCallId) as Array<{ type: string }>
+			expect(content.some((b) => b.type === "diff")).toBe(false)
+		}
+	})
+
+	// A failed mutation must not surface a diff — the client would otherwise
+	// render a change that never landed.
+	it("emits no diff content blocks when the edit/write tool call failed", async () => {
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-edit-fail",
+				toolName: "edit",
+				args: { path: join(tmpDir, "a.txt"), edits: [{ oldText: "x", newText: "y" }] },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-edit-fail",
+				toolName: "edit",
+				result: { content: [{ type: "text", text: "boom" }] },
+				isError: true,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const content = terminalContent("tc-edit-fail") as Array<{ type: string }>
+		expect(content.some((b) => b.type === "diff")).toBe(false)
+	})
+})
+
+// Pure adapter coverage for the FileChange → v1 Diff mapping, including the
+// delete branch the edit/write tools never produce today.
+describe("fileChangeToDiffContent", () => {
+	it("maps add to a diff with oldText null", () => {
+		expect(fileChangeToDiffContent({ operation: "add", path: "/a.txt", newText: "new" })).toEqual({
+			type: "diff",
+			path: "/a.txt",
+			newText: "new",
+			oldText: null,
+		})
+	})
+
+	it("maps modify to a diff carrying both texts", () => {
+		expect(fileChangeToDiffContent({ operation: "modify", path: "/a.txt", oldText: "old", newText: "new" })).toEqual({
+			type: "diff",
+			path: "/a.txt",
+			oldText: "old",
+			newText: "new",
+		})
+	})
+
+	it("maps delete to a diff omitting newText", () => {
+		expect(fileChangeToDiffContent({ operation: "delete", path: "/a.txt", oldText: "gone" })).toEqual({
+			type: "diff",
+			path: "/a.txt",
+			oldText: "gone",
+		})
 	})
 })
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -3078,6 +3078,38 @@ describe("KimchiAcpAgent per-turn diffs", () => {
 		])
 	})
 
+	// pi's edit tool accepts a legacy single-edit arg shape {path, oldText,
+	// newText} (no edits array) and normalizes it internally. A legacy-shape
+	// call must still emit its diff rather than silently producing none.
+	it("emits a diff for an edit tool call using the legacy single-edit arg shape", async () => {
+		const target = join(tmpDir, "legacy.txt")
+		writeFileSync(target, "old text")
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-edit-legacy",
+				toolName: "edit",
+				args: { path: target, oldText: "old text", newText: "new text" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-edit-legacy",
+				toolName: "edit",
+				result: { content: [{ type: "text", text: "Edited legacy.txt" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		const content = terminalContent("tc-edit-legacy") as Array<{ type: string }>
+		const diffs = content.filter((b) => b.type === "diff")
+		expect(diffs).toEqual([{ type: "diff", path: target, oldText: "old text", newText: "new text" }])
+	})
+
 	it("emits one diff content block per edit for an edit tool call with multiple edits", async () => {
 		const target = join(tmpDir, "multi.txt")
 		writeFileSync(target, "one two")
@@ -3176,6 +3208,60 @@ describe("KimchiAcpAgent per-turn diffs", () => {
 		const content = terminalContent("tc-write-over") as Array<{ type: string }>
 		const diffs = content.filter((b) => b.type === "diff")
 		expect(diffs).toEqual([{ type: "diff", path: target, oldText: "before content", newText: "after content" }])
+	})
+
+	// pi's write tool resolves args.path with stripAtPrefix +
+	// normalizeUnicodeSpaces before touching disk. The pre-write read must
+	// match that resolution or an overwrite of "@notes.txt" / "a b.txt" (typed
+	// as "a\u00A0b.txt") would be misclassified as a new-file 'add'.
+	it("resolves @-prefixed and unicode-space write paths for the pre-write read", async () => {
+		const atTarget = join(tmpDir, "notes.txt")
+		writeFileSync(atTarget, "at before")
+		const spaceTarget = join(tmpDir, "my file.txt")
+		writeFileSync(spaceTarget, "space before")
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-write-at",
+				toolName: "write",
+				args: { path: "@notes.txt", content: "at after" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-write-at",
+				toolName: "write",
+				result: { content: [{ type: "text", text: "ok" }] },
+				isError: false,
+			})
+			fake.emit({
+				type: "tool_execution_start",
+				toolCallId: "tc-write-nbsp",
+				toolName: "write",
+				// No-break space as typed by an LLM mimicking the on-disk name.
+				args: { path: "my\u00A0file.txt", content: "space after" },
+			})
+			fake.emit({
+				type: "tool_execution_end",
+				toolCallId: "tc-write-nbsp",
+				toolName: "write",
+				result: { content: [{ type: "text", text: "ok" }] },
+				isError: false,
+			})
+			fake.emit(agentEnd())
+		}
+
+		const res = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "do" }] })
+		expect(res.stopReason).toBe("end_turn")
+
+		// Emitted diff paths stay verbatim from args.path; only the pre-write
+		// READ uses the normalized path.
+		const atDiffs = (terminalContent("tc-write-at") as Array<{ type: string }>).filter((b) => b.type === "diff")
+		expect(atDiffs).toEqual([{ type: "diff", path: "@notes.txt", oldText: "at before", newText: "at after" }])
+		const nbspDiffs = (terminalContent("tc-write-nbsp") as Array<{ type: string }>).filter((b) => b.type === "diff")
+		expect(nbspDiffs).toEqual([
+			{ type: "diff", path: "my\u00A0file.txt", oldText: "space before", newText: "space after" },
+		])
 	})
 
 	it("emits no diff content blocks for read-only tool calls", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -2,7 +2,7 @@
 // @agentclientprotocol/sdk. Lets IDE extensions, Zed, openclaw drive kimchi in-process.
 
 import { closeSync, openSync, readdirSync, readFileSync, readSync } from "node:fs"
-import { join } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { Readable, Writable } from "node:stream"
 import {
 	type SessionInfo as AcpSessionInfo,
@@ -154,13 +154,48 @@ type TurnContext = {
 	hiddenToolCallIds: Set<string>
 	announcedToolCallIds: Set<string>
 	lastStreamedContent: Map<string, string>
+	/**
+	 * Pre-write file contents read at tool_execution_start for `write` tool
+	 * calls: the original file content if the file existed (later surfaced as
+	 * the diff's oldText), null for a new file. Keyed by toolCallId; the entry
+	 * is consumed and cleared at tool_execution_end. Args travel only on
+	 * tool_execution_start (ToolExecutionEndEvent carries none), so everything
+	 * the end event needs must be captured here.
+	 */
+	preWriteContents: Map<string, string | null>
+	/**
+	 * File changes derived from tool args at tool_execution_start for the
+	 * mutation tools (edit, write). Emitted as ACP `diff` content blocks at
+	 * tool_execution_end; key removed once consumed. Read-only tools never
+	 * appear here.
+	 */
+	pendingFileChanges: Map<string, FileChange[]>
 	resolve: (res: PromptResponse) => void
 	reject: (err: unknown) => void
+}
+
+/**
+ * Internal file-mutation abstraction shared by the v1 and (future) v2 ACP
+ * diff adapters. Populated from tool args at tool_execution_start so the v1
+ * emission ({@link fileChangeToDiffContent}) is a pure adapter over data
+ * already known before the tool ran — v2 migration is a pure adapter swap.
+ */
+export interface FileChange {
+	path: string
+	operation: "add" | "modify" | "delete"
+	/** undefined for "add" */
+	oldText?: string
+	/** undefined for "delete" */
+	newText?: string
 }
 
 type SessionRecord = {
 	session: AgentSession
 	unsubscribe: () => void
+	// Session cwd, captured at newSession/loadSession time. AgentSession keeps
+	// its cwd private, but the ACP server needs it to resolve relative tool
+	// paths (pre-write reads for per-turn diffs).
+	cwd: string
 	turn?: TurnContext
 	/**
 	 * Session-wide monotonic counter for ACP messageIds. Every distinct
@@ -424,6 +459,7 @@ export class KimchiAcpAgent implements Agent {
 			const record: SessionRecord = {
 				session,
 				unsubscribe: () => {},
+				cwd: session.sessionManager.getCwd(),
 				nextBlockId: 0,
 				contentIndexToBlockId: new Map(),
 				nextToolCallId: 0,
@@ -668,6 +704,9 @@ export class KimchiAcpAgent implements Agent {
 			const record: SessionRecord = {
 				session,
 				unsubscribe: () => {},
+				// The session header cwd was validated against params.cwd above, so
+				// the session manager's cwd is the session's true cwd.
+				cwd: session.sessionManager.getCwd(),
 				nextBlockId: 0,
 				contentIndexToBlockId: new Map(),
 				nextToolCallId: 0,
@@ -777,6 +816,8 @@ export class KimchiAcpAgent implements Agent {
 			hiddenToolCallIds: new Set(),
 			announcedToolCallIds: new Set(),
 			lastStreamedContent: new Map(),
+			preWriteContents: new Map(),
+			pendingFileChanges: new Map(),
 			resolve: turnResolve,
 			reject: turnReject,
 		}
@@ -1006,6 +1047,13 @@ export class KimchiAcpAgent implements Agent {
 					this.retireToolCall(entry, turn, event.toolCallId)
 					return
 				}
+				// Capture the diff data now — tool_execution_end carries no args.
+				// For `write` the pre-existing content must be read before the tool
+				// runs; afterwards the file already holds the new content.
+				const fileChanges = fileChangesForToolCall(event.toolName, event.args, entry.cwd, turn, event.toolCallId)
+				if (fileChanges.length > 0) {
+					turn.pendingFileChanges.set(event.toolCallId, fileChanges)
+				}
 				const acpToolCallId = this.getOrAllocateAcpToolCallId(entry, event.toolCallId, event.toolName)
 				if (turn.announcedToolCallIds.has(event.toolCallId)) {
 					// Pending tool_call was already sent via toolcall_start → emit update
@@ -1060,12 +1108,21 @@ export class KimchiAcpAgent implements Agent {
 					this.retireToolCall(entry, turn, event.toolCallId, { removeFromHidden: true })
 					return
 				}
+				// Consume the per-call capture so a later turn reusing the id (or a
+				// retried call) can't leak stale diff data across tool calls.
+				const fileChanges = turn.pendingFileChanges.get(event.toolCallId) ?? []
+				turn.pendingFileChanges.delete(event.toolCallId)
+				turn.preWriteContents.delete(event.toolCallId)
+				// Diffs are additional content blocks, appended after the existing
+				// text/image content. Failed mutations emit no diff: the client
+				// would otherwise render a change that never landed.
+				const diffs = event.isError ? [] : fileChanges.map(fileChangeToDiffContent)
 				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
 				const update: SessionUpdate = buildToolCallUpdate({
 					toolCallId: acpToolCallId,
 					piToolCallId: event.toolCallId,
 					status: event.isError ? "failed" : "completed",
-					content: toolResultContent(event.result),
+					content: [...toolResultContent(event.result), ...diffs],
 					rawOutput: event.result,
 				})
 				this.send({ sessionId, update })
@@ -1842,6 +1899,76 @@ function replayTextParts(text: string): ReplayTextPart[] {
 function extractStreamContent(args: unknown): string | undefined {
 	const a = (args ?? {}) as Record<string, unknown>
 	return asString(a.content) ?? asString(a.newText) ?? asString(a.command)
+}
+
+// ACP v1 Diff = { path, newText, oldText? }. The v1 adapter maps one
+// FileChange to one ToolCallContent with type "diff": add carries
+// oldText: null, modify carries both texts, delete omits newText (no tool
+// produces deletes today; the branch exists so the adapter is total over
+// FileChange and the v2 migration stays a pure adapter swap).
+export function fileChangeToDiffContent(change: FileChange): ToolCallContent {
+	switch (change.operation) {
+		case "add":
+			return { type: "diff", path: change.path, newText: change.newText ?? "", oldText: null }
+		case "modify":
+			return { type: "diff", path: change.path, newText: change.newText ?? "", oldText: change.oldText ?? null }
+		case "delete":
+			// The SDK's v1 Diff type marks newText required, but the protocol
+			// treats it as absent for deletions (oldText is the "None for new
+			// files" mirror). Cast keeps the wire shape per the v1 mapping.
+			return { type: "diff", path: change.path, oldText: change.oldText ?? null } as ToolCallContent
+	}
+}
+
+// Reads the pre-write content for a `write` tool call. Returns null when the
+// file doesn't exist yet (new-file add) or can't be read — either way the
+// diff simply omits oldText rather than breaking the tool_call_update.
+function readPreWriteContent(toolPath: string, cwd: string): string | null {
+	// pi's write tool resolves args.path via resolveToCwd (absolute paths pass
+	// through; relative paths join cwd). resolveToCwd isn't exported from the
+	// package index, so replicate the two cases args actually produce.
+	const absolute = isAbsolute(toolPath) ? toolPath : resolve(cwd, toolPath)
+	try {
+		return readFileSync(absolute, "utf-8")
+	} catch {
+		return null
+	}
+}
+
+// Derives FileChange entries from a tool's arguments. Only the mutation tools
+// (edit, write) produce changes; everything else returns [] so read-only
+// tools never attach diffs. For `write`, the pre-existing file content is
+// also recorded into TurnContext.preWriteContents (per the ticket's
+// TurnContext contract) and doubles as the diff's oldText.
+function fileChangesForToolCall(
+	toolName: string,
+	args: unknown,
+	cwd: string,
+	turn: { preWriteContents: Map<string, string | null> },
+	toolCallId: string,
+): FileChange[] {
+	const a = (args ?? {}) as Record<string, unknown>
+	const path = typeof a.path === "string" ? a.path : undefined
+	if (toolName === "edit") {
+		if (!path || !Array.isArray(a.edits)) return []
+		const changes: FileChange[] = []
+		for (const e of a.edits) {
+			if (!e || typeof e !== "object") continue
+			const edit = e as { oldText?: unknown; newText?: unknown }
+			if (typeof edit.oldText !== "string" || typeof edit.newText !== "string") continue
+			changes.push({ operation: "modify", path, oldText: edit.oldText, newText: edit.newText })
+		}
+		return changes
+	}
+	if (toolName === "write") {
+		if (!path || typeof a.content !== "string") return []
+		const previous = readPreWriteContent(path, cwd)
+		turn.preWriteContents.set(toolCallId, previous)
+		return previous === null
+			? [{ operation: "add", path, newText: a.content }]
+			: [{ operation: "modify", path, oldText: previous, newText: a.content }]
+	}
+	return []
 }
 
 // UserMessage.content is `string | (TextContent | ImageContent)[]` per pi-ai

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -2,8 +2,10 @@
 // @agentclientprotocol/sdk. Lets IDE extensions, Zed, openclaw drive kimchi in-process.
 
 import { closeSync, openSync, readdirSync, readFileSync, readSync } from "node:fs"
+import { homedir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 import { Readable, Writable } from "node:stream"
+import { fileURLToPath } from "node:url"
 import {
 	type SessionInfo as AcpSessionInfo,
 	type Agent,
@@ -167,9 +169,10 @@ type TurnContext = {
 	 * File changes derived from tool args at tool_execution_start for the
 	 * mutation tools (edit, write). Emitted as ACP `diff` content blocks at
 	 * tool_execution_end; key removed once consumed. Read-only tools never
-	 * appear here.
+	 * appear here. Write entries keep their operation undecided until the end
+	 * event resolves add-vs-modify from preWriteContents.
 	 */
-	pendingFileChanges: Map<string, FileChange[]>
+	pendingFileChanges: Map<string, PendingFileChange[]>
 	resolve: (res: PromptResponse) => void
 	reject: (err: unknown) => void
 }
@@ -188,6 +191,16 @@ export interface FileChange {
 	/** undefined for "delete" */
 	newText?: string
 }
+
+/**
+ * Captured-at-start representation of a pending diff. Edit calls resolve to
+ * FileChange immediately (args carry both texts). Write calls carry the
+ * "write" sentinel: whether the change is an add or a modify depends on
+ * TurnContext.preWriteContents, which is only consulted at tool_execution_end
+ * ({@link resolveFileChange}) — that is what keeps preWriteContents the
+ * single source of truth for the write oldText.
+ */
+type PendingFileChange = FileChange | { operation: "write"; path: string; newText: string }
 
 type SessionRecord = {
 	session: AgentSession
@@ -1050,7 +1063,7 @@ export class KimchiAcpAgent implements Agent {
 				// Capture the diff data now — tool_execution_end carries no args.
 				// For `write` the pre-existing content must be read before the tool
 				// runs; afterwards the file already holds the new content.
-				const fileChanges = fileChangesForToolCall(event.toolName, event.args, entry.cwd, turn, event.toolCallId)
+				const fileChanges = collectFileChanges(event.toolName, event.args, entry.cwd, turn, event.toolCallId)
 				if (fileChanges.length > 0) {
 					turn.pendingFileChanges.set(event.toolCallId, fileChanges)
 				}
@@ -1110,13 +1123,14 @@ export class KimchiAcpAgent implements Agent {
 				}
 				// Consume the per-call capture so a later turn reusing the id (or a
 				// retried call) can't leak stale diff data across tool calls.
-				const fileChanges = turn.pendingFileChanges.get(event.toolCallId) ?? []
+				const pending = turn.pendingFileChanges.get(event.toolCallId) ?? []
 				turn.pendingFileChanges.delete(event.toolCallId)
+				const preWrite = turn.preWriteContents.get(event.toolCallId)
 				turn.preWriteContents.delete(event.toolCallId)
 				// Diffs are additional content blocks, appended after the existing
 				// text/image content. Failed mutations emit no diff: the client
 				// would otherwise render a change that never landed.
-				const diffs = event.isError ? [] : fileChanges.map(fileChangeToDiffContent)
+				const diffs = event.isError ? [] : pending.map((p) => fileChangeToDiffContent(resolveFileChange(p, preWrite)))
 				const acpToolCallId = this.resolveAcpToolCallId(entry, event.toolCallId)
 				const update: SessionUpdate = buildToolCallUpdate({
 					toolCallId: acpToolCallId,
@@ -1920,39 +1934,62 @@ export function fileChangeToDiffContent(change: FileChange): ToolCallContent {
 	}
 }
 
+// Faithful replication of pi's resolveToCwd (dist/core/tools/path-utils.js →
+// resolvePath with normalizeUnicodeSpaces + stripAtPrefix): the write tool
+// resolves args.path this way, so the pre-write read must match or a path
+// like "@notes.txt" or "~/file (with NBSP).md" would be misclassified as a
+// new file. pi-coding-agent only exports "." and "./hooks", so the helper
+// can't be imported — replicated here. Drift surfaces as an 'add' diff on an
+// overwritten file, not corruption.
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g
+function resolveToolPath(input: string, cwd: string): string {
+	let p = input.replace(UNICODE_SPACES, " ")
+	if (p.startsWith("@")) p = p.slice(1)
+	if (p === "~") {
+		p = homedir()
+	} else if (p.startsWith("~/") || (process.platform === "win32" && p.startsWith("~\\"))) {
+		p = join(homedir(), p.slice(2))
+	}
+	if (/^file:\/\//.test(p)) p = fileURLToPath(p)
+	return isAbsolute(p) ? resolve(p) : resolve(cwd, p)
+}
+
 // Reads the pre-write content for a `write` tool call. Returns null when the
 // file doesn't exist yet (new-file add) or can't be read — either way the
 // diff simply omits oldText rather than breaking the tool_call_update.
 function readPreWriteContent(toolPath: string, cwd: string): string | null {
-	// pi's write tool resolves args.path via resolveToCwd (absolute paths pass
-	// through; relative paths join cwd). resolveToCwd isn't exported from the
-	// package index, so replicate the two cases args actually produce.
-	const absolute = isAbsolute(toolPath) ? toolPath : resolve(cwd, toolPath)
 	try {
-		return readFileSync(absolute, "utf-8")
+		return readFileSync(resolveToolPath(toolPath, cwd), "utf-8")
 	} catch {
 		return null
 	}
 }
 
-// Derives FileChange entries from a tool's arguments. Only the mutation tools
-// (edit, write) produce changes; everything else returns [] so read-only
-// tools never attach diffs. For `write`, the pre-existing file content is
-// also recorded into TurnContext.preWriteContents (per the ticket's
-// TurnContext contract) and doubles as the diff's oldText.
-function fileChangesForToolCall(
+// Derives pending file-change entries from a tool's arguments. Only the
+// mutation tools (edit, write) produce changes; everything else returns []
+// so read-only tools never attach diffs.
+function collectFileChanges(
 	toolName: string,
 	args: unknown,
 	cwd: string,
 	turn: { preWriteContents: Map<string, string | null> },
 	toolCallId: string,
-): FileChange[] {
+): PendingFileChange[] {
 	const a = (args ?? {}) as Record<string, unknown>
 	const path = typeof a.path === "string" ? a.path : undefined
 	if (toolName === "edit") {
-		if (!path || !Array.isArray(a.edits)) return []
+		if (!path) return []
+		// pi's edit tool accepts the multi-edit shape {path, edits: [...]} and
+		// normalizes a legacy single-edit shape {path, oldText, newText}
+		// internally. Mirror that normalization so legacy-shape calls still
+		// emit a diff instead of silently producing none.
+		const editsInput: unknown[] = Array.isArray(a.edits)
+			? a.edits
+			: typeof a.oldText === "string" && typeof a.newText === "string"
+				? [{ oldText: a.oldText, newText: a.newText }]
+				: []
 		const changes: FileChange[] = []
-		for (const e of a.edits) {
+		for (const e of editsInput) {
 			if (!e || typeof e !== "object") continue
 			const edit = e as { oldText?: unknown; newText?: unknown }
 			if (typeof edit.oldText !== "string" || typeof edit.newText !== "string") continue
@@ -1962,13 +1999,25 @@ function fileChangesForToolCall(
 	}
 	if (toolName === "write") {
 		if (!path || typeof a.content !== "string") return []
-		const previous = readPreWriteContent(path, cwd)
-		turn.preWriteContents.set(toolCallId, previous)
-		return previous === null
-			? [{ operation: "add", path, newText: a.content }]
-			: [{ operation: "modify", path, oldText: previous, newText: a.content }]
+		// Capture the pre-existing content now (before the tool overwrites it).
+		// The entry is stored with its operation undecided; tool_execution_end
+		// resolves add-vs-modify from preWriteContents via resolveFileChange,
+		// keeping that map the single source of truth for the write oldText.
+		turn.preWriteContents.set(toolCallId, readPreWriteContent(path, cwd))
+		return [{ operation: "write", path, newText: a.content }]
 	}
 	return []
+}
+
+// Resolves a captured-at-start entry to a concrete FileChange for the v1
+// adapter. "write" entries become "add" when the file didn't exist (or the
+// pre-write read failed, or no pre-write content was captured) and "modify"
+// with the recorded oldText otherwise.
+function resolveFileChange(pending: PendingFileChange, preWrite: string | null | undefined): FileChange {
+	if (pending.operation !== "write") return pending
+	return preWrite === null || preWrite === undefined
+		? { operation: "add", path: pending.path, newText: pending.newText }
+		: { operation: "modify", path: pending.path, oldText: preWrite, newText: pending.newText }
 }
 
 // UserMessage.content is `string | (TextContent | ImageContent)[]` per pi-ai

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1955,12 +1955,17 @@ function resolveToolPath(input: string, cwd: string): string {
 }
 
 // Reads the pre-write content for a `write` tool call. Returns null when the
-// file doesn't exist yet (new-file add) or can't be read — either way the
-// diff simply omits oldText rather than breaking the tool_call_update.
+// file doesn't exist yet (new-file add). Other read errors are logged — the
+// diff still omits oldText rather than breaking the tool_call_update, but a
+// swallowed EACCES/ETOOLARGE would otherwise be indistinguishable from
+// "file did not exist".
 function readPreWriteContent(toolPath: string, cwd: string): string | null {
 	try {
 		return readFileSync(resolveToolPath(toolPath, cwd), "utf-8")
-	} catch {
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			process.stderr.write(`acp per-turn-diff: pre-write read failed for ${toolPath}: ${String(err)}\n`)
+		}
 		return null
 	}
 }


### PR DESCRIPTION
## Linked issue

Closes #1039

## What does this PR do?

Implements ticket #04 — Per-Turn Diffs in Kimchi ACP. The ACP server attaches `Diff` content blocks to `tool_call_update` notifications for `edit` and `write` tool calls. Uses an internal `FileChange` abstraction with v1 adapter. Handles legacy edit arg shapes, pre-write content capture at `tool_execution_start`, and faithful path resolution matching pi-mono's `resolveToCwd`.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed

<img width="841" height="497" alt="image" src="https://github.com/user-attachments/assets/18d020ec-4bba-4971-bec8-d72f532ee246" />
<img width="840" height="258" alt="image" src="https://github.com/user-attachments/assets/706771e7-81e7-4af7-8a01-4b4e9ec695d5" />
<img width="845" height="189" alt="image" src="https://github.com/user-attachments/assets/d596f4b3-58be-479e-810d-3080c3b34139" />

