### PR TITLE
fix: send reasoning_effort=none for ai-enabler models when thinking is off

### DIFF
--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -311,6 +311,154 @@ describe("hideThinkingExtension", () => {
 		expect(text).toBe("A  B  C")
 	})
 
+	// --- <thinking> tags ---
+
+	it("strips <thinking> blocks when hideThinking is true (streaming)", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, [
+			"Before ",
+			"<thinking>",
+			"long reasoning",
+			"</thinking>",
+			" After",
+		])
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe("Before  After")
+	})
+
+	it("dims <thinking> content when hideThinking is false (streaming)", async () => {
+		_setHideThinking(false)
+		const { endResult } = await simulateStreaming(h, ["Before ", "<thinking>", "long reason", "</thinking>", " After"])
+		expect(endResult).toBeDefined()
+		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(text).toBe(`Before ${fg(ANSI.dim, "long reason")}\n\n After`)
+	})
+
+	it("hides <thinking> tag and dims content during streaming", async () => {
+		_setHideThinking(false)
+		const content = [{ type: "text" as const, text: "" }]
+		const message = { role: "assistant" as const, content }
+
+		await h.messageStart({ type: "message_start", message })
+
+		content[0].text += "Hello "
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		content[0].text += "<thinking>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Hello ")
+
+		content[0].text += "long reasoning"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "long reasoning")}`)
+
+		content[0].text += "</thinking>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "long reasoning")}`)
+
+		content[0].text += " World"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe(`Hello ${fg(ANSI.dim, "long reasoning")}\n\n World`)
+	})
+
+	it("restores <thinking> content in context event", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["Before ", "<thinking>", "long deep", "</thinking>", " After"])
+		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(displayText).toBe("Before  After")
+
+		const contextResult = await h.context({
+			type: "context",
+			messages: [{ role: "assistant", content: [{ type: "text", text: displayText }] }],
+		})
+
+		expect(contextResult).toBeDefined()
+		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
+		expect(restored[0].content[0].text).toBe("Before <thinking>long deep</thinking> After")
+	})
+
+	it("hides trailing content when <thinking> is never closed (hideThinking is true)", async () => {
+		_setHideThinking(true)
+		const content = [{ type: "text" as const, text: "" }]
+		const message = { role: "assistant" as const, content }
+
+		await h.messageStart({ type: "message_start", message })
+		content[0].text += "Before "
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		content[0].text += "<thinking>"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		content[0].text += "never closed"
+		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
+		expect(content[0].text).toBe("Before ")
+
+		// An unclosed tag is not a closed thinking pair, so message_end returns
+		// undefined; the streamed text was already truncated above.
+		const endResult = await h.messageEnd({ type: "message_end", message })
+		expect(endResult).toBeUndefined()
+		expect(content[0].text).toBe("Before ")
+	})
+
+	// --- orphaned close tags (kimi-k2.x thinking=off fragments) ---
+
+	// Mirrored from a real session (kimchi-session-…01a01465.html): kimi-k2.7
+	// with thinkingLevel=off streams reasoning as plain text terminated by
+	// </think> with no opening tag. Regression: the raw close tag leaked into
+	// the TUI because every gate required a balanced open+close pair.
+
+	it("strips trailing orphan </think> with no opener (hideThinking is true)", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["reasoning text", "</think>"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("reasoning text")
+	})
+
+	it("strips leading and trailing orphan </think> (hideThinking is true)", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["</think>Need to describe", " the branch.", "</think>"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("Need to describe the branch.")
+	})
+
+	it("strips leading orphan </think> from final answer (hideThinking is true)", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["</think>Current branch: ", "fix/foo"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("Current branch: fix/foo")
+	})
+
+	it("strips orphan close tags when hideThinking is false", async () => {
+		_setHideThinking(false)
+		const { endResult } = await simulateStreaming(h, ["</think>answer"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("answer")
+	})
+
+	it("does not strip close tags that belong to balanced blocks", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["A <think>hidden</think> B </think> C"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("A  B  C")
+	})
+
+	it("strips chunked orphan </think> arriving char by char", async () => {
+		_setHideThinking(true)
+		const { content, endResult } = await simulateStreaming(h, ["plan", "</t", "hi", "nk>"])
+		// message_end transforms the full original and returns the display text
+		const display =
+			(endResult as { message: { content: Array<{ text: string }> } } | undefined)?.message.content[0].text ??
+			content[0].text
+		expect(display).toBe("plan")
+	})
+
+	it("strips orphan </thinking> and </mm:think> close tags", async () => {
+		_setHideThinking(true)
+		const { endResult } = await simulateStreaming(h, ["</thinking>middle </mm:think> end"])
+		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		expect(display).toBe("middle  end")
+	})
+
 	// --- mm:think tags ---
 
 	it("dims <mm:think> content when hideThinking is false", async () => {
@@ -402,6 +550,11 @@ describe("filterThinkingForDisplay", () => {
 			input: "plain text without thinking",
 			hideThinking: true,
 			expected: "plain text without thinking",
+		},
+		"strips empty thinking tags": {
+			input: "Before <thinking></thinking> After",
+			hideThinking: true,
+			expected: "Before  After",
 		},
 		"handles multiple thinking blocks": {
 			input: "A <think>first</think> B <think>second</think> C",

--- a/src/extensions/hide-thinking.test.ts
+++ b/src/extensions/hide-thinking.test.ts
@@ -35,6 +35,28 @@ interface Handlers {
 	context: Handler
 }
 
+interface TextMessage {
+	role: string
+	content: Array<{ type: string; text: string }>
+}
+
+interface MessageEndResult {
+	message: TextMessage
+}
+
+function getText(result: MessageEndResult | undefined): string {
+	if (!result) throw new Error("expected message_end result")
+	return result.message.content[0].text
+}
+
+function getContextText(result: unknown, index = 0): string {
+	if (!result || typeof result !== "object" || !("messages" in result)) {
+		throw new Error("expected context result")
+	}
+	const messages = (result as { messages: TextMessage[] }).messages
+	return messages[index].content[0].text
+}
+
 function setupExtension(): Handlers {
 	const { handlers, api } = createMockApi()
 	hideThinkingExtension(api)
@@ -56,7 +78,7 @@ async function simulateStreaming(h: Handlers, tokens: string[]) {
 		content[0].text += token
 		await h.messageUpdate({ type: "message_update", message, assistantMessageEvent: {} })
 	}
-	const endResult = await h.messageEnd({ type: "message_end", message })
+	const endResult = (await h.messageEnd({ type: "message_end", message })) as MessageEndResult | undefined
 	return { message, content, endResult }
 }
 
@@ -120,7 +142,7 @@ describe("hideThinkingExtension", () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "reason", "</think>", " After"])
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe(`Before ${fg(ANSI.dim, "reason")}\n\n After`)
 	})
 
@@ -131,7 +153,7 @@ describe("hideThinkingExtension", () => {
 		const { endResult } = await simulateStreaming(h, ["Hello ", "<think>", "let me think...", "</think>", " World"])
 
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe("Hello  World")
 	})
 
@@ -150,7 +172,7 @@ describe("hideThinkingExtension", () => {
 		])
 
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		const expectedLines = thinkingLines.slice(-5)
 		const expectedDimmed = expectedLines.map((l) => fg(ANSI.dim, l)).join("\n")
 		expect(text).toBe(`Before ${expectedDimmed}\n\n After`)
@@ -228,7 +250,7 @@ describe("hideThinkingExtension", () => {
 	it("restores original thinking content in context event after streaming", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<think>", "deep reasoning", "</think>", " After"])
-		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const displayText = getText(endResult)
 		expect(displayText).toBe("Before  After")
 
 		// Simulate structuredClone (context event gets cloned messages)
@@ -241,9 +263,8 @@ describe("hideThinkingExtension", () => {
 		})
 
 		expect(contextResult).toBeDefined()
-		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
-		expect(restored[1].content[0].text).toBe("Before <think>deep reasoning</think> After")
-		expect(restored[0].content[0].text).toBe("question")
+		expect(getContextText(contextResult, 1)).toBe("Before <think>deep reasoning</think> After")
+		expect(getContextText(contextResult)).toBe("question")
 	})
 
 	it("populates shadow map for each transformed block", async () => {
@@ -307,7 +328,7 @@ describe("hideThinkingExtension", () => {
 		])
 
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe("A  B  C")
 	})
 
@@ -323,7 +344,7 @@ describe("hideThinkingExtension", () => {
 			" After",
 		])
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe("Before  After")
 	})
 
@@ -331,7 +352,7 @@ describe("hideThinkingExtension", () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<thinking>", "long reason", "</thinking>", " After"])
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe(`Before ${fg(ANSI.dim, "long reason")}\n\n After`)
 	})
 
@@ -366,7 +387,7 @@ describe("hideThinkingExtension", () => {
 	it("restores <thinking> content in context event", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<thinking>", "long deep", "</thinking>", " After"])
-		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const displayText = getText(endResult)
 		expect(displayText).toBe("Before  After")
 
 		const contextResult = await h.context({
@@ -375,8 +396,7 @@ describe("hideThinkingExtension", () => {
 		})
 
 		expect(contextResult).toBeDefined()
-		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
-		expect(restored[0].content[0].text).toBe("Before <thinking>long deep</thinking> After")
+		expect(getContextText(contextResult)).toBe("Before <thinking>long deep</thinking> After")
 	})
 
 	it("hides trailing content when <thinking> is never closed (hideThinking is true)", async () => {
@@ -410,35 +430,35 @@ describe("hideThinkingExtension", () => {
 	it("strips trailing orphan </think> with no opener (hideThinking is true)", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["reasoning text", "</think>"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("reasoning text")
 	})
 
 	it("strips leading and trailing orphan </think> (hideThinking is true)", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["</think>Need to describe", " the branch.", "</think>"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("Need to describe the branch.")
 	})
 
 	it("strips leading orphan </think> from final answer (hideThinking is true)", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["</think>Current branch: ", "fix/foo"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("Current branch: fix/foo")
 	})
 
 	it("strips orphan close tags when hideThinking is false", async () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["</think>answer"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("answer")
 	})
 
 	it("does not strip close tags that belong to balanced blocks", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["A <think>hidden</think> B </think> C"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("A  B  C")
 	})
 
@@ -446,16 +466,14 @@ describe("hideThinkingExtension", () => {
 		_setHideThinking(true)
 		const { content, endResult } = await simulateStreaming(h, ["plan", "</t", "hi", "nk>"])
 		// message_end transforms the full original and returns the display text
-		const display =
-			(endResult as { message: { content: Array<{ text: string }> } } | undefined)?.message.content[0].text ??
-			content[0].text
+		const display = endResult?.message.content[0].text ?? content[0].text
 		expect(display).toBe("plan")
 	})
 
 	it("strips orphan </thinking> and </mm:think> close tags", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["</thinking>middle </mm:think> end"])
-		const display = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const display = getText(endResult)
 		expect(display).toBe("middle  end")
 	})
 
@@ -465,7 +483,7 @@ describe("hideThinkingExtension", () => {
 		_setHideThinking(false)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm reason", "</mm:think>", " After"])
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe(`Before ${fg(ANSI.dim, "mm reason")}\n\n After`)
 	})
 
@@ -473,7 +491,7 @@ describe("hideThinkingExtension", () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["Hello ", "<mm:think>", "mm reasoning", "</mm:think>", " World"])
 		expect(endResult).toBeDefined()
-		const text = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const text = getText(endResult)
 		expect(text).toBe("Hello  World")
 	})
 
@@ -508,7 +526,7 @@ describe("hideThinkingExtension", () => {
 	it("restores <mm:think> content in context event", async () => {
 		_setHideThinking(true)
 		const { endResult } = await simulateStreaming(h, ["Before ", "<mm:think>", "mm deep", "</mm:think>", " After"])
-		const displayText = (endResult as { message: { content: Array<{ text: string }> } }).message.content[0].text
+		const displayText = getText(endResult)
 		expect(displayText).toBe("Before  After")
 
 		const contextResult = await h.context({
@@ -517,8 +535,7 @@ describe("hideThinkingExtension", () => {
 		})
 
 		expect(contextResult).toBeDefined()
-		const restored = (contextResult as { messages: Array<{ content: Array<{ text: string }> }> }).messages
-		expect(restored[0].content[0].text).toBe("Before <mm:think>mm deep</mm:think> After")
+		expect(getContextText(contextResult)).toBe("Before <mm:think>mm deep</mm:think> After")
 	})
 
 	it("context handler is a no-op when shadow map is empty", async () => {

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -31,6 +31,17 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
 
+interface ThinkTagVariant {
+	open: string
+	close: string
+}
+
+const THINK_TAG_VARIANTS: ThinkTagVariant[] = [
+	{ open: "<think>", close: "</think>" },
+	{ open: "<thinking>", close: "</thinking>" },
+	{ open: "<mm:think>", close: "</mm:think>" },
+]
+
 const THINK_TAG_PATTERN = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>|<mm:think>[\s\S]*?<\/mm:think>/g
 
 // Orphaned close tags: some models (observed with kimi-k2.x when thinking is
@@ -38,30 +49,29 @@ const THINK_TAG_PATTERN = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>|<mm:think>[\
 // matching open tag. After the closed-block replace pass has consumed all
 // balanced pairs, any remaining close tag is unmatched by definition and is
 // never meaningful prose, so it is safe to strip it for display.
-const ORPHAN_CLOSE_TAG_PATTERN = /<\/(?:mm:think|thinking|think)>/g
+const ORPHAN_CLOSE_TAG_PATTERN = new RegExp(
+	`</(?:${THINK_TAG_VARIANTS.map((v) => v.close.slice(2, -1)).join("|")})>`,
+	"g",
+)
 
 function stripOrphanCloseTags(text: string): string {
 	return text.replace(ORPHAN_CLOSE_TAG_PATTERN, "")
 }
 
 function containsCloseTag(text: string): boolean {
-	return text.includes("</think>") || text.includes("</thinking>") || text.includes("</mm:think>")
+	return THINK_TAG_VARIANTS.some((v) => text.includes(v.close))
 }
 
 function containsAnyThinkTag(text: string): boolean {
-	return (
-		text.includes("<think>") || text.includes("<thinking>") || text.includes("<mm:think>") || containsCloseTag(text)
-	)
+	return THINK_TAG_VARIANTS.some((v) => text.includes(v.open)) || containsCloseTag(text)
 }
 
 function getOpenTag(match: string): string {
-	if (match.startsWith("<mm:think>")) return "<mm:think>"
-	return match.startsWith("<thinking>") ? "<thinking>" : "<think>"
+	return THINK_TAG_VARIANTS.find((v) => match.startsWith(v.open))?.open ?? "<think>"
 }
 
 function getCloseTag(match: string): string {
-	if (match.startsWith("<mm:think>")) return "</mm:think>"
-	return match.startsWith("<thinking>") ? "</thinking>" : "</think>"
+	return THINK_TAG_VARIANTS.find((v) => match.endsWith(v.close))?.close ?? "</think>"
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +217,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 		return dimThinkingContent(inner) + separator
 	})
 	// 2. Handle unclosed open tags (thinking content still streaming)
-	for (const openTag of ["<think>", "<thinking>", "<mm:think>"]) {
+	for (const openTag of THINK_TAG_VARIANTS.map((v) => v.open)) {
 		const openIdx = result.indexOf(openTag)
 		if (openIdx !== -1) {
 			const before = result.slice(0, openIdx)

--- a/src/extensions/hide-thinking.ts
+++ b/src/extensions/hide-thinking.ts
@@ -31,21 +31,37 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { ANSI, fg } from "../ansi.js"
 import { isSubagent } from "./prompt-construction/prompt-enrichment.js"
 
-const THINK_TAG_PATTERN = /<think>[\s\S]*?<\/think>|<mm:think>[\s\S]*?<\/mm:think>/g
+const THINK_TAG_PATTERN = /<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>|<mm:think>[\s\S]*?<\/mm:think>/g
 
-function containsThinkTags(text: string): boolean {
+// Orphaned close tags: some models (observed with kimi-k2.x when thinking is
+// off) emit reasoning as plain text terminated by a close tag with no
+// matching open tag. After the closed-block replace pass has consumed all
+// balanced pairs, any remaining close tag is unmatched by definition and is
+// never meaningful prose, so it is safe to strip it for display.
+const ORPHAN_CLOSE_TAG_PATTERN = /<\/(?:mm:think|thinking|think)>/g
+
+function stripOrphanCloseTags(text: string): string {
+	return text.replace(ORPHAN_CLOSE_TAG_PATTERN, "")
+}
+
+function containsCloseTag(text: string): boolean {
+	return text.includes("</think>") || text.includes("</thinking>") || text.includes("</mm:think>")
+}
+
+function containsAnyThinkTag(text: string): boolean {
 	return (
-		(text.includes("<think>") && text.includes("</think>")) ||
-		(text.includes("<mm:think>") && text.includes("</mm:think>"))
+		text.includes("<think>") || text.includes("<thinking>") || text.includes("<mm:think>") || containsCloseTag(text)
 	)
 }
 
 function getOpenTag(match: string): string {
-	return match.startsWith("<mm:think>") ? "<mm:think>" : "<think>"
+	if (match.startsWith("<mm:think>")) return "<mm:think>"
+	return match.startsWith("<thinking>") ? "<thinking>" : "<think>"
 }
 
 function getCloseTag(match: string): string {
-	return match.startsWith("<mm:think>") ? "</mm:think>" : "</think>"
+	if (match.startsWith("<mm:think>")) return "</mm:think>"
+	return match.startsWith("<thinking>") ? "</thinking>" : "</think>"
 }
 
 // ---------------------------------------------------------------------------
@@ -103,7 +119,7 @@ function lastNLines(text: string, n: number): string {
 }
 
 function stripThinkingTags(text: string): string {
-	return text.replace(THINK_TAG_PATTERN, "")
+	return stripOrphanCloseTags(text.replace(THINK_TAG_PATTERN, ""))
 }
 
 /**
@@ -158,7 +174,7 @@ function stripMarkdownSyntax(text: string): string {
 }
 
 function replaceThinkingTagsWithDimmed(text: string): string {
-	return text.replace(THINK_TAG_PATTERN, (match, offset, fullString) => {
+	const replaced = text.replace(THINK_TAG_PATTERN, (match, offset, fullString) => {
 		const openTag = getOpenTag(match)
 		const closeTag = getCloseTag(match)
 		const content = stripMarkdownSyntax(match.slice(openTag.length, -closeTag.length))
@@ -168,6 +184,7 @@ function replaceThinkingTagsWithDimmed(text: string): string {
 		const separator = after.trimStart().length > 0 ? "\n\n" : ""
 		return dimThinkingContent(visible) + separator
 	})
+	return stripOrphanCloseTags(replaced)
 }
 
 /**
@@ -190,7 +207,7 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 		return dimThinkingContent(inner) + separator
 	})
 	// 2. Handle unclosed open tags (thinking content still streaming)
-	for (const openTag of ["<think>", "<mm:think>"]) {
+	for (const openTag of ["<think>", "<thinking>", "<mm:think>"]) {
 		const openIdx = result.indexOf(openTag)
 		if (openIdx !== -1) {
 			const before = result.slice(0, openIdx)
@@ -203,7 +220,8 @@ function applyStreamingDisplay(text: string, hideThinking: boolean): string {
 			break
 		}
 	}
-	return result
+	// 3. Strip orphaned close tags (e.g. kimi-k2.x thinking=off fragments).
+	return stripOrphanCloseTags(result)
 }
 
 export function filterThinkingForDisplay(text: string): string {
@@ -288,8 +306,9 @@ export default function hideThinkingExtension(pi: ExtensionAPI): void {
 			if (!newContent) continue
 			state.original += newContent
 
-			// Only touch the block when there is (or might be) a think tag.
-			if (!state.original.includes("<think>") && !state.original.includes("<mm:think>")) {
+			// Only touch the block when there is (or might be) a think tag —
+			// including orphaned close tags emitted without an opener.
+			if (!containsAnyThinkTag(state.original)) {
 				state.lastDisplayLength = block.text.length
 				continue
 			}
@@ -320,10 +339,10 @@ export default function hideThinkingExtension(pi: ExtensionAPI): void {
 				// Capture any trailing content added after our last message_update.
 				const remaining = block.text.slice(streamState.lastDisplayLength)
 				const fullOriginal = streamState.original + remaining
-				if (containsThinkTags(fullOriginal)) {
+				if (containsAnyThinkTag(fullOriginal)) {
 					blockOriginals.set(i, fullOriginal)
 				}
-			} else if (containsThinkTags(block.text)) {
+			} else if (containsAnyThinkTag(block.text)) {
 				blockOriginals.set(i, block.text)
 			}
 		}

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -137,6 +137,18 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")
 	})
 
+	it("does not set compat for non-anthropic ai-enabler models", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
+	})
+
 	it("sets thinkingLevelMap for ai-enabler models so thinking=off sends reasoning_effort=none", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -85,6 +85,7 @@ describe("updateModelsConfig", () => {
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				provider: "ai-enabler",
+				thinkingLevelMap: { off: "none" },
 			},
 		])
 	})
@@ -136,7 +137,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")
 	})
 
-	it("omits compat for non-anthropic models", async () => {
+	it("sets thinkingLevelMap for ai-enabler models so thinking=off sends reasoning_effort=none", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
@@ -145,7 +146,9 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
+		expect(config.providers["kimchi-dev"].models[0].thinkingLevelMap).toEqual({
+			off: "none",
+		})
 	})
 
 	it("sets compat for claude-* models regardless of upstream provider (e.g. azure_ai)", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -170,7 +170,13 @@ export interface PiModelConfig {
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
 	// Persisted so telemetry can resolve the actual upstream provider after cache round-trip.
 	provider: string
-	compat?: { supportsReasoningEffort?: boolean; cacheControlFormat?: "anthropic"; supportsUsageInStreaming?: boolean }
+	compat?: {
+		supportsReasoningEffort?: boolean
+		cacheControlFormat?: "anthropic"
+		supportsUsageInStreaming?: boolean
+	}
+	/** Maps thinking levels to provider-specific values. `off: "none"` sends `reasoning_effort: "none"`. */
+	thinkingLevelMap?: Partial<Record<string, string | null>>
 	/** Model-level API type: upstream custom-provider parseModels falls through to this field. */
 	api?: string
 	/** Model-level base URL: upstream custom-provider parseModels falls through to this field. */
@@ -186,10 +192,17 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// Claude models routed through openai-completions need:
 	// - cacheControlFormat: "anthropic" so pi injects cache_control markers
 	// - supportsUsageInStreaming: true so stream_options.include_usage is sent
+	//
+	// ai-enabler models don't support chat_template_kwargs, so we rely on the
+	// default `openai` thinkingFormat which sends `reasoning_effort`. Setting
+	// thinkingLevelMap.off = "none" ensures that the off level sends
+	// reasoning_effort: "none" instead of omitting it, which would leave
+	// thinking enabled by default.
 	const compat =
 		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
 			: undefined
+	const thinkingLevelMap = m.provider === "ai-enabler" ? { off: "none" as const } : undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,
@@ -201,6 +214,7 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 		// Store upstream provider for telemetry round-trip via models.json
 		provider: m.provider,
 		...(compat && { compat }),
+		...(thinkingLevelMap && { thinkingLevelMap }),
 	}
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import type { ThinkingLevel } from "./extensions/agents/personas/types.js"
 import { getVersion } from "./utils.js"
 
 const KIMCHI_API = "https://llm.kimchi.dev"
@@ -176,7 +177,7 @@ export interface PiModelConfig {
 		supportsUsageInStreaming?: boolean
 	}
 	/** Maps thinking levels to provider-specific values. `off: "none"` sends `reasoning_effort: "none"`. */
-	thinkingLevelMap?: Partial<Record<string, string | null>>
+	thinkingLevelMap?: Partial<Record<ThinkingLevel, string | null>>
 	/** Model-level API type: upstream custom-provider parseModels falls through to this field. */
 	api?: string
 	/** Model-level base URL: upstream custom-provider parseModels falls through to this field. */


### PR DESCRIPTION
## Summary

This PR fixes two issues around thinking/reasoning control for ai-enabler models (kimi-k2.x on SGLang):

**1. ai-enabler models keep thinking when the user disables it**

ai-enabler models are hosted on SGLang behind our LiteLLM gateway. The gateway strips `chat_template_kwargs`, so the qwen-chat-template format does not work. Without a `thinkingLevelMap.off = "none"` entry, pi-ai sends no `reasoning_effort` at all when thinking is off, and SGLang defaults to thinking enabled.

The fix maps `off → "none"` in `thinkingLevelMap` so pi-ai sends `reasoning_effort: "none"`, which SGLang honors to disable thinking.

**2. Orphaned thinking close tags leak raw text into the TUI**

kimi-k2.x with `thinkingLevel=off` sometimes streams reasoning as plain text terminated by a bare `</thinking>` with no opening tag (observed in session 01a01465). The hide-thinking extension required balanced open+close pairs, so these fragments passed through unfiltered.

The fix adds:
- `stripOrphanCloseTags`: removes unmatched `</think>`, `</thinking>`, `</mm:think>` close tags after balanced-block replacement
- `containsAnyThinkTag`: gates streaming and final transforms on any thinking tag (open or close), replacing the pair-only `containsThinkTags`
- Support for balanced `<thinking>...</thinking>` blocks (in addition to `<think>` and `<mm:think>`)
- Streaming regression tests mirroring the leaked session fragments

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project conventions (pnpm, biome, vitest)
- [x] Tests added/updated for behavior change
- [x] No new dependencies introduced