### PR TITLE
fix(ide-adapter): fix pasteToEditor implementation after Pi upgrade to 0.84.1

### DIFF
--- a/src/extensions/ide-adapter/index.ts
+++ b/src/extensions/ide-adapter/index.ts
@@ -327,8 +327,9 @@ export default function ideAdapterExtension(pi: ExtensionAPI): void {
 						// Force an immediate TUI render so the pasted text appears
 						// without waiting for the next user input event.
 						currentCtx.ui.setStatus("ide-adapter-mention", undefined)
-					} catch {
+					} catch (err) {
 						// If paste fails (e.g. no active editor), fall back to queue
+						console.warn("[ide-adapter] pasteToEditor failed, falling back to queue:", err)
 						localQueueAtMention(mention)
 					}
 				} else {

--- a/src/paste-to-editor-patch.test.ts
+++ b/src/paste-to-editor-patch.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it, vi } from "vitest"
 import "./paste-to-editor-patch.js"
 
 describe("pasteToEditor patch", () => {
-	it("routes pasteToEditor through ui.handleInput instead of editor.handleInput", () => {
+	it("routes pasteToEditor through ui.handleTerminalInput instead of editor.handleInput", () => {
 		const fakeIm = {
 			ui: {
-				handleInput: vi.fn(),
+				handleTerminalInput: vi.fn(),
 			},
 			editor: {
 				handleInput: vi.fn(),
@@ -17,8 +17,8 @@ describe("pasteToEditor patch", () => {
 		const ctx = (InteractiveMode.prototype as any).createExtensionUIContext.call(fakeIm)
 		ctx.pasteToEditor("hello")
 
-		expect(fakeIm.ui.handleInput).toHaveBeenCalledOnce()
-		expect(fakeIm.ui.handleInput).toHaveBeenCalledWith("\x1b[200~hello\x1b[201~")
+		expect(fakeIm.ui.handleTerminalInput).toHaveBeenCalledOnce()
+		expect(fakeIm.ui.handleTerminalInput).toHaveBeenCalledWith("\x1b[200~hello\x1b[201~")
 		expect(fakeIm.editor.handleInput).not.toHaveBeenCalled()
 	})
 })

--- a/src/paste-to-editor-patch.ts
+++ b/src/paste-to-editor-patch.ts
@@ -1,6 +1,6 @@
 /**
  * Patches the upstream pi SDK's `createExtensionUIContext` so that
- * `pasteToEditor` routes through `ui.handleInput` instead of `editor.handleInput`.
+ * `pasteToEditor` routes through `ui.handleTerminalInput` instead of `editor.handleInput`.
  *
  * This ensures pasted text goes through the UI's input handling layer,
  * which properly processes bracketed-paste sequences.
@@ -17,7 +17,7 @@ export function applyPasteToEditorPatch(): void {
 	imProto.createExtensionUIContext = function patchedCreateExtensionUIContext() {
 		const ctx = originalCreateExtensionUIContext.call(this)
 		ctx.pasteToEditor = (text: string) => {
-			this.ui.handleInput(`\x1b[200~${text}\x1b[201~`)
+			this.ui.handleTerminalInput(`\x1b[200~${text}\x1b[201~`)
 		}
 		return ctx
 	}


### PR DESCRIPTION
## Linked issue

Closes #1047

## What does this PR do?

This PR fixes a regression in the "Send to Kimchi" functionality of the Kimchi JetBrains plugin where clicking the IDE button no longer injected the selected file path into the TUI prompt at the cursor position. The Pi package upgrade to `0.84.1` (b443380) renamed `TUI.handleInput` to `TUI.handleTerminalInput` in `@earendil-works/pi-tui`, but our runtime patch in `paste-to-editor-patch.ts` was still calling the old method name — causing a silent `TypeError` that fell back to the queue-based prepend, giving users no control over path placement:

```
[ide-adapter] pasteToEditor failed, falling back to queue: TypeError: this.ui.handleInput is not a function. (In 'this.ui.handleInput(`\x1B[200~${text}\x1B[201~`)', 'this.ui.handleInput' is undefined)
      at <anonymous> (/$bunfs/root/kimchi:322551:26)
      at dispatchNotification (/$bunfs/root/kimchi:361319:41)                                                                                                                                                                                        
      at <anonymous> (/$bunfs/root/kimchi:361256:27)
      at <anonymous> (/$bunfs/root/kimchi:361065:18)
      at <anonymous> (/$bunfs/root/kimchi:360987:27)
      at emit (node:events:98:22)
      at <anonymous> (ws:196:22)
```

**Key Changes:**
- Renamed `this.ui.handleInput` to `this.ui.handleTerminalInput` in `paste-to-editor-patch.ts` to match the Pi 0.84.1 API.
- Updated the patch test to mock and assert against `handleTerminalInput` instead of `handleInput`.
- Added error logging to the `at_mentioned` handler's catch block in `ide-adapter/index.ts` so paste failures are surfaced to `stderr` instead of being silently swallowed.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
