### PR TITLE
feat(login): Add OpenAI Codex support, improve Kimchi provider handling in auth workflows

### DIFF
--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -207,7 +207,7 @@ export function setKimchiAuthToken(
 	}
 }
 
-function getKimchiProviderIds(modelRegistry: ModelRegistryLike): Set<string> {
+export function getKimchiProviderIds(modelRegistry: ModelRegistryLike): Set<string> {
 	return new Set([
 		KIMCHI_PROVIDER_ID,
 		...modelRegistry

--- a/src/extensions/login/index.test.ts
+++ b/src/extensions/login/index.test.ts
@@ -2,12 +2,19 @@ import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agen
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import loginExtension from "./index.js"
 
-const loadConfigMock = vi.hoisted(() => vi.fn())
+const { clearApiKeyMock, loadConfigMock } = vi.hoisted(() => ({
+	clearApiKeyMock: vi.fn(),
+	loadConfigMock: vi.fn(),
+}))
 
 vi.mock("../../config.js", () => ({
-	clearApiKey: vi.fn(),
+	clearApiKey: clearApiKeyMock,
 	loadConfig: loadConfigMock,
 	writeApiKey: vi.fn(),
+}))
+
+vi.mock("../billing/status.js", () => ({
+	refreshBillingStatusFromConfig: vi.fn(),
 }))
 
 // Keep the real chatCompletionsApi (URL builder + scheme normalization) so baseUrl assertions
@@ -25,7 +32,7 @@ function providerConfigFor(customLlmEndpoint: string | undefined): ProviderConfi
 	loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint })
 	const registerProvider = vi.fn()
 	loginExtension({ on: vi.fn(), registerProvider } as unknown as ExtensionAPI)
-	const [providerId, providerConfig] = registerProvider.mock.calls[0]
+	const [providerId, providerConfig] = registerProvider.mock.calls.find(([provider]) => provider === "kimchi-dev") ?? []
 	expect(providerId).toBe("kimchi-dev")
 	return providerConfig
 }
@@ -58,5 +65,48 @@ describe("loginExtension", () => {
 		const config = providerConfigFor(undefined)
 		expect(config.baseUrl).toBeUndefined()
 		expect(config.oauth?.name).toBe("Kimchi")
+	})
+
+	it("restores OpenAI Codex subscription login while builtin API-key providers stay disabled", () => {
+		loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint: undefined })
+		const registerProvider = vi.fn()
+
+		loginExtension({
+			on: vi.fn(),
+			registerProvider,
+		} as unknown as ExtensionAPI)
+
+		expect(registerProvider.mock.calls[0]?.[0]).toMatchObject({
+			id: "openai-codex",
+			name: "OpenAI Codex",
+			auth: { oauth: { name: "OpenAI (ChatGPT Plus/Pro)" } },
+		})
+	})
+
+	it("logs out every internal Kimchi provider when the single Kimchi entry is selected", () => {
+		loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint: undefined })
+		const on = vi.fn()
+		const originalLogout = vi.fn()
+		const authStorage = { logout: originalLogout }
+		const modelRegistry = {
+			authStorage,
+			getAll: () => [
+				{ id: "sol", provider: "kimchi-dev" },
+				{ id: "sol", provider: "kimchi-dev/openai" },
+				{ id: "claude", provider: "kimchi-dev/anthropic" },
+			],
+		}
+
+		loginExtension({ on, registerProvider: vi.fn() } as unknown as ExtensionAPI)
+		const sessionStart = on.mock.calls[0]?.[1]
+		sessionStart({}, { modelRegistry })
+		authStorage.logout("kimchi-dev")
+
+		expect(originalLogout.mock.calls.map(([provider]) => provider)).toEqual([
+			"kimchi-dev",
+			"kimchi-dev/openai",
+			"kimchi-dev/anthropic",
+		])
+		expect(clearApiKeyMock).toHaveBeenCalledOnce()
 	})
 })

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -1,9 +1,11 @@
 import { resolve } from "node:path"
+import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth"
+import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
 import { chatCompletionsApi, updateModelsConfig, validateApiKey } from "../../models.js"
 import { refreshBillingStatusFromConfig } from "../billing/status.js"
-import { KIMCHI_PROVIDER_ID, setKimchiAuthToken } from "./flow.js"
+import { getKimchiProviderIds, KIMCHI_PROVIDER_ID, setKimchiAuthToken } from "./flow.js"
 
 const KIMCHI_LOGOUT_PATCHED = Symbol("kimchi.logoutPatched")
 
@@ -11,6 +13,10 @@ export default function loginExtension(pi: ExtensionAPI): void {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
 	if (!agentDir) return
 	const modelsJsonPath = resolve(agentDir, "models.json")
+
+	// Builtin providers are disabled globally; explicitly restore the approved subscription provider.
+	registerBunOAuthFlows()
+	pi.registerProvider(openaiCodexProvider())
 
 	pi.on("session_start", (_event, ctx) => {
 		// Re-read config every session start (not once at load): the API key can change mid-process
@@ -29,11 +35,15 @@ export default function loginExtension(pi: ExtensionAPI): void {
 
 		const originalLogout = patchedAuthStorage.logout.bind(patchedAuthStorage)
 		patchedAuthStorage.logout = (provider: string) => {
-			originalLogout(provider)
 			if (provider === KIMCHI_PROVIDER_ID) {
+				for (const providerId of getKimchiProviderIds(ctx.modelRegistry)) {
+					originalLogout(providerId)
+				}
 				clearApiKey()
 				void refreshBillingStatusFromConfig({ mode: "forced" })
+				return
 			}
+			originalLogout(provider)
 		}
 		patchedAuthStorage[KIMCHI_LOGOUT_PATCHED] = true
 	})

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -67,7 +67,7 @@ function makeFakeInteractiveMode(registry: ReturnType<typeof makeFakeModelRegist
 			requestRender: vi.fn(),
 		},
 		session: {
-			modelRegistry: registry,
+			modelRuntime: registry,
 			setModel: vi.fn().mockResolvedValue(undefined),
 		},
 		showSelector: vi.fn((build: (done: () => void) => { component: unknown; focus?: unknown }) => {
@@ -474,12 +474,14 @@ it("rolls back API-key auth when fresh discovery succeeds but no Kimchi models b
 	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
 
-it("routes the subscription option to upstream OAuth providers without showing Kimchi as a duplicate", async () => {
+it("routes the subscription option to OpenAI Codex without showing internal Kimchi providers", async () => {
 	const registry = makeFakeModelRegistry()
 	const fakeIm = makeFakeInteractiveMode(registry)
 	fakeIm.getLoginProviderOptions.mockReturnValue([
 		{ id: "kimchi-dev", name: "Kimchi", authType: "oauth" },
-		{ id: "anthropic", name: "Claude", authType: "oauth" },
+		{ id: "kimchi-dev/openai", name: "Kimchi", authType: "oauth" },
+		{ id: "kimchi-dev/anthropic", name: "Kimchi", authType: "oauth" },
+		{ id: "openai-codex", name: "OpenAI Codex", authType: "oauth" },
 	])
 
 	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
@@ -490,7 +492,37 @@ it("routes the subscription option to upstream OAuth providers without showing K
 	await waitForMockCall(fakeIm.showLoginDialog)
 
 	expect(fakeIm.getLoginProviderOptions).toHaveBeenCalledWith("oauth")
-	expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("anthropic", "Claude")
+	expect(fakeIm.showLoginDialog).toHaveBeenCalledWith("openai-codex", "OpenAI Codex")
+})
+
+it("shows one Kimchi entry in generic configure and logout provider lists", async () => {
+	const providers = [
+		{ id: "kimchi-dev", name: "Kimchi", auth: { apiKey: { name: "API key" } } },
+		{ id: "kimchi-dev/openai", name: "Kimchi", auth: { apiKey: { name: "API key" } } },
+		{ id: "kimchi-dev/anthropic", name: "Kimchi", auth: { apiKey: { name: "API key" } } },
+		{ id: "anthropic", name: "Anthropic", auth: { apiKey: { name: "API key" } } },
+	]
+	const modelRuntime = {
+		getProvider: (providerId: string) => providers.find((provider) => provider.id === providerId),
+		getProviderAuthStatus: () => ({ configured: false }),
+		getProviders: () => providers,
+		isUsingOAuth: () => false,
+		listCredentials: async () => providers.map((provider) => ({ providerId: provider.id, type: "api_key" as const })),
+	}
+	const mode = { session: { modelRuntime } }
+	// biome-ignore lint/suspicious/noExplicitAny: private upstream prototype methods are patched by design
+	const prototype = InteractiveMode.prototype as any
+
+	expect(
+		prototype.getLoginProviderOptions
+			.call(mode, "api_key")
+			.map(({ id }: { id: string }) => id)
+			.sort(),
+	).toEqual(["anthropic", "kimchi-dev"])
+	expect((await prototype.getLogoutProviderOptions.call(mode)).map(({ id }: { id: string }) => id).sort()).toEqual([
+		"anthropic",
+		"kimchi-dev",
+	])
 })
 
 it("pre-populates subscription provider models in models.json before upstream login", async () => {

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -15,6 +15,7 @@ import { Spacer, Text } from "@earendil-works/pi-tui"
 import {
 	createLoginChoiceSelector,
 	formatBrowserLoginMessage,
+	isKimchiProvider,
 	KIMCHI_DEFAULT_ENDPOINT,
 	KIMCHI_PROVIDER_ID,
 	performKimchiApiKeyLogin,
@@ -46,7 +47,7 @@ interface ModelRegistry {
 }
 
 interface SessionLike {
-	modelRegistry: ModelRegistry
+	modelRuntime: ModelRegistry
 	setModel(model: ModelLike): Promise<void>
 }
 
@@ -97,6 +98,16 @@ function addLoginFeedback(im: InteractiveMode, text: string): void {
 // biome-ignore lint/suspicious/noExplicitAny: private upstream prototype mutation
 const imProto = InteractiveMode.prototype as any
 
+const originalGetLoginProviderOptions = imProto.getLoginProviderOptions as (
+	// biome-ignore lint/suspicious/noExplicitAny: `this` context type for upstream prototype method is unknown
+	this: any,
+	authType?: "oauth" | "api_key",
+) => AuthSelectorProvider[]
+const originalGetLogoutProviderOptions = imProto.getLogoutProviderOptions as (
+	// biome-ignore lint/suspicious/noExplicitAny: `this` context type for upstream prototype method is unknown
+	this: any,
+) => Promise<AuthSelectorProvider[]>
+
 /**
  * Mutable delegate for the original upstream showOAuthSelector.
  * Exposed as a writable object property so tests can stub the logout
@@ -113,15 +124,29 @@ export const loginDelegate = {
 }
 
 export const warningDelegate = {
-	// biome-ignore lint/suspicious/noExplicitAny: `this` context type for upstream prototype method is unknown
+	// biome-ignore lint/suspicious/noExplicitAny: `this` context type for upstream prototype method is unknown`
 	original: imProto.showWarning as (this: any, warningMessage: string) => void,
 }
 
 /** Exported for testing: applies the prototype patch (idempotent re-apply is safe). */
 export function applyLoginCommandPatch(): void {
+	imProto.getLoginProviderOptions = patchedGetLoginProviderOptions
+	imProto.getLogoutProviderOptions = patchedGetLogoutProviderOptions
 	imProto.handleLoginCommand = patchedHandleLoginCommand
 	imProto.showOAuthSelector = patchedShowOAuthSelector
 	imProto.showWarning = patchedShowWarning
+}
+
+function visibleAuthProviders(providers: AuthSelectorProvider[]): AuthSelectorProvider[] {
+	return providers.filter((provider) => provider.id === KIMCHI_PROVIDER_ID || !isKimchiProvider(provider.id))
+}
+
+function patchedGetLoginProviderOptions(this: InteractiveMode, authType?: "oauth" | "api_key"): AuthSelectorProvider[] {
+	return visibleAuthProviders(originalGetLoginProviderOptions.call(this, authType))
+}
+
+async function patchedGetLogoutProviderOptions(this: InteractiveMode): Promise<AuthSelectorProvider[]> {
+	return visibleAuthProviders(await originalGetLogoutProviderOptions.call(this))
 }
 
 async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
@@ -129,7 +154,7 @@ async function handleKimchiLogin(im: InteractiveMode): Promise<void> {
 	const showStatus = modeLike.showStatus?.bind(modeLike)
 	const showError = im.showError.bind(im)
 	const session = modeLike.session
-	const registry = session?.modelRegistry
+	const registry = session?.modelRuntime
 	if (!registry) {
 		showError("Kimchi login failed: model registry is unavailable")
 		return
@@ -153,7 +178,7 @@ async function handleKimchiApiKeyLogin(im: InteractiveMode): Promise<void> {
 	const showStatus = modeLike.showStatus?.bind(modeLike)
 	const showError = im.showError.bind(im)
 	const session = modeLike.session
-	const registry = session?.modelRegistry
+	const registry = session?.modelRuntime
 	if (!registry) {
 		showError("Kimchi API-key login failed: model registry is unavailable")
 		return
@@ -192,15 +217,13 @@ function showSubscriptionLogin(im: InteractiveMode): void {
 		!modeLike.showSelector ||
 		!modeLike.getLoginProviderOptions ||
 		!modeLike.showLoginDialog ||
-		!modeLike.session?.modelRegistry
+		!modeLike.session?.modelRuntime
 	) {
 		void oauthDelegate.original.call(im, "login")
 		return
 	}
 
-	const providerOptions = modeLike
-		.getLoginProviderOptions("oauth")
-		.filter((provider) => provider.id !== KIMCHI_PROVIDER_ID)
+	const providerOptions = modeLike.getLoginProviderOptions("oauth").filter((provider) => !isKimchiProvider(provider.id))
 	if (providerOptions.length === 0) {
 		modeLike.showStatus?.("No subscription providers available.")
 		return
@@ -225,7 +248,7 @@ function showSubscriptionLogin(im: InteractiveMode): void {
 
 					// After upstream login returns, refresh the registry so the models
 					// from models.json become available without requiring a manual /reload.
-					const registry = modeLike.session?.modelRegistry
+					const registry = modeLike.session?.modelRuntime
 					if (registry && typeof registry.refresh === "function") {
 						try {
 							await registry.refresh()
@@ -301,11 +324,11 @@ function patchedShowWarning(this: InteractiveMode, warningMessage: string): void
 
 function hasModelsAfterStartupAuth(im: InteractiveMode): boolean {
 	const modeLike = im as unknown as {
-		session?: { model?: unknown; modelRegistry?: { getAvailable?: () => unknown[] } }
+		session?: { model?: unknown; modelRuntime?: { getAvailable?: () => unknown[] } }
 	}
 	if (modeLike.session?.model) return true
 	try {
-		return (modeLike.session?.modelRegistry?.getAvailable?.().length ?? 0) > 0
+		return (modeLike.session?.modelRuntime?.getAvailable?.().length ?? 0) > 0
 	} catch {
 		return false
 	}

--- a/tests/e2e/tui/login-provider-selection.test.ts
+++ b/tests/e2e/tui/login-provider-selection.test.ts
@@ -1,0 +1,55 @@
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { INPUT_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { PROMPT_READY, runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("auth menus offer OpenAI Codex and show one Kimchi provider", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "login-provider-selection",
+			responses: [],
+			seedHome: (homeDir) => {
+				writeFileSync(
+					join(homeDir, ".config", "kimchi", "harness", "auth.json"),
+					JSON.stringify({
+						"kimchi-dev": { type: "api_key", key: "test-key" },
+						"kimchi-dev/anthropic": { type: "api_key", key: "test-key" },
+						"kimchi-dev/openai": { type: "api_key", key: "test-key" },
+						"openai-codex": { type: "oauth", access: "test-token", refresh: "", expires: 4_102_444_800_000 },
+					}),
+				)
+			},
+		},
+		async (_fixture, trace) => {
+			terminal.write("/login")
+			await waitForText(terminal, "/login", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "Use a subscription", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.keyDown(2)
+			terminal.submit("")
+			await waitForText(terminal, "OpenAI Codex", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("OpenAI Codex subscription provider visible")
+
+			terminal.submit("")
+			await waitForText(terminal, "Select OpenAI Codex login method", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("bundled OpenAI Codex OAuth flow loaded")
+
+			terminal.keyEscape()
+			await waitForText(terminal, PROMPT_READY, { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.write("/logout")
+			await waitForText(terminal, "/logout", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "Select provider to logout", { timeoutMs: INPUT_TIMEOUT_MS })
+
+			const kimchiRows = viewText(terminal)
+				.split("\n")
+				.filter((line) => line.includes("Kimchi") && line.includes("configured"))
+			expect(kimchiRows).toHaveLength(1)
+			trace.step("one Kimchi credential row visible")
+		},
+	)
+})


### PR DESCRIPTION
## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

### What was wrong

The Pi upgrade introduced several related authentication regressions:

- `KIMCHI_DISABLE_BUILTIN_PROVIDERS=1` removed the `openai-codex` subscription provider together with the intentionally disabled direct API-key providers.
- The custom login adapter still read `session.modelRegistry`, while current Pi exposes `session.modelRuntime`. Subscription login therefore fell back to Pi's generic authentication menu.
- Internal `kimchi-dev/*` routing providers leaked into configure/logout menus as duplicate-looking Kimchi entries.
- The standalone Bun binary did not register Pi's bundled OAuth flows, so selecting OpenAI Codex failed with `Cannot find module './openai-codex.js' from '/$bunfs/root/kimchi'`.

### Fix

- Restore only Pi's native `openai-codex` subscription provider; direct built-in API-key providers remain disabled.
- Register Pi's bundle-safe OAuth loaders before exposing OpenAI Codex.
- Update the login adapter to use `session.modelRuntime`.
- Hide internal `kimchi-dev/*` providers from shared configure/logout option lists.
- Make the single visible Kimchi logout clear credentials for every managed Kimchi provider.

### Validation

- Focused Vitest coverage for provider registration, subscription selection, provider-list deduplication, and logout fan-out.
- `pnpm run check`.
- `pnpm run build:binary`.
- TUI E2E verifies the compiled binary opens the OpenAI Codex login-method prompt and renders one Kimchi logout row.

### Scope

This is a harness-only authentication/UI fix. It does not change Proxy or Kubecast provider selection, fallback, or billing behavior.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
