### PR TITLE
feat(acp): system prompt injection via _meta["kimchi.dev"].systemPrompt

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { AgentSession, parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
 import {
 	isCliAtFileArg,
 	isExperimentalFeaturesArg,
@@ -669,7 +669,12 @@ try {
 		if (IS_ACP_MODE) {
 			const { runAcpMode } = await import("./modes/acp/server.js")
 			const { McpServerManager } = await import("./extensions/mcp-adapter/server-manager.js")
-			await runAcpMode({ extensionFactories, agentDir, mcpServerManager: new McpServerManager() })
+			await runAcpMode({
+				extensionFactories,
+				agentDir,
+				mcpServerManager: new McpServerManager(),
+				appendSystemPrompt: parsePiArgs(rawArgs).appendSystemPrompt,
+			})
 		} else {
 			// Delegate to pi-mono's CLI main function, injecting the kimchi extension
 			const { main } = await import("@earendil-works/pi-coding-agent")

--- a/src/modes/acp/default-session-wiring.test.ts
+++ b/src/modes/acp/default-session-wiring.test.ts
@@ -78,12 +78,12 @@ describe("default session factory/loader _meta wiring", () => {
 		return { extensionFactories: [], agentDir, ...extra }
 	}
 
-	it("defaultSessionFactory threads _meta['kimchi.dev'].systemPrompt into DefaultResourceLoader.appendSystemPrompt", async () => {
+	it("defaultSessionFactory threads _meta['kimchi.dev'].appendSystemPrompt into DefaultResourceLoader.appendSystemPrompt", async () => {
 		const factory = defaultSessionFactory(makeOptions())
 		await factory({
 			cwd,
 			mcpServers: [],
-			_meta: { "kimchi.dev": { systemPrompt: "You are a worker under AO supervision." } },
+			_meta: { "kimchi.dev": { appendSystemPrompt: "You are a worker under AO supervision." } },
 		})
 		expect(capturedLoaderOptions).toHaveLength(1)
 		expect(invokeCapturedOverride()).toEqual(["You are a worker under AO supervision."])
@@ -94,7 +94,7 @@ describe("default session factory/loader _meta wiring", () => {
 		await factory({
 			cwd,
 			mcpServers: [],
-			_meta: { "kimchi.dev": { systemPrompt: "meta prompt" } },
+			_meta: { "kimchi.dev": { appendSystemPrompt: "meta prompt" } },
 		})
 		expect(capturedLoaderOptions).toHaveLength(1)
 		expect(invokeCapturedOverride()).toEqual(["cli base prompt", "meta prompt"])
@@ -109,7 +109,7 @@ describe("default session factory/loader _meta wiring", () => {
 		expect(invokeCapturedOverride()).toEqual([])
 	})
 
-	it("defaultSessionLoader threads _meta['kimchi.dev'].systemPrompt identically", async () => {
+	it("defaultSessionLoader threads _meta['kimchi.dev'].appendSystemPrompt identically", async () => {
 		const sessionId = "wiring-load-1"
 		const sessionDir = join(agentDir, "sessions", encodeCwdDir(cwd))
 		mkdirSync(sessionDir, { recursive: true })
@@ -128,7 +128,7 @@ describe("default session factory/loader _meta wiring", () => {
 			sessionId,
 			cwd,
 			mcpServers: [],
-			_meta: { "kimchi.dev": { systemPrompt: "Loaded sessions get the same prompt." } },
+			_meta: { "kimchi.dev": { appendSystemPrompt: "Loaded sessions get the same prompt." } },
 		})
 		expect(capturedLoaderOptions).toHaveLength(1)
 		expect(invokeCapturedOverride()).toEqual(["Loaded sessions get the same prompt."])

--- a/src/modes/acp/default-session-wiring.test.ts
+++ b/src/modes/acp/default-session-wiring.test.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+type ResourceLoaderOptions = Record<string, unknown>
+
+const capturedLoaderOptions: ResourceLoaderOptions[] = []
+
+// Partial mock: keep the entire real pi-coding-agent package, but record the
+// options handed to DefaultResourceLoader and stub createAgentSession. The
+// wiring under test ends at the resource loader; a real session creation
+// would pull in model/auth setup unrelated to the _meta → appendSystemPrompt
+// thread-through.
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>()
+	class CapturingResourceLoader extends actual.DefaultResourceLoader {
+		// biome-ignore lint/suspicious/noExplicitAny: test double forwarding the real ctor options
+		constructor(options: any) {
+			capturedLoaderOptions.push(options as ResourceLoaderOptions)
+			super(options)
+		}
+	}
+	return {
+		...actual,
+		DefaultResourceLoader: CapturingResourceLoader,
+		createAgentSession: async () => ({ session: { sessionId: "stubbed-session" } }) as never,
+	}
+})
+
+// Stub the skill-list block: buildSkillListBlock(cwd) would otherwise
+// discover the real HOME's skills and pollute the asserted prompt array (the
+// block itself is upstream's contribution appended after the _meta entries).
+vi.mock("./skill-commands.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./skill-commands.js")>()
+	return { ...actual, buildSkillListBlock: () => "" }
+})
+
+import { defaultSessionFactory, defaultSessionLoader, type RunAcpOptions } from "./server.js"
+
+// Mirror of server.ts's private encodeCwdDir — the encoding is a public
+// on-disk format (see its comment).
+function encodeCwdDir(cwd: string): string {
+	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`
+}
+
+// Since the rebase onto upstream/master, DefaultResourceLoader is configured
+// through appendSystemPromptOverride (upstream added the skill-list block via
+// an override), not a static appendSystemPrompt array. Invoke the captured
+// override the way pi's resource loader does (with the discovered base
+// entries — empty here because the temp cwd has no append-system prompt file)
+// and assert on the appended entries.
+type AppendOverride = (base: string[]) => string[]
+
+function invokeCapturedOverride(index = 0): string[] {
+	const override = capturedLoaderOptions[index].appendSystemPromptOverride as AppendOverride | undefined
+	if (!override) throw new Error("expected DefaultResourceLoader to receive an appendSystemPromptOverride")
+	return override([])
+}
+
+describe("default session factory/loader _meta wiring", () => {
+	let agentDir: string
+	let cwd: string
+	const tempDirs: string[] = []
+
+	beforeEach(() => {
+		capturedLoaderOptions.length = 0
+		agentDir = mkdtempSync(join(tmpdir(), "kimchi-acp-wiring-agent-"))
+		cwd = mkdtempSync(join(tmpdir(), "kimchi-acp-wiring-cwd-"))
+		tempDirs.push(agentDir, cwd)
+	})
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+	})
+
+	function makeOptions(extra?: Partial<RunAcpOptions>): RunAcpOptions {
+		return { extensionFactories: [], agentDir, ...extra }
+	}
+
+	it("defaultSessionFactory threads _meta['kimchi.dev'].systemPrompt into DefaultResourceLoader.appendSystemPrompt", async () => {
+		const factory = defaultSessionFactory(makeOptions())
+		await factory({
+			cwd,
+			mcpServers: [],
+			_meta: { "kimchi.dev": { systemPrompt: "You are a worker under AO supervision." } },
+		})
+		expect(capturedLoaderOptions).toHaveLength(1)
+		expect(invokeCapturedOverride()).toEqual(["You are a worker under AO supervision."])
+	})
+
+	it("defaultSessionFactory appends meta content after --append-system-prompt CLI flag content", async () => {
+		const factory = defaultSessionFactory(makeOptions({ appendSystemPrompt: ["cli base prompt"] }))
+		await factory({
+			cwd,
+			mcpServers: [],
+			_meta: { "kimchi.dev": { systemPrompt: "meta prompt" } },
+		})
+		expect(capturedLoaderOptions).toHaveLength(1)
+		expect(invokeCapturedOverride()).toEqual(["cli base prompt", "meta prompt"])
+	})
+
+	it("defaultSessionFactory leaves appendSystemPrompt unset when no meta is present (backward compat)", async () => {
+		const factory = defaultSessionFactory(makeOptions())
+		await factory({ cwd, mcpServers: [] })
+		expect(capturedLoaderOptions).toHaveLength(1)
+		// Only the upstream skill-list block may be appended — and an empty
+		// temp cwd yields no skills, so the result must be empty.
+		expect(invokeCapturedOverride()).toEqual([])
+	})
+
+	it("defaultSessionLoader threads _meta['kimchi.dev'].systemPrompt identically", async () => {
+		const sessionId = "wiring-load-1"
+		const sessionDir = join(agentDir, "sessions", encodeCwdDir(cwd))
+		mkdirSync(sessionDir, { recursive: true })
+		writeFileSync(
+			join(sessionDir, `2026-05-09T00-00-00.000Z_${sessionId}.jsonl`),
+			`${JSON.stringify({
+				type: "session",
+				version: 3,
+				id: sessionId,
+				timestamp: "2026-05-09T00:00:00Z",
+				cwd,
+			})}\n`,
+		)
+		const loader = defaultSessionLoader(makeOptions())
+		await loader({
+			sessionId,
+			cwd,
+			mcpServers: [],
+			_meta: { "kimchi.dev": { systemPrompt: "Loaded sessions get the same prompt." } },
+		})
+		expect(capturedLoaderOptions).toHaveLength(1)
+		expect(invokeCapturedOverride()).toEqual(["Loaded sessions get the same prompt."])
+	})
+})

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -6770,18 +6770,18 @@ describe("resolveAcpAppendSystemPrompt", () => {
 		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": {} } }, noOptions)).toBeUndefined()
 	})
 
-	it("threads _meta['kimchi.dev'].systemPrompt through for newSession", () => {
-		const params = { _meta: { "kimchi.dev": { systemPrompt: "You are a worker under AO supervision." } } }
+	it("threads _meta['kimchi.dev'].appendSystemPrompt through for newSession", () => {
+		const params = { _meta: { "kimchi.dev": { appendSystemPrompt: "You are a worker under AO supervision." } } }
 		expect(resolveAcpAppendSystemPrompt(params, noOptions)).toEqual(["You are a worker under AO supervision."])
 	})
 
-	it("threads _meta['kimchi.dev'].systemPrompt through identically for loadSession", () => {
-		const params = { _meta: { "kimchi.dev": { systemPrompt: "Loaded sessions get the same prompt." } } }
+	it("threads _meta['kimchi.dev'].appendSystemPrompt through identically for loadSession", () => {
+		const params = { _meta: { "kimchi.dev": { appendSystemPrompt: "Loaded sessions get the same prompt." } } }
 		expect(resolveAcpAppendSystemPrompt(params, noOptions)).toEqual(["Loaded sessions get the same prompt."])
 	})
 
 	it("appends meta content after CLI flag content when both are present", () => {
-		const params = { _meta: { "kimchi.dev": { systemPrompt: "meta prompt" } } }
+		const params = { _meta: { "kimchi.dev": { appendSystemPrompt: "meta prompt" } } }
 		expect(resolveAcpAppendSystemPrompt(params, { appendSystemPrompt: ["cli one", "cli two"] })).toEqual([
 			"cli one",
 			"cli two",
@@ -6793,11 +6793,23 @@ describe("resolveAcpAppendSystemPrompt", () => {
 		expect(resolveAcpAppendSystemPrompt({}, { appendSystemPrompt: ["cli only"] })).toEqual(["cli only"])
 	})
 
-	it("ignores non-string, empty, and whitespace-only meta systemPrompt values", () => {
-		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: 42 } } }, noOptions)).toBeUndefined()
-		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: "" } } }, noOptions)).toBeUndefined()
+	it("ignores non-string, empty, and whitespace-only meta appendSystemPrompt values", () => {
 		expect(
-			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: "   \n  " } } }, noOptions),
+			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { appendSystemPrompt: 42 } } }, noOptions),
+		).toBeUndefined()
+		expect(
+			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { appendSystemPrompt: "" } } }, noOptions),
+		).toBeUndefined()
+		expect(
+			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { appendSystemPrompt: "   \n  " } } }, noOptions),
+		).toBeUndefined()
+	})
+
+	it("ignores the plain systemPrompt key — the meta value appends, it never replaces", () => {
+		// The plain `systemPrompt` name is reserved: if a replace-the-system-prompt
+		// API is ever exposed over _meta, it gets its own distinctly named key.
+		expect(
+			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: "ignored" } } }, noOptions),
 		).toBeUndefined()
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -68,12 +68,12 @@ import {
 	fileChangeToDiffContent,
 	initializeHeadlessTheme,
 	KimchiAcpAgent,
-	resolveAcpAppendSystemPrompt,
 	stripAnsi,
 	toAcpSessionInfo,
 	userMessageText,
 } from "./server.js"
 import { getAcpClientInfo, resetAcpClientInfo } from "./state.js"
+import { resolveAcpAppendSystemPrompt } from "./system-prompt.js"
 
 function cleanPermissionEnv(): void {
 	Reflect.deleteProperty(process.env, "KIMCHI_ACTIVE_FERMENT")

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -68,6 +68,7 @@ import {
 	fileChangeToDiffContent,
 	initializeHeadlessTheme,
 	KimchiAcpAgent,
+	resolveAcpAppendSystemPrompt,
 	stripAnsi,
 	toAcpSessionInfo,
 	userMessageText,
@@ -6757,5 +6758,52 @@ describe("userMessageText", () => {
 	it("returns empty string for null / non-array user content", () => {
 		expect(userMessageText(null)).toBe("")
 		expect(userMessageText(42)).toBe("")
+	})
+})
+
+describe("resolveAcpAppendSystemPrompt", () => {
+	const noOptions = {}
+
+	it("returns undefined when neither CLI flag nor ACP meta is present (backward compat)", () => {
+		expect(resolveAcpAppendSystemPrompt({}, noOptions)).toBeUndefined()
+		expect(resolveAcpAppendSystemPrompt({ _meta: {} }, noOptions)).toBeUndefined()
+		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": {} } }, noOptions)).toBeUndefined()
+	})
+
+	it("threads _meta['kimchi.dev'].systemPrompt through for newSession", () => {
+		const params = { _meta: { "kimchi.dev": { systemPrompt: "You are a worker under AO supervision." } } }
+		expect(resolveAcpAppendSystemPrompt(params, noOptions)).toEqual(["You are a worker under AO supervision."])
+	})
+
+	it("threads _meta['kimchi.dev'].systemPrompt through identically for loadSession", () => {
+		const params = { _meta: { "kimchi.dev": { systemPrompt: "Loaded sessions get the same prompt." } } }
+		expect(resolveAcpAppendSystemPrompt(params, noOptions)).toEqual(["Loaded sessions get the same prompt."])
+	})
+
+	it("appends meta content after CLI flag content when both are present", () => {
+		const params = { _meta: { "kimchi.dev": { systemPrompt: "meta prompt" } } }
+		expect(resolveAcpAppendSystemPrompt(params, { appendSystemPrompt: ["cli one", "cli two"] })).toEqual([
+			"cli one",
+			"cli two",
+			"meta prompt",
+		])
+	})
+
+	it("returns CLI flag content unchanged when no meta is present", () => {
+		expect(resolveAcpAppendSystemPrompt({}, { appendSystemPrompt: ["cli only"] })).toEqual(["cli only"])
+	})
+
+	it("ignores non-string, empty, and whitespace-only meta systemPrompt values", () => {
+		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: 42 } } }, noOptions)).toBeUndefined()
+		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: "" } } }, noOptions)).toBeUndefined()
+		expect(
+			resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": { systemPrompt: "   \n  " } } }, noOptions),
+		).toBeUndefined()
+	})
+
+	it("tolerates non-object _meta and non-object kimchi.dev payloads", () => {
+		expect(resolveAcpAppendSystemPrompt({ _meta: "nope" }, noOptions)).toBeUndefined()
+		expect(resolveAcpAppendSystemPrompt({ _meta: { "kimchi.dev": "nope" } }, noOptions)).toBeUndefined()
+		expect(resolveAcpAppendSystemPrompt({ _meta: null }, noOptions)).toBeUndefined()
 	})
 })

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -142,7 +142,7 @@ export interface RunAcpOptions {
 	/**
 	 * Content of the `--append-system-prompt` CLI flag, forwarded verbatim to
 	 * every session's DefaultResourceLoader. When a client also sends
-	 * `_meta["kimchi.dev"].systemPrompt`, meta content is appended after this.
+	 * `_meta["kimchi.dev"].appendSystemPrompt`, meta content is appended after this.
 	 */
 	appendSystemPrompt?: string[]
 	/** Override for tests. Defaults to the pi-coding-agent-backed factory. */
@@ -1813,7 +1813,7 @@ async function createSessionSettings(cwd: string, options: RunAcpOptions, params
 			if (cachedSkillListBlock === undefined) {
 				cachedSkillListBlock = buildSkillListBlock(cwd)
 			}
-			// CLI flag content first, then _meta["kimchi.dev"].systemPrompt,
+			// CLI flag content first, then _meta["kimchi.dev"].appendSystemPrompt,
 			// then the skill list block (matches upstream override behaviour).
 			return [
 				...(resolveAcpAppendSystemPrompt(params, options) ?? []),
@@ -1914,16 +1914,22 @@ export function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 }
 
 /**
- * Extracts `_meta["kimchi.dev"].systemPrompt` from an ACP request and merges
- * it with the `--append-system-prompt` CLI flag content (CLI flag first, meta
- * second) into the array DefaultResourceLoader appends to the composed system
- * prompt via the same appendSystemPrompt mechanism the CLI flag uses.
+ * Extracts `_meta["kimchi.dev"].appendSystemPrompt` from an ACP request and
+ * merges it with the `--append-system-prompt` CLI flag content (CLI flag first,
+ * meta second) into the array DefaultResourceLoader appends to the composed
+ * system prompt via the same appendSystemPrompt mechanism the CLI flag uses.
+ *
+ * The key is deliberately named `appendSystemPrompt` — matching the CLI flag
+ * and the pi-mono resource-loader option — because the meta value is *appended*
+ * to the composed system prompt, never replacing it. This keeps the plain
+ * `systemPrompt` name free should a replace-the-system-prompt API ever be
+ * exposed over `_meta`.
  *
  * Returns `undefined` when neither source contributes anything, so sessions
- * created without `_meta["kimchi.dev"].systemPrompt` behave exactly as before.
- * The `_meta` namespace mirrors CAPABILITIES_KEY (`kimchi.dev`) — ACP reserves
- * `_meta` (additionalProperties: true) for custom data because "Implementations
- * MUST NOT add any custom fields at the root of a type".
+ * created without `_meta["kimchi.dev"].appendSystemPrompt` behave exactly as
+ * before. The `_meta` namespace mirrors CAPABILITIES_KEY (`kimchi.dev`) — ACP
+ * reserves `_meta` (additionalProperties: true) for custom data because
+ * "Implementations MUST NOT add any custom fields at the root of a type".
  */
 export function resolveAcpAppendSystemPrompt(
 	params: { _meta?: unknown },
@@ -1932,7 +1938,7 @@ export function resolveAcpAppendSystemPrompt(
 	const kimchiMeta = (params._meta as Record<string, unknown> | null | undefined)?.[CAPABILITIES_KEY]
 	const metaPrompt =
 		typeof kimchiMeta === "object" && kimchiMeta !== null
-			? (kimchiMeta as Record<string, unknown>).systemPrompt
+			? (kimchiMeta as Record<string, unknown>).appendSystemPrompt
 			: undefined
 	const metaEntries = typeof metaPrompt === "string" && metaPrompt.trim() !== "" ? [metaPrompt] : []
 	const combined = [...(options.appendSystemPrompt ?? []), ...metaEntries]

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -139,6 +139,12 @@ export type AcpSessionLoader = (params: LoadSessionRequest) => Promise<AgentSess
 export interface RunAcpOptions {
 	extensionFactories: ExtensionFactory[]
 	agentDir: string
+	/**
+	 * Content of the `--append-system-prompt` CLI flag, forwarded verbatim to
+	 * every session's DefaultResourceLoader. When a client also sends
+	 * `_meta["kimchi.dev"].systemPrompt`, meta content is appended after this.
+	 */
+	appendSystemPrompt?: string[]
 	/** Override for tests. Defaults to the pi-coding-agent-backed factory. */
 	sessionFactory?: AcpSessionFactory
 	/** Override for tests. Defaults to {@link defaultSessionLister}. */
@@ -1778,7 +1784,7 @@ function defaultSessionLister(options: RunAcpOptions): AcpSessionLister {
  * timeout, and load resources. Both the session loader and factory
  * diverge only in how they obtain a SessionManager.
  */
-async function createSessionSettings(cwd: string, options: RunAcpOptions) {
+async function createSessionSettings(cwd: string, options: RunAcpOptions, params: { _meta?: unknown }) {
 	// Construct untrusted first: pi's SettingsManager.create defaults
 	// projectTrusted to TRUE, which would let an untrusted repo's
 	// .pi/settings.json influence HTTP behavior (e.g. disable the idle
@@ -1807,7 +1813,12 @@ async function createSessionSettings(cwd: string, options: RunAcpOptions) {
 			if (cachedSkillListBlock === undefined) {
 				cachedSkillListBlock = buildSkillListBlock(cwd)
 			}
-			return cachedSkillListBlock ? [cachedSkillListBlock] : []
+			// CLI flag content first, then _meta["kimchi.dev"].systemPrompt,
+			// then the skill list block (matches upstream override behaviour).
+			return [
+				...(resolveAcpAppendSystemPrompt(params, options) ?? []),
+				...(cachedSkillListBlock ? [cachedSkillListBlock] : []),
+			]
 		},
 	})
 	await resourceLoader.reload()
@@ -1889,7 +1900,7 @@ function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 			const msg = err instanceof Error ? err.message : String(err)
 			throw RequestError.invalidParams(undefined, `failed to open session: ${msg}`)
 		}
-		const { settingsManager, resourceLoader } = await createSessionSettings(cwd, options)
+		const { settingsManager, resourceLoader } = await createSessionSettings(cwd, options, params)
 		const { session } = await createAgentSession({
 			cwd,
 			agentDir: options.agentDir,
@@ -1901,10 +1912,36 @@ function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 	}
 }
 
+/**
+ * Extracts `_meta["kimchi.dev"].systemPrompt` from an ACP request and merges
+ * it with the `--append-system-prompt` CLI flag content (CLI flag first, meta
+ * second) into the array DefaultResourceLoader appends to the composed system
+ * prompt via the same appendSystemPrompt mechanism the CLI flag uses.
+ *
+ * Returns `undefined` when neither source contributes anything, so sessions
+ * created without `_meta["kimchi.dev"].systemPrompt` behave exactly as before.
+ * The `_meta` namespace mirrors CAPABILITIES_KEY (`kimchi.dev`) — ACP reserves
+ * `_meta` (additionalProperties: true) for custom data because "Implementations
+ * MUST NOT add any custom fields at the root of a type".
+ */
+export function resolveAcpAppendSystemPrompt(
+	params: { _meta?: unknown },
+	options: Pick<RunAcpOptions, "appendSystemPrompt">,
+): string[] | undefined {
+	const kimchiMeta = (params._meta as Record<string, unknown> | null | undefined)?.[CAPABILITIES_KEY]
+	const metaPrompt =
+		typeof kimchiMeta === "object" && kimchiMeta !== null
+			? (kimchiMeta as Record<string, unknown>).systemPrompt
+			: undefined
+	const metaEntries = typeof metaPrompt === "string" && metaPrompt.trim() !== "" ? [metaPrompt] : []
+	const combined = [...(options.appendSystemPrompt ?? []), ...metaEntries]
+	return combined.length > 0 ? combined : undefined
+}
+
 function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
 	return async (params: NewSessionRequest): Promise<AgentSession> => {
 		const cwd = params.cwd ?? process.cwd()
-		const { settingsManager, resourceLoader } = await createSessionSettings(cwd, options)
+		const { settingsManager, resourceLoader } = await createSessionSettings(cwd, options, params)
 		const { session } = await createAgentSession({
 			cwd,
 			agentDir: options.agentDir,

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1825,7 +1825,8 @@ async function createSessionSettings(cwd: string, options: RunAcpOptions, params
 	return { settingsManager, resourceLoader }
 }
 
-function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
+/** Exported for tests: the production session loader used by {@link KimchiAcpAgent}. */
+export function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 	return async (params: LoadSessionRequest): Promise<AgentSession> => {
 		const cwd = params.cwd
 		// Mirror defaultSessionLister: encode cwd inline because pi doesn't
@@ -1938,7 +1939,8 @@ export function resolveAcpAppendSystemPrompt(
 	return combined.length > 0 ? combined : undefined
 }
 
-function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
+/** Exported for tests: the production session factory used by {@link KimchiAcpAgent}. */
+export function defaultSessionFactory(options: RunAcpOptions): AcpSessionFactory {
 	return async (params: NewSessionRequest): Promise<AgentSession> => {
 		const cwd = params.cwd ?? process.cwd()
 		const { settingsManager, resourceLoader } = await createSessionSettings(cwd, options, params)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -107,6 +107,7 @@ import {
 	tryParseSkillCommand,
 } from "./skill-commands.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
+import { resolveAcpAppendSystemPrompt } from "./system-prompt.js"
 import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./tool-calls/utils.js"
 import { asString, truncate } from "./utils.js"
 
@@ -1911,38 +1912,6 @@ export function defaultSessionLoader(options: RunAcpOptions): AcpSessionLoader {
 		})
 		return session
 	}
-}
-
-/**
- * Extracts `_meta["kimchi.dev"].appendSystemPrompt` from an ACP request and
- * merges it with the `--append-system-prompt` CLI flag content (CLI flag first,
- * meta second) into the array DefaultResourceLoader appends to the composed
- * system prompt via the same appendSystemPrompt mechanism the CLI flag uses.
- *
- * The key is deliberately named `appendSystemPrompt` — matching the CLI flag
- * and the pi-mono resource-loader option — because the meta value is *appended*
- * to the composed system prompt, never replacing it. This keeps the plain
- * `systemPrompt` name free should a replace-the-system-prompt API ever be
- * exposed over `_meta`.
- *
- * Returns `undefined` when neither source contributes anything, so sessions
- * created without `_meta["kimchi.dev"].appendSystemPrompt` behave exactly as
- * before. The `_meta` namespace mirrors CAPABILITIES_KEY (`kimchi.dev`) — ACP
- * reserves `_meta` (additionalProperties: true) for custom data because
- * "Implementations MUST NOT add any custom fields at the root of a type".
- */
-export function resolveAcpAppendSystemPrompt(
-	params: { _meta?: unknown },
-	options: Pick<RunAcpOptions, "appendSystemPrompt">,
-): string[] | undefined {
-	const kimchiMeta = (params._meta as Record<string, unknown> | null | undefined)?.[CAPABILITIES_KEY]
-	const metaPrompt =
-		typeof kimchiMeta === "object" && kimchiMeta !== null
-			? (kimchiMeta as Record<string, unknown>).appendSystemPrompt
-			: undefined
-	const metaEntries = typeof metaPrompt === "string" && metaPrompt.trim() !== "" ? [metaPrompt] : []
-	const combined = [...(options.appendSystemPrompt ?? []), ...metaEntries]
-	return combined.length > 0 ? combined : undefined
 }
 
 /** Exported for tests: the production session factory used by {@link KimchiAcpAgent}. */

--- a/src/modes/acp/system-prompt.ts
+++ b/src/modes/acp/system-prompt.ts
@@ -1,0 +1,36 @@
+import { CAPABILITIES_KEY } from "./capabilities.js"
+
+/** Minimal options shape needed by {@link resolveAcpAppendSystemPrompt}. */
+export type AppendSystemPromptOptions = { appendSystemPrompt?: string[] }
+
+/**
+ * Extracts `_meta["kimchi.dev"].appendSystemPrompt` from an ACP request and
+ * merges it with the `--append-system-prompt` CLI flag content (CLI flag first,
+ * meta second) into the array DefaultResourceLoader appends to the composed
+ * system prompt via the same appendSystemPrompt mechanism the CLI flag uses.
+ *
+ * The key is deliberately named `appendSystemPrompt` — matching the CLI flag
+ * and the pi-mono resource-loader option — because the meta value is *appended*
+ * to the composed system prompt, never replacing it. This keeps the plain
+ * `systemPrompt` name free should a replace-the-system-prompt API ever be
+ * exposed over `_meta`.
+ *
+ * Returns `undefined` when neither source contributes anything, so sessions
+ * created without `_meta["kimchi.dev"].appendSystemPrompt` behave exactly as
+ * before. The `_meta` namespace mirrors CAPABILITIES_KEY (`kimchi.dev`) — ACP
+ * reserves `_meta` (additionalProperties: true) for custom data because
+ * "Implementations MUST NOT add any custom fields at the root of a type".
+ */
+export function resolveAcpAppendSystemPrompt(
+	params: { _meta?: unknown },
+	options: AppendSystemPromptOptions,
+): string[] | undefined {
+	const kimchiMeta = (params._meta as Record<string, unknown> | null | undefined)?.[CAPABILITIES_KEY]
+	const metaPrompt =
+		typeof kimchiMeta === "object" && kimchiMeta !== null
+			? (kimchiMeta as Record<string, unknown>).appendSystemPrompt
+			: undefined
+	const metaEntries = typeof metaPrompt === "string" && metaPrompt.trim() !== "" ? [metaPrompt] : []
+	const combined = [...(options.appendSystemPrompt ?? []), ...metaEntries]
+	return combined.length > 0 ? combined : undefined
+}

--- a/tests/e2e/acp/append-system-prompt-meta.test.ts
+++ b/tests/e2e/acp/append-system-prompt-meta.test.ts
@@ -1,10 +1,14 @@
-// ACP integration: a client sends `_meta["kimchi.dev"].systemPrompt` on
-// `session/new` — the path an orchestrating ACP client uses to inject a
-// role instruction without touching the binary's CLI flags. Expected: the
-// built binary threads it through DefaultResourceLoader into the system
-// prompt of the request the model receives. To make the effect
-// client-visible, the fake LLM is scripted to obey the injected
-// instruction — it opens its reply with the mandatory greeting marker.
+// ACP integration: a client sends `_meta["kimchi.dev"].appendSystemPrompt` on
+// `session/new` — the path an orchestrating ACP client uses to append a role
+// instruction to the composed system prompt without touching the binary's CLI
+// flags. The key deliberately mirrors `--append-system-prompt` (and pi-mono's
+// DefaultResourceLoader option of the same name): the meta value is appended
+// to the system prompt, never replacing it — a plain `systemPrompt` key stays
+// free for a potential future replace API. Expected: the built binary threads
+// the meta value through DefaultResourceLoader into the system prompt of the
+// request the model receives. To make the effect client-visible, the fake LLM
+// is scripted to obey the injected instruction — it opens its reply with the
+// mandatory greeting marker.
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { type AcpFixture, PROMPT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
@@ -14,12 +18,12 @@ const INJECTION =
 	`MANDATORY RULE: Begin every reply, before anything else, with exactly this marker: ${GREETING}. ` +
 	"Never omit this marker, not even for short answers."
 
-describe("ACP system prompt injection via _meta", () => {
+describe("ACP system prompt append via _meta", () => {
 	let fixture: AcpFixture
 
 	beforeEach(async () => {
 		fixture = await startAcpFixture({
-			artifactName: "system-prompt-meta",
+			artifactName: "append-system-prompt-meta",
 			responses: [
 				// The fake LLM "obeys" the injected rule; the assertion that the
 				// instruction actually reached the model happens on the recorded
@@ -36,12 +40,12 @@ describe("ACP system prompt injection via _meta", () => {
 	})
 
 	it(
-		"threads _meta['kimchi.dev'].systemPrompt from session/new into the model's system prompt",
+		"appends _meta['kimchi.dev'].appendSystemPrompt from session/new to the model's system prompt",
 		async () => {
 			const ns = await fixture.conn.newSession({
 				cwd: fixture.workDir,
 				mcpServers: [],
-				_meta: { "kimchi.dev": { systemPrompt: INJECTION } },
+				_meta: { "kimchi.dev": { appendSystemPrompt: INJECTION } },
 			})
 
 			const promptPromise = fixture.conn.prompt({
@@ -63,7 +67,7 @@ describe("ACP system prompt injection via _meta", () => {
 			)
 
 			// Wire-level proof: the chat request the built binary sent to the model
-			// carries the injected rule inside its system prompt.
+			// carries the appended rule inside its system prompt.
 			const chatRequests = fixture.fake.requests.filter((r) => r.url.includes("chat/completions"))
 			expect(chatRequests.length).toBeGreaterThan(0)
 			const messages = (chatRequests[0].body as { messages?: Array<{ role: string; content: unknown }> }).messages ?? []
@@ -71,7 +75,7 @@ describe("ACP system prompt injection via _meta", () => {
 				.filter((m) => m.role === "system")
 				.map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
 			const systemPrompt = systemMessages.join("\n")
-			expect(systemPrompt, "model-facing system prompt should contain the injected mandatory greeting rule").toContain(
+			expect(systemPrompt, "model-facing system prompt should contain the appended mandatory greeting rule").toContain(
 				INJECTION,
 			)
 		},

--- a/tests/e2e/acp/system-prompt-meta.test.ts
+++ b/tests/e2e/acp/system-prompt-meta.test.ts
@@ -1,0 +1,80 @@
+// ACP integration: a client sends `_meta["kimchi.dev"].systemPrompt` on
+// `session/new` — the path an orchestrating ACP client uses to inject a
+// role instruction without touching the binary's CLI flags. Expected: the
+// built binary threads it through DefaultResourceLoader into the system
+// prompt of the request the model receives. To make the effect
+// client-visible, the fake LLM is scripted to obey the injected
+// instruction — it opens its reply with the mandatory greeting marker.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type AcpFixture, PROMPT_TIMEOUT_MS, STARTUP_TIMEOUT_MS, startAcpFixture } from "./support/acp-fixture.js"
+
+const GREETING = "CLIENT-GREETING-OK"
+const INJECTION =
+	`MANDATORY RULE: Begin every reply, before anything else, with exactly this marker: ${GREETING}. ` +
+	"Never omit this marker, not even for short answers."
+
+describe("ACP system prompt injection via _meta", () => {
+	let fixture: AcpFixture
+
+	beforeEach(async () => {
+		fixture = await startAcpFixture({
+			artifactName: "system-prompt-meta",
+			responses: [
+				// The fake LLM "obeys" the injected rule; the assertion that the
+				// instruction actually reached the model happens on the recorded
+				// request below, so this scripted greeting cannot produce a false
+				// positive — without the injection there is nothing in the prompt
+				// that would justify it.
+				{ stream: [GREETING, " — how can I help?"] },
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it(
+		"threads _meta['kimchi.dev'].systemPrompt from session/new into the model's system prompt",
+		async () => {
+			const ns = await fixture.conn.newSession({
+				cwd: fixture.workDir,
+				mcpServers: [],
+				_meta: { "kimchi.dev": { systemPrompt: INJECTION } },
+			})
+
+			const promptPromise = fixture.conn.prompt({
+				sessionId: ns.sessionId,
+				prompt: [{ type: "text", text: "Say hi." }],
+			})
+			const result = await Promise.race([
+				promptPromise,
+				new Promise<{ stopReason: "TIMEOUT" }>((resolvePromise) =>
+					setTimeout(() => resolvePromise({ stopReason: "TIMEOUT" }), PROMPT_TIMEOUT_MS),
+				),
+			])
+			expect(result.stopReason).toBe("end_turn")
+
+			// Client-visible effect: the agent's reply opens with the greeting.
+			const chunks = fixture.client.agentTextBySession().get(ns.sessionId) ?? ""
+			expect(chunks.startsWith(GREETING), `agent reply should start with the mandatory greeting, got: ${chunks}`).toBe(
+				true,
+			)
+
+			// Wire-level proof: the chat request the built binary sent to the model
+			// carries the injected rule inside its system prompt.
+			const chatRequests = fixture.fake.requests.filter((r) => r.url.includes("chat/completions"))
+			expect(chatRequests.length).toBeGreaterThan(0)
+			const messages = (chatRequests[0].body as { messages?: Array<{ role: string; content: unknown }> }).messages ?? []
+			const systemMessages = messages
+				.filter((m) => m.role === "system")
+				.map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+			const systemPrompt = systemMessages.join("\n")
+			expect(systemPrompt, "model-facing system prompt should contain the injected mandatory greeting rule").toContain(
+				INJECTION,
+			)
+		},
+		PROMPT_TIMEOUT_MS,
+	)
+})


### PR DESCRIPTION
## Linked issue

Closes #1035

## What does this PR do?

Implements ticket #02 — System Prompt Injection via ACP Meta. The ACP server reads `_meta["kimchi.dev"].systemPrompt` from `NewSessionRequest` and `LoadSessionRequest` and passes it to `DefaultResourceLoader` as `appendSystemPrompt`. When both the CLI `--append-system-prompt` flag and ACP meta are present, CLI content comes first, meta content second. Includes wiring tests verifying the full factory/loader → DefaultResourceLoader path.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
