### PR TITLE
feat(permissions): add dedicated EventBus channels for permission lifecycle

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1517,11 +1517,13 @@ describe("compound command with session rules", () => {
 describe("handleCompoundConfirm", () => {
 	let session: SessionMemory
 	let activeAborts: Set<AbortController>
+	const mockPi = { events: { emit: vi.fn() } } as unknown as ExtensionAPI
 
 	beforeEach(() => {
 		session = new SessionMemory()
 		session.clear()
 		activeAborts = new Set()
+		vi.mocked(mockPi.events.emit).mockClear()
 	})
 
 	it("returns undefined for allow-all-once", async () => {
@@ -1532,6 +1534,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1546,6 +1549,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1564,6 +1568,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a"],
 		})
 
@@ -1582,6 +1587,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1600,6 +1606,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1618,6 +1625,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1634,6 +1642,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1650,6 +1659,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1672,6 +1682,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1686,6 +1697,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: [],
 		})
 
@@ -1702,6 +1714,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo hello"],
 		})
 
@@ -1721,6 +1734,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1749,6 +1763,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo hello", "whoami"],
 		})
 
@@ -1766,6 +1781,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
+		pi: mockPi,
 			subcommands: ["echo a"],
 		})
 

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1534,7 +1534,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1549,7 +1549,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1568,7 +1568,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a"],
 		})
 
@@ -1587,7 +1587,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1606,7 +1606,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "echo b"],
 		})
 
@@ -1625,7 +1625,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1642,7 +1642,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1659,7 +1659,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1682,7 +1682,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1697,7 +1697,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: [],
 		})
 
@@ -1714,7 +1714,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo hello"],
 		})
 
@@ -1734,7 +1734,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a", "whoami"],
 		})
 
@@ -1763,7 +1763,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo hello", "whoami"],
 		})
 
@@ -1781,7 +1781,7 @@ describe("handleCompoundConfirm", () => {
 			ctx,
 			session,
 			activeAborts,
-		pi: mockPi,
+			pi: mockPi,
 			subcommands: ["echo a"],
 		})
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -345,9 +345,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		activeAbortControllers.clear()
 		updateStatus(ctx)
 		maybeShowYoloWarning(ctx)
-		if (pi.events?.emit) {
-			pi.events.emit(PERMISSION_EVENTS.MODE_CHANGED, { from, to: next, reason })
-		}
+		pi.events.emit(PERMISSION_EVENTS.MODE_CHANGED, { from, to: next, reason })
 	}
 
 	function cycleMode(ctx: ExtensionContext): void {
@@ -401,13 +399,11 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		})
 		loaded = lc
 		rebuildConfigRules()
-		if (pi.events?.emit) {
-			pi.events.emit(PERMISSION_EVENTS.CONFIG_LOADED, {
-				cwd: ctx.cwd,
-				ruleCount: configRules.length + builtinRules.length,
-				errors,
-			})
-		}
+		pi.events.emit(PERMISSION_EVENTS.CONFIG_LOADED, {
+			cwd: ctx.cwd,
+			ruleCount: configRules.length + builtinRules.length,
+			errors,
+		})
 		return { errors }
 	}
 
@@ -898,7 +894,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			// auto-promote the session to plan mode so the rest of the conversation
 			// runs under the right tool set instead of silently approving here.
 			if (toolName === "questionnaire" && mode === "default") {
-				changeMode(ctx, "default", { mode: "plan", initiatedBy: "user", source: "runtime" }, "questionnaire_promote")
+				changeMode(ctx, "default", { mode: "plan", initiatedBy: "user", source: "runtime" }, "questionnaire_promotion")
 				return undefined
 			}
 			if (isReadOnlyTool(toolName)) return undefined
@@ -1001,7 +997,7 @@ interface ConfirmOptions {
 	riskScore?: RiskScore
 	activeAborts: Set<AbortController>
 	allRules?: () => Rule[]
-	pi?: ExtensionAPI
+	pi: ExtensionAPI
 }
 
 async function handleConfirm(
@@ -1015,20 +1011,18 @@ async function handleConfirm(
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
 
-		if (opts.pi?.events?.emit) {
-			opts.pi.events.emit("notification", {
-				notification_type: "permission_prompt",
-				tool_name: event.toolName,
-				tool_use_id: event.toolCallId,
-			})
-			opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
-				toolCallId: event.toolCallId,
-				toolName: event.toolName,
-				compound: false,
-				riskScore: opts.riskScore,
-				classifierReason: opts.subtitle,
-			})
-		}
+		opts.pi.events.emit("notification", {
+			notification_type: "permission_prompt",
+			tool_name: event.toolName,
+			tool_use_id: event.toolCallId,
+		})
+		opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
+			toolCallId: event.toolCallId,
+			toolName: event.toolName,
+			compound: false,
+			riskScore: opts.riskScore,
+			classifierReason: opts.subtitle,
+		})
 
 		const input = event.input
 		const outcome = await prompter.request({
@@ -1041,17 +1035,15 @@ async function handleConfirm(
 			signal: abort.signal,
 		})
 
-		if (opts.pi?.events?.emit) {
-			opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
-				toolCallId: event.toolCallId,
-				toolName: event.toolName,
-				decision: approvalOutcomeToDecision(outcome),
-				ruleAdded:
-					outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
-						? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
-						: undefined,
-			})
-		}
+		opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+			toolCallId: event.toolCallId,
+			toolName: event.toolName,
+			decision: approvalOutcomeToDecision(outcome),
+			ruleAdded:
+				outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
+					? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+					: undefined,
+		})
 
 		return applyApprovalOutcome(outcome, opts.session)
 	} finally {
@@ -1071,20 +1063,18 @@ export async function handleCompoundConfirm(
 		const prompter = resolvePrompter(opts.ctx)
 		if (!prompter) return { block: true, reason: "No UI to confirm permission" }
 
-		if (opts.pi?.events?.emit) {
-			opts.pi.events.emit("notification", {
-				notification_type: "permission_prompt",
-				tool_name: event.toolName,
-				tool_use_id: event.toolCallId,
-			})
-			opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
-				toolCallId: event.toolCallId,
-				toolName: event.toolName,
-				compound: true,
-				riskScore: opts.riskScore,
-				classifierReason: opts.subtitle,
-			})
-		}
+		opts.pi.events.emit("notification", {
+			notification_type: "permission_prompt",
+			tool_name: event.toolName,
+			tool_use_id: event.toolCallId,
+		})
+		opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
+			toolCallId: event.toolCallId,
+			toolName: event.toolName,
+			compound: true,
+			riskScore: opts.riskScore,
+			classifierReason: opts.subtitle,
+		})
 
 		if (opts.ctx.mode !== "tui") {
 			// Non-TUI transports (chiefly ACP) present compound commands as one
@@ -1100,17 +1090,15 @@ export async function handleCompoundConfirm(
 				choices: buildPermissionChoices(event.toolName, input),
 				signal: abort.signal,
 			})
-			if (opts.pi?.events?.emit) {
-				opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
-					toolCallId: event.toolCallId,
-					toolName: event.toolName,
-					decision: approvalOutcomeToDecision(outcome),
-					ruleAdded:
-						outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
-							? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
-							: undefined,
-				})
-			}
+			opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				decision: approvalOutcomeToDecision(outcome),
+				ruleAdded:
+					outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
+						? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+						: undefined,
+			})
 			return applyApprovalOutcome(outcome, opts.session)
 		}
 
@@ -1125,17 +1113,15 @@ export async function handleCompoundConfirm(
 			signal: abort.signal,
 		})
 
-		if (opts.pi?.events?.emit) {
-			opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
-				toolCallId: event.toolCallId,
-				toolName: event.toolName,
-				decision: compoundOutcomeToDecision(outcome),
-				ruleAdded:
-					outcome.kind === "allow-all-remember" && outcome.rules.length > 0
-						? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
-						: undefined,
-			})
-		}
+		opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+			toolCallId: event.toolCallId,
+			toolName: event.toolName,
+			decision: compoundOutcomeToDecision(outcome),
+			ruleAdded:
+				outcome.kind === "allow-all-remember" && outcome.rules.length > 0
+					? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+					: undefined,
+		})
 
 		if (outcome.kind === "aborted") return "aborted"
 		if (outcome.kind === "allow-all-once") return undefined

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1130,6 +1130,10 @@ export async function handleCompoundConfirm(
 				toolCallId: event.toolCallId,
 				toolName: event.toolName,
 				decision: compoundOutcomeToDecision(outcome),
+				ruleAdded:
+					outcome.kind === "allow-all-remember" && outcome.rules.length > 0
+						? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+						: undefined,
 			})
 		}
 
@@ -1237,6 +1241,10 @@ function approvalOutcomeToDecision(outcome: ApprovalOutcome): PermissionDecision
 			return "deny"
 		case "aborted":
 			return "aborted"
+		default: {
+			const _exhaustive: never = outcome
+			throw new Error(`Unhandled approval outcome: ${(_exhaustive as ApprovalOutcome).kind}`)
+		}
 	}
 }
 
@@ -1254,6 +1262,10 @@ function compoundOutcomeToDecision(outcome: CompoundApprovalOutcome): Permission
 			return "deny"
 		case "aborted":
 			return "aborted"
+		default: {
+			const _exhaustive: never = outcome
+			throw new Error(`Unhandled compound approval outcome: ${(_exhaustive as CompoundApprovalOutcome).kind}`)
+		}
 	}
 }
 

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -56,6 +56,8 @@ import {
 	promptForCompoundApproval,
 	terminalPrompter,
 	withWorkingHidden,
+	type ApprovalOutcome,
+	type CompoundApprovalOutcome,
 } from "./prompts.js"
 import { evaluateRules, parseRules, stringifyRule } from "./rules.js"
 import { SessionMemory } from "./session-memory.js"
@@ -66,7 +68,8 @@ import {
 	isReadOnlyTool,
 	splitCompoundCommand,
 } from "./taxonomy.js"
-import type { PermissionMode, PermissionModeState, RiskScore, Rule } from "./types.js"
+import { PERMISSION_EVENTS, type ModeChangeReason, type PermissionDecision } from "./permissions-events.js"
+import type { PermissionMode, PermissionModeState, RiskScore, Rule, RuleSource } from "./types.js"
 
 /**
  * Check whether a file path is within .kimchi/plans/ relative to cwd.
@@ -330,8 +333,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		ctx: ExtensionContext,
 		current: PermissionMode,
 		next: PermissionModeState,
+		reason: ModeChangeReason,
 		skipNotify?: boolean,
 	): void {
+		const from = getRuntimePermissionMode()
 		setRuntimePermissionMode(ctx, next, skipNotify)
 		if (current === "plan" && next.mode !== "plan") restoreToolsFromPlanMode()
 		if (next.mode === "plan") applyPlanModeTools()
@@ -340,13 +345,16 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		activeAbortControllers.clear()
 		updateStatus(ctx)
 		maybeShowYoloWarning(ctx)
+		if (pi.events?.emit) {
+			pi.events.emit(PERMISSION_EVENTS.MODE_CHANGED, { from, to: next, reason })
+		}
 	}
 
 	function cycleMode(ctx: ExtensionContext): void {
 		const { mode: current } = getRuntimePermissionMode()
 		const idx = MODES.findIndex((m) => m.mode === current)
 		const next = MODES[(idx + 1) % MODES.length].mode
-		changeMode(ctx, current, { mode: next, initiatedBy: "user", source: "runtime" })
+		changeMode(ctx, current, { mode: next, initiatedBy: "user", source: "runtime" }, "user_shift_tab")
 	}
 
 	// Ferment calls notifyFermentActive() when a ferment is activated or cleared,
@@ -366,7 +374,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				mode: "yolo",
 				source: "runtime",
 				initiatedBy: "ferment",
-			})
+			}, "ferment_elevation")
 		} else if (preFermentMode) {
 			const saved = preFermentMode
 			preFermentMode = undefined
@@ -374,7 +382,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			// ferment elevation. If the user changed mode manually mid-ferment,
 			// their choice wins over the restore.
 			if (current.initiatedBy === "ferment") {
-				changeMode(currentCtx, current.mode, saved)
+				changeMode(currentCtx, current.mode, saved, "ferment_restore")
 			}
 		}
 	})
@@ -388,6 +396,13 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		})
 		loaded = lc
 		rebuildConfigRules()
+		if (pi.events?.emit) {
+			pi.events.emit(PERMISSION_EVENTS.CONFIG_LOADED, {
+				cwd: ctx.cwd,
+				ruleCount: configRules.length + builtinRules.length,
+				errors,
+			})
+		}
 		return { errors }
 	}
 
@@ -459,7 +474,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			}
 		}
 
-		changeMode(ctx, current.mode, next)
+		changeMode(ctx, current.mode, next, "session_start")
 
 		const sessionId = ctx.sessionManager.getSessionId()
 		unsubscribePermissionFlagController = getSessionPermissionFlagController(sessionId)?.subscribe(({ mode: next }) => {
@@ -470,7 +485,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 
 			// ACP already emitted the config update from controller.setMode().
 			// This call is only for local transition side effects.
-			changeMode(ctx, current.mode, next, true)
+			changeMode(ctx, current.mode, next, "controller", true)
 		})
 	})
 
@@ -554,7 +569,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			} catch {
 				// Non-fatal: plan persistence is best-effort.
 			}
-			changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" })
+			changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" }, "plan_approval")
 			executePlan(planPath, text)
 		} else if (choice === START_AS_FERMENT) {
 			// ── Tool-swap contract ────────────────────────────────────────────────
@@ -623,7 +638,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					defaultFermentRuntime.setActive(draft)
 					if (pi.events) emitFermentCreated(pi.events, draft)
 					appendRefEntry(pi, draft.id)
-					changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" })
+					changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" }, "plan_approval")
 					ctx.ui?.notify?.(
 						`Saved draft ferment "${draft.name}". The plan didn't include a "## Chunks" section, so it wasn't auto-scoped. Use /ferment list to resume and scope it interactively.`,
 					)
@@ -705,7 +720,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					},
 					{ triggerTurn: true },
 				)
-				changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" })
+				changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" }, "plan_approval")
 			} catch (err) {
 				// Promotion failed before activation. Keep the planning profile, clear
 				// the half-set runtime state, and tell the user that they can retry.
@@ -878,7 +893,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			// auto-promote the session to plan mode so the rest of the conversation
 			// runs under the right tool set instead of silently approving here.
 			if (toolName === "questionnaire" && mode === "default") {
-				changeMode(ctx, "default", { mode: "plan", initiatedBy: "user", source: "runtime" })
+				changeMode(ctx, "default", { mode: "plan", initiatedBy: "user", source: "runtime" }, "questionnaire_promote")
 				return undefined
 			}
 			if (isReadOnlyTool(toolName)) return undefined
@@ -961,7 +976,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		getLoaded: () => loaded,
 		getPermissionMode: () => getRuntimePermissionMode().mode,
 		setPermissionMode: (ctx, mode) =>
-			changeMode(ctx, getRuntimePermissionMode().mode, { mode, initiatedBy: "user", source: "runtime" }),
+			changeMode(ctx, getRuntimePermissionMode().mode, { mode, initiatedBy: "user", source: "runtime" }, "command"),
 		rebuildConfigRules,
 		reloadConfig: (ctx) => {
 			const { errors } = doLoadConfig(ctx)
@@ -1001,6 +1016,13 @@ async function handleConfirm(
 				tool_name: event.toolName,
 				tool_use_id: event.toolCallId,
 			})
+			opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				compound: false,
+				riskScore: opts.riskScore,
+				classifierReason: opts.subtitle,
+			})
 		}
 
 		const input = event.input
@@ -1013,6 +1035,18 @@ async function handleConfirm(
 			choices: buildPermissionChoices(event.toolName, input),
 			signal: abort.signal,
 		})
+
+		if (opts.pi?.events?.emit) {
+			opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				decision: approvalOutcomeToDecision(outcome),
+				ruleAdded:
+					outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
+						? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+						: undefined,
+			})
+		}
 
 		return applyApprovalOutcome(outcome, opts.session)
 	} finally {
@@ -1038,6 +1072,13 @@ export async function handleCompoundConfirm(
 				tool_name: event.toolName,
 				tool_use_id: event.toolCallId,
 			})
+			opts.pi.events.emit(PERMISSION_EVENTS.BEFORE_PROMPT, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				compound: true,
+				riskScore: opts.riskScore,
+				classifierReason: opts.subtitle,
+			})
 		}
 
 		if (opts.ctx.mode !== "tui") {
@@ -1054,6 +1095,17 @@ export async function handleCompoundConfirm(
 				choices: buildPermissionChoices(event.toolName, input),
 				signal: abort.signal,
 			})
+			if (opts.pi?.events?.emit) {
+				opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+					toolCallId: event.toolCallId,
+					toolName: event.toolName,
+					decision: approvalOutcomeToDecision(outcome),
+					ruleAdded:
+						outcome.kind === "allow-remember" || outcome.kind === "allow-remember-wildcard"
+							? { toolName: event.toolName, behavior: "allow" as const, source: "session" as RuleSource }
+							: undefined,
+				})
+			}
 			return applyApprovalOutcome(outcome, opts.session)
 		}
 
@@ -1067,6 +1119,14 @@ export async function handleCompoundConfirm(
 			ctx: opts.ctx,
 			signal: abort.signal,
 		})
+
+		if (opts.pi?.events?.emit) {
+			opts.pi.events.emit(PERMISSION_EVENTS.AFTER_DECISION, {
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				decision: compoundOutcomeToDecision(outcome),
+			})
+		}
 
 		if (outcome.kind === "aborted") return "aborted"
 		if (outcome.kind === "allow-all-once") return undefined
@@ -1156,6 +1216,40 @@ function linkAbortSignal(signal: AbortSignal | undefined, controller: AbortContr
 	const abort = () => controller.abort()
 	signal.addEventListener("abort", abort, { once: true })
 	return () => signal.removeEventListener("abort", abort)
+}
+
+function approvalOutcomeToDecision(outcome: ApprovalOutcome): PermissionDecision {
+	switch (outcome.kind) {
+		case "allow-once":
+			return "allow_once"
+		case "allow-remember":
+			return "allow_remember"
+		case "allow-remember-wildcard":
+			return "allow_remember_wildcard"
+		case "deny-with-feedback":
+			return "deny_with_feedback"
+		case "deny":
+			return "deny"
+		case "aborted":
+			return "aborted"
+	}
+}
+
+function compoundOutcomeToDecision(outcome: CompoundApprovalOutcome): PermissionDecision {
+	switch (outcome.kind) {
+		case "allow-all-once":
+			return "allow_once"
+		case "allow-all-remember":
+			return "allow_remember"
+		case "pick-per-subcommand":
+			return "pick_per_subcommand"
+		case "deny-with-feedback":
+			return "deny_with_feedback"
+		case "deny":
+			return "deny"
+		case "aborted":
+			return "aborted"
+	}
 }
 
 function splitFlag(raw: boolean | string | undefined): string[] {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -47,17 +47,18 @@ import {
 	setPermissionMode,
 } from "./mode-controller.js"
 import { getSessionPermissionFlagController } from "./mode-controller-registry.js"
+import { type ModeChangeReason, PERMISSION_EVENTS, type PermissionDecision } from "./permissions-events.js"
 import { saveApprovedPlan } from "./plan-persistence.js"
 import type { ToolPermissionPrompter } from "./prompter.js"
 import planModeSupplement from "./prompts/plan-mode-supplement.js"
 import {
+	type ApprovalOutcome,
 	buildPermissionChoices,
+	type CompoundApprovalOutcome,
 	type CompoundSubcommand,
 	promptForCompoundApproval,
 	terminalPrompter,
 	withWorkingHidden,
-	type ApprovalOutcome,
-	type CompoundApprovalOutcome,
 } from "./prompts.js"
 import { evaluateRules, parseRules, stringifyRule } from "./rules.js"
 import { SessionMemory } from "./session-memory.js"
@@ -68,7 +69,6 @@ import {
 	isReadOnlyTool,
 	splitCompoundCommand,
 } from "./taxonomy.js"
-import { PERMISSION_EVENTS, type ModeChangeReason, type PermissionDecision } from "./permissions-events.js"
 import type { PermissionMode, PermissionModeState, RiskScore, Rule, RuleSource } from "./types.js"
 
 /**
@@ -370,11 +370,16 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		const current = getRuntimePermissionMode()
 		if (hasActive) {
 			if (current.initiatedBy === "user") preFermentMode = current
-			changeMode(currentCtx, current.mode, {
-				mode: "yolo",
-				source: "runtime",
-				initiatedBy: "ferment",
-			}, "ferment_elevation")
+			changeMode(
+				currentCtx,
+				current.mode,
+				{
+					mode: "yolo",
+					source: "runtime",
+					initiatedBy: "ferment",
+				},
+				"ferment_elevation",
+			)
 		} else if (preFermentMode) {
 			const saved = preFermentMode
 			preFermentMode = undefined

--- a/src/extensions/permissions/permissions-events.ts
+++ b/src/extensions/permissions/permissions-events.ts
@@ -36,10 +36,10 @@ export type ModeChangeReason =
 	| "ferment_elevation"
 	| "ferment_restore"
 	| "plan_approval"
-	| "questionnaire_promote"
+	| "questionnaire_promotion"
 	| "command"
 	| "session_start"
-	| "controller"
+	| "controller" // ACP/IDE SessionPermissionFlagController setMode callback
 
 export interface PermissionModeChangedPayload {
 	from: PermissionModeState

--- a/src/extensions/permissions/permissions-events.ts
+++ b/src/extensions/permissions/permissions-events.ts
@@ -1,0 +1,91 @@
+/**
+ * Permission domain event channels published via pi.events.
+ *
+ * The permissions extension emits these events; any extension (including
+ * external `-e` loaded ones) can subscribe via `pi.events.on(channel, handler)`.
+ * This keeps permission lifecycle observations decoupled from the permissions
+ * extension internals.
+ *
+ * Privacy: payloads carry structured fields only (tool name, mode, decision
+ * type). Raw command text, file paths, and user feedback strings are intentionally
+ * NOT emitted — mirroring the bash-tool-guard and loop-guard stance.
+ *
+ * Interception: these channels are notification-only (fire-and-forget).
+ * The EventBus.emit() returns void. For interception/blocking, extensions
+ * should use the upstream `pi.on("tool_call", ...)` event which supports
+ * returning `{ block: true, reason }`.
+ */
+
+import type { PermissionMode, PermissionModeState, RiskScore, RuleSource } from "./types.js"
+
+export const PERMISSION_EVENTS = {
+	MODE_CHANGED: "permissions:mode_changed",
+	BEFORE_PROMPT: "permissions:before_prompt",
+	AFTER_DECISION: "permissions:after_decision",
+	CONFIG_LOADED: "permissions:config_loaded",
+} as const
+
+export type PermissionEventChannel = (typeof PERMISSION_EVENTS)[keyof typeof PERMISSION_EVENTS]
+
+// ---------------------------------------------------------------------------
+// Mode change
+// ---------------------------------------------------------------------------
+
+export type ModeChangeReason =
+	| "user_shift_tab"
+	| "ferment_elevation"
+	| "ferment_restore"
+	| "plan_approval"
+	| "questionnaire_promote"
+	| "command"
+	| "session_start"
+	| "controller"
+
+export interface PermissionModeChangedPayload {
+	from: PermissionModeState
+	to: PermissionModeState
+	reason: ModeChangeReason
+}
+
+// ---------------------------------------------------------------------------
+// Before / after prompt
+// ---------------------------------------------------------------------------
+
+export interface PermissionBeforePromptPayload {
+	toolCallId: string
+	toolName: string
+	mode?: PermissionMode
+	compound: boolean
+	riskScore?: RiskScore
+	classifierReason?: string
+}
+
+export type PermissionDecision =
+	| "allow_once"
+	| "allow_remember"
+	| "allow_remember_wildcard"
+	| "deny"
+	| "deny_with_feedback"
+	| "aborted"
+	| "pick_per_subcommand"
+
+export interface PermissionAfterDecisionPayload {
+	toolCallId: string
+	toolName: string
+	decision: PermissionDecision
+	ruleAdded?: {
+		toolName: string
+		behavior: "allow" | "deny"
+		source: RuleSource
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config loaded
+// ---------------------------------------------------------------------------
+
+export interface PermissionConfigLoadedPayload {
+	cwd: string
+	ruleCount: number
+	errors: string[]
+}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -3916,6 +3916,7 @@ describe("ACP mode controller integration with permissions extension", () => {
 				},
 			}),
 			setActiveToolIdsByServer: () => {},
+			events: { emit: () => {} },
 		} as unknown as import("@earendil-works/pi-coding-agent").ExtensionAPI
 
 		permissionsExtension(pi)


### PR DESCRIPTION
## Summary

Adds typed EventBus channels for the permissions extension, following the established kimchi-dev pattern (ferment/domain-events.ts, bash-tool-guard-events.ts, loop-guard-events.ts). This lets external extensions (loaded via -e, packages, or install) observe permission lifecycle events without importing permissions internals.

## New channels (src/extensions/permissions/permissions-events.ts)

| Channel | When |
|---|---|
| permissions:mode_changed | Mode transitions (shift+tab, ferment elevation, plan approval, etc.) |
| permissions:before_prompt | Before showing an approval dialog |
| permissions:after_decision | After user decides (allow-once, allow-Remember, deny, aborted) |
| permissions:config_loaded | After permission config is loaded/reloaded |

## Changes

- permissions-events.ts (new): Channel constants + typed payload interfaces. Privacy: structured fields only — no raw command text, file paths, or user feedback.
- index.ts: changeMode() now takes a required reason param and emits MODE_CHANGED (all 10 call sites updated). handleConfirm() and handleCompoundConfirm() emit BEFORE_PROMPT and AFTER_DECISION (both TUI and non-TUI/ACP paths). doLoadConfig() emits CONFIG_LOADED.
- Existing notification channel emits are preserved for backward compat with hook-adapters.

## Type of change

- [x] New feature

## Checklist

- [x] Code follows the repo conventions (co-located *-events.ts, typed payloads, privacy-conscious fields)
- [x] Typecheck passes (pnpm run typecheck)
- [x] Lint passes (pnpm run lint)
- [x] Tests pass (pnpm run test — 8290 passed, 1 pre-existing unrelated failure in server.test.ts ACP image capability detection)