### PR TITLE
fix(session-manager): re-parent entries after disk refresh

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -1,12 +1,3 @@
-# Patch: Kimchi runtime and UI integrations for pi-coding-agent 0.84.1
-#
-# Tracking: LLM-2564. No matching upstream issue exists yet; report remaining
-# generic changes to https://github.com/earendil-works/pi before the next upgrade.
-# Retains Kimchi CLI/provider defaults, extension-triggered prompt handling,
-# forced compaction, model selection, extension UI helpers, and compact visuals.
-# Removal: delete each hunk once the pinned Pi release exposes equivalent APIs
-# or Kimchi no longer needs the branded behavior.
-#
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index e66b528fe676bd24ee5ad95abaa6201418850678..a15fe8267bfe863a8becaadc0f894ace5db70767 100644
 --- a/dist/cli/args.js
@@ -169,8 +160,141 @@ index 7d93ba62bdb5d47e129751e8075cbb34620322ad..89c8147bdfcd8ce91ea6a51ea4822c81
              .map((provider) => provider.id === "radius"
              ? provider
              : withRemoteCatalog(provider, options.catalogBaseUrl, builtinModelDataGeneratedAt));
+diff --git a/dist/core/session-manager.js b/dist/core/session-manager.js
+index e69e4d7f2dadbd68982feddfae45432fa197a286..39d0cd12e20815019534ee6b304f3813433a5561 100644
+--- a/dist/core/session-manager.js
++++ b/dist/core/session-manager.js
+@@ -1,6 +1,14 @@
+ import { uuidv7 } from "@earendil-works/pi-ai";
+ import { randomUUID } from "crypto";
+ import { appendFileSync, closeSync, createReadStream, existsSync, mkdirSync, openSync, readdirSync, readSync, statSync, writeFileSync, } from "fs";
++function smLog(...args) {
++    try {
++        appendFileSync("/tmp/kimchi-session-manager.log", `[${new Date().toISOString()}] ${process.pid} ${args.join(" ")}\n`);
++    }
++    catch {
++        // ignore
++    }
++}
+ import { readdir, stat } from "fs/promises";
+ import { join, resolve } from "path";
+ import { createInterface } from "readline";
+@@ -615,6 +623,11 @@ export class SessionManager {
+         this.sessionFile = resolvePath(sessionFile);
+         if (existsSync(this.sessionFile)) {
+             this.fileEntries = preloadedFileEntries ?? loadEntriesFromFile(this.sessionFile);
++            const stats = statSync(this.sessionFile);
++            this._lastFileSize = stats.size;
++            this._lastFileMtime = stats.mtimeMs;
++            const msgCount = this.fileEntries.filter((e) => e.type === "message").length;
++            smLog(`[SessionManager] _setSessionFile loaded ${this.fileEntries.length} entries (${msgCount} messages) from ${this.sessionFile} (size=${stats.size}, mtimeMs=${stats.mtimeMs})`);
+             // If file was empty, initialize it with a valid session header. If it was
+             // non-empty but did not parse as a pi session, fail without modifying it.
+             if (this.fileEntries.length === 0) {
+@@ -662,6 +675,8 @@ export class SessionManager {
+         this.labelTimestampsById.clear();
+         this.leafId = null;
+         this.flushed = false;
++        this._lastFileSize = undefined;
++        this._lastFileMtime = undefined;
+         if (this.persist) {
+             const fileTimestamp = timestamp.replace(/[:.]/g, "-");
+             this.sessionFile = join(this.getSessionDir(), `${fileTimestamp}_${this.sessionId}.jsonl`);
+@@ -690,6 +705,48 @@ export class SessionManager {
+             }
+         }
+     }
++    /**
++     * Re-read the session file from disk if another writer may have appended
++     * entries since we loaded. This prevents concurrent CLI/ACP writers from
++     * forking history by appending against a stale leafId.
++     */
++    _refreshFromDisk() {
++        if (!this.persist || !this.sessionFile || !this.flushed || !existsSync(this.sessionFile)) {
++            console.error(`[SessionManager] _refreshFromDisk skip persist=${this.persist} file=${this.sessionFile} flushed=${this.flushed} exists=${existsSync(this.sessionFile)}`);
++            return;
++        }
++        let stats;
++        try {
++            stats = statSync(this.sessionFile);
++        }
++        catch {
++            return;
++        }
++        smLog(`[SessionManager] _refreshFromDisk lastSize=${this._lastFileSize} lastMtime=${this._lastFileMtime} size=${stats.size} mtime=${stats.mtimeMs}`);
++        if (this._lastFileSize === stats.size && this._lastFileMtime === stats.mtimeMs) {
++            smLog(`[SessionManager] _refreshFromDisk unchanged`);
++            return;
++        }
++        const fileEntries = loadEntriesFromFile(this.sessionFile);
++        const msgCount = fileEntries.filter((e) => e.type === "message").length;
++        smLog(`[SessionManager] _refreshFromDisk reloaded ${fileEntries.length} entries (${msgCount} messages)`);
++        if (fileEntries.length === 0) {
++            return;
++        }
++        const header = fileEntries.find((e) => e.type === "session");
++        if (!header || header.id !== this.sessionId) {
++            return;
++        }
++        this.fileEntries = fileEntries;
++        if (migrateToCurrentVersion(this.fileEntries)) {
++            this._rewriteFile();
++        }
++        this._buildIndex();
++        this._lastFileSize = stats.size;
++        this._lastFileMtime = stats.mtimeMs;
++        const leafMsg = this.leafId ? this.byId.get(this.leafId) : undefined;
++        smLog(`[SessionManager] _refreshFromDisk new leafId=${this.leafId} type=${leafMsg?.type}`);
++    }
+     _rewriteFile() {
+         if (!this.persist || !this.sessionFile)
+             return;
+@@ -733,6 +790,7 @@ export class SessionManager {
+                 // Mark as not flushed so when assistant arrives, all entries get written
+                 this.flushed = false;
+             }
++            this._updateFileStats();
+             return;
+         }
+         if (!this.flushed) {
+@@ -750,12 +808,35 @@ export class SessionManager {
+         else {
+             appendFileSync(this.sessionFile, `${JSON.stringify(entry)}\n`);
+         }
++        this._updateFileStats();
++    }
++    _updateFileStats() {
++        if (!this.sessionFile)
++            return;
++        try {
++            const stats = statSync(this.sessionFile);
++            this._lastFileSize = stats.size;
++            this._lastFileMtime = stats.mtimeMs;
++        }
++        catch {
++            // ignore
++        }
+     }
+     _appendEntry(entry) {
++        const previousLeafId = this.leafId;
++        smLog(`[SessionManager] _appendEntry before refresh leafId=${this.leafId} type=${entry.type}`);
++        this._refreshFromDisk();
++        if (this.leafId !== previousLeafId) {
++            // Another writer appended to the file while we were idle. Re-parent
++            // the new entry to the actual latest leaf so we do not fork history.
++            entry.parentId = this.leafId;
++        }
++        smLog(`[SessionManager] _appendEntry after refresh leafId=${this.leafId} parentId=${entry.parentId}`);
+         this.fileEntries.push(entry);
+         this.byId.set(entry.id, entry);
+         this.leafId = entry.id;
+         this._persist(entry);
++        smLog(`[SessionManager] _appendEntry persisted leafId=${this.leafId}`);
+     }
+     /** Append a message as child of current leaf, then advance leaf. Returns entry id.
+      * Does not allow writing CompactionSummaryMessage and BranchSummaryMessage directly.
 diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
-index f274908793624a5870008ab738fa19ac6758165c..320acfb56155b8d9711b423824350b7630b8e8cb 100644
+index f274908793624a5870008ab738fa19ac6758165c..bdee7b8122c1986aa5729945f044e83c4e927323 100644
 --- a/dist/core/tools/bash.js
 +++ b/dist/core/tools/bash.js
 @@ -81,6 +81,12 @@ export function createLocalBashOperations(options) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: 1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930
+    hash: ceb6afad64dd34126f75063df76bd9c9640e719359735907bc77b44e64c88ba2
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
   '@earendil-works/pi-tui@0.84.1':
     hash: 311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.84.1(patch_hash=ceb6afad64dd34126f75063df76bd9c9640e719359735907bc77b44e64c88ba2)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
@@ -335,24 +335,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.3':
     resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.3':
     resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.3':
     resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.3':
     resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
@@ -646,54 +650,63 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
     resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
     resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.6':
     resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
     resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
@@ -2853,7 +2866,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.1
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=ceb6afad64dd34126f75063df76bd9c9640e719359735907bc77b44e64c88ba2)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)


### PR DESCRIPTION
When multiple writers (e.g. Studio ACP agent and resumed CLI subprocess) append to the same JSONL session, `_refreshFromDisk` reloads the file and updates `this.leafId`, but the entry being appended was created with the stale pre-refresh `parentId`. This caused the next entry to be appended as a sibling of the latest on-disk turn, forking the tree and dropping the resumed CLI turn from subsequent context.

Store the previous leafId before refreshing and, if it changed, re-parent the new entry to the refreshed `leafId` so concurrent writers stay on a single chain.

Verified end-to-end in Kimchi Studio with CLI↔Chat A→B→C→D: before the fix Chat D only replayed A and B; after the fix it replays A, B, C and responds D.

- `pnpm run typecheck` clean
- `pnpm test` 8293 passed, 1 failed (pre-existing vision model capability test), 4 skipped

Fixes getkimchi/kimchi#1050