### PR TITLE
fix(nudge): reset continuation and empty-turn nudge state on model switch

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -258,6 +258,35 @@ describe("ContinuationNudge session-level tool tracking", () => {
 		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
 	})
 
+	it("resetForModelSwitch clears the session-level tool latch", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		guard.resetForNewUserInput()
+		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
+
+		guard.resetForModelSwitch()
+
+		expect(guard.hasToolBeenCalledThisSession()).toBe(false)
+		expect(guard.hasToolBeenCalledThisCycle()).toBe(false)
+		expect(guard.hasToolBeenCalledThisRun()).toBe(false)
+		// A text-only turn after the model switch is treated like a fresh
+		// session and is not nudged.
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("resetForModelSwitch clears pending nudge response state", () => {
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+
+		guard.resetForModelSwitch()
+
+		expect(guard.isNudgeResponsePending()).toBe(false)
+		expect(guard.isDoneSignalReceived()).toBe(false)
+	})
+
 	it("does not consume a nudge slot while no tools have been called this session", () => {
 		// Fresh session, no tools yet — repeated text-only turns must not burn
 		// the per-cycle budget, so when a tool is eventually called the full
@@ -393,6 +422,17 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 		// Simulate an unrelated user input arriving while an Agent is running.
 		guard.resetForNewUserInput()
 		// The nudge must still be suppressed — we are still waiting for the result.
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("resetForModelSwitch does NOT clear pending delegation count", () => {
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		guard.markDelegationCall()
+		// User switches models while an Agent result is still in flight.
+		guard.resetForModelSwitch()
+		// Delegated agents are independent of the orchestrator model, so the
+		// pending count must survive the switch to keep the nudge suppressed.
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
 
@@ -545,6 +585,18 @@ describe("EmptyTurnNudge", () => {
 		// Reset re-arms the nudge for the next user-input cycle
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+	})
+
+	it("re-arms after resetForModelSwitch", () => {
+		const guard = new EmptyTurnNudge()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		// A new model gets a fresh empty-turn budget even within the same cycle.
+		guard.resetForModelSwitch()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
 	})
 
 	it("does not nudge when the user aborted the turn (stopReason: aborted)", () => {

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -109,6 +109,27 @@ export class ContinuationNudge {
 		// would incorrectly allow the nudge to fire while Agents are still in flight.
 	}
 
+	/**
+	 * Reset the session-level tool latch when the active model changes.
+	 *
+	 * A new model has not yet demonstrated tool-calling behaviour in this
+	 * session, so the fresh-session suppression should apply until it makes
+	 * its first tool call. Without this reset, a model that legitimately
+	 * opens with an orientation/clarification text turn (e.g. kimi-k2.7 in
+	 * single-model mode) is immediately nudged because the previous model
+	 * already called tools.
+	 */
+	resetForModelSwitch(): void {
+		this.toolsCalledThisSession = false
+		this.toolsCalledSinceLastUserInput = false
+		this.toolsCalledThisAgentRun = false
+		this.nudgeCountThisCycle = 0
+		this.nudgeResponsePending = false
+		this.accumulatedResponseText = ""
+		// pendingDelegationCount is intentionally NOT reset here — delegated
+		// agents are independent of which orchestrator model is active.
+	}
+
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
 		this.toolsCalledThisAgentRun = true
@@ -230,6 +251,17 @@ export class EmptyTurnNudge {
 	}
 
 	resetForNewUserInput(): void {
+		this.nudgeCountThisCycle = 0
+	}
+
+	/**
+	 * Reset the per-cycle empty-turn budget when the active model changes.
+	 *
+	 * A new model has its own empty-turn behaviour, so it should get the
+	 * full per-cycle budget rather than inheriting any budget consumed by
+	 * the previous model.
+	 */
+	resetForModelSwitch(): void {
 		this.nudgeCountThisCycle = 0
 	}
 }

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1019,4 +1019,83 @@ describe("continuation nudge turn_end handler", () => {
 		expect(sendMessageCalls.length).toBe(1)
 		expect((sendMessageCalls[0].message as { content?: string }).content).toContain("If you have finished")
 	})
+
+	it("does not nudge after a model switch when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// User switches models (e.g. via the UI model picker).
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "set",
+		})
+
+		// New user input after the switch.
+		await fire("input", { source: "user" })
+
+		// New model responds with orientation text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// No nudge should fire — the model switch reset the session-level
+		// tool latch, so the new model's orientation turn is treated like a
+		// fresh session.
+		expect(sendMessageCalls.length).toBe(0)
+	})
+
+	it("does not nudge after a model cycle when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// User cycles models (e.g. via the keyboard shortcut).
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "cycle",
+		})
+
+		// New user input after the cycle.
+		await fire("input", { source: "user" })
+
+		// New model responds with orientation text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// Cycling is a user-initiated switch and must also reset the latch.
+		expect(sendMessageCalls.length).toBe(0)
+	})
+
+	it("still nudges after a model restore when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// Session restore is not a user-initiated switch; the conversation
+		// continues and the session-level tool latch must stay true.
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "restore",
+		})
+
+		// New user input after restore.
+		await fire("input", { source: "user" })
+
+		// Model responds with text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// Nudge should fire because restore must not reset the latch.
+		expect(sendMessageCalls.length).toBe(1)
+		expect((sendMessageCalls[0].message as { customType?: string }).customType).toBe("nudge")
+	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -290,8 +290,23 @@ export default function (skillPaths: string[]) {
 				}
 			})
 
-			pi.on("model_select", async (_event, ctx) => {
+			pi.on("model_select", async (event, ctx) => {
 				notifyIfDeprecated(ctx)
+
+				// A user-initiated model switch (UI picker, /model, or cycling)
+				// is a fresh start for tool-calling behaviour from the new model's
+				// perspective. Reset the session-level latch so the first text-only
+				// turn after the switch is treated like the first turn of a new
+				// session (nudge suppressed until the new model calls a tool).
+				// Session restore is deliberately excluded: a restored session is
+				// continuing an existing conversation, not starting fresh.
+				if (event.source === "set" || event.source === "cycle") {
+					const sessionId = ctx.sessionManager.getSessionId()
+					const continuationNudge = getContinuationNudge(sessionId)
+					const emptyTurnNudge = getEmptyTurnNudge(sessionId)
+					continuationNudge.resetForModelSwitch()
+					emptyTurnNudge.resetForModelSwitch()
+				}
 			})
 
 			// Detect the inverse of the context-event nudge below: the orchestrator reasons


### PR DESCRIPTION
## Problem

`ContinuationNudge`'s session-level latch (`toolsCalledThisSession`) is session-scoped, but tool-calling behavior is model-scoped. After the user switches models mid-session, the new model hasn't called any tools yet — but inherits the previous model's latch. Its legitimate opening orientation turn (text-only, e.g. kimi-k2.7 in single-model mode) is then misclassified as text-only drift and the continuation nudge fires.

Because the transcript is full of the previous model's completed tool work, the nudge's `<done>` escape hatch looks plausible to the new model; it answers with `<done>` or a text turn ending in `stop`. The nudge-response text is swallowed by `message_update`, and the stop-respect guard in `turn_end` sends no further nudge — so the agent loop silently exits right after the model announced its plan. The user has to re-prompt to get it going.

## Fix

On user-initiated model switches (`model_select` sources `"set"` and `"cycle"`), reset the nudge state:

- `ContinuationNudge.resetForModelSwitch()` clears the session/cycle/run tool latches, the per-cycle nudge budget, and pending nudge-response state. `pendingDelegationCount` is deliberately preserved — delegated agents are independent of which orchestrator model is active, and the nudge must stay suppressed while Agent results are in flight.
- `EmptyTurnNudge.resetForModelSwitch()` gives the new model a fresh per-cycle empty-turn budget.

Session restore (source `"restore"`) is deliberately excluded: a restored session continues an existing conversation, so the latch must survive.

## Tests

- `resetForModelSwitch` clears session latch and pending nudge-response state
- `resetForModelSwitch` does NOT clear `pendingDelegationCount`
- `EmptyTurnNudge.resetForModelSwitch` re-arms the budget
- Integration: `"set"` and `"cycle"` switches suppress the nudge after prior tool calls; `"restore"` still nudges