### PR TITLE
fix(billing): show BYO inference guidance when Community inference is blocked

### DIFF
--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -164,19 +164,22 @@ describe("LogoHeader", () => {
 		expect(rightSection).toContain("\x1b[36m/ferment exit\x1b[0m")
 	})
 
-	it("shows a right-column account notice instead of the secondary ferment tip", () => {
+	it("shows a long blocked-Community notice instead of the secondary ferment tip", () => {
 		const theme = createMockTheme()
 		const header = new LogoHeader(theme, {
 			getRightColumnNotice: () =>
-				"You are using Community tier. For faster performance, upgrade to Coder at app.kimchi.dev/pricing",
+				"You are using the community tier you can bring your own inference to the harness. To use Kimchi inference, upgrade to Code.",
 		})
 		const lines = header.render(120)
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
 
 		expect(rightText).toContain("Kimchi's special:")
 		expect(rightText).toContain("/ferment")
-		expect(rightText).toContain("You are using Community tier")
-		expect(rightText).toContain("app.kimchi.dev/pricing")
+		expect(rightText).toContain("You are using the community tier")
+		expect(rightText).toContain("bring your own")
+		expect(rightText).toContain("inference to the harness")
+		expect(rightText).toContain("upgrade")
+		expect(rightText).toContain("to Code.")
 		expect(rightText).not.toContain("ferment exit")
 	})
 

--- a/src/components/logo.test.ts
+++ b/src/components/logo.test.ts
@@ -168,18 +168,18 @@ describe("LogoHeader", () => {
 		const theme = createMockTheme()
 		const header = new LogoHeader(theme, {
 			getRightColumnNotice: () =>
-				"You are using the community tier you can bring your own inference to the harness. To use Kimchi inference, upgrade to Code.",
+				"You are using the Community tier. You can bring your own inference to the harness. To use Kimchi inference, upgrade to Coder.",
 		})
 		const lines = header.render(120)
 		const rightText = lines.slice(1, -1).map(stripAnsi).join(" ")
 
 		expect(rightText).toContain("Kimchi's special:")
 		expect(rightText).toContain("/ferment")
-		expect(rightText).toContain("You are using the community tier")
+		expect(rightText).toContain("You are using the Community tier")
 		expect(rightText).toContain("bring your own")
 		expect(rightText).toContain("inference to the harness")
 		expect(rightText).toContain("upgrade")
-		expect(rightText).toContain("to Code.")
+		expect(rightText).toContain("to Coder.")
 		expect(rightText).not.toContain("ferment exit")
 	})
 

--- a/src/extensions/billing/status.test.ts
+++ b/src/extensions/billing/status.test.ts
@@ -4,7 +4,7 @@ const {
 	AUTOMATIC_REFRESH_MIN_INTERVAL_MS,
 	BILLING_EXHAUSTED_MESSAGE,
 	BILLING_RATE_LIMITED_MESSAGE,
-	COMMUNITY_TIER_HEADER_NOTICE,
+	COMMUNITY_TIER_MESSAGES,
 	budgetEndpointFromLlmEndpoint,
 	configureBillingCreditsApi,
 	creditsEndpointFromLlmEndpoint,
@@ -50,12 +50,12 @@ describe("billing status", () => {
 		expect(formatBudgetLimit("0.000000")).toBe("unlimited")
 	})
 
-	it("warns and drops the upsell for a Community tier reported as blocked", () => {
+	it("shows BYO guidance instead of a credit warning when Community inference is blocked", () => {
 		observeCreditsPayload({
 			serverless: true,
-			tier: "community",
+			tier: "free-slow",
 			is_paid_tier: false,
-			billing_status: "depleted",
+			billing_status: "free_tier",
 			has_credits: false,
 			remaining: 0,
 		})
@@ -64,11 +64,12 @@ describe("billing status", () => {
 			serverless: true,
 			plan: "community",
 			isPaidTier: false,
-			creditStatus: "exhausted",
+			creditStatus: "ok",
+			restrictedMode: true,
 			remainingCredits: 0,
 		})
-		expect(getCommunityTierHeaderNotice()).toBeUndefined()
-		expect(getBillingWarnings()[0]).toEqual({ kind: "exhausted", message: BILLING_EXHAUSTED_MESSAGE })
+		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_MESSAGES.inferenceBlocked)
+		expect(getBillingWarnings()).toEqual([])
 		expect(getBillingStatusLine()).toEqual({ amount: "$0.00" })
 	})
 
@@ -143,7 +144,7 @@ describe("billing status", () => {
 			remaining: "12",
 		})
 
-		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_HEADER_NOTICE)
+		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_MESSAGES.available)
 		expect(getBillingWarnings()[0]).toBeUndefined()
 	})
 
@@ -163,7 +164,7 @@ describe("billing status", () => {
 			creditStatus: "ok",
 			remainingCredits: 2,
 		})
-		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_HEADER_NOTICE)
+		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_MESSAGES.available)
 		expect(getBillingWarnings()[0]).toBeUndefined()
 		expect(getBillingStatusLine()).toEqual({ amount: "$2.00" })
 	})
@@ -836,7 +837,7 @@ describe("billing status", () => {
 			has_credits: true,
 			remaining: "3",
 		})
-		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_HEADER_NOTICE)
+		expect(getCommunityTierHeaderNotice()).toBe(COMMUNITY_TIER_MESSAGES.available)
 
 		observeCreditsPayload({
 			serverless: true,

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -72,8 +72,11 @@ interface RefreshBillingStatusOptions {
 }
 
 export const LOW_CREDITS_THRESHOLD_USD = 5
-export const COMMUNITY_TIER_HEADER_NOTICE =
-	"You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing"
+export const COMMUNITY_TIER_MESSAGES = {
+	available: "You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing",
+	inferenceBlocked:
+		"You are using the community tier you can bring your own inference to the harness. To use Kimchi inference, upgrade to Code.",
+} as const
 export const BILLING_EXHAUSTED_MESSAGE = "You ran out of credits. Top up at https://app.kimchi.dev/billing"
 // A zero balance is reached both by a paid subscriber demoted to free-tier limits and by a free
 // user whose included credits were never spendable, who was therefore rate limited all along. The
@@ -314,10 +317,11 @@ export function getCommunityTierHeaderNotice(
 	status: BillingStatus | undefined = currentBillingStatus,
 ): string | undefined {
 	if (status?.plan !== "community") return undefined
+	if (isCommunityInferenceBlocked(status)) return COMMUNITY_TIER_MESSAGES.inferenceBlocked
 	// A depleted paid subscriber is reported as community, so this would tell them to upgrade to the
 	// plan they already pay for. The credit warning carries the actionable remedy instead.
 	if (isCreditsExhausted(status)) return undefined
-	return COMMUNITY_TIER_HEADER_NOTICE
+	return COMMUNITY_TIER_MESSAGES.available
 }
 
 export function getBillingWarnings(status: BillingStatus | undefined = currentBillingStatus): BillingWarning[] {
@@ -329,6 +333,10 @@ export function getBillingWarnings(status: BillingStatus | undefined = currentBi
 
 function getCreditBillingWarning(status: BillingStatus | undefined): BillingWarning | undefined {
 	if (!status) return undefined
+	// Community users are blocked because their plan does not include Kimchi inference,
+	// not because they ran out of credits. Show the BYO/upgrade message instead of the
+	// generic top-up warning, which would give them the wrong action.
+	if (isCommunityInferenceBlocked(status)) return undefined
 
 	// Server-declared: it named the balance spent, or has_credits=false says it is refusing
 	// requests outright. Never soften an explicit statement with an inference.
@@ -361,6 +369,25 @@ function getCreditBillingWarning(status: BillingStatus | undefined): BillingWarn
 	}
 
 	return undefined
+}
+
+/**
+ * A Community user is considered blocked only when the backend reports both of these facts:
+ *
+ * - The organization is on the Community plan.
+ * - `has_credits` is explicitly `false`, meaning Kimchi inference requests will be rejected.
+ *
+ * The backend decides which Community organizations are blocked. The harness does not receive the
+ * organization's signup date or the reason for the decision, so it must not try to recreate that
+ * policy from the plan name or credit balance.
+ *
+ * A zero balance alone is not enough: an exhausted Coder subscriber may be reported as Community
+ * while still receiving slower, rate-limited inference. Likewise, `has_credits: false` alone is not
+ * enough because it can also describe an exhausted Teams user. Checking both values prevents either
+ * user from receiving the wrong message.
+ */
+function isCommunityInferenceBlocked(status: BillingStatus): boolean {
+	return status.plan === "community" && status.restrictedMode === true
 }
 
 /**

--- a/src/extensions/billing/status.ts
+++ b/src/extensions/billing/status.ts
@@ -75,7 +75,7 @@ export const LOW_CREDITS_THRESHOLD_USD = 5
 export const COMMUNITY_TIER_MESSAGES = {
 	available: "You are using Community tier. For faster performance, upgrade to Coder at https://app.kimchi.dev/pricing",
 	inferenceBlocked:
-		"You are using the community tier you can bring your own inference to the harness. To use Kimchi inference, upgrade to Code.",
+		"You are using the Community tier. You can bring your own inference to the harness. To use Kimchi inference, upgrade to Coder.",
 } as const
 export const BILLING_EXHAUSTED_MESSAGE = "You ran out of credits. Top up at https://app.kimchi.dev/billing"
 // A zero balance is reached both by a paid subscriber demoted to free-tier limits and by a free

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
-import { INPUT_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { fullText, INPUT_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -124,7 +124,37 @@ test("shows a rate-limit warning when a depleted Coder plan reports as free tier
 	)
 })
 
-test("shows Community tier notice from the credits API in the startup header", async ({ terminal }) => {
+test("explains BYO inference when the backend blocks a Community user", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "billing-community-inference-blocked",
+			creditsResponses: [
+				{
+					serverless: true,
+					tier: "free-slow",
+					is_paid_tier: false,
+					billing_status: "free_tier",
+					has_credits: false,
+					remaining: "0",
+				},
+			],
+			responses: [],
+		},
+		async () => {
+			await waitForText(terminal, "You are using the community tier", { full: true })
+			await waitForText(terminal, "bring your own", { full: true })
+			await waitForText(terminal, "inference to the harness", { full: true })
+			await waitForText(terminal, "To use Kimchi inference", { full: true })
+			await waitForText(terminal, "upgrade", { full: true })
+			await waitForText(terminal, "to Code.", { full: true })
+			expect(fullText(terminal)).not.toContain("You ran out of credits")
+			expect(fullText(terminal)).not.toContain("Top up at")
+		},
+	)
+})
+
+test("keeps the available Community notice while the backend still serves inference", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
 		{

--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -142,12 +142,12 @@ test("explains BYO inference when the backend blocks a Community user", async ({
 			responses: [],
 		},
 		async () => {
-			await waitForText(terminal, "You are using the community tier", { full: true })
+			await waitForText(terminal, "You are using the Community tier", { full: true })
 			await waitForText(terminal, "bring your own", { full: true })
 			await waitForText(terminal, "inference to the harness", { full: true })
 			await waitForText(terminal, "To use Kimchi inference", { full: true })
 			await waitForText(terminal, "upgrade", { full: true })
-			await waitForText(terminal, "to Code.", { full: true })
+			await waitForText(terminal, "to Coder.", { full: true })
 			expect(fullText(terminal)).not.toContain("You ran out of credits")
 			expect(fullText(terminal)).not.toContain("Top up at")
 		},


### PR DESCRIPTION
When the backend blocks a Community organization from Kimchi inference, replace the generic 'out of credits' warning with guidance to bring your own inference or upgrade to Code.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
