### PR TITLE
fix(acp): refresh idle cached session from disk before replay

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -134,12 +134,29 @@ class FakeAgentSession {
 	// Branch entries returned to the replay walker. Tests fill this with the
 	// shape buildSessionContext consumers expect (type:"message" + role).
 	branch: unknown[] = []
+	contextMessages: unknown[] = []
+	sessionFile: string | undefined
+	onSetSessionFile: ((sessionFile: string) => void) | undefined
+	agent = {
+		state: {
+			messages: [] as unknown[],
+		},
+	}
 	sessionManager = {
 		getBranch: () => this.branch,
 		getSessionId: () => this.sessionId,
 		getEntries: () => this.branch,
 		getCwd: () => this.cwd,
 		getSessionDir: () => `${this.cwd}/.fake-agent-sessions-dir`,
+		getSessionFile: () => this.sessionFile,
+		setSessionFile: (sessionFile: string) => {
+			this.onSetSessionFile?.(sessionFile)
+		},
+		buildSessionContext: () => ({
+			messages: this.contextMessages,
+			thinkingLevel: "off",
+			model: null,
+		}),
 		appendCustomEntry: (customType: string, data?: unknown) => {
 			this.branch.push({ type: "custom", customType, data })
 			return "entry-id"
@@ -4797,7 +4814,7 @@ describe("KimchiAcpAgent loadSession", () => {
 		expect(loaderCalls.count).toBe(0)
 	})
 
-	it("replays and returns an already loaded session without reopening it", async () => {
+	it("replays an already loaded session from memory when its backing file does not exist", async () => {
 		const loaderCalls = { count: 0 }
 		const live = new FakeAgentSession("live-1")
 		live.branch = [userTextEntry("already here", "u1", null)]
@@ -4833,6 +4850,74 @@ describe("KimchiAcpAgent loadSession", () => {
 			sessionUpdate: "user_message_chunk",
 			content: { type: "text", text: "already here" },
 		})
+	})
+
+	it("refreshes an already loaded session from disk before replay and the next prompt", async () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "kimchi-acp-refresh-"))
+		try {
+			const sessionFile = join(tmpDir, "live-refresh.jsonl")
+			writeFileSync(sessionFile, "backing file exists\n")
+
+			const live = new FakeAgentSession("live-refresh", tmpDir)
+			const staleMessages = [
+				{ role: "user", content: "one" },
+				{ role: "user", content: "two" },
+			]
+			const freshMessages = [...staleMessages, { role: "user", content: "three from CLI" }]
+			live.sessionFile = sessionFile
+			live.branch = [userTextEntry("one", "u1", null), userTextEntry("two", "u2", "u1")]
+			live.contextMessages = staleMessages
+			live.agent.state.messages = staleMessages
+			live.onSetSessionFile = () => {
+				live.branch = [
+					userTextEntry("one", "u1", null),
+					userTextEntry("two", "u2", "u1"),
+					userTextEntry("three from CLI", "u3", "u2"),
+				]
+				live.contextMessages = freshMessages
+			}
+
+			let loaderCalls = 0
+			const { conn, updates } = makeRecordingConn()
+			const agent = new KimchiAcpAgent(conn, {
+				extensionFactories: [],
+				agentDir: tmpDir,
+				sessionFactory: async () => asSession(live),
+				sessionLoader: async () => {
+					loaderCalls++
+					return asSession(new FakeAgentSession("unused"))
+				},
+			})
+			await agent.newSession({ cwd: tmpDir, mcpServers: [] })
+
+			await agent.loadSession({
+				sessionId: "live-refresh",
+				cwd: tmpDir,
+				mcpServers: [],
+			})
+
+			expect(loaderCalls).toBe(0)
+			expect(live.agent.state.messages).toEqual(freshMessages)
+			expect(
+				replayOnly(updates).map((update) =>
+					update.update.sessionUpdate === "user_message_chunk"
+						? (update.update as { content: { text: string } }).content.text
+						: undefined,
+				),
+			).toEqual(["one", "two", "three from CLI"])
+
+			live.promptImpl = async () => {
+				expect(live.agent.state.messages).toEqual(freshMessages)
+			}
+			await expect(
+				agent.prompt({
+					sessionId: "live-refresh",
+					prompt: [{ type: "text", text: "four from Chat" }],
+				}),
+			).resolves.toEqual({ stopReason: "end_turn" })
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true })
+		}
 	})
 
 	it("returns configOptions in loadSession response", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1,7 +1,7 @@
 // ACP (Agent Client Protocol) mode: JSON-RPC 2.0 over stdio using
 // @agentclientprotocol/sdk. Lets IDE extensions, Zed, openclaw drive kimchi in-process.
 
-import { closeSync, openSync, readdirSync, readFileSync, readSync } from "node:fs"
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync } from "node:fs"
 import { join } from "node:path"
 import { Readable, Writable } from "node:stream"
 import {
@@ -572,6 +572,7 @@ export class KimchiAcpAgent implements Agent {
 			if (existing.turn) {
 				throw RequestError.invalidRequest(undefined, `session ${sessionId} has a turn in progress; cancel it first`)
 			}
+			this.refreshSessionFromDisk(existing.session, sessionId)
 			this.replayTranscript(existing.session)
 			this.sendAvailableCommandsUpdate(sessionId)
 
@@ -596,6 +597,39 @@ export class KimchiAcpAgent implements Agent {
 				this.loadingSessions.delete(sessionId)
 			}
 		}
+	}
+
+	/**
+	 * Refresh an idle cached ACP session from its JSONL before replaying it.
+	 *
+	 * Studio can temporarily hand the same persisted session to a CLI process.
+	 * The CLI appends to disk while ACP still owns an idle AgentSession whose
+	 * SessionManager leaf and agent message state are now stale. Reload both in
+	 * place so a subsequent loadSession sees the CLI turn and the next ACP prompt
+	 * uses it as model context. Sessions without a materialized backing file (for
+	 * example, a newly-created session before its first assistant response) keep
+	 * their current in-memory state.
+	 */
+	private refreshSessionFromDisk(session: AgentSession, expectedSessionId: string): void {
+		const { sessionManager } = session
+		const sessionFile = sessionManager.getSessionFile()
+		if (!sessionFile || !existsSync(sessionFile)) return
+
+		try {
+			sessionManager.setSessionFile(sessionFile)
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err)
+			throw RequestError.invalidParams(undefined, `failed to refresh session: ${msg}`)
+		}
+
+		if (sessionManager.getSessionId() !== expectedSessionId) {
+			throw RequestError.invalidParams(
+				undefined,
+				`session header id ${sessionManager.getSessionId()} does not match requested sessionId ${expectedSessionId}`,
+			)
+		}
+
+		session.agent.state.messages = sessionManager.buildSessionContext().messages
 	}
 
 	private async loadSessionFresh(params: LoadSessionRequest): Promise<LoadSessionResponse> {


### PR DESCRIPTION
When Studio hands the same persisted session to a CLI process, the CLI
appends turns to disk while ACP still owns an idle AgentSession whose
SessionManager leaf and agent message state are now stale. Reload both
in place during loadSession so the CLI turn appears in the replay and
the next ACP prompt uses the updated messages as model context.
Sessions without a materialized backing file keep their in-memory state.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
