### PR TITLE
fix(permissions): treat workflow output tools as read-only

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -79,6 +79,7 @@ const testEnv: EnvironmentInfo = {
 }
 
 const TEST_SESSION_ID = "test-session"
+const WORKFLOW_OUTPUT_TOOLS = ["workflow_submit_result", "workflow_submit_questions"]
 
 // Helper to create mock ExtensionContext with ui.select
 // When an AbortSignal is passed and aborted=true, returns undefined to trigger "aborted" outcome
@@ -265,6 +266,17 @@ describe("permissions plan-mode tool visibility", () => {
 					createMockContext([]),
 				),
 			).resolves.toBeUndefined()
+		}
+	})
+
+	it("keeps workflow output tools visible and allowed under explicit --plan", async () => {
+		const harness = createPermissionsHarness(["read", ...WORKFLOW_OUTPUT_TOOLS], { plan: true })
+
+		await harness.fire("session_start", {}, createMockContext([]))
+
+		expect(harness.activeTools().sort()).toEqual(["read", ...WORKFLOW_OUTPUT_TOOLS].sort())
+		for (const toolName of WORKFLOW_OUTPUT_TOOLS) {
+			await expect(harness.fire("tool_call", { toolName, input: {} }, createMockContext([]))).resolves.toBeUndefined()
 		}
 	})
 
@@ -982,6 +994,41 @@ describe("permissions ferment tool classification", () => {
 
 		expect(readResult).toBeUndefined()
 		expect(bashResult).toBeUndefined()
+		expect(classifyToolCall).not.toHaveBeenCalled()
+	})
+})
+
+describe("permissions workflow output tool classification", () => {
+	beforeEach(() => {
+		vi.mocked(classifyToolCall).mockClear()
+	})
+
+	afterEach(() => {
+		unregisterSessionPermissionFlagController(TEST_SESSION_ID)
+		Reflect.deleteProperty(process.env, `${PERMISSIONS_ENV_KEY}_${TEST_SESSION_ID}`)
+		vi.unstubAllEnvs()
+	})
+
+	it("allows workflow output tools in auto mode without invoking the classifier", async () => {
+		const harness = createPermissionsHarness(WORKFLOW_OUTPUT_TOOLS, { auto: true })
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		for (const toolName of WORKFLOW_OUTPUT_TOOLS) {
+			await expect(harness.fire("tool_call", { toolName, input: {} }, ctx)).resolves.toBeUndefined()
+		}
+		expect(classifyToolCall).not.toHaveBeenCalled()
+	})
+
+	it("allows workflow output tools in default mode without prompting", async () => {
+		const harness = createPermissionsHarness(WORKFLOW_OUTPUT_TOOLS)
+		const ctx = createMockContext([])
+		await harness.fire("session_start", {}, ctx)
+
+		for (const toolName of WORKFLOW_OUTPUT_TOOLS) {
+			await expect(harness.fire("tool_call", { toolName, input: {} }, ctx)).resolves.toBeUndefined()
+		}
+		expect(ctx.ui.select).not.toHaveBeenCalled()
 		expect(classifyToolCall).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -21,6 +21,12 @@ describe("classifyTool", () => {
 		expect(classifyTool("bash")).toBe("execute")
 	})
 
+	it("classifies workflow output tools as read-only without widening the submit namespace", () => {
+		expect(classifyTool("workflow_submit_result")).toBe("readOnly")
+		expect(classifyTool("workflow_submit_questions")).toBe("readOnly")
+		expect(classifyTool("workflow_submit_deployment")).toBe("unknown")
+	})
+
 	it("heuristic classifies read-named custom tools as read-only", () => {
 		expect(classifyTool("search_logs")).toBe("readOnly")
 		expect(classifyTool("list_clusters")).toBe("readOnly")

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -16,6 +16,8 @@ const STATIC_CATEGORIES: Record<string, ToolCategory> = {
 	web_fetch: "readOnly",
 	questionnaire: "readOnly",
 	set_phase: "readOnly",
+	workflow_submit_result: "readOnly",
+	workflow_submit_questions: "readOnly",
 }
 
 const READ_ONLY_NAME_HINT = /^(read|get|list|search|query|describe|find|grep|ls|loki_|view|show)/i

--- a/src/shared/planning/tool-catalog.test.ts
+++ b/src/shared/planning/tool-catalog.test.ts
@@ -12,9 +12,21 @@ import {
 const namesOf = (entries: ToolEntry[]): string[] => entries.map((t) => t.name)
 
 const TODO_TOOL_NAMES = ["create_todos", "update_todos", "add_todo", "mark_todo", "clear_todos"]
+const WORKFLOW_OUTPUT_TOOL_NAMES = ["workflow_submit_result", "workflow_submit_questions"]
 
 const TOOL_NAMES = {
-	sharedCore: ["read", "grep", "find", "ls", "skill", "web_fetch", "web_search", "mcp", ...TODO_TOOL_NAMES],
+	sharedCore: [
+		"read",
+		"grep",
+		"find",
+		"ls",
+		"skill",
+		"web_fetch",
+		"web_search",
+		...WORKFLOW_OUTPUT_TOOL_NAMES,
+		"mcp",
+		...TODO_TOOL_NAMES,
+	],
 	adhocOnly: ["questionnaire"],
 	fermentPlanningTools: [
 		"set_phase",
@@ -43,8 +55,8 @@ const TOOL_NAMES = {
 }
 
 describe("SHARED_CORE_TOOLS", () => {
-	it("contains the read-only discovery tools, the skill loader, the mcp gateway, plus 5 todo lifecycle tools", () => {
-		expect(SHARED_CORE_TOOLS).toHaveLength(13)
+	it("contains read-only discovery, workflow output, MCP, and todo tools", () => {
+		expect(SHARED_CORE_TOOLS).toHaveLength(TOOL_NAMES.sharedCore.length)
 		for (const name of TOOL_NAMES.sharedCore) {
 			expect(SHARED_CORE_TOOLS).toContainEqual(expect.objectContaining({ name }))
 		}
@@ -156,7 +168,7 @@ describe("getToolsForProfile", () => {
 	describe("idle", () => {
 		it("returns only shared core tools", () => {
 			const result = getToolsForProfile("idle")
-			expect(result).toHaveLength(13)
+			expect(result).toHaveLength(TOOL_NAMES.sharedCore.length)
 			expect(namesOf(result)).toEqual(TOOL_NAMES.sharedCore)
 		})
 

--- a/src/shared/planning/tool-catalog.ts
+++ b/src/shared/planning/tool-catalog.ts
@@ -99,6 +99,11 @@ export const SHARED_CORE_TOOLS: ToolEntry[] = [
 	{ name: "skill", modes: ["shared"] },
 	{ name: "web_fetch", modes: ["shared"] },
 	{ name: "web_search", modes: ["shared"] },
+	// Framework-owned workflow control-plane tools. They are registered only
+	// while a reporting/asking step is active, but must survive restrictive
+	// planning profiles so the step can return its result or questions.
+	{ name: "workflow_submit_result", modes: ["shared"] },
+	{ name: "workflow_submit_questions", modes: ["shared"] },
 	// MCP gateway — discovery + proxy for MCP server tools. Treated as a
 	// shared discovery tool (analogous to read/grep/find): harmless when no
 	// servers are configured, and required during planning so the model can


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The workflow control-plane tools registered by @kimchi-dev/kimchi-workflows (workflow_submit_result, workflow_submit_questions) fell through classifyTool() as "unknown", so default/auto modes routed them to the permission classifier and prompted the user — blocking workflows on a permission prompt just to display a questionnaire or return a step result. Both tools only mutate in-memory workflow state and are required for a workflow step to complete.

Statically classify both tools as readOnly (same treatment as the built-in questionnaire tool), and add them to SHARED_CORE_TOOLS so they survive restrictive planning profiles.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
