### PR TITLE
fix: bash_control checkin cadence control + todo churn reduction

### DIFF
--- a/src/extensions/bash-background/bash-background-tool.ts
+++ b/src/extensions/bash-background/bash-background-tool.ts
@@ -87,7 +87,7 @@ export function createBackgroundBashToolDefinition(
 
 	const description =
 		wrapped.description +
-		" Long-running commands run in the background: you receive a tail-window of output plus a process handle at each checkin (default every 15s, or every checkin_interval seconds when provided), then drive it to completion with the bash_control tool. Always set a timeout appropriate to the command — do not shorten it artificially."
+		" Long-running commands run in the background: you receive a tail-window of output plus a process handle at each checkin (default every 15s, or every checkin_interval seconds when provided), then drive it to completion with the bash_control tool. For commands expected to run several minutes (builds, installs, training), set a longer checkin_interval (e.g. 60–120s) to avoid waking up every 15s; the cadence can also be changed later via bash_control's checkin_interval. Always set a timeout appropriate to the command — do not shorten it artificially."
 
 	async function execute(
 		toolCallId: string,

--- a/src/extensions/bash-background/bash-control-tool.test.ts
+++ b/src/extensions/bash-background/bash-control-tool.test.ts
@@ -258,9 +258,9 @@ describe("bash_control — error cases", () => {
 		expect(registry.getEntry(handle)?.state).toBe("running")
 	})
 
-	it("returns an error for checkin_interval <= 0 and leaves cadence unchanged", async () => {
+	it("returns an error for checkin_interval <= 0 or non-finite and leaves cadence unchanged", async () => {
 		const { registry, tool, handle } = setup()
-		for (const bad of [0, -5]) {
+		for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
 			const result = await callExecute(tool, { handle, action: "continue", checkin_interval: bad })
 			expect((result.content[0] as { text: string }).text).toContain("checkin_interval must be a positive number")
 			expect(result.details.reason).toBe("invalid-params")

--- a/src/extensions/bash-background/bash-control-tool.test.ts
+++ b/src/extensions/bash-background/bash-control-tool.test.ts
@@ -67,7 +67,7 @@ function setup() {
 
 async function callExecute(
 	tool: ReturnType<typeof createBashControlToolDefinition>,
-	params: { handle: string; action: "continue" | "stop"; extend_seconds?: number },
+	params: { handle: string; action: "continue" | "stop"; extend_seconds?: number; checkin_interval?: number },
 ) {
 	const result = await tool.execute("call-1", params as never, undefined, undefined, undefined as never)
 	return result
@@ -85,12 +85,19 @@ describe("createBashControlToolDefinition — shape", () => {
 		expect(tool.name).toBe("bash_control")
 	})
 
-	it("schema has handle, action (continue|stop), optional extend_seconds", () => {
+	it("schema has handle, action (continue|stop), optional extend_seconds and checkin_interval", () => {
 		const tool = createBashControlToolDefinition(() => undefined)
 		const schema = tool.parameters as unknown as { properties: Record<string, unknown> }
 		expect(schema.properties).toHaveProperty("handle")
 		expect(schema.properties).toHaveProperty("action")
 		expect(schema.properties).toHaveProperty("extend_seconds")
+		expect(schema.properties).toHaveProperty("checkin_interval")
+	})
+
+	it("description distinguishes checkin_interval (cadence) from extend_seconds (deadline)", () => {
+		const tool = createBashControlToolDefinition(() => undefined)
+		expect(tool.description).toContain("checkin_interval")
+		expect(tool.description).toContain("extend_seconds")
 	})
 
 	it("description mentions continue/stop", () => {
@@ -98,6 +105,50 @@ describe("createBashControlToolDefinition — shape", () => {
 		expect(tool.description).toContain("continue")
 		expect(tool.description).toContain("stop")
 	})
+})
+
+it("checkin_interval changes the cadence for the re-armed wait", async () => {
+	vi.useFakeTimers()
+	const { ops, registry, tool, handle } = setup()
+	// Continue with cadence 5s: the next checkin must NOT resolve at the spawn-time 1s.
+	const execPromise = callExecute(tool, { handle, action: "continue", checkin_interval: 5 })
+	await Promise.resolve()
+	expect(registry.getEntry(handle)?.intervalSeconds).toBe(5)
+	let resolved = false
+	void execPromise.then(() => {
+		resolved = true
+	})
+	await vi.advanceTimersByTimeAsync(1000)
+	expect(resolved).toBe(false)
+	ops.emit("slow cadence\n")
+	await vi.advanceTimersByTimeAsync(4000)
+	await execPromise
+	expect(resolved).toBe(true)
+	await ops.exit(0).catch(() => {})
+})
+
+it("continue without checkin_interval keeps the spawn-time cadence", async () => {
+	vi.useFakeTimers()
+	const { ops, registry, tool, handle } = setup()
+	const execPromise = callExecute(tool, { handle, action: "continue" })
+	await Promise.resolve()
+	expect(registry.getEntry(handle)?.intervalSeconds).toBe(1)
+	await vi.advanceTimersByTimeAsync(1000)
+	await execPromise
+	await ops.exit(0).catch(() => {})
+})
+
+it("checkin_interval combined with extend_seconds applies both", async () => {
+	vi.useFakeTimers()
+	const { ops, registry, tool, handle } = setup()
+	const before = registry.getEntry(handle)?.deadlineMs
+	const execPromise = callExecute(tool, { handle, action: "continue", extend_seconds: 30, checkin_interval: 2 })
+	await Promise.resolve()
+	expect(registry.getEntry(handle)?.deadlineMs).toBe(before !== undefined ? before + 30_000 : undefined)
+	expect(registry.getEntry(handle)?.intervalSeconds).toBe(2)
+	await vi.advanceTimersByTimeAsync(2000)
+	await execPromise
+	await ops.exit(0).catch(() => {})
 })
 
 describe("bash_control — action 'continue'", () => {
@@ -194,6 +245,27 @@ describe("bash_control — error cases", () => {
 		expect(result.details.exited).toBe(true)
 		expect(result.details.reason).toBe("no-registry")
 		expect((result.content[0] as { text: string }).text).toContain("no active bash session registry")
+	})
+
+	it("returns an error when checkin_interval is passed with action 'stop'", async () => {
+		const { registry, tool, handle } = setup()
+		const result = await callExecute(tool, { handle, action: "stop", checkin_interval: 5 })
+		expect((result.content[0] as { text: string }).text).toContain(
+			"checkin_interval is only valid with action 'continue'",
+		)
+		expect(result.details.reason).toBe("invalid-params")
+		// Process must NOT have been killed by the rejected call.
+		expect(registry.getEntry(handle)?.state).toBe("running")
+	})
+
+	it("returns an error for checkin_interval <= 0 and leaves cadence unchanged", async () => {
+		const { registry, tool, handle } = setup()
+		for (const bad of [0, -5]) {
+			const result = await callExecute(tool, { handle, action: "continue", checkin_interval: bad })
+			expect((result.content[0] as { text: string }).text).toContain("checkin_interval must be a positive number")
+			expect(result.details.reason).toBe("invalid-params")
+		}
+		expect(registry.getEntry(handle)?.intervalSeconds).toBe(1)
 	})
 
 	it("returns an error for an unknown handle", async () => {

--- a/src/extensions/bash-background/bash-control-tool.ts
+++ b/src/extensions/bash-background/bash-control-tool.ts
@@ -38,6 +38,12 @@ const bashControlSchema = Type.Object({
 				"Only valid with action 'continue'. Pushes the process deadline out by this many seconds before re-arming the checkin. Omit or use 0 to keep the existing deadline.",
 		}),
 	),
+	checkin_interval: Type.Optional(
+		Type.Number({
+			description:
+				"Only valid with action 'continue'. Changes the checkin cadence (seconds) for this and subsequent waits. Raise it (e.g. 60–300) for long-running processes to avoid polling every checkin; this is NOT the deadline — use extend_seconds to move the auto-kill time. Omit to keep the current cadence.",
+		}),
+	),
 })
 
 export type BashControlInput = Static<typeof bashControlSchema>
@@ -64,7 +70,7 @@ export const BASH_CONTROL_TOOL_DESCRIPTION = `Control a background bash process 
 
 After the \`bash\` tool spawns a long-running command in the background and returns a \`handle\` at a checkin, call this tool to decide what happens next:
 
-- action "continue": keep the process running and receive the next tail-window of output at the next checkin. Optionally pass \`extend_seconds\` to push the deadline out first (preventing an imminent auto-kill).
+- action "continue": keep the process running and receive the next tail-window of output at the next checkin. Optionally pass \`extend_seconds\` to push the deadline out first (preventing an imminent auto-kill), and/or \`checkin_interval\` to change how often you are woken with status updates — for long builds, prefer a longer interval (e.g. 60–300s) over polling every 15s.
 - action "stop": kill the process immediately and return its final tail-window of output plus exit code.
 
 Use this tool only when a \`bash\` result includes a \`handle\` in its details (i.e. the command is still running in the background). For commands that ran synchronously (timeout <= 5), there is no handle and no need to call this tool.`
@@ -87,7 +93,29 @@ export function createBashControlToolDefinition(
 		content: { type: "text"; text: string }[]
 		details: BashControlDetails
 	}> {
-		const { handle, action, extend_seconds } = params
+		const { handle, action, extend_seconds, checkin_interval } = params
+		if (action === "stop" && checkin_interval !== undefined) {
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Error: checkin_interval is only valid with action 'continue'.",
+					},
+				],
+				details: { handle, exited: false, exitCode: null, action, reason: "invalid-params" },
+			}
+		}
+		if (checkin_interval !== undefined && checkin_interval <= 0) {
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Error: checkin_interval must be a positive number of seconds (got ${checkin_interval}).`,
+					},
+				],
+				details: { handle, exited: false, exitCode: null, action, reason: "invalid-params" },
+			}
+		}
 		const registry = getRegistry()
 		if (!registry) {
 			return {
@@ -169,6 +197,13 @@ export function createBashControlToolDefinition(
 		// deadline auto-kill doesn't fire before the next checkin resolves.
 		if (extend_seconds !== undefined && extend_seconds > 0) {
 			registry.extend(handle, extend_seconds)
+		}
+
+		// Optionally change the checkin cadence for this and subsequent waits.
+		// entry.intervalSeconds is read fresh at each re-arm (see below), so the
+		// new cadence applies immediately.
+		if (checkin_interval !== undefined) {
+			registry.setIntervalSeconds(handle, checkin_interval)
 		}
 
 		// Turn abort (ESC) must kill the process, same as bash-background-tool.

--- a/src/extensions/bash-background/bash-control-tool.ts
+++ b/src/extensions/bash-background/bash-control-tool.ts
@@ -105,7 +105,7 @@ export function createBashControlToolDefinition(
 				details: { handle, exited: false, exitCode: null, action, reason: "invalid-params" },
 			}
 		}
-		if (checkin_interval !== undefined && checkin_interval <= 0) {
+		if (checkin_interval !== undefined && (!Number.isFinite(checkin_interval) || checkin_interval <= 0)) {
 			return {
 				content: [
 					{

--- a/src/extensions/bash-background/process-registry.ts
+++ b/src/extensions/bash-background/process-registry.ts
@@ -357,6 +357,8 @@ export interface ProcessRegistry {
 	kill(handle: string, reason?: string): Promise<void>
 	/** Push the deadline out by `addSeconds` and re-arm the deadline timer. */
 	extend(handle: string, addSeconds: number): void
+	/** Change the checkin cadence for a running process (applies at the next re-arm). */
+	setIntervalSeconds(handle: string, seconds: number): void
 	/** Promise that resolves with the exit code when the process ends. */
 	whenExited(handle: string): Promise<{ exitCode: number | null }>
 	/** Read-only entry state, or undefined if unknown. */
@@ -509,6 +511,14 @@ export function createProcessRegistry(): ProcessRegistry {
 		armDeadline(entry)
 	}
 
+	function setIntervalSeconds(handle: string, seconds: number): void {
+		const entry = entries.get(handle)
+		if (!entry) return
+		if (entry.state !== "running") return
+		if (seconds <= 0) return
+		entry.intervalSeconds = seconds
+	}
+
 	function whenExited(handle: string): Promise<{ exitCode: number | null }> {
 		const entry = entries.get(handle)
 		if (!entry) return Promise.resolve({ exitCode: null })
@@ -562,6 +572,7 @@ export function createProcessRegistry(): ProcessRegistry {
 		finalSnapshot,
 		kill,
 		extend,
+		setIntervalSeconds,
 		whenExited,
 		getEntry,
 		remove,

--- a/src/extensions/bash-background/process-registry.ts
+++ b/src/extensions/bash-background/process-registry.ts
@@ -515,7 +515,7 @@ export function createProcessRegistry(): ProcessRegistry {
 		const entry = entries.get(handle)
 		if (!entry) return
 		if (entry.state !== "running") return
-		if (seconds <= 0) return
+		if (!Number.isFinite(seconds) || seconds <= 0) return
 		entry.intervalSeconds = seconds
 	}
 

--- a/src/extensions/questionnaire/questionnaire.test.ts
+++ b/src/extensions/questionnaire/questionnaire.test.ts
@@ -258,8 +258,11 @@ describe("questionnaire environment behavior", () => {
 		getActiveTools: ReturnType<typeof vi.fn>
 		setActiveTools: ReturnType<typeof vi.fn>
 		events: { emit: ReturnType<typeof vi.fn> }
+		getFlag: ReturnType<typeof vi.fn>
 		// Captures the registered session_start handler so tests can fire it.
 		_sessionStart: ((event: unknown, ctx: { hasUI: boolean }) => void) | null
+		// Captures the registered before_agent_start handler so tests can fire it.
+		_beforeAgentStart: ((event: { systemPrompt: string }, ctx: { hasUI: boolean }) => unknown) | null
 	}
 
 	function makePi(activeTools: string[] = ["questionnaire"]): FakePi {
@@ -269,10 +272,13 @@ describe("questionnaire environment behavior", () => {
 			getActiveTools: vi.fn(() => activeTools),
 			setActiveTools: vi.fn(),
 			events: { emit: vi.fn() },
+			getFlag: vi.fn(() => undefined),
 			_sessionStart: null,
+			_beforeAgentStart: null,
 		}
 		pi.on.mockImplementation((event: string, handler: (e: unknown, ctx: { hasUI: boolean }) => void) => {
-			if (event === "session_start") pi._sessionStart = handler
+			if (event === "session_start") pi._sessionStart = handler as FakePi["_sessionStart"]
+			if (event === "before_agent_start") pi._beforeAgentStart = handler as FakePi["_beforeAgentStart"]
 		})
 		return pi
 	}
@@ -319,6 +325,43 @@ describe("questionnaire environment behavior", () => {
 		// because the tool is already in the active set.
 		const writes = pi.setActiveTools.mock.calls
 		expect(writes).toEqual([])
+	})
+
+	// ─── before_agent_start: autonomous-mode prompt injection ────────────────
+
+	it("injects autonomous-mode instruction when headless and not ferment-oneshot", () => {
+		const pi = makePi(["questionnaire"])
+		pi.getFlag = vi.fn(() => undefined) // not ferment-oneshot
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+
+		const result = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false }) as
+			| { systemPrompt: string }
+			| undefined
+
+		expect(result).toBeDefined()
+		expect(result!.systemPrompt).toContain("BASE")
+		expect(result!.systemPrompt).toContain("Autonomous mode")
+		expect(result!.systemPrompt).toContain("no human or judge")
+		expect(result!.systemPrompt).toContain("Do NOT end your turn with questions")
+	})
+
+	it("does not inject when UI is attached (interactive session)", () => {
+		const pi = makePi(["questionnaire"])
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+
+		const result = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: true })
+
+		expect(result).toBeUndefined()
+	})
+
+	it("does not inject when ferment-oneshot is true (judge handles questions)", () => {
+		const pi = makePi(["questionnaire"])
+		pi.getFlag = vi.fn((name: string) => (name === "ferment-oneshot" ? true : undefined))
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+
+		const result = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false })
+
+		expect(result).toBeUndefined()
 	})
 
 	it("execute returns a 'do not retry' steer when no UI is attached (defense-in-depth)", async () => {

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -183,6 +183,20 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 		}
 	})
 
+	// In headless sessions without a ferment-oneshot judge, there is no
+	// audience for questions — not a human (no TUI), not a judge (no
+	// ferment-oneshot flag). Inject a system-prompt instruction so the model
+	// acts autonomously instead of ending turns with questions into the void.
+	// Ferment one-shot sessions are excluded: ask_user routes to the LLM judge
+	// there, so questions have a real audience.
+	pi.on("before_agent_start", (event, ctx: ExtensionContext) => {
+		if (ctx.hasUI) return
+		if (pi.getFlag?.("ferment-oneshot") === true) return
+		return {
+			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.`,
+		}
+	})
+
 	pi.registerTool({
 		name: "questionnaire",
 		label: "Questionnaire",

--- a/src/extensions/todos/tool.test.ts
+++ b/src/extensions/todos/tool.test.ts
@@ -60,12 +60,24 @@ describe("todo tools", () => {
 		})
 	})
 
-	it("describes update_todos as a batch replacement path", () => {
+	it("describes update_todos as whole-list replacement for plan changes only", () => {
 		const tools = registeredTools()
 		const tool = tools[UPDATE_TODOS_TOOL_NAME]
 
 		expect(tool.description).toContain("Replace the entire todo list")
 		expect(tool.description).toContain("mark_todo instead")
+		expect(tool.description).toContain("add_todo instead")
+		// Guards against regressing to the "batch progress updates" wording that
+		// invited whole-list rewrites for routine status changes.
+		expect(tool.promptSnippet).toBe("Replace the whole todo list when the plan changes")
+	})
+
+	it("describes add_todo as the preferred single-item append path", () => {
+		const tools = registeredTools()
+		const tool = tools.add_todo
+
+		expect(tool.promptSnippet).toBe("Add one todo — prefer over rewriting the list")
+		expect(tool.description).toContain("Prefer this over rewriting the whole list")
 	})
 
 	it("describes and executes create_todos as the initial planning path", async () => {
@@ -86,6 +98,62 @@ describe("todo tools", () => {
 
 		expect(result.content).toEqual([{ type: "text", text: "Updated 1 todos in global." }])
 		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").map((todo) => todo.content)).toEqual(["inspect trace"])
+	})
+
+	it("marking an unchanged status is a no-op with a corrective notice", async () => {
+		const tools = registeredTools()
+		const ctx = fakeCtx("session")
+
+		await tools.add_todo.execute("add-1", { content: "alpha", status: "pending" }, undefined, undefined, ctx)
+		const before = getTodosForScope(GLOBAL_TODO_SCOPE, "session")
+
+		const result = await tools.mark_todo.execute("mark-1", { id: 1, status: "pending" }, undefined, undefined, ctx)
+
+		expect(result.content).toEqual([
+			{
+				type: "text",
+				text: "Todo #1 is already 'pending' — no change made. Don't re-mark todos whose status hasn't changed.",
+			},
+		])
+		expect(result.details).toBeNull()
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session")).toEqual(before)
+	})
+
+	it("marking the same status with a new note still writes", async () => {
+		const tools = registeredTools()
+		const ctx = fakeCtx("session")
+
+		await tools.add_todo.execute("add-1", { content: "alpha" }, undefined, undefined, ctx)
+		const result = await tools.mark_todo.execute(
+			"mark-1",
+			{ id: 1, status: "pending", note: "blocked on fixture" },
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(result.content).toEqual([{ type: "text", text: "Marked todo #1 pending in global." }])
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session").find((todo) => todo.id === 1)?.note).toBe(
+			"blocked on fixture",
+		)
+	})
+
+	it("marking an unknown id returns a soft steer, not an error", async () => {
+		const tools = registeredTools()
+		const result = await tools.mark_todo.execute(
+			"mark-1",
+			{ id: 42, status: "completed" },
+			undefined,
+			undefined,
+			fakeCtx("session"),
+		)
+
+		expect(result.details).toBeNull()
+		expect(result.content[0].text).toBe(
+			"Todo #42 doesn't exist in global — the list may have been replaced. Check the current ids in the todo list before marking again.",
+		)
+		expect(result.content[0].text).not.toContain("Failed")
+		expect(getTodosForScope(GLOBAL_TODO_SCOPE, "session")).toEqual([])
 	})
 
 	it("adds, marks, and clears todos", async () => {

--- a/src/extensions/todos/tool.ts
+++ b/src/extensions/todos/tool.ts
@@ -216,10 +216,39 @@ async function executeMarkTodo(
 		}
 		const scope = resolved.scope
 		const todos = getTodosForScope(scope, sessionId)
-		let found = false
+		const existing = todos.find((todo) => todo.id === id)
+		if (!existing) {
+			// Soft steer, not an error: an unknown id usually means the list was
+			// replaced (e.g. by update_todos or another scope) — tell the model to
+			// re-read state rather than retry the same mark.
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `Todo #${id} doesn't exist in ${formatScopeLabel(scope)} — the list may have been replaced. Check the current ids in the todo list before marking again.`,
+					},
+				],
+				details: null,
+			}
+		}
+
+		// No-op fast path: same status and no field changes — skip the write
+		// (and the session-branch churn that comes with it) and tell the model
+		// not to re-mark, so duplicate marks don't look productive.
+		if (existing.status === status && params.activeForm === undefined && params.note === undefined) {
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: `Todo #${id} is already '${status}' — no change made. Don't re-mark todos whose status hasn't changed.`,
+					},
+				],
+				details: null,
+			}
+		}
+
 		const nextTodos = todos.map((todo) => {
 			if (todo.id !== id) return todo
-			found = true
 			return {
 				...todo,
 				status,
@@ -227,10 +256,6 @@ async function executeMarkTodo(
 				...(params.note !== undefined ? { note: params.note } : {}),
 			}
 		})
-		if (!found) {
-			const label = formatScopeLabel(scope)
-			throw new Error(`Todo #${id} not found in ${label}`)
-		}
 
 		const details = applyWriteTodos({ scope, todos: nextTodos }, sessionId)
 		const label = formatScopeLabel(details.scope)
@@ -289,8 +314,8 @@ export function registerTodosTool(pi: ExtensionAPI): void {
 		name: UPDATE_TODOS_TOOL_NAME,
 		label: "Update Todos",
 		description:
-			"Replace the entire todo list. Use only when the plan changes significantly (adding, removing, or reordering items). For routine status changes, use mark_todo instead — it is lighter and pairs more naturally with a work tool call. Always pair this with the next work tool call in the same turn — never make a turn that is only a todo update.",
-		promptSnippet: "Replace the todo list for batch progress updates",
+			"Replace the entire todo list. Use only when the plan changes significantly (adding, removing, or reordering items). For routine status changes, use mark_todo instead — it is lighter and pairs more naturally with a work tool call. For appending a single item, use add_todo instead of rewriting the whole list. Always pair this with the next work tool call in the same turn — never make a turn that is only a todo update.",
+		promptSnippet: "Replace the whole todo list when the plan changes",
 		parameters: TODO_TOOL_PARAMETERS,
 		executionMode: "parallel",
 		execute: executeWriteTodos,
@@ -300,8 +325,8 @@ export function registerTodosTool(pi: ExtensionAPI): void {
 		name: ADD_TODO_TOOL_NAME,
 		label: "Add Todo",
 		description:
-			"Add one todo to the current list. Use for a missing follow-up item. Pair this with the next work tool call in the same turn when possible.",
-		promptSnippet: "Add a single todo item",
+			"Add one todo to the current list. Use for a missing follow-up item. Prefer this over rewriting the whole list with update_todos just to append one item. Pair this with the next work tool call in the same turn when possible.",
+		promptSnippet: "Add one todo — prefer over rewriting the list",
 		parameters: ADD_TODO_PARAMETERS,
 		executionMode: "parallel",
 		execute: executeAddTodo,


### PR DESCRIPTION
## Summary

Three fixes addressing orchestration overhead identified in terminal-bench 2.1 benchmark analysis (446 trials, 10.5M output tokens). Analysis reports and re-runnable scripts are in `.kimchi/docs/`.

### Chunk A — bash_control checkin cadence control (new feature)

**Problem:** 1,612 bash_control polling turns across 165 trials; median 18s between polls, 26% <15s apart. The `checkin_interval` could only be set at spawn time (14 of thousands of spawns used it, max 60s). Mid-flight, only the kill deadline (`extend_seconds`) was adjustable — the cadence was locked at the spawn-time default (usually 15s), so the agent burned a full LLM turn per heartbeat on long builds.

**Fix:** Add optional `checkin_interval` param to `bash_control continue`. When provided, updates the registry entry's `intervalSeconds` via a new `registry.setIntervalSeconds()` method (mirrors `extend()`'s guards: entry must exist, be running, and receive a positive value, incl. NaN/Infinity guard). The new cadence takes effect immediately at the next re-arm.

### Chunk B — Todo churn reduction (bug)

**Problem:** 126 whole-list `update_todos` rewrites (6–9 items resent each), `add_todo` used only twice in 446 trials, 122 no-op `mark_todo` transitions. Root causes: `update_todos` promptSnippet said "batch progress updates" (inviting whole-list rewrites for routine status changes), and `mark_todo` had no no-op detection.

**Fixes:**
- `update_todos` promptSnippet: "batch progress updates" → "when the plan changes" (matches its own description); explicit note to use `add_todo` for appends
- `add_todo` promptSnippet + description: "prefer over rewriting the list"
- `mark_todo` no-op fast path: same status + no field changes → corrective steer, no store write
- `mark_todo` unknown id: throw → soft steer (avoids error→retry churn)

### Chunk C — Autonomous-mode system prompt (new feature)

**Problem:** in headless non-ferment sessions (e.g. benchmark runs), the agent routinely stalls waiting for user input that will never arrive.

**Fix:** `questionnaire` extension's `before_agent_start` handler appends an autonomous-mode instruction to the system prompt when `!ctx.hasUI && !ferment-oneshot` — telling the model to make reasonable assumptions and proceed rather than asking questions. Ferment one-shot is excluded: its LLM judge answers `ask_user` and must not be disrupted.

---

## Benchmark validation (terminal-bench 2.1, 90-trial run with this PR's build)

Full analysis: `.kimchi/docs/new-run-failure-evaluation-2026-08-20.md`, `quality-assessment-2026-08-20.md`, `post-fix-evaluation-2026-08-20.md`.

### The fixes work (measured against the pre-fix 446-trial baseline)

| Metric | Pre-fix | Post-fix | Change |
|--------|---------|----------|--------|
| No-op `mark_todo` transitions | 122 | 6 | **-95%** |
| Whole-list `update_todos` rewrites | 126 | 6 | **-95%** |
| Max todo calls/trial | 49 | 17 | -65% |
| Polling handles with >20 continues | 6 (max 43) | **0 (max 12)** | eliminated |
| Polling share of output tokens | 2.5% | 1.4% | halved |
| Todo-tool adoption | 76% of trials | 77% | unchanged (no tracking degraded) |
| bash_control adoption | 38% | 43% | unchanged |

### `checkin_interval` saw strong, deliberate adoption — the model uses it unprompted

- **146 of 223 `bash_control continue` calls (65%) set it**, across **28 of 39 polling trials (72%)**
- Values: `60s` ×57, `30s` ×45, `15s` ×16, `300s` ×12, `120s` ×10
- Context-aware: `train-fasttext` used `300s` ×9 during long training; `protein-assembly` used `15s` ×9 while actively babysitting a phase; `caffe-cifar-10` escalated 30s→60s as its build settled. One session reasons explicitly: *"checkin_interval is now 300 seconds"*

### Pass rate & timeouts (corrected numbers)

- Pass: **49/90 (54.4%)** vs 47.2% in the pre-fix single-attempt comparison run
- Timeouts: **32/90 (35.6%)** vs 52.8% comparable — improved but **not eliminated**. Failure classification of the 32 remaining timeouts:
  - **~12 hit by provider-5xx retry burn** — 5xx errors arrive wrapped in HTTP-200 bodies and single turns spent up to **1,805s inside the retry-with-backoff loop** (regex-chess burned its entire 1,800s budget on one turn). The retry policy, not the error rate, is the problem.
  - **2 functionally solved but failed on lifecycle**: `pypi-server` / `kv-store-grpc` — the agent solved and verified the task, but the server ran as a harness-managed background process and died with the session; the verifier couldn't connect. (Fix candidate: prompt guidance to `setsid`/`nohup` persist-after-me servers.)
  - **~14 deterministic budget-exceeders** (compile-compcert, train-fasttext, both path-tracings…) — same tasks that always time out; `tune-mjcf` and `llm-inference-batching-scheduler` died within single-digit percent of the threshold.
- 9 scored fails are genuine near-misses; two revealed **verification-methodology mismatches** (agent verifies with different flags than the test), one is benchmark staleness (mteb-leaderboard's expected answer changed since authoring).

## Checklist

- [x] Tests added/updated for all chunks
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] Unit tests pass (incl. post-rebase rerun: 272 tests across the touched suites)

## Test plan

- [x] Unit tests pass (`bash-control-tool.test.ts`, `tool.test.ts`, `questionnaire.test.ts`)
- [x] Benchmark validation with this build (see above)
- [ ] Manual smoke: spawn `sleep 30` with default interval, continue with `checkin_interval: 1` → cadence changes immediately
