### PR TITLE
Status line: prioritize permissions/model; unified compaction/shedding pipeline

### DIFF
--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -9,11 +9,14 @@ import * as MULTI_MODEL from "../extensions/multi-model.js"
 import * as TAGS from "../extensions/tags.js"
 import {
 	buildContextCompact,
+	buildControlsLineSegments,
 	buildModelAbbrev,
 	buildPhaseCompact,
 	buildScriptPayload,
+	renderFittedLine,
 	SHORTCUT_TAIL,
 	StatusLine,
+	StatusLineScript,
 } from "./status-line.js"
 
 // ── Mock status-line-config.ts ───────────────────────────────────────────────
@@ -86,11 +89,13 @@ function createMockStatusLineData(opts?: {
 	permissionsMode?: string
 	permissionsWarning?: string
 	updateAvailable?: string
+	lsp?: string
 }): ReadonlyFooterDataProvider {
 	const statuses = new Map<string, string>()
 	if (opts?.permissionsMode) statuses.set("permissions-mode", opts.permissionsMode)
 	if (opts?.permissionsWarning) statuses.set("permissions-warning", opts.permissionsWarning)
 	if (opts?.updateAvailable) statuses.set("update-available", opts.updateAvailable)
+	if (opts?.lsp) statuses.set("lsp", opts.lsp)
 	return {
 		getExtensionStatuses: vi.fn(() => statuses),
 	} as unknown as ReadonlyFooterDataProvider
@@ -132,6 +137,44 @@ function stubPlatform(value: NodeJS.Platform): () => void {
 	return () => Object.defineProperty(process, "platform", { value: original })
 }
 
+/** Mock an active "my-ferment" in the running state with a manual stop policy. */
+function mockActiveFerment(): void {
+	const ferment = {
+		id: "f-1",
+		name: "my-ferment",
+		status: "running",
+		mode: "yolo",
+		phases: [],
+		activePhaseId: undefined,
+	} as unknown as ReturnType<typeof FERMENT.getActiveFerment>
+	vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(ferment)
+	vi.spyOn(FERMENT, "getFermentContinuationPolicy").mockReturnValue("manual")
+}
+
+/** Standard billing fixture: $5 credits, 13.73% of a $2k budget. */
+function setTestBilling(): void {
+	setBillingStatusForTest({
+		serverless: true,
+		plan: "coder",
+		isPaidTier: true,
+		remainingCredits: 5,
+		creditStatus: "low",
+		budget: {
+			period: { startTime: "2026-07-01T00:00:00Z", endTime: "2026-08-01T00:00:00Z" },
+			budgets: [
+				{
+					scope: "USER",
+					scopeId: "owner",
+					budgetLimitUsd: "2000.000000",
+					totalSpendUsd: "274.594050",
+					providerBudgets: [],
+				},
+			],
+		},
+		updatedAt: "2026-07-07T00:00:00.000Z",
+	})
+}
+
 /** CompactionContext stub using plain markers — used to unit-test the builder
  *  functions in isolation, with predictable visible output. The builders only
  *  rely on dim/accent for ANSI wrapping, so identity functions are safe here
@@ -140,7 +183,6 @@ const compactCtx = {
 	dim: (s: string) => s,
 	accent: (s: string) => s,
 	semantic: (name: string, s: string) => `[${name}:${s}]`,
-	showCommandHint: true,
 }
 
 describe("compact-form builders", () => {
@@ -344,12 +386,19 @@ describe("StatusLine behavioural acceptance at representative widths", () => {
 		expect(visible).toContain("default")
 	})
 
-	it("width 60: shortcuts stripped from unpinned, pinned content survives at far right", () => {
+	it("width 60: shortcut hints stripped, pinned phase sheds, core trio survives compact", () => {
 		withPinned(["context", "phase"], () => {
 			const { raw, visible } = renderAt(60, { percent: 50 })
 			expect(visibleWidth(raw)).toBeLessThanOrEqual(60)
+			// Core trio survives in compact form.
+			expect(visible).toContain("● default")
+			expect(visible).toContain("m-m (claude-opus-4-6)")
+			expect(visible).toContain("50% ctx")
+			// Shortcut hints are gone and the low-priority pinned phase shed —
+			// pinned is not immune to shedding (hardcoded priority wins).
 			expect(visible).not.toContain("ctrl+p")
-			expect(visible).toContain("explore")
+			expect(visible).not.toContain("shift+tab")
+			expect(visible).not.toContain("explore")
 		})
 	})
 
@@ -558,12 +607,17 @@ describe("StatusLine segment coverage", () => {
 		withPinned(["budget"], () => {
 			const statusLine = new StatusLine(createMockContext(), theme, createMockStatusLineData())
 			const visible = renderVisible(statusLine, 200)
-			const compact = renderVisible(statusLine, 42)
+			const compact = renderVisible(statusLine, 60)
+			const shed = renderVisible(statusLine, 42)
 
 			expect(visible).not.toContain("Credits:")
 			expect(visible).toContain("Budget: 13.73% ($274.59/$2k)")
+			// Narrower: budget shrinks to the percentage-only form …
 			expect(compact).toContain("Budget: 13.73%")
 			expect(compact).not.toContain("$274.59/$2k")
+			// … and sheds entirely before the core trio is touched.
+			expect(shed).not.toContain("Budget:")
+			expect(shed).toContain("m-m (claude-opus-4-6)")
 		})
 	})
 
@@ -689,8 +743,9 @@ describe("StatusLine regression tests", () => {
 	})
 
 	it("never produces an orphan ` ·  · ` double separator at any width", () => {
-		// Compaction never removes whole segments, so we should never see two
-		// adjacent separators. Truncation cuts the tail, not the middle.
+		// Shedding removes whole segments under pressure, but survivors are
+		// re-joined, so we should never see two adjacent separators.
+		// Truncation cuts the tail, not the middle.
 		vi.spyOn(TAGS, "getActiveTags").mockReturnValue(["team:platform", "env:prod"])
 		const data = createMockStatusLineData({ permissionsMode: "● default" })
 		const sl = new StatusLine(createMockContext(), theme, data)
@@ -774,13 +829,24 @@ describe("status line pinning", () => {
 		})
 	})
 
-	it("pinned context shows full bar form (with █) at width=20", () => {
+	it("pinned context shows full bar form (with █) at wide width", () => {
 		withPinned(["context"], () => {
 			const sl = makeStatusLine({ percent: 50 })
-			const visible = stripAnsi(sl.render(20)[0])
+			const visible = stripAnsi(sl.render(200)[0])
 			// Full form includes the bar characters; compact form is just "N% ctx"
 			expect(visible).toContain("█")
 			expect(visible).toContain("░")
+		})
+	})
+
+	it("pinned context bar is the first thing sacrificed when space is tight", () => {
+		withPinned(["context"], () => {
+			const sl = makeStatusLine({ percent: 50 })
+			const visible = stripAnsi(sl.render(60)[0])
+			// The percentage survives; the bar doesn't.
+			expect(visible).toContain("50% ctx")
+			expect(visible).not.toContain("█")
+			expect(visible).not.toContain("░")
 		})
 	})
 
@@ -890,5 +956,231 @@ describe("status line pinning", () => {
 				expect(visibleWidth(raw), `width=${w}`).toBeLessThanOrEqual(w)
 			}
 		})
+	})
+})
+
+describe("status line priority shedding", () => {
+	let theme: Theme
+	let restorePlatform: () => void
+
+	const permissionsMode = "● default \x1b[2m→ shift+tab\x1b[0m"
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		pinnedElements = []
+		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+		restorePlatform = stubPlatform("darwin")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		restorePlatform()
+		pinnedElements = []
+	})
+
+	function renderVisible(width: number, ctxOpts?: MockContextOpts): string {
+		return renderVisibleWith(createMockStatusLineData({ permissionsMode }), width, ctxOpts)
+	}
+
+	function renderVisibleWith(data: ReadonlyFooterDataProvider, width: number, ctxOpts?: MockContextOpts): string {
+		const sl = new StatusLine(createMockContext(ctxOpts), theme, data)
+		const lines = sl.render(width)
+		return stripAnsi(lines[lines.length - 1])
+	}
+
+	it("sheds pinned phase before anything else as the width shrinks", () => {
+		withPinned(["context", "phase", "agents", "usage"], () => {
+			vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(2)
+			const visible = renderVisible(85, { percent: 50 })
+			expect(visible).not.toContain("explore")
+			expect(visible).toContain("2 agents")
+			expect(visible).toContain("↑0 ↓0")
+			expect(visible).toContain("50% ctx")
+		})
+	})
+
+	it("sheds usage next", () => {
+		withPinned(["context", "phase", "agents", "usage"], () => {
+			vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(2)
+			const visible = renderVisible(75, { percent: 50 })
+			expect(visible).not.toContain("explore")
+			expect(visible).not.toContain("↑0 ↓0")
+			expect(visible).toContain("2 agents")
+		})
+	})
+
+	it("sheds pinned agents before touching the core trio", () => {
+		withPinned(["context", "phase", "agents", "usage"], () => {
+			vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(2)
+			const visible = renderVisible(60, { percent: 50 })
+			// Pinned is not immune: agents/usage/phase are all gone …
+			expect(visible).not.toContain("agent")
+			expect(visible).not.toContain("↑0")
+			expect(visible).not.toContain("explore")
+			// … while permissions, model and context survive compact.
+			expect(visible).toContain("● default")
+			expect(visible).toContain("m-m (claude-opus-4-6)")
+			expect(visible).toContain("50% ctx")
+		})
+	})
+
+	it("never sheds permissions, model, or context — even when only the core trio fits", () => {
+		withPinned(["context"], () => {
+			const visible = renderVisible(45, { percent: 50 })
+			expect(visible).toContain("● default")
+			expect(visible).toContain("m-m (claude-opus-4-6)")
+			expect(visible).toContain("50% ctx")
+			expect(visibleWidth(visible)).toBeLessThanOrEqual(45)
+		})
+	})
+
+	it("renders permissions and model first, ferment follows — never the other way around", () => {
+		mockActiveFerment()
+		const visible = renderVisible(200)
+		const permIdx = visible.indexOf("● default")
+		const modelIdx = visible.indexOf("multi-model (claude-opus-4-6)")
+		const fermentIdx = visible.indexOf("Ferment: my-ferment")
+		expect(permIdx).toBeGreaterThanOrEqual(0)
+		expect(modelIdx).toBeGreaterThan(permIdx)
+		expect(fermentIdx).toBeGreaterThan(modelIdx)
+	})
+
+	it("sheds the ferment before the model when space runs out", () => {
+		mockActiveFerment()
+		const visible = renderVisible(60)
+		expect(visible).not.toContain("my-ferment")
+		expect(visible).toContain("m-m (claude-opus-4-6)")
+		expect(visible).toContain("● default")
+	})
+
+	it("sheds lsp before any core segment", () => {
+		const data = createMockStatusLineData({ permissionsMode: "● default", lsp: "LSP:typescript-language-server" })
+		const wide = renderVisibleWith(data, 100)
+		expect(wide).toContain("typescript-language-server")
+
+		const narrow = renderVisibleWith(data, 70)
+		expect(narrow).not.toContain("typescript-language-server")
+		expect(narrow).toContain("m-m (claude-opus-4-6)")
+		expect(narrow).toContain("● default")
+	})
+})
+
+describe("script controls line (statusLine.command path)", () => {
+	let theme: Theme
+	let restorePlatform: () => void
+
+	const permissionsMode = "● default \x1b[2m→ shift+tab\x1b[0m"
+
+	beforeEach(() => {
+		theme = createMockTheme()
+		pinnedElements = []
+		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
+		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+		restorePlatform = stubPlatform("darwin")
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		setBillingStatusForTest(undefined)
+		restorePlatform()
+		pinnedElements = []
+	})
+
+	function controlsLine(width: number): { raw: string; visible: string } {
+		const data = createMockStatusLineData({ permissionsMode })
+		const segments = buildControlsLineSegments(createMockContext(), theme, data)
+		const raw = renderFittedLine(segments, width, theme)
+		return { raw, visible: stripAnsi(raw) }
+	}
+
+	it("wide width: shows permissions, model, ferment, credits, budget — permissions and model lead", () => {
+		setTestBilling()
+		mockActiveFerment()
+		const { visible } = controlsLine(200)
+
+		expect(visible).toContain("● default → shift+tab")
+		expect(visible).toContain("multi-model (claude-opus-4-6)")
+		expect(visible).toContain("Ferment: my-ferment")
+		expect(visible).toContain("Credits: $5.00")
+		expect(visible).toContain("Budget: 13.73% ($274.59/$2k)")
+
+		const permIdx = visible.indexOf("● default")
+		const modelIdx = visible.indexOf("multi-model (claude-opus-4-6)")
+		const fermentIdx = visible.indexOf("Ferment: my-ferment")
+		expect(modelIdx).toBeGreaterThan(permIdx)
+		expect(fermentIdx).toBeGreaterThan(modelIdx)
+	})
+
+	it("excludes non-controls segments (agents, context) even when pinned in config", () => {
+		withPinned(["agents", "context"], () => {
+			vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(2)
+			const { visible } = controlsLine(200)
+			expect(visible).not.toContain("agent")
+			expect(visible).not.toContain("ctx")
+		})
+	})
+
+	it("narrow width: sheds budget, credits, and ferment before the model", () => {
+		setTestBilling()
+		mockActiveFerment()
+		const { raw, visible } = controlsLine(60)
+
+		expect(visibleWidth(raw)).toBeLessThanOrEqual(60)
+		expect(visible).toContain("● default")
+		expect(visible).toContain("m-m (claude-opus-4-6)")
+		expect(visible).not.toContain("my-ferment")
+		expect(visible).not.toContain("Credits")
+		expect(visible).not.toContain("Budget:")
+	})
+
+	it("budget shrinks to the percentage-only form before shedding", () => {
+		setTestBilling()
+		const { visible } = controlsLine(80)
+		expect(visible).toContain("Budget: 13.73%")
+		expect(visible).not.toContain("$274.59/$2k")
+	})
+})
+
+describe("StatusLineScript", () => {
+	it("passes the render width to the controls callback", () => {
+		let received = -1
+		const sls = new StatusLineScript((width) => {
+			received = width
+			return "controls"
+		})
+		sls.render(73)
+		expect(received).toBe(73)
+	})
+
+	it("renders script lines first, then a blank line, then the controls line", () => {
+		const sls = new StatusLineScript(() => "controls")
+		sls.setLines(["one", "two"])
+		expect(sls.render(80)).toEqual(["one", "two", "", "controls"])
+	})
+
+	it("truncates each script line to the render width", () => {
+		const sls = new StatusLineScript(() => "controls")
+		sls.setLines(["short", "x".repeat(50)])
+		const lines = sls.render(20)
+		expect(lines[0]).toBe("short")
+		// truncateToWidth cuts with an ellipsis marker; the invariant that
+		// matters is "never wider than the render width".
+		expect(visibleWidth(lines[1])).toBeLessThanOrEqual(20)
+		expect(stripAnsi(lines[1])).toMatch(/^x+/)
+	})
+
+	it("omits the blank line and controls block when the callback returns null", () => {
+		const sls = new StatusLineScript(() => null)
+		sls.setLines(["one"])
+		expect(sls.render(80)).toEqual(["one"])
 	})
 })

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -7,6 +7,7 @@ import { setBillingStatusForTest } from "../extensions/billing/status.js"
 import * as FERMENT from "../extensions/ferment/index.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
 import * as TAGS from "../extensions/tags.js"
+import type { Ferment } from "../ferment/types.js"
 import {
 	buildContextCompact,
 	buildControlsLineSegments,
@@ -137,18 +138,41 @@ function stubPlatform(value: NodeJS.Platform): () => void {
 	return () => Object.defineProperty(process, "platform", { value: original })
 }
 
-/** Mock an active "my-ferment" in the running state with a manual stop policy. */
-function mockActiveFerment(): void {
-	const ferment = {
+/** Build a typed Ferment mock without `as unknown as` casts. */
+function createFermentMock(overrides?: Partial<Ferment>): Ferment {
+	return {
 		id: "f-1",
 		name: "my-ferment",
 		status: "running",
-		mode: "yolo",
+		worktree: { path: "/test" },
+		scoping: {},
 		phases: [],
-		activePhaseId: undefined,
-	} as unknown as ReturnType<typeof FERMENT.getActiveFerment>
-	vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(ferment)
+		decisions: [],
+		memories: [],
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+/** Mock an active "my-ferment" in the running state with a manual stop policy. */
+function mockActiveFerment(): void {
+	vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(createFermentMock())
 	vi.spyOn(FERMENT, "getFermentContinuationPolicy").mockReturnValue("manual")
+}
+
+/** Shared setup for status-line behavioural tests. */
+function setupStatusLineTest(): { theme: Theme; restorePlatform: () => void } {
+	pinnedElements = []
+	vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
+	vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
+	vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
+	vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+	vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
+	vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
+	const theme = createMockTheme()
+	const restorePlatform = stubPlatform("darwin")
+	return { theme, restorePlatform }
 }
 
 /** Standard billing fixture: $5 credits, 13.73% of a $2k budget. */
@@ -432,14 +456,7 @@ describe("StatusLine behavioural acceptance at representative widths", () => {
 	})
 
 	it("with an active ferment, shows ferment when pinned", () => {
-		const ferment = {
-			id: "f-1",
-			name: "my-ferment",
-			status: "running",
-			mode: "yolo",
-			phases: [],
-			activePhaseId: undefined,
-		} as unknown as ReturnType<typeof FERMENT.getActiveFerment>
+		const ferment = createFermentMock()
 		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(ferment)
 		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
 		vi.spyOn(FERMENT, "getFermentContinuationPolicy").mockReturnValue("manual")
@@ -966,15 +983,9 @@ describe("status line priority shedding", () => {
 	const permissionsMode = "● default \x1b[2m→ shift+tab\x1b[0m"
 
 	beforeEach(() => {
-		theme = createMockTheme()
-		pinnedElements = []
-		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
-		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
-		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
-		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
-		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
-		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
-		restorePlatform = stubPlatform("darwin")
+		const setup = setupStatusLineTest()
+		theme = setup.theme
+		restorePlatform = setup.restorePlatform
 	})
 
 	afterEach(() => {
@@ -1077,15 +1088,9 @@ describe("script controls line (statusLine.command path)", () => {
 	const permissionsMode = "● default \x1b[2m→ shift+tab\x1b[0m"
 
 	beforeEach(() => {
-		theme = createMockTheme()
-		pinnedElements = []
-		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
-		vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(0)
-		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(undefined)
-		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
-		vi.spyOn(TAGS, "getActiveTags").mockReturnValue([])
-		vi.spyOn(TAGS, "getCurrentPhase").mockReturnValue("explore")
-		restorePlatform = stubPlatform("darwin")
+		const setup = setupStatusLineTest()
+		theme = setup.theme
+		restorePlatform = setup.restorePlatform
 	})
 
 	afterEach(() => {
@@ -1097,7 +1102,7 @@ describe("script controls line (statusLine.command path)", () => {
 
 	function controlsLine(width: number): { raw: string; visible: string } {
 		const data = createMockStatusLineData({ permissionsMode })
-		const segments = buildControlsLineSegments(createMockContext(), theme, data)
+		const segments = buildControlsLineSegments({ ctx: createMockContext(), theme, statusLineData: data })
 		const raw = renderFittedLine(segments, width, theme)
 		return { raw, visible: stripAnsi(raw) }
 	}

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -471,6 +471,24 @@ describe("StatusLine behavioural acceptance at representative widths", () => {
 			expect(visibleWidth(narrow.raw)).toBeLessThanOrEqual(70)
 		})
 	})
+
+	it("keeps permissions and model first even when persisted settings pin them", () => {
+		const ferment = createFermentMock()
+		vi.spyOn(FERMENT, "getActiveFerment").mockReturnValue(ferment)
+		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
+		vi.spyOn(FERMENT, "getFermentContinuationPolicy").mockReturnValue("manual")
+
+		withPinned(["permissions", "model"], () => {
+			const { visible } = renderAt(200)
+			const permIdx = visible.indexOf("● default")
+			const modelIdx = visible.indexOf("multi-model (claude-opus-4-6)")
+			const fermentIdx = visible.indexOf("Ferment: my-ferment")
+
+			expect(permIdx).toBe(0)
+			expect(modelIdx).toBeGreaterThan(permIdx)
+			expect(fermentIdx).toBeGreaterThan(modelIdx)
+		})
+	})
 })
 
 describe("StatusLine segment coverage", () => {

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -688,9 +688,14 @@ export class StatusLine implements Component {
 		// the core permissions/model/context trio is touched.
 		const survivors = fitWithBudgetStep(allSegments, contentBudget, this.theme)
 
+		// Core segments (permissions/model) must always lead the line, even if a
+		// persisted config marks them as pinned. Pinning only affects display order
+		// for non-core segments.
+		const CORE_LEAD_IDS: Set<SegmentId> = new Set(["permissions", "model"])
+
 		// Display order is unchanged: unpinned group left, pinned group right.
-		const unpinned = survivors.filter((s) => !pinnedSet.has(s.id))
-		const pinned = survivors.filter((s) => pinnedSet.has(s.id))
+		const unpinned = survivors.filter((s) => !pinnedSet.has(s.id) || CORE_LEAD_IDS.has(s.id))
+		const pinned = survivors.filter((s) => pinnedSet.has(s.id) && !CORE_LEAD_IDS.has(s.id))
 
 		// Build content: unpinned (left) then pinned (right).
 		let contentLine: string

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -18,7 +18,7 @@ import { getPermissionMode } from "../extensions/permissions/mode-controller.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
-type SegmentId =
+export type SegmentId =
 	| "permissions"
 	| "model"
 	| "ferment"
@@ -47,7 +47,7 @@ type SegmentRaw =
 	| { kind: "ferment"; prefix: string; prefixWidth: number }
 
 /** A single piece of the status line. */
-interface Segment {
+export interface Segment {
 	/** Stable identifier used by compaction steps to find this segment. */
 	id: SegmentId
 	/** Already-colorized text (includes ANSI). */
@@ -75,8 +75,6 @@ interface CompactionContext {
 	accent: (s: string) => string
 	/** Apply a named semantic color (e.g. "error", "warning") to a string. */
 	semantic: (color: string, s: string) => string
-	/** Set to `false` once the command hint should no longer be appended. */
-	showCommandHint: boolean
 }
 
 const HARNESS_SETTINGS_PATH = join(homedir(), ".config", "kimchi", "harness", "settings.json")
@@ -167,7 +165,7 @@ export function buildScriptPayload(
 export class StatusLineScript implements Component {
 	private cachedLines: string[] = []
 
-	constructor(private getControlsLine: () => string | null) {}
+	constructor(private getControlsLine: (width: number) => string | null) {}
 
 	setLines(lines: string[]): void {
 		this.cachedLines = lines
@@ -176,10 +174,12 @@ export class StatusLineScript implements Component {
 	invalidate(): void {}
 
 	render(width: number): string[] {
-		const controls = this.getControlsLine()
 		const scriptLines = this.cachedLines.map((line) => truncateToWidth(line, width))
+		// The callback returns an already-fitted line (compaction ladder →
+		// priority shed → truncation applied inside), so no extra work here.
+		const controls = this.getControlsLine(width)
 		if (!controls) return scriptLines
-		return [...scriptLines, "", truncateToWidth(controls, width)]
+		return [...scriptLines, "", controls]
 	}
 }
 
@@ -281,14 +281,6 @@ function recompactSegment<K extends SegmentRaw["kind"]>(
 /** The ordered compaction steps */
 const STEPS: CompactionStep[] = [
 	{
-		name: "drop-command-hint",
-		apply: (_segs, ctx) => {
-			if (!ctx.showCommandHint) return false
-			ctx.showCommandHint = false
-			return true
-		},
-	},
-	{
 		name: "drop-context-bar",
 		apply: (segs, ctx) =>
 			recompactSegment(segs, "context", "context", (raw) => buildContextCompact(ctx, raw.percent, raw.pctColor)),
@@ -312,58 +304,331 @@ const STEPS: CompactionStep[] = [
 	},
 ]
 
-/** Render a line from segments, separator, and optional command hint. */
-function renderLine(
+/** Visible width of the line a segment array would render to. */
+function segmentsLineWidth(segments: Segment[], sepWidth: number): number {
+	if (segments.length === 0) return 0
+	return segments.reduce((sum, s) => sum + s.width, 0) + (segments.length - 1) * sepWidth
+}
+
+function joinSegments(segments: Segment[], sep: string): string {
+	return segments.map((s) => s.text).join(sep)
+}
+
+/** Whole-segment shedding order, applied after the compaction ladder when the
+ *  line still doesn't fit. Segments earlier in this list disappear first.
+ *
+ *  The core three — permissions, model, context — are deliberately NOT in this
+ *  list: they are the modes the user changes most frequently and must survive
+ *  any terminal width. Compaction still shrinks them (context bar → `N% ctx`,
+ *  shortcut hints stripped); only outright removal is off the table.
+ *
+ *  This order is hardcoded and beats user pinning: a pinned segment is a
+ *  display preference, not a survival guarantee. */
+const SHED_ORDER: SegmentId[] = ["lsp", "team", "tags", "phase", "usage", "agents", "credits", "budget", "ferment"]
+
+/** Fit segments into `width` columns: run the compaction ladder, then shed
+ *  whole segments in SHED_ORDER until the line fits. Never mutates the input
+ *  array; returns the surviving segments (compacted in place on a copy).
+ *  May still exceed `width` when only core segments remain — the caller
+ *  tail-truncates in that case. */
+export function fitSegments(
 	segments: Segment[],
-	ctx: CompactionContext,
-	sep: string,
-	sepWidth: number,
-	commandHint: { text: string; width: number },
 	width: number,
-): { text: string; width: number } {
-	if (segments.length === 0) {
-		return { text: "", width: 0 }
+	ctx: CompactionContext,
+	sepWidth: number,
+	extraSteps: CompactionStep[] = [],
+): Segment[] {
+	const working = [...segments]
+	const fits = () => segmentsLineWidth(working, sepWidth) <= width
+
+	if (fits()) return working
+
+	for (const step of [...STEPS, ...extraSteps]) {
+		step.apply(working, ctx)
+		if (fits()) return working
 	}
 
-	const joinedText = segments.map((s) => s.text).join(sep)
-	const joinedWidth = segments.reduce((sum, s) => sum + s.width, 0) + (segments.length - 1) * sepWidth
+	for (const id of SHED_ORDER) {
+		const i = working.findIndex((s) => s.id === id)
+		if (i === -1) continue
+		working.splice(i, 1)
+		if (fits()) return working
+	}
 
-	// Try to fit command hint if requested
-	if (ctx.showCommandHint && joinedWidth + 2 + commandHint.width <= width) {
-		const padding = width - joinedWidth - commandHint.width
+	return working
+}
+
+// ── Segment construction (shared by StatusLine and the script controls line) ─
+
+function dimText(theme: Theme, s: string): string {
+	return theme.fg("dim", s)
+}
+
+function accentText(theme: Theme, s: string): string {
+	return `${resolvedAccentFg(theme)}${s}${RST_FG}`
+}
+
+function semanticText(theme: Theme, color: "success" | "warning" | "error", s: string): string {
+	return `${resolvedSemanticFg(theme, color)}${s}${RST_FG}`
+}
+
+export function buildCompactionContext(theme: Theme): CompactionContext {
+	return {
+		dim: (s) => dimText(theme, s),
+		accent: (s) => accentText(theme, s),
+		semantic: (color, s) => semanticText(theme, color as "success" | "warning" | "error", s),
+	}
+}
+
+/** `abbrev-budget` needs the theme (via `formatBudgetStatusLine`), which
+ *  CompactionContext doesn't carry — so it can't live in the STEPS array. */
+function buildAbbrevBudgetStep(theme: Theme): CompactionStep {
+	return {
+		name: "abbrev-budget",
+		apply: (segs) =>
+			recompactSegment(segs, "budget", "budget", (raw) => {
+				const text = formatBudgetStatusLine(raw.percentage, theme)
+				return { id: "budget", text, width: visibleWidth(text), raw }
+			}),
+	}
+}
+
+/** Fit segments into `width` (compaction ladder → priority shed), join them
+ *  into one line, and tail-truncate if even the core survivors overflow.
+ *  Shared fitting logic for any line built from status-line segments. */
+export function renderFittedLine(segments: Segment[], width: number, theme: Theme): string {
+	const sep = ` ${dimText(theme, "·")} `
+	const sepWidth = visibleWidth(sep)
+	const survivors = fitSegments(segments, width, buildCompactionContext(theme), sepWidth, [
+		buildAbbrevBudgetStep(theme),
+	])
+	return truncateToWidth(joinSegments(survivors, sep), width)
+}
+
+function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
+	const multiModel = getMultiModelEnabled(ctx.sessionManager)
+	const rawModelId = ctx.model?.id ?? "n/a"
+	const label = multiModel ? `multi-model (${rawModelId})` : rawModelId
+	const text = `${accentText(theme, label)} ${dimText(theme, "→ ctrl+p")}`
+	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId: rawModelId } }
+}
+
+function buildUsageSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	let totalInput = 0
+	let totalOutput = 0
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (entry.type === "message") {
+			const msg = entry.message
+			if (msg?.role === "assistant" && msg.usage) {
+				totalInput += msg.usage.input ?? 0
+				totalOutput += msg.usage.output ?? 0
+			}
+		}
+	}
+	if (!totalInput && !totalOutput) {
+		const text = dimText(theme, "↑0 ↓0")
+		return { id: "usage", text, width: visibleWidth(text) }
+	}
+	const tokens = [totalInput ? `↑${formatCount(totalInput)}` : "", totalOutput ? `↓${formatCount(totalOutput)}` : ""]
+		.filter(Boolean)
+		.join(" ")
+	return { id: "usage", text: dimText(theme, tokens), width: visibleWidth(tokens) }
+}
+
+function buildContextSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const contextUsage = ctx.getContextUsage()
+	const pct = contextUsage?.percent ?? 0
+
+	if (pct === 0) {
+		const bar = dimText(theme, "░".repeat(BAR_WIDTH))
+		const text = `${bar} ${accentText(theme, "0%")} ${dimText(theme, "ctx")}`
 		return {
-			text: `${joinedText}${" ".repeat(padding)}${commandHint.text}`,
-			width, // text fills exactly `width` columns
+			id: "context",
+			text,
+			width: visibleWidth(text),
+			raw: { kind: "context", percent: 0, pctColor: undefined },
 		}
 	}
 
-	return { text: joinedText, width: joinedWidth }
+	const filled = Math.max(0, Math.min(BAR_WIDTH, Math.round((pct / 100) * BAR_WIDTH)))
+	const bar = `${semanticText(theme, "success", "█".repeat(filled))}${dimText(theme, "░".repeat(BAR_WIDTH - filled))}`
+	const pctColor = pct > 90 ? "error" : pct > 70 ? "warning" : undefined
+	const pctStr = pctColor
+		? semanticText(theme, pctColor, `${Math.round(pct)}%`)
+		: accentText(theme, `${Math.round(pct)}%`)
+	const text = `${bar} ${pctStr} ${dimText(theme, "ctx")}`
+	return { id: "context", text, width: visibleWidth(text), raw: { kind: "context", percent: pct, pctColor } }
 }
 
-/** Main layout function — applies compaction steps in order, then truncates if
- *  the fully-compacted line still doesn't fit. We deliberately do not shed
- *  whole segments: disappearing elements look worse than a clean tail truncation. */
-function layoutStatusLine(
-	segments: Segment[],
-	width: number,
-	ctx: CompactionContext,
-	sep: string,
-	sepWidth: number,
-	commandHint: { text: string; width: number },
-): string {
-	// Initial attempt with no compaction.
-	let line = renderLine(segments, ctx, sep, sepWidth, commandHint, width)
-	if (line.width <= width) return line.text
+function buildPhaseSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const phase = getCurrentPhase(ctx.sessionManager.getSessionId())
+	if (!phase) {
+		const text = `${dimText(theme, "phase:")}${dimText(theme, "—")}`
+		return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase: "—" } }
+	}
+	const text = `${dimText(theme, "phase:")}${accentText(theme, phase)}`
+	return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase } }
+}
 
-	// Apply each compaction step in order, re-rendering and stopping the first time we fit.
-	for (const step of STEPS) {
-		step.apply(segments, ctx)
-		line = renderLine(segments, ctx, sep, sepWidth, commandHint, width)
-		if (line.width <= width) return line.text
+type ParsedTag = { key: string; value: string }
+
+function buildTagsSegment(theme: Theme, parsed: ParsedTag[], pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const display = parsed.filter((t) => t.key !== "team" && t.key !== "phase")
+	if (display.length === 0) {
+		const text = `${dimText(theme, "tags:")} ${dimText(theme, "—")}`
+		return { id: "tags", text, width: visibleWidth(text) }
+	}
+	const formatted = display.map((t) => dimText(theme, `${t.key}:${t.value}`)).join(dimText(theme, " "))
+	const text = `${dimText(theme, "tags:")}${formatted}`
+	return { id: "tags", text, width: visibleWidth(text) }
+}
+
+function buildTeamSegment(theme: Theme, parsed: ParsedTag[], pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const team = parsed.find((t) => t.key === "team")
+	if (!team) {
+		const text = `${dimText(theme, "team:")} ${dimText(theme, "—")}`
+		return { id: "team", text, width: visibleWidth(text) }
+	}
+	const text = `${dimText(theme, "team:")}${accentText(theme, team.value)}`
+	return { id: "team", text, width: visibleWidth(text) }
+}
+
+function buildPermissionsSegment(
+	theme: Theme,
+	statusLineData: ReadonlyFooterDataProvider,
+	pinned: boolean,
+): Segment | null {
+	const mode = statusLineData.getExtensionStatuses().get("permissions-mode")
+	if (!mode) {
+		if (pinned) {
+			const text = `${dimText(theme, "● ")}${dimText(theme, "— ")}${dimText(theme, "→ shift+tab")}`
+			return { id: "permissions", text, width: visibleWidth(text) }
+		}
+		return null
+	}
+	return { id: "permissions", text: mode, width: visibleWidth(mode) }
+}
+
+function buildLspSegment(theme: Theme, statusLineData: ReadonlyFooterDataProvider): Segment | null {
+	const lspStatus = statusLineData.getExtensionStatuses().get("lsp")
+	if (!lspStatus) return null
+	// Style "LSP:" as dimmed label, server names as accent. Preserve the
+	// space after the colon so the label and value don't render run-together
+	// (e.g. "LSP:typescript-language-server" instead of "LSP: typescript-language-server").
+	const colonIdx = lspStatus.indexOf(":")
+	if (colonIdx === -1) return { id: "lsp", text: accentText(theme, lspStatus), width: visibleWidth(lspStatus) }
+	const label = dimText(theme, lspStatus.slice(0, colonIdx + 1))
+	const value = lspStatus.slice(colonIdx + 1).trimStart()
+	const text = value.length > 0 ? `${label} ${accentText(theme, value)}` : label
+	return { id: "lsp", text, width: visibleWidth(text) }
+}
+
+function buildCreditsSegment(theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const amount = getBillingStatusLine()?.amount
+	if (!amount) return null
+	const text = formatCreditsStatusLine(amount, theme)
+	return { id: "credits", text, width: visibleWidth(text) }
+}
+
+function buildBudgetSegment(theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const budget = getBillingStatusLine()?.budget
+	if (!budget) return null
+	const [percentage = budget] = budget.split(" ", 1)
+	const text = formatBudgetStatusLine(budget, theme)
+	return { id: "budget", text, width: visibleWidth(text), raw: { kind: "budget", percentage } }
+}
+
+function buildAgentsSegment(theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const count = getActiveAgentCount()
+	if (count === 0) {
+		const text = dimText(theme, "0 agents")
+		return { id: "agents", text, width: visibleWidth(text) }
+	}
+	const text = accentText(theme, `${count} agent${count === 1 ? "" : "s"}`)
+	return { id: "agents", text, width: visibleWidth(text) }
+}
+
+function buildFermentSegment(theme: Theme, pinned: boolean): Segment | null {
+	const display = formatFermentStatusLineDisplay(getActiveFerment(), getFermentContinuationPolicy(), {
+		dim: (s) => dimText(theme, s),
+		accent: (s) => accentText(theme, s),
+	})
+	// No active ferment: only show the placeholder when the user has
+	// explicitly pinned the segment (so they can see it's wired up but
+	// idle). Unpinned, hide it entirely — "Ferment: —" is noise when no
+	// ferment is running.
+	if (!display) {
+		if (!pinned) return null
+		const text = `${dimText(theme, "Ferment:")} ${dimText(theme, "—")}`
+		return { id: "ferment", text, width: visibleWidth(text) }
 	}
 
-	// Fully compacted line still overflows — truncate the tail.
-	return truncateToWidth(line.text, width)
+	// Active ferment: always render, even when unpinned. The status line is
+	// the primary surface for ferment progress and must not be hidden by
+	// default. This matches the ScriptFooter path (ui.ts) which shows the
+	// ferment segment unconditionally when there is one.
+	return {
+		id: "ferment",
+		text: display.text,
+		width: display.width,
+		raw: { kind: "ferment", prefix: display.prefix, prefixWidth: display.prefixWidth },
+	}
+}
+
+/** Build the full status-line segment pool in display order.
+ *  Permissions and model ALWAYS lead — they are the modes the user changes
+ *  most frequently, so no other segment (ferment name included) may push them
+ *  off the left edge. Everything else follows. */
+export function buildStatusLineSegments(
+	ctx: ExtensionContext,
+	theme: Theme,
+	statusLineData: ReadonlyFooterDataProvider,
+	pinned: ReadonlySet<SegmentId>,
+): Segment[] {
+	const tags = getActiveTags(ctx.sessionManager)
+		.map(parseTag)
+		.filter((t): t is ParsedTag => t !== null)
+
+	return [
+		buildPermissionsSegment(theme, statusLineData, pinned.has("permissions")),
+		buildModelSegment(ctx, theme),
+		buildFermentSegment(theme, pinned.has("ferment")),
+		buildCreditsSegment(theme, pinned.has("credits")),
+		buildBudgetSegment(theme, pinned.has("budget")),
+		buildAgentsSegment(theme, pinned.has("agents")),
+		buildContextSegment(ctx, theme, pinned.has("context")),
+		buildUsageSegment(ctx, theme, pinned.has("usage")),
+		buildPhaseSegment(ctx, theme, pinned.has("phase")),
+		buildTagsSegment(theme, tags, pinned.has("tags")),
+		buildTeamSegment(theme, tags, pinned.has("team")),
+		buildLspSegment(theme, statusLineData),
+	].filter((s): s is Segment => s !== null)
+}
+
+/** Segments shown below a custom `statusLine.command` script's output
+ *  (StatusLineScript's controls line). A subset of the full pool: the script
+ *  usually covers context/usage itself, so the controls line carries
+ *  permissions, model, ferment, and billing — in pool order so permissions
+ *  and model lead — fitted through the same compaction/shed pipeline. */
+const CONTROLS_LINE_IDS: ReadonlySet<SegmentId> = new Set(["permissions", "model", "ferment", "credits", "budget"])
+const CONTROLS_LINE_PINNED: ReadonlySet<SegmentId> = new Set(["credits", "budget"])
+
+export function buildControlsLineSegments(
+	ctx: ExtensionContext,
+	theme: Theme,
+	statusLineData: ReadonlyFooterDataProvider,
+): Segment[] {
+	return buildStatusLineSegments(ctx, theme, statusLineData, CONTROLS_LINE_PINNED).filter((s) =>
+		CONTROLS_LINE_IDS.has(s.id),
+	)
 }
 
 export class StatusLine implements Component {
@@ -376,185 +641,7 @@ export class StatusLine implements Component {
 	invalidate(): void {}
 
 	private dim(s: string): string {
-		return this.theme.fg("dim", s)
-	}
-
-	private accent(s: string): string {
-		const ansi = resolvedAccentFg(this.theme)
-		return `${ansi}${s}${RST_FG}`
-	}
-
-	private modelSegment(): Segment {
-		const multiModel = getMultiModelEnabled(this.ctx.sessionManager)
-		const rawModelId = this.ctx.model?.id ?? "n/a"
-		const label = multiModel ? `multi-model (${rawModelId})` : rawModelId
-		const text = `${this.accent(label)} ${this.dim("→ ctrl+p")}`
-		return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId: rawModelId } }
-	}
-
-	private usageSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		let totalInput = 0
-		let totalOutput = 0
-		for (const entry of this.ctx.sessionManager.getEntries()) {
-			if (entry.type === "message") {
-				const msg = entry.message
-				if (msg?.role === "assistant" && msg.usage) {
-					totalInput += msg.usage.input ?? 0
-					totalOutput += msg.usage.output ?? 0
-				}
-			}
-		}
-		if (!totalInput && !totalOutput) {
-			const text = this.dim("↑0 ↓0")
-			return { id: "usage", text, width: visibleWidth(text) }
-		}
-		const tokens = [totalInput ? `↑${formatCount(totalInput)}` : "", totalOutput ? `↓${formatCount(totalOutput)}` : ""]
-			.filter(Boolean)
-			.join(" ")
-		return { id: "usage", text: this.dim(tokens), width: visibleWidth(tokens) }
-	}
-
-	private contextSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		const contextUsage = this.ctx.getContextUsage()
-		const pct = contextUsage?.percent ?? 0
-
-		if (pct === 0) {
-			const bar = this.dim("░".repeat(BAR_WIDTH))
-			const text = `${bar} ${this.accent("0%")} ${this.dim("ctx")}`
-			return {
-				id: "context",
-				text,
-				width: visibleWidth(text),
-				raw: { kind: "context", percent: 0, pctColor: undefined },
-			}
-		}
-
-		const filled = Math.max(0, Math.min(BAR_WIDTH, Math.round((pct / 100) * BAR_WIDTH)))
-		const fill = resolvedSemanticFg(this.theme, "success")
-		const bar = `${fill}${"█".repeat(filled)}${RST_FG}${this.dim("░".repeat(BAR_WIDTH - filled))}`
-		const pctColor = pct > 90 ? "error" : pct > 70 ? "warning" : undefined
-		const pctStr = pctColor
-			? `${resolvedSemanticFg(this.theme, pctColor)}${Math.round(pct)}%${RST_FG}`
-			: this.accent(`${Math.round(pct)}%`)
-		const text = `${bar} ${pctStr} ${this.dim("ctx")}`
-		return { id: "context", text, width: visibleWidth(text), raw: { kind: "context", percent: pct, pctColor } }
-	}
-
-	private phaseSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		const phase = getCurrentPhase(this.ctx.sessionManager.getSessionId())
-		if (!phase) {
-			const text = `${this.dim("phase:")}${this.dim("—")}`
-			return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase: "—" } }
-		}
-		const text = `${this.dim("phase:")}${this.accent(phase)}`
-		return { id: "phase", text, width: visibleWidth(text), raw: { kind: "phase", phase } }
-	}
-
-	private tagsSegment(parsed: Array<{ key: string; value: string }>, pinned = false): Segment | null {
-		if (!pinned) return null
-		const display = parsed.filter((t) => t.key !== "team" && t.key !== "phase")
-		if (display.length === 0) {
-			const text = `${this.dim("tags:")} ${this.dim("—")}`
-			return { id: "tags", text, width: visibleWidth(text) }
-		}
-		const formatted = display.map((t) => this.dim(`${t.key}:${t.value}`)).join(this.dim(" "))
-		const text = `${this.dim("tags:")}${formatted}`
-		return { id: "tags", text, width: visibleWidth(text) }
-	}
-
-	private teamSegment(parsed: Array<{ key: string; value: string }>, pinned = false): Segment | null {
-		if (!pinned) return null
-		const team = parsed.find((t) => t.key === "team")
-		if (!team) {
-			const text = `${this.dim("team:")} ${this.dim("—")}`
-			return { id: "team", text, width: visibleWidth(text) }
-		}
-		const text = `${this.dim("team:")}${this.accent(team.value)}`
-		return { id: "team", text, width: visibleWidth(text) }
-	}
-
-	private permissionsSegment(pinned = false): Segment | null {
-		const mode = this.statusLineData.getExtensionStatuses().get("permissions-mode")
-		if (!mode) {
-			if (pinned) {
-				const text = `${this.dim("● ")}${this.dim("— ")}${this.dim("→ shift+tab")}`
-				return { id: "permissions", text, width: visibleWidth(text) }
-			}
-			return null
-		}
-		return { id: "permissions", text: mode, width: visibleWidth(mode) }
-	}
-
-	private lspSegment(): Segment | null {
-		const lspStatus = this.statusLineData.getExtensionStatuses().get("lsp")
-		if (!lspStatus) return null
-		// Style "LSP:" as dimmed label, server names as accent. Preserve the
-		// space after the colon so the label and value don't render run-together
-		// (e.g. "LSP:typescript-language-server" instead of "LSP: typescript-language-server").
-		const colonIdx = lspStatus.indexOf(":")
-		if (colonIdx === -1) return { id: "lsp", text: this.accent(lspStatus), width: visibleWidth(lspStatus) }
-		const label = this.dim(lspStatus.slice(0, colonIdx + 1))
-		const value = lspStatus.slice(colonIdx + 1).trimStart()
-		const text = value.length > 0 ? `${label} ${this.accent(value)}` : label
-		return { id: "lsp", text, width: visibleWidth(text) }
-	}
-
-	private creditsSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		const amount = getBillingStatusLine()?.amount
-		if (!amount) return null
-		const text = formatCreditsStatusLine(amount, this.theme)
-		return { id: "credits", text, width: visibleWidth(text) }
-	}
-
-	private budgetSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		const budget = getBillingStatusLine()?.budget
-		if (!budget) return null
-		const [percentage = budget] = budget.split(" ", 1)
-		const text = formatBudgetStatusLine(budget, this.theme)
-		return { id: "budget", text, width: visibleWidth(text), raw: { kind: "budget", percentage } }
-	}
-
-	private subagentSegment(pinned = false): Segment | null {
-		if (!pinned) return null
-		const count = getActiveAgentCount()
-		if (count === 0) {
-			const text = this.dim("0 agents")
-			return { id: "agents", text, width: visibleWidth(text) }
-		}
-		const text = this.accent(`${count} agent${count === 1 ? "" : "s"}`)
-		return { id: "agents", text, width: visibleWidth(text) }
-	}
-
-	private fermentSegment(pinned = false): Segment | null {
-		const display = formatFermentStatusLineDisplay(getActiveFerment(), getFermentContinuationPolicy(), {
-			dim: (s) => this.dim(s),
-			accent: (s) => this.accent(s),
-		})
-		// No active ferment: only show the placeholder when the user has
-		// explicitly pinned the segment (so they can see it's wired up but
-		// idle). Unpinned, hide it entirely — "Ferment: —" is noise when no
-		// ferment is running.
-		if (!display) {
-			if (!pinned) return null
-			const text = `${this.dim("Ferment:")} ${this.dim("—")}`
-			return { id: "ferment", text, width: visibleWidth(text) }
-		}
-
-		// Active ferment: always render, even when unpinned. The status line is
-		// the primary surface for ferment progress and must not be hidden by
-		// default. This matches the ScriptFooter path (ui.ts) which shows the
-		// ferment segment unconditionally when there is one.
-		return {
-			id: "ferment",
-			text: display.text,
-			width: display.width,
-			raw: { kind: "ferment", prefix: display.prefix, prefixWidth: display.prefixWidth },
-		}
+		return dimText(this.theme, s)
 	}
 
 	private permissionsWarning(): string | null {
@@ -576,28 +663,7 @@ export class StatusLine implements Component {
 	render(width: number): string[] {
 		const config = readStatusLineConfig()
 		const pinnedSet = new Set<SegmentId>(config.pinned)
-
-		const tags = getActiveTags(this.ctx.sessionManager)
-			.map(parseTag)
-			.filter((t): t is { key: string; value: string } => t !== null)
-
-		const allSegments: Segment[] = [
-			this.fermentSegment(pinnedSet.has("ferment")),
-			this.permissionsSegment(pinnedSet.has("permissions")),
-			this.modelSegment(),
-			this.creditsSegment(pinnedSet.has("credits")),
-			this.budgetSegment(pinnedSet.has("budget")),
-			this.subagentSegment(pinnedSet.has("agents")),
-			this.contextSegment(pinnedSet.has("context")),
-			this.usageSegment(pinnedSet.has("usage")),
-			this.phaseSegment(pinnedSet.has("phase")),
-			this.tagsSegment(tags, pinnedSet.has("tags")),
-			this.teamSegment(tags, pinnedSet.has("team")),
-			this.lspSegment(),
-		].filter((s): s is Segment => s !== null)
-
-		const unpinnedSegments = allSegments.filter((s) => !pinnedSet.has(s.id))
-		const pinnedSegments = allSegments.filter((s) => pinnedSet.has(s.id))
+		const allSegments = buildStatusLineSegments(this.ctx, this.theme, this.statusLineData, pinnedSet)
 
 		const sep = ` ${this.dim("·")} `
 		const sepWidth = visibleWidth(sep)
@@ -611,43 +677,26 @@ export class StatusLine implements Component {
 		const hintReserve = hintWidth + minHintGap
 		const contentBudget = Math.max(0, width - hintReserve)
 
-		const ctx: CompactionContext = {
-			dim: (s) => this.dim(s),
-			accent: (s) => this.accent(s),
-			semantic: (color, s) =>
-				`${resolvedSemanticFg(this.theme, color as "success" | "warning" | "error")}${s}${RST_FG}`,
-			showCommandHint: false, // hint is appended manually after all content
-		}
+		// Fit ALL segments as one pool against the full content budget. Pinned
+		// segments get no upfront reservation: the hardcoded compaction/shedding
+		// priority beats pinning, so a pinned low-priority segment sheds before
+		// the core permissions/model/context trio is touched.
+		const survivors = fitSegments(allSegments, contentBudget, buildCompactionContext(this.theme), sepWidth, [
+			buildAbbrevBudgetStep(this.theme),
+		])
 
-		// Reserve space for pinned segments so the unpinned portion compacts correctly.
-		const getPinnedTotalWidth = () =>
-			pinnedSegments.length > 0
-				? pinnedSegments.reduce((sum, s) => sum + s.width, 0) + (pinnedSegments.length - 1) * sepWidth + sepWidth // one sep between unpinned and pinned
-				: 0
-		let pinnedTotalWidth = getPinnedTotalWidth()
-		if (pinnedTotalWidth > contentBudget) {
-			recompactSegment(pinnedSegments, "budget", "budget", (raw) => {
-				const text = formatBudgetStatusLine(raw.percentage, this.theme)
-				return { id: "budget", text, width: visibleWidth(text), raw }
-			})
-			pinnedTotalWidth = getPinnedTotalWidth()
-		}
-		const unpinnedBudget = Math.max(0, contentBudget - pinnedTotalWidth)
-
-		const unpinnedLine = layoutStatusLine(unpinnedSegments, unpinnedBudget, ctx, sep, sepWidth, {
-			text: hintText,
-			width: hintWidth,
-		})
+		// Display order is unchanged: unpinned group left, pinned group right.
+		const unpinned = survivors.filter((s) => !pinnedSet.has(s.id))
+		const pinned = survivors.filter((s) => pinnedSet.has(s.id))
 
 		// Build content: unpinned (left) then pinned (right).
 		let contentLine: string
-		if (unpinnedSegments.length > 0 && pinnedSegments.length > 0) {
-			const pinnedText = pinnedSegments.map((s) => s.text).join(sep)
-			contentLine = `${unpinnedLine}${sep}${pinnedText}`
-		} else if (pinnedSegments.length > 0) {
-			contentLine = pinnedSegments.map((s) => s.text).join(sep)
+		if (unpinned.length > 0 && pinned.length > 0) {
+			contentLine = `${joinSegments(unpinned, sep)}${sep}${joinSegments(pinned, sep)}`
+		} else if (pinned.length > 0) {
+			contentLine = joinSegments(pinned, sep)
 		} else {
-			contentLine = unpinnedLine
+			contentLine = joinSegments(unpinned, sep)
 		}
 
 		// Append hint at the far right when there is room; truncate if not.

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -327,10 +327,11 @@ function joinSegments(segments: Segment[], sep: string): string {
 const SHED_ORDER: SegmentId[] = ["lsp", "team", "tags", "phase", "usage", "agents", "credits", "budget", "ferment"]
 
 /** Fit segments into `width` columns: run the compaction ladder, then shed
- *  whole segments in SHED_ORDER until the line fits. Never mutates the input
- *  array; returns the surviving segments (compacted in place on a copy).
- *  May still exceed `width` when only core segments remain — the caller
- *  tail-truncates in that case. */
+ *  whole segments in SHED_ORDER until the line fits. The input `segments`
+ *  array and the segment objects themselves are not mutated — a shallow copy
+ *  of each segment is compacted/shed internally. Returns the surviving
+ *  segments; if only core segments remain and still overflow, the caller is
+ *  responsible for tail-truncating the rendered line. */
 export function fitSegments(
 	segments: Segment[],
 	width: number,
@@ -338,7 +339,7 @@ export function fitSegments(
 	sepWidth: number,
 	extraSteps: CompactionStep[] = [],
 ): Segment[] {
-	const working = [...segments]
+	const working = segments.map((s) => ({ ...s }))
 	const fits = () => segmentsLineWidth(working, sepWidth) <= width
 
 	if (fits()) return working
@@ -398,11 +399,15 @@ function buildAbbrevBudgetStep(theme: Theme): CompactionStep {
  *  Shared fitting logic for any line built from status-line segments. */
 export function renderFittedLine(segments: Segment[], width: number, theme: Theme): string {
 	const sep = ` ${dimText(theme, "·")} `
-	const sepWidth = visibleWidth(sep)
-	const survivors = fitSegments(segments, width, buildCompactionContext(theme), sepWidth, [
-		buildAbbrevBudgetStep(theme),
-	])
+	const survivors = fitWithBudgetStep(segments, width, theme)
 	return truncateToWidth(joinSegments(survivors, sep), width)
+}
+
+/** Fit segments using the full pipeline. Encapsulates the budget abbreviation
+ *  step so callers don't repeat the same `fitSegments` invocation shape. */
+function fitWithBudgetStep(segments: Segment[], width: number, theme: Theme): Segment[] {
+	const sep = ` ${dimText(theme, "·")} `
+	return fitSegments(segments, width, buildCompactionContext(theme), visibleWidth(sep), [buildAbbrevBudgetStep(theme)])
 }
 
 function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
@@ -583,14 +588,18 @@ function buildFermentSegment(theme: Theme, pinned: boolean): Segment | null {
 	}
 }
 
+export interface StatusLineBuildContext {
+	ctx: ExtensionContext
+	theme: Theme
+	statusLineData: ReadonlyFooterDataProvider
+}
+
 /** Build the full status-line segment pool in display order.
  *  Permissions and model ALWAYS lead — they are the modes the user changes
  *  most frequently, so no other segment (ferment name included) may push them
  *  off the left edge. Everything else follows. */
 export function buildStatusLineSegments(
-	ctx: ExtensionContext,
-	theme: Theme,
-	statusLineData: ReadonlyFooterDataProvider,
+	{ ctx, theme, statusLineData }: StatusLineBuildContext,
 	pinned: ReadonlySet<SegmentId>,
 ): Segment[] {
 	const tags = getActiveTags(ctx.sessionManager)
@@ -621,14 +630,8 @@ export function buildStatusLineSegments(
 const CONTROLS_LINE_IDS: ReadonlySet<SegmentId> = new Set(["permissions", "model", "ferment", "credits", "budget"])
 const CONTROLS_LINE_PINNED: ReadonlySet<SegmentId> = new Set(["credits", "budget"])
 
-export function buildControlsLineSegments(
-	ctx: ExtensionContext,
-	theme: Theme,
-	statusLineData: ReadonlyFooterDataProvider,
-): Segment[] {
-	return buildStatusLineSegments(ctx, theme, statusLineData, CONTROLS_LINE_PINNED).filter((s) =>
-		CONTROLS_LINE_IDS.has(s.id),
-	)
+export function buildControlsLineSegments(buildCtx: StatusLineBuildContext): Segment[] {
+	return buildStatusLineSegments(buildCtx, CONTROLS_LINE_PINNED).filter((s) => CONTROLS_LINE_IDS.has(s.id))
 }
 
 export class StatusLine implements Component {
@@ -663,10 +666,12 @@ export class StatusLine implements Component {
 	render(width: number): string[] {
 		const config = readStatusLineConfig()
 		const pinnedSet = new Set<SegmentId>(config.pinned)
-		const allSegments = buildStatusLineSegments(this.ctx, this.theme, this.statusLineData, pinnedSet)
+		const allSegments = buildStatusLineSegments(
+			{ ctx: this.ctx, theme: this.theme, statusLineData: this.statusLineData },
+			pinnedSet,
+		)
 
 		const sep = ` ${this.dim("·")} `
-		const sepWidth = visibleWidth(sep)
 
 		const hintText = this.dim("/ for commands")
 		const hintWidth = visibleWidth(hintText)
@@ -681,9 +686,7 @@ export class StatusLine implements Component {
 		// segments get no upfront reservation: the hardcoded compaction/shedding
 		// priority beats pinning, so a pinned low-priority segment sheds before
 		// the core permissions/model/context trio is touched.
-		const survivors = fitSegments(allSegments, contentBudget, buildCompactionContext(this.theme), sepWidth, [
-			buildAbbrevBudgetStep(this.theme),
-		])
+		const survivors = fitWithBudgetStep(allSegments, contentBudget, this.theme)
 
 		// Display order is unchanged: unpinned group left, pinned group right.
 		const unpinned = survivors.filter((s) => !pinnedSet.has(s.id))

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -350,7 +350,7 @@ export default function uiExtension(pi: ExtensionAPI) {
 			// built-in status line: permissions and model lead, the compaction
 			// ladder and priority shedding apply at narrow widths.
 			const getControlsLine = (width: number): string | null => {
-				const segments = buildControlsLineSegments(ctx, theme, statusLineData)
+				const segments = buildControlsLineSegments({ ctx, theme, statusLineData })
 				if (segments.length === 0) return null
 				return renderFittedLine(segments, width, theme)
 			}

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -10,18 +10,22 @@ import { isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedAccentFg } from "../ansi.js"
 import { PromptEditor } from "../components/editor.js"
 import { LogoHeader } from "../components/logo.js"
-import { buildScriptPayload, readStatusLineCommand, StatusLine, StatusLineScript } from "../components/status-line.js"
+import {
+	buildControlsLineSegments,
+	buildScriptPayload,
+	readStatusLineCommand,
+	renderFittedLine,
+	StatusLine,
+	StatusLineScript,
+} from "../components/status-line.js"
 import { collapseAll, expandNext, resetState } from "../expand-state.js"
 import { refreshGitBranch } from "../utils.js"
-import { getBillingStatusLine, getCommunityTierHeaderNotice, subscribeBillingStatus } from "./billing/status.js"
-import { formatBudgetStatusLine, formatCreditsStatusLine } from "./billing/status-line-format.js"
+import { getCommunityTierHeaderNotice, subscribeBillingStatus } from "./billing/status.js"
 import { isBareExitAlias } from "./exit-utils.js"
-import { getActiveFerment, getFermentContinuationPolicy } from "./ferment/index.js"
-import { formatFermentStatusLineDisplay } from "./ferment/status-line.js"
 import { formatDuration } from "./format.js"
 import { sessionHasImages } from "./model-guard.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "./multi-model.js"
-import { getOrchestratorModelId, getOrchestratorModelRef, splitModelRef } from "./orchestration/model-roles.js"
+import { getOrchestratorModelRef, splitModelRef } from "./orchestration/model-roles.js"
 import { isRawInputCaptureActive } from "./shared-input.js"
 import {
 	isSessionModeOnboardingStatusLineSuppressed,
@@ -342,23 +346,13 @@ export default function uiExtension(pi: ExtensionAPI) {
 				return new SuppressibleStatusLine(new StatusLine(ctx, theme, statusLineData), tui)
 			}
 			scriptCmd = cmd
-			const getControlsLine = (): string | null => {
-				const parts: string[] = []
-				const ferment = formatFermentStatusLineDisplay(getActiveFerment(), getFermentContinuationPolicy(), {
-					dim: (s) => theme.fg("dim", s),
-					accent: (s) => `${resolvedAccentFg(theme)}${s}${RST_FG}`,
-				})
-				if (ferment) parts.push(ferment.text)
-				const perm = statusLineData.getExtensionStatuses().get("permissions-mode")
-				if (perm) parts.push(perm)
-				const billing = getBillingStatusLine()
-				if (billing?.amount) parts.push(formatCreditsStatusLine(billing.amount, theme))
-				if (billing?.budget) parts.push(formatBudgetStatusLine(billing.budget, theme))
-				const modelId = getMultiModelEnabled(ctx.sessionManager)
-					? `multi-model (${getOrchestratorModelId(sessionId)})`
-					: (ctx.model?.id ?? "n/a")
-				parts.push(`${resolvedAccentFg(theme)}${modelId}${RST_FG} ${theme.fg("dim", "→ ctrl+p")}`)
-				return parts.join(` ${theme.fg("dim", "·")} `)
+			// The controls line runs through the same segment pipeline as the
+			// built-in status line: permissions and model lead, the compaction
+			// ladder and priority shedding apply at narrow widths.
+			const getControlsLine = (width: number): string | null => {
+				const segments = buildControlsLineSegments(ctx, theme, statusLineData)
+				if (segments.length === 0) return null
+				return renderFittedLine(segments, width, theme)
 			}
 			scriptStatusLine = new StatusLineScript(getControlsLine)
 			scriptTui = tui

--- a/tests/e2e/tui/plan-to-ferment-promo.test.ts
+++ b/tests/e2e/tui/plan-to-ferment-promo.test.ts
@@ -51,8 +51,10 @@ test("plan-to-ferment promotion — Start as ferment immediately continues execu
 			extraArgs: ["--plan=true"],
 		},
 		async (fixture, trace) => {
-			// Stage 1: plan mode confirmed in status line.
-			await waitForText(terminal, "plan → shift+tab", { timeoutMs: STARTUP_TIMEOUT_MS })
+			// Stage 1: plan mode confirmed in status line. The shortcut hint may be
+			// stripped under the new compaction ladder, so match "plan" with or
+			// without "→ shift+tab" and anchored by the model segment.
+			await waitForText(terminal, /plan(?: → shift\+tab)? · basic\b/, { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("status line confirms plan mode")
 
 			// Stage 2: submit request → model emits plan with PLAN_COMPLETE marker.
@@ -75,7 +77,9 @@ test("plan-to-ferment promotion — Start as ferment immediately continues execu
 			trace.step("selected 'Start as ferment'")
 
 			// Stage 5: dropdown closes — Ferment is running under auto permissions.
-			await waitForText(terminal, /Ferment: .* · Running · .* · auto ·/, { timeoutMs: STREAM_TIMEOUT_MS })
+			// Status-line order is now permissions/model first, then ferment, so
+			// look for "auto" leading and "Ferment: ... · Running" somewhere after.
+			await waitForText(terminal, /auto · .* · Ferment: .* · Running/, { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("status line transitioned to auto — ferment created")
 
 			// Stage 6: verify the ferment artifact was written.
@@ -134,8 +138,10 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 			extraArgs: ["--plan=true"],
 		},
 		async (fixture, trace) => {
-			// Stage 1: plan mode confirmed in status line.
-			await waitForText(terminal, "plan → shift+tab", { timeoutMs: STARTUP_TIMEOUT_MS })
+			// Stage 1: plan mode confirmed in status line. The shortcut hint may be
+			// stripped under the new compaction ladder, so match "plan" with or
+			// without "→ shift+tab" and anchored by the model segment.
+			await waitForText(terminal, /plan(?: → shift\+tab)? · basic\b/, { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("status line confirms plan mode")
 
 			// Stage 2: submit request → model emits plan with PLAN_COMPLETE marker.
@@ -152,10 +158,10 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 			terminal.keyPress(Key.Enter)
 			trace.step("pressed Enter to select default dropdown option ('Execute the plan')")
 
-			// Stage 4: the plan-complete handler (permissions/index.ts:506-540) writes
-			// the approved plan to .kimchi/plans/ and transitions to auto mode.
-			// Verify both side effects appear in the TUI.
-			await waitForText(terminal, "auto → shift+tab", { timeoutMs: STREAM_TIMEOUT_MS })
+			// Stage 4: the plan-complete handler transitions to auto mode.
+			// Match "auto" with or without the stripped shortcut hint, anchored by
+			// the model segment.
+			await waitForText(terminal, /auto(?: → shift\+tab)? · basic\b/, { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("status line transitioned to auto — handler fired and mode changed")
 
 			// Verify the approved plan file was written (proof that plan-complete


### PR DESCRIPTION
## What changed

Both the built-in status line and the custom `statusLine.command` controls line now share a single fitting pipeline:

- **Core trio never sheds:** permissions mode, model, and compact `N% ctx`.
- **Compaction first:** context bar → `N% ctx`, `multi-model` → `m-m`, shortcut hints stripped, `phase:` / `Ferment:` prefixes dropped, budget → percentage-only form.
- **Shedding if needed:** `lsp → team → tags → phase → usage → agents → credits → budget → ferment`.
- **Truncate only as last resort.**

Display order is fixed so **permissions and model always lead**, even with an active ferment. Pinned segments are now a display preference only — the hardcoded priority beats pinning.

The script-path controls line is width-aware and reuses the same segments, compaction, and shedding as the built-in line (previously it put ferment first, model last, and had no fitting at all).

## Screenshots

<img width="1777" height="744" alt="Screenshot 2026-08-19 at 17 06 57" src="https://github.com/user-attachments/assets/f56399c3-8567-4d8e-8cdb-7920a24ff5a7" />

<img width="1266" height="744" alt="Screenshot 2026-08-19 at 17 07 04" src="https://github.com/user-attachments/assets/a953acf5-d8d1-4cdb-9f25-38a7e55d21cc" />

<img width="832" height="744" alt="Screenshot 2026-08-19 at 17 07 07" src="https://github.com/user-attachments/assets/7e1a4aae-26a9-4c26-b6cc-0dbe81c2f3d4" />

<img width="601" height="744" alt="Screenshot 2026-08-19 at 17 07 10" src="https://github.com/user-attachments/assets/061a098f-976e-436b-841f-d3375d8d61a0" />

<img width="384" height="744" alt="Screenshot 2026-08-19 at 17 07 14" src="https://github.com/user-attachments/assets/0e149226-ab30-4a62-8fa7-fb0def856d78" />

## Verification

- `src/components/status-line.test.ts`: 71 tests green.
- `src/extensions/ui.test.ts`: 27 tests green.
- `src/extensions/customize-status-line-command.test.ts`: 14 tests green.
- `pnpm run typecheck` and `pnpm run lint` clean.