### PR TITLE
fix: stop working animation when prompted

### DIFF
--- a/src/extensions/ferment/prompt-ui.test.ts
+++ b/src/extensions/ferment/prompt-ui.test.ts
@@ -9,14 +9,30 @@ const tipWidgetLocationMock = vi.hoisted(() => ({
 	set: vi.fn(),
 }))
 
+const workingAnimationMock = vi.hoisted(() => ({
+	pauseWorkingAnimation: vi.fn(),
+	resumeWorkingAnimation: vi.fn(),
+}))
+
 vi.mock("../tips/index.js", () => ({
 	setTipWidgetLocation: tipWidgetLocationMock.set,
 }))
+
+vi.mock("../ui.js", async () => {
+	const actual = await vi.importActual<typeof import("../ui.js")>("../ui.js")
+	return {
+		...actual,
+		pauseWorkingAnimation: workingAnimationMock.pauseWorkingAnimation,
+		resumeWorkingAnimation: workingAnimationMock.resumeWorkingAnimation,
+	}
+})
 
 beforeEach(() => {
 	tipWidgetLocationMock.restore.mockReset()
 	tipWidgetLocationMock.set.mockReset()
 	tipWidgetLocationMock.set.mockReturnValue(tipWidgetLocationMock.restore)
+	workingAnimationMock.pauseWorkingAnimation.mockReset()
+	workingAnimationMock.resumeWorkingAnimation.mockReset()
 })
 
 describe("ferment prompt UI", () => {
@@ -64,6 +80,8 @@ describe("ferment prompt UI", () => {
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
 		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.pauseWorkingAnimation).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.resumeWorkingAnimation).toHaveBeenCalledTimes(1)
 	})
 
 	it("passes existing content as editor prefill for edit prompts", async () => {
@@ -82,6 +100,8 @@ describe("ferment prompt UI", () => {
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
 		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.pauseWorkingAnimation).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.resumeWorkingAnimation).toHaveBeenCalledTimes(1)
 	})
 
 	it("hides tips while a selection prompt replaces the editor", async () => {
@@ -99,6 +119,8 @@ describe("ferment prompt UI", () => {
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
 		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
 		expect(tipWidgetLocationMock.restore).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.pauseWorkingAnimation).toHaveBeenCalledTimes(1)
+		expect(workingAnimationMock.resumeWorkingAnimation).toHaveBeenCalledTimes(1)
 	})
 })
 

--- a/src/extensions/ferment/prompt-ui.ts
+++ b/src/extensions/ferment/prompt-ui.ts
@@ -3,6 +3,7 @@ import type { Component, TUI } from "@earendil-works/pi-tui"
 import type { ScopingQuestionType } from "../../ferment/types.js"
 import { type Answer, createQuestionForm, type Question, type QuestionType } from "../questionnaire/index.js"
 import { setTipWidgetLocation } from "../tips/index.js"
+import { pauseWorkingAnimation, resumeWorkingAnimation } from "../ui.js"
 
 type PromptUi = Pick<ExtensionUIContext, "select" | "input" | "editor" | "custom" | "setWorkingVisible">
 
@@ -51,6 +52,7 @@ export interface PromptFormResult {
 
 export async function withWorkingHidden<T>(ui: PromptUi, fn: () => Promise<T>): Promise<T> {
 	const restoreTips = setTipWidgetLocation("hidden")
+	pauseWorkingAnimation()
 	try {
 		ui.setWorkingVisible?.(false)
 		return await fn()
@@ -58,6 +60,7 @@ export async function withWorkingHidden<T>(ui: PromptUi, fn: () => Promise<T>): 
 		try {
 			ui.setWorkingVisible?.(true)
 		} finally {
+			resumeWorkingAnimation()
 			restoreTips()
 		}
 	}

--- a/src/extensions/spinner.test.ts
+++ b/src/extensions/spinner.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createWorkingAnimator, resetWorkingAnimatorForTest } from "./spinner.js"
+
+const DOT_CYCLE_MS = 500
+const DOT_STATES = ["", ".", "..", "..."] as const
+const MESSAGE_CYCLE_MS = 6000
+
+describe("createWorkingAnimator", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		resetWorkingAnimatorForTest()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("fires an initial update from the setTimeout(0) hand-off", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		expect(onUpdate).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(0)
+		expect(onUpdate).toHaveBeenCalledTimes(1)
+		const [char, message] = onUpdate.mock.calls[0]
+		expect(typeof char).toBe("string")
+		expect(char.length).toBeGreaterThan(0)
+		expect(message).toMatch(/(Stirring|Marinating|Chopping|Cooking)/)
+		anim.stop()
+	})
+
+	it("updates the spin frame on the configured interval", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0) // initial render
+		onUpdate.mockClear()
+
+		// After the initial render, the spin interval for "Stirring" (frameIdx 0)
+		// is 140ms. Advancing one tick should advance spinIdx.
+		vi.advanceTimersByTime(140)
+		expect(onUpdate).toHaveBeenCalledTimes(1)
+		anim.stop()
+	})
+
+	it("cycles the dot suffix on DOT_CYCLE_MS", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0) // initial render at dotIdx 0
+		const initialMessage = onUpdate.mock.calls[0][1]
+		onUpdate.mockClear()
+
+		// Advance one dot cycle. dotIdx advances from 0 -> 1, so the latest
+		// message suffix changes from "" to ".". Spin ticks also fire in the
+		// same window, so we assert on the last emitted message.
+		vi.advanceTimersByTime(DOT_CYCLE_MS)
+		expect(onUpdate).toHaveBeenCalled()
+		expect(onUpdate.mock.calls.at(-1)?.[1]).not.toBe(initialMessage)
+		anim.stop()
+	})
+
+	it("cycles to a different message after MESSAGE_CYCLE_MS", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0) // initial render
+		const initialMessage = onUpdate.mock.calls[0][1]
+		onUpdate.mockClear()
+
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS)
+		// msgId fires: render() + restartSpin() — at minimum 1 onUpdate call.
+		expect(onUpdate).toHaveBeenCalled()
+		const newMessage = onUpdate.mock.calls.at(-1)?.[1]
+		expect(newMessage).not.toBe(initialMessage)
+		anim.stop()
+	})
+
+	it("pause() stops further updates but preserves state", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0) // initial render
+		const pausedMessage = onUpdate.mock.calls[0][1]
+		onUpdate.mockClear()
+
+		anim.pause()
+
+		// Advance through several cycle intervals — no callbacks should fire.
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS * 2)
+		expect(onUpdate).not.toHaveBeenCalled()
+
+		// The pre-pause message must not change just because we paused.
+		// (We can only verify it by recording it before pause.)
+		expect(pausedMessage).toBeTruthy()
+	})
+
+	it("resume() continues from the preserved state without resetting", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0) // initial render
+		const messageAtPause = onUpdate.mock.calls[0][1]
+		onUpdate.mockClear()
+
+		anim.pause()
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS * 2)
+		expect(onUpdate).not.toHaveBeenCalled()
+
+		anim.resume()
+
+		// First fire after resume is the setTimeout(0) hand-off — emits the
+		// same message+spinIdx+dotIdx that was preserved across pause.
+		vi.advanceTimersByTime(0)
+		expect(onUpdate).toHaveBeenCalledTimes(1)
+		expect(onUpdate.mock.calls[0][1]).toBe(messageAtPause)
+
+		anim.stop()
+	})
+
+	it("stop() clears all timers — no updates fire afterward", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		onUpdate.mockClear()
+
+		anim.stop()
+
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS * 3)
+		expect(onUpdate).not.toHaveBeenCalled()
+	})
+
+	it("does not duplicate timers across multiple pause/resume cycles", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		onUpdate.mockClear()
+
+		for (let i = 0; i < 5; i++) {
+			anim.pause()
+			anim.resume()
+		}
+
+		// After 5 pause/resume cycles, the next tick should produce exactly
+		// one update — the initial setTimeout(0) hand-off — not several.
+		vi.advanceTimersByTime(0)
+		const callsAfterFirstTick = onUpdate.mock.calls.length
+		expect(callsAfterFirstTick).toBe(1)
+
+		// Advancing by DOT_CYCLE_MS should not produce a burst of updates:
+		// the dot timer fires once and the spin timer fires a few times, but
+		// the total is bounded by the real timers (no duplicates).
+		onUpdate.mockClear()
+		vi.advanceTimersByTime(DOT_CYCLE_MS)
+		expect(onUpdate.mock.calls.length).toBeGreaterThanOrEqual(1)
+		expect(onUpdate.mock.calls.length).toBeLessThanOrEqual(5)
+
+		// Exactly one spin tick per spin interval (frame 0 = 140ms).
+		onUpdate.mockClear()
+		vi.advanceTimersByTime(140)
+		expect(onUpdate.mock.calls.length).toBe(1)
+
+		anim.stop()
+	})
+
+	it("resume() is a no-op when already running", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		onUpdate.mockClear()
+
+		anim.resume() // already running — must not schedule duplicate timers
+
+		// No new timer was scheduled, so advancing by 0 should not fire anything.
+		vi.advanceTimersByTime(0)
+		expect(onUpdate).not.toHaveBeenCalled()
+
+		// The original spin timer is still intact and fires on its interval.
+		vi.advanceTimersByTime(140)
+		expect(onUpdate).toHaveBeenCalledTimes(1)
+
+		anim.stop()
+	})
+
+	it("pause() is a no-op when already paused", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		onUpdate.mockClear()
+
+		anim.pause()
+		anim.pause() // already paused — must not throw or schedule
+
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS)
+		expect(onUpdate).not.toHaveBeenCalled()
+
+		anim.resume()
+		anim.stop()
+	})
+
+	it("emits a message whose dot suffix matches the DOT_STATES cycle", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		const initialMessage = onUpdate.mock.calls[0][1]
+
+		// Extract the base message (everything before any trailing dots) and the
+		// initial suffix. The base stays the same while dotIdx cycles.
+		const baseMessage = initialMessage.replace(/\.*$/, "")
+		const initialSuffix = initialMessage.slice(baseMessage.length)
+
+		// Advance dotIdx through every DOT_CYCLE_MS step and collect suffixes.
+		const seenSuffixes = new Set<string>()
+		seenSuffixes.add(initialSuffix)
+		for (let i = 1; i < DOT_STATES.length; i++) {
+			vi.advanceTimersByTime(DOT_CYCLE_MS)
+			const m = onUpdate.mock.calls.at(-1)?.[1]
+			if (typeof m === "string") {
+				seenSuffixes.add(m.slice(baseMessage.length))
+			}
+		}
+		expect(seenSuffixes).toEqual(new Set(DOT_STATES))
+		anim.stop()
+	})
+
+	it("stop() after resume() cleans up the newly scheduled timers", () => {
+		const onUpdate = vi.fn()
+		const anim = createWorkingAnimator(onUpdate)
+		vi.advanceTimersByTime(0)
+		anim.pause()
+		anim.resume()
+		vi.advanceTimersByTime(0)
+		onUpdate.mockClear()
+
+		anim.stop()
+		vi.advanceTimersByTime(MESSAGE_CYCLE_MS * 2)
+		expect(onUpdate).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/spinner.ts
+++ b/src/extensions/spinner.ts
@@ -67,11 +67,29 @@ const MESSAGE_CYCLE_MS = 6000
 
 let _resumeFrameIdx = 0
 
-export function createWorkingAnimator(onUpdate: (char: string, message: string) => void): () => void {
+/**
+ * Reset the module-level frame index so tests start from the first animation
+ * frame deterministically. Production code should not call this.
+ */
+export function resetWorkingAnimatorForTest(): void {
+	_resumeFrameIdx = 0
+}
+
+export interface WorkingAnimator {
+	stop(): void
+	pause(): void
+	resume(): void
+}
+
+export function createWorkingAnimator(onUpdate: (char: string, message: string) => void): WorkingAnimator {
 	let frameIdx = _resumeFrameIdx
 	let spinIdx = 0
 	let dotIdx = 0
+	let running = false
 	let spinId: ReturnType<typeof setInterval> | undefined
+	let initId: ReturnType<typeof setTimeout> | undefined
+	let dotId: ReturnType<typeof setInterval> | undefined
+	let msgId: ReturnType<typeof setInterval> | undefined
 
 	function render() {
 		const f = COOKING_FRAMES[frameIdx]
@@ -88,30 +106,64 @@ export function createWorkingAnimator(onUpdate: (char: string, message: string) 
 		}, interval)
 	}
 
-	const initId = setTimeout(() => {
-		render()
-		restartSpin()
-	}, 0)
+	function scheduleTimers() {
+		initId = setTimeout(() => {
+			render()
+			restartSpin()
+		}, 0)
 
-	const dotId = setInterval(() => {
-		dotIdx = (dotIdx + 1) % DOT_STATES.length
-		render()
-	}, DOT_CYCLE_MS)
+		dotId = setInterval(() => {
+			dotIdx = (dotIdx + 1) % DOT_STATES.length
+			render()
+		}, DOT_CYCLE_MS)
 
-	const msgId = setInterval(() => {
-		frameIdx = (frameIdx + 1) % COOKING_FRAMES.length
-		spinIdx = 0
-		dotIdx = 0
-		_resumeFrameIdx = frameIdx
-		render()
-		restartSpin()
-	}, MESSAGE_CYCLE_MS)
+		msgId = setInterval(() => {
+			frameIdx = (frameIdx + 1) % COOKING_FRAMES.length
+			spinIdx = 0
+			dotIdx = 0
+			_resumeFrameIdx = frameIdx
+			render()
+			restartSpin()
+		}, MESSAGE_CYCLE_MS)
+	}
 
-	return () => {
-		clearTimeout(initId)
-		if (spinId) clearInterval(spinId)
-		clearInterval(dotId)
-		clearInterval(msgId)
-		_resumeFrameIdx = (frameIdx + 1) % COOKING_FRAMES.length
+	function clearAllTimers() {
+		if (initId !== undefined) {
+			clearTimeout(initId)
+			initId = undefined
+		}
+		if (spinId !== undefined) {
+			clearInterval(spinId)
+			spinId = undefined
+		}
+		if (dotId !== undefined) {
+			clearInterval(dotId)
+			dotId = undefined
+		}
+		if (msgId !== undefined) {
+			clearInterval(msgId)
+			msgId = undefined
+		}
+	}
+
+	scheduleTimers()
+	running = true
+
+	return {
+		stop() {
+			clearAllTimers()
+			_resumeFrameIdx = (frameIdx + 1) % COOKING_FRAMES.length
+			running = false
+		},
+		pause() {
+			if (!running) return
+			clearAllTimers()
+			running = false
+		},
+		resume() {
+			if (running) return
+			scheduleTimers()
+			running = true
+		},
 	}
 }

--- a/src/extensions/ui.test.ts
+++ b/src/extensions/ui.test.ts
@@ -1,7 +1,7 @@
 import { Key, matchesKey } from "@earendil-works/pi-tui"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { isBareExitAlias } from "./exit-utils.js"
-import { ctrlCCascadeDecision, findNextCompatibleModel } from "./ui.js"
+import { __setWorkingAnimatorForTest, ctrlCCascadeDecision, findNextCompatibleModel, withWorkingHidden } from "./ui.js"
 
 // Helper to create a minimal Model mock
 function makeModel(id: string, contextWindow: number, input: string[] = ["text", "image"]) {
@@ -206,5 +206,148 @@ describe("findNextCompatibleModel", () => {
 		const result = findNextCompatibleModel(models, 0, 50_000, false)
 		expect(result.model).toBeUndefined()
 		expect(result.skipped).toHaveLength(1)
+	})
+})
+
+describe("withWorkingHidden — cooking animator pause/resume", () => {
+	afterEach(() => {
+		// Reset module-level controller so tests don't leak state into each other.
+		__setWorkingAnimatorForTest(undefined)
+	})
+
+	function fakeCtx() {
+		return {
+			ui: {
+				setWorkingVisible: vi.fn(),
+			},
+		}
+	}
+
+	it("pauses the working animator before the prompt and resumes after", async () => {
+		const order: string[] = []
+		const ctx = fakeCtx()
+		ctx.ui.setWorkingVisible = vi.fn((v: boolean) => order.push(`setWorkingVisible:${v}`))
+		const controller = {
+			pause: vi.fn(() => order.push("pause")),
+			resume: vi.fn(() => order.push("resume")),
+			stop: vi.fn(() => order.push("stop")),
+		}
+		__setWorkingAnimatorForTest(controller)
+
+		const result = await withWorkingHidden(ctx, async () => {
+			order.push("prompt")
+			return "ok"
+		})
+
+		expect(result).toBe("ok")
+		expect(controller.pause).toHaveBeenCalledTimes(1)
+		expect(controller.resume).toHaveBeenCalledTimes(1)
+		expect(controller.stop).not.toHaveBeenCalled()
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+		// Order: pause → setWorkingVisible(false) → prompt → setWorkingVisible(true) → resume
+		expect(order).toEqual(["pause", "setWorkingVisible:false", "prompt", "setWorkingVisible:true", "resume"])
+	})
+
+	it("resumes the animator even when the prompt throws", async () => {
+		const order: string[] = []
+		const ctx = fakeCtx()
+		ctx.ui.setWorkingVisible = vi.fn((v: boolean) => order.push(`setWorkingVisible:${v}`))
+		const controller = {
+			pause: vi.fn(() => order.push("pause")),
+			resume: vi.fn(() => order.push("resume")),
+			stop: vi.fn(),
+		}
+		__setWorkingAnimatorForTest(controller)
+
+		await expect(
+			withWorkingHidden(ctx, async () => {
+				order.push("prompt")
+				throw new Error("prompt failed")
+			}),
+		).rejects.toThrow("prompt failed")
+
+		expect(controller.pause).toHaveBeenCalledTimes(1)
+		expect(controller.resume).toHaveBeenCalledTimes(1)
+		// setWorkingVisible(false) is still called before the prompt,
+		// setWorkingVisible(true) is restored in finally.
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+		expect(order).toEqual(["pause", "setWorkingVisible:false", "prompt", "setWorkingVisible:true", "resume"])
+	})
+
+	it("resumes the animator even when the prompt resolves to undefined", async () => {
+		const ctx = fakeCtx()
+		const controller = {
+			pause: vi.fn(),
+			resume: vi.fn(),
+			stop: vi.fn(),
+		}
+		__setWorkingAnimatorForTest(controller)
+
+		const result = await withWorkingHidden(ctx, async () => undefined)
+		expect(result).toBeUndefined()
+		expect(controller.pause).toHaveBeenCalledTimes(1)
+		expect(controller.resume).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not throw when no controller is registered", async () => {
+		__setWorkingAnimatorForTest(undefined)
+		const ctx = fakeCtx()
+		// No animator registered — pause/resume are no-ops, should not throw.
+		await expect(withWorkingHidden(ctx, async () => "ok")).resolves.toBe("ok")
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(1, false)
+		expect(ctx.ui.setWorkingVisible).toHaveBeenNthCalledWith(2, true)
+	})
+
+	it("works when ctx.ui.setWorkingVisible is absent", async () => {
+		const controller = {
+			pause: vi.fn(),
+			resume: vi.fn(),
+			stop: vi.fn(),
+		}
+		__setWorkingAnimatorForTest(controller)
+		// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
+		const ctx = { ui: undefined as any }
+		await expect(withWorkingHidden(ctx, async () => 42)).resolves.toBe(42)
+		expect(controller.pause).toHaveBeenCalledTimes(1)
+		expect(controller.resume).toHaveBeenCalledTimes(1)
+	})
+
+	it("only resumes the animator after the outermost nested prompt finishes", async () => {
+		const order: string[] = []
+		const ctx = fakeCtx()
+		ctx.ui.setWorkingVisible = vi.fn((v: boolean) => order.push(`setWorkingVisible:${v}`))
+		const controller = {
+			pause: vi.fn(() => order.push("pause")),
+			resume: vi.fn(() => order.push("resume")),
+			stop: vi.fn(),
+		}
+		__setWorkingAnimatorForTest(controller)
+
+		const result = await withWorkingHidden(ctx, async () => {
+			order.push("outer-prompt")
+			return await withWorkingHidden(ctx, async () => {
+				order.push("inner-prompt")
+				return "nested"
+			})
+		})
+
+		expect(result).toBe("nested")
+		// Only the outermost pause/resume should touch the animator; the inner
+		// pair is a depth-based no-op so the animator stays paused until the
+		// outer prompt finishes.
+		expect(controller.pause).toHaveBeenCalledTimes(1)
+		expect(controller.resume).toHaveBeenCalledTimes(1)
+		expect(order).toEqual([
+			"pause",
+			"setWorkingVisible:false",
+			"outer-prompt",
+			"setWorkingVisible:false",
+			"inner-prompt",
+			"setWorkingVisible:true",
+			"setWorkingVisible:true",
+			"resume",
+		])
 	})
 })

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -28,7 +28,7 @@ import {
 	registerSharedStatusLineRenderer,
 	setSessionModeOnboardingStatusLineSuppressed,
 } from "./shared-status-line.js"
-import { createWorkingAnimator } from "./spinner.js"
+import { createWorkingAnimator, type WorkingAnimator } from "./spinner.js"
 import { createBranchPoller } from "./ui-branch-poll.js"
 
 export { requestSharedStatusLineRender, setSessionModeOnboardingStatusLineSuppressed } from "./shared-status-line.js"
@@ -119,6 +119,36 @@ let currentIdeSelectionIndicatorText: string | null = null
 // the abort stage consumes the event, so we can't rely on it.
 let lastCtrlCTime = 0
 const CTRL_C_EXIT_WINDOW_MS = 500
+
+// Working animation controller — replaced every turn_start. Module-level so
+// helpers outside `uiExtension` (e.g. `withWorkingHidden`) can pause/resume it
+// without owning it.
+let workingAnimator: WorkingAnimator | undefined
+let workingAnimationPauseDepth = 0
+
+export function pauseWorkingAnimation(): void {
+	if (workingAnimationPauseDepth === 0) {
+		workingAnimator?.pause()
+	}
+	workingAnimationPauseDepth++
+}
+
+export function resumeWorkingAnimation(): void {
+	if (workingAnimationPauseDepth === 0) return
+	workingAnimationPauseDepth--
+	if (workingAnimationPauseDepth === 0) {
+		workingAnimator?.resume()
+	}
+}
+
+/**
+ * @internal — test-only override for the working animation controller.
+ * Production callers must not touch this; `startIndicator` /
+ * `stopIndicator` own the controller lifecycle.
+ */
+export function __setWorkingAnimatorForTest(controller: WorkingAnimator | undefined): void {
+	workingAnimator = controller
+}
 
 /** Cascade: text → clear, streaming → abort, otherwise → exit. */
 export type CtrlCAction = "clear" | "abort" | "exit"
@@ -249,18 +279,23 @@ function runScript(
  * permission prompts, ferment step recovery). Command handlers run when the
  * agent is idle and don't need this.
  *
- * Uses try/finally so the indicator is restored even if the prompt throws
- * or the user cancels.
+ * Pauses the cooking animator's timers so `setWorkingIndicator` /
+ * `setWorkingMessage` stop firing while the prompt has focus — otherwise
+ * upstream would call `requestRender()` every 40–200 ms, producing visible
+ * full-screen redraws behind a static prompt. Uses try/finally so the
+ * animator is restored even if the prompt throws or the user cancels.
  */
 export async function withWorkingHidden<T>(
 	ctx: Pick<ExtensionContext, "ui"> | { ui?: { setWorkingVisible?: (visible: boolean) => void } },
 	fn: () => Promise<T>,
 ): Promise<T> {
+	pauseWorkingAnimation()
 	ctx.ui?.setWorkingVisible?.(false)
 	try {
 		return await fn()
 	} finally {
 		ctx.ui?.setWorkingVisible?.(true)
+		resumeWorkingAnimation()
 	}
 }
 
@@ -302,8 +337,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 		const sessionId = ctx.sessionManager.getSessionId()
 
 		setSessionModeOnboardingStatusLineSuppressed(false)
-		stopWorkingAnimation?.()
-		stopWorkingAnimation = undefined
+		workingAnimator?.stop()
+		workingAnimator = undefined
 		resetState()
 		currentCtx = ctx
 		sessionStartMs = Date.now()
@@ -549,8 +584,8 @@ export default function uiExtension(pi: ExtensionAPI) {
 	})
 
 	pi.on("session_shutdown", () => {
-		stopWorkingAnimation?.()
-		stopWorkingAnimation = undefined
+		workingAnimator?.stop()
+		workingAnimator = undefined
 		currentCtx = null
 		branchPoller.stop()
 	})
@@ -560,8 +595,6 @@ export default function uiExtension(pi: ExtensionAPI) {
 			ctx.shutdown()
 		}
 	})
-
-	let stopWorkingAnimation: (() => void) | undefined
 
 	// ── Indicator lifecycle ──────────────────────────────────────────────────
 	//
@@ -574,8 +607,13 @@ export default function uiExtension(pi: ExtensionAPI) {
 	// one exception: while they have keyboard focus the spinner must be hidden
 	// so it doesn't show behind the form. Each tool that shows an interactive
 	// prompt during a turn wraps the call in `withWorkingHidden(ctx, fn)`
-	// (exported below) — it calls setWorkingVisible(false), runs the prompt, then
-	// restores setWorkingVisible(true) in a finally block. Currently:
+	// (exported below) — it pauses the cooking animator AND calls
+	// setWorkingVisible(false), runs the prompt, then resumes the animator and
+	// restores setWorkingVisible(true) in a finally block. Pausing the animator
+	// (not just hiding the indicator) is required: the animator's onUpdate
+	// callback unconditionally calls setWorkingIndicator/setWorkingMessage, and
+	// upstream turns those into requestRender() — a hidden indicator that keeps
+	// firing still redraws the screen behind a static prompt. Currently:
 	//   - questionnaire       (questionnaire.ts)
 	//   - ask_user / confirm  (ferment/prompt-ui.ts)
 	//   - permission prompts   (permissions/prompts.ts)
@@ -586,8 +624,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 
 	const startIndicator = (ctx: ExtensionContext) => {
 		ctx.ui.setWorkingVisible(true)
-		stopWorkingAnimation?.()
-		stopWorkingAnimation = createWorkingAnimator((char, message) => {
+		workingAnimator?.stop()
+		workingAnimationPauseDepth = 0
+		workingAnimator = createWorkingAnimator((char, message) => {
 			const accent = resolvedAccentFg(ctx.ui.theme)
 			ctx.ui.setWorkingIndicator({ frames: [`${accent}${char}${RST_FG}`] })
 			ctx.ui.setWorkingMessage(`${accent}${message}${RST_FG}`)
@@ -595,8 +634,9 @@ export default function uiExtension(pi: ExtensionAPI) {
 	}
 
 	const stopIndicator = (ctx: ExtensionContext) => {
-		stopWorkingAnimation?.()
-		stopWorkingAnimation = undefined
+		workingAnimator?.stop()
+		workingAnimator = undefined
+		workingAnimationPauseDepth = 0
 		ctx.ui.setWorkingVisible(false)
 	}
 


### PR DESCRIPTION
When an interactive prompt is show the spinner animation should stop. This indicates properly that the LLM is not working and it fixes a redraw problem that was causing the spinner to steal focus.

fixes #869

## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
