### PR TITLE
fix(context): strip cross-model thinking blocks from LLM context

### DIFF
--- a/src/extensions/orchestration/continuation-nudge.test.ts
+++ b/src/extensions/orchestration/continuation-nudge.test.ts
@@ -258,6 +258,35 @@ describe("ContinuationNudge session-level tool tracking", () => {
 		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
 	})
 
+	it("resetForModelSwitch clears the session-level tool latch", () => {
+		const guard = new ContinuationNudge()
+		guard.resetForNewUserInput()
+		guard.recordToolCall()
+		guard.resetForNewUserInput()
+		expect(guard.hasToolBeenCalledThisSession()).toBe(true)
+
+		guard.resetForModelSwitch()
+
+		expect(guard.hasToolBeenCalledThisSession()).toBe(false)
+		expect(guard.hasToolBeenCalledThisCycle()).toBe(false)
+		expect(guard.hasToolBeenCalledThisRun()).toBe(false)
+		// A text-only turn after the model switch is treated like a fresh
+		// session and is not nudged.
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("resetForModelSwitch clears pending nudge response state", () => {
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		guard.evaluateTurn(textOnlyMessage)
+		expect(guard.isNudgeResponsePending()).toBe(true)
+
+		guard.resetForModelSwitch()
+
+		expect(guard.isNudgeResponsePending()).toBe(false)
+		expect(guard.isDoneSignalReceived()).toBe(false)
+	})
+
 	it("does not consume a nudge slot while no tools have been called this session", () => {
 		// Fresh session, no tools yet — repeated text-only turns must not burn
 		// the per-cycle budget, so when a tool is eventually called the full
@@ -393,6 +422,17 @@ describe("ContinuationNudge Agent-pending suppression", () => {
 		// Simulate an unrelated user input arriving while an Agent is running.
 		guard.resetForNewUserInput()
 		// The nudge must still be suppressed — we are still waiting for the result.
+		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
+	})
+
+	it("resetForModelSwitch does NOT clear pending delegation count", () => {
+		const guard = new ContinuationNudge()
+		simulateSessionWithPriorToolCall(guard)
+		guard.markDelegationCall()
+		// User switches models while an Agent result is still in flight.
+		guard.resetForModelSwitch()
+		// Delegated agents are independent of the orchestrator model, so the
+		// pending count must survive the switch to keep the nudge suppressed.
 		expect(guard.evaluateTurn(textOnlyMessage)).toBe(false)
 	})
 
@@ -545,6 +585,18 @@ describe("EmptyTurnNudge", () => {
 		// Reset re-arms the nudge for the next user-input cycle
 		guard.resetForNewUserInput()
 		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+	})
+
+	it("re-arms after resetForModelSwitch", () => {
+		const guard = new EmptyTurnNudge()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
+		// A new model gets a fresh empty-turn budget even within the same cycle.
+		guard.resetForModelSwitch()
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(true)
+		expect(guard.evaluateTurn(emptyMessage)).toBe(false)
 	})
 
 	it("does not nudge when the user aborted the turn (stopReason: aborted)", () => {

--- a/src/extensions/orchestration/continuation-nudge.ts
+++ b/src/extensions/orchestration/continuation-nudge.ts
@@ -109,6 +109,27 @@ export class ContinuationNudge {
 		// would incorrectly allow the nudge to fire while Agents are still in flight.
 	}
 
+	/**
+	 * Reset the session-level tool latch when the active model changes.
+	 *
+	 * A new model has not yet demonstrated tool-calling behaviour in this
+	 * session, so the fresh-session suppression should apply until it makes
+	 * its first tool call. Without this reset, a model that legitimately
+	 * opens with an orientation/clarification text turn (e.g. kimi-k2.7 in
+	 * single-model mode) is immediately nudged because the previous model
+	 * already called tools.
+	 */
+	resetForModelSwitch(): void {
+		this.toolsCalledThisSession = false
+		this.toolsCalledSinceLastUserInput = false
+		this.toolsCalledThisAgentRun = false
+		this.nudgeCountThisCycle = 0
+		this.nudgeResponsePending = false
+		this.accumulatedResponseText = ""
+		// pendingDelegationCount is intentionally NOT reset here — delegated
+		// agents are independent of which orchestrator model is active.
+	}
+
 	recordToolCall(): void {
 		this.toolsCalledSinceLastUserInput = true
 		this.toolsCalledThisAgentRun = true
@@ -230,6 +251,17 @@ export class EmptyTurnNudge {
 	}
 
 	resetForNewUserInput(): void {
+		this.nudgeCountThisCycle = 0
+	}
+
+	/**
+	 * Reset the per-cycle empty-turn budget when the active model changes.
+	 *
+	 * A new model has its own empty-turn behaviour, so it should get the
+	 * full per-cycle budget rather than inheriting any budget consumed by
+	 * the previous model.
+	 */
+	resetForModelSwitch(): void {
 		this.nudgeCountThisCycle = 0
 	}
 }

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1019,4 +1019,83 @@ describe("continuation nudge turn_end handler", () => {
 		expect(sendMessageCalls.length).toBe(1)
 		expect((sendMessageCalls[0].message as { content?: string }).content).toContain("If you have finished")
 	})
+
+	it("does not nudge after a model switch when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// User switches models (e.g. via the UI model picker).
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "set",
+		})
+
+		// New user input after the switch.
+		await fire("input", { source: "user" })
+
+		// New model responds with orientation text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// No nudge should fire — the model switch reset the session-level
+		// tool latch, so the new model's orientation turn is treated like a
+		// fresh session.
+		expect(sendMessageCalls.length).toBe(0)
+	})
+
+	it("does not nudge after a model cycle when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// User cycles models (e.g. via the keyboard shortcut).
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "cycle",
+		})
+
+		// New user input after the cycle.
+		await fire("input", { source: "user" })
+
+		// New model responds with orientation text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// Cycling is a user-initiated switch and must also reset the latch.
+		expect(sendMessageCalls.length).toBe(0)
+	})
+
+	it("still nudges after a model restore when the previous model called tools", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// Session restore is not a user-initiated switch; the conversation
+		// continues and the session-level tool latch must stay true.
+		await fire("model_select", {
+			model: { id: "kimi-k2.7", provider: "kimchi-dev" },
+			previousModel: undefined,
+			source: "restore",
+		})
+
+		// New user input after restore.
+		await fire("input", { source: "user" })
+
+		// Model responds with text only, no tool calls.
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I'll review the branch in detail." }]),
+		})
+
+		// Nudge should fire because restore must not reset the latch.
+		expect(sendMessageCalls.length).toBe(1)
+		expect((sendMessageCalls[0].message as { customType?: string }).customType).toBe("nudge")
+	})
 })

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -290,8 +290,23 @@ export default function (skillPaths: string[]) {
 				}
 			})
 
-			pi.on("model_select", async (_event, ctx) => {
+			pi.on("model_select", async (event, ctx) => {
 				notifyIfDeprecated(ctx)
+
+				// A user-initiated model switch (UI picker, /model, or cycling)
+				// is a fresh start for tool-calling behaviour from the new model's
+				// perspective. Reset the session-level latch so the first text-only
+				// turn after the switch is treated like the first turn of a new
+				// session (nudge suppressed until the new model calls a tool).
+				// Session restore is deliberately excluded: a restored session is
+				// continuing an existing conversation, not starting fresh.
+				if (event.source === "set" || event.source === "cycle") {
+					const sessionId = ctx.sessionManager.getSessionId()
+					const continuationNudge = getContinuationNudge(sessionId)
+					const emptyTurnNudge = getEmptyTurnNudge(sessionId)
+					continuationNudge.resetForModelSwitch()
+					emptyTurnNudge.resetForModelSwitch()
+				}
 			})
 
 			// Detect the inverse of the context-event nudge below: the orchestrator reasons

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -72,6 +72,7 @@ import {
 } from "../orchestration/model-roles.js"
 import { registerModelRolesCommand } from "../orchestration/model-roles-command.js"
 import { type ContextFile, loadGlobalContextFiles, loadProjectContextFiles } from "./context-files.js"
+import { stripCrossModelThinking } from "./strip-cross-model-thinking.js"
 import {
 	buildSystemPrompt,
 	DELEGATION_TOOL_NAMES,
@@ -445,10 +446,14 @@ export default function (skillPaths: string[]) {
 				)
 			})
 
-			pi.on("context", async (event) => {
+			pi.on("context", async (event, ctx) => {
 				let messages = stripStaleNudges(event.messages)
 				messages = stripEmptyToolCalls(messages)
 				messages = stripUiOnlyMessages(messages)
+				// Keep this strip in prompt-enrichment: context handlers registered
+				// later (hide-thinking et al.) must not reintroduce thinking blocks.
+				// Rationale in strip-cross-model-thinking.ts.
+				messages = stripCrossModelThinking(messages, ctx.model)
 				if (messages !== event.messages) return { messages }
 			})
 		}
@@ -459,8 +464,9 @@ export default function (skillPaths: string[]) {
 			// and MiniMax M2.7) emit empty tool calls after a real write/edit call,
 			// which the runtime rejects with a "Tool  not found" result that would
 			// otherwise accumulate in the subagent's context across turns.
-			pi.on("context", async (event) => {
-				const messages = stripEmptyToolCalls(event.messages)
+			pi.on("context", async (event, ctx) => {
+				let messages = stripEmptyToolCalls(event.messages)
+				messages = stripCrossModelThinking(messages, ctx.model)
 				if (messages !== event.messages) return { messages }
 			})
 		}

--- a/src/extensions/prompt-construction/strip-cross-model-thinking.test.ts
+++ b/src/extensions/prompt-construction/strip-cross-model-thinking.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AssistantMessage } from "@earendil-works/pi-ai"
+import { describe, expect, it } from "vitest"
+import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
+import { type ActiveModelRef, stripCrossModelThinking } from "./strip-cross-model-thinking.js"
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../../../", import.meta.url)))
+
+const ACTIVE_MODEL: ActiveModelRef = { provider: "kimchi-dev", api: "openai-completions", id: "kimi-k2.7" }
+
+function makeUser(text: string): OrchestratorMessages[number] {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() }
+}
+
+function makeAssistant(
+	origin: { provider: string; api: string; model: string },
+	content: AssistantMessage["content"],
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: origin.api,
+		provider: origin.provider,
+		model: origin.model,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+const GLM = { provider: "kimchi-dev", api: "openai-completions", model: "glm-5.2-fp8" }
+const KIMI = { provider: "kimchi-dev", api: "openai-completions", model: "kimi-k2.7" }
+const ANTHROPIC = { provider: "anthropic", api: "anthropic-messages", model: "claude-sonnet-4" }
+
+describe("stripCrossModelThinking", () => {
+	it("removes cross-model thinking blocks but keeps text and tool calls", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("continue"),
+			makeAssistant(GLM, [
+				{ type: "thinking", thinking: "I should read the detail page..." },
+				{ type: "text", text: "getFullProviderDisplayName is used in two places." },
+				{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.ts" } },
+			]),
+		]
+
+		const result = stripCrossModelThinking(messages, ACTIVE_MODEL)
+
+		expect(result).not.toBe(messages)
+		const assistant = result[1] as AssistantMessage
+		expect(assistant.content).toEqual([
+			{ type: "text", text: "getFullProviderDisplayName is used in two places." },
+			{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.ts" } },
+		])
+	})
+
+	it("preserves same-model thinking blocks verbatim", () => {
+		const thinking = { type: "thinking", thinking: "my own reasoning", thinkingSignature: "sig" } as const
+		const messages: OrchestratorMessages = [makeAssistant(KIMI, [thinking, { type: "text", text: "done" }])]
+
+		const result = stripCrossModelThinking(messages, ACTIVE_MODEL)
+
+		expect(result).toBe(messages)
+		expect((result[0] as AssistantMessage).content[0]).toEqual(thinking)
+	})
+
+	it("keeps a cross-model thinking-only message with empty content (pi-ai skips it downstream)", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("go"),
+			makeAssistant(GLM, [{ type: "thinking", thinking: "internal plan only" }]),
+		]
+
+		const result = stripCrossModelThinking(messages, ACTIVE_MODEL)
+
+		expect(result).toHaveLength(2)
+		expect((result[1] as AssistantMessage).content).toEqual([])
+	})
+
+	it("removes redacted cross-model thinking blocks", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant(ANTHROPIC, [
+				{ type: "thinking", thinking: "", redacted: true, thinkingSignature: "opaque" },
+				{ type: "text", text: "answer" },
+			]),
+		]
+
+		const result = stripCrossModelThinking(messages, { provider: "openai", api: "openai-completions", id: "gpt-5" })
+
+		expect((result[0] as AssistantMessage).content).toEqual([{ type: "text", text: "answer" }])
+	})
+
+	it("in a mixed history strips only mismatched blocks and keeps same-model thinking", () => {
+		const messages: OrchestratorMessages = [
+			makeAssistant(GLM, [
+				{ type: "thinking", thinking: "glm plan" },
+				{ type: "text", text: "glm text" },
+			]),
+			makeAssistant(KIMI, [
+				{ type: "thinking", thinking: "kimi plan" },
+				{ type: "text", text: "kimi text" },
+			]),
+			makeUser("continue"),
+		]
+
+		const result = stripCrossModelThinking(messages, ACTIVE_MODEL)
+
+		expect((result[0] as AssistantMessage).content).toEqual([{ type: "text", text: "glm text" }])
+		expect((result[1] as AssistantMessage).content).toEqual([
+			{ type: "thinking", thinking: "kimi plan" },
+			{ type: "text", text: "kimi text" },
+		])
+		expect(result[2]).toBe(messages[2])
+	})
+
+	it("returns the same array reference when there is no cross-model thinking", () => {
+		const messages: OrchestratorMessages = [
+			makeUser("hi"),
+			makeAssistant(KIMI, [{ type: "text", text: "Done." }]),
+			makeAssistant(GLM, [{ type: "text", text: "cross-model text without thinking stays" }]),
+		]
+
+		expect(stripCrossModelThinking(messages, ACTIVE_MODEL)).toBe(messages)
+	})
+
+	it("returns the same array reference when there is no active model", () => {
+		const messages: OrchestratorMessages = [makeAssistant(GLM, [{ type: "thinking", thinking: "plan" }])]
+		expect(stripCrossModelThinking(messages, undefined)).toBe(messages)
+	})
+
+	it("returns the same array reference for an empty message list", () => {
+		const messages: OrchestratorMessages = []
+		expect(stripCrossModelThinking(messages, ACTIVE_MODEL)).toBe(messages)
+	})
+})
+
+describe("stripCrossModelThinking wiring contract", () => {
+	it("every context handler in prompt-enrichment applies the strip", () => {
+		const source = readFileSync(resolve(REPO_ROOT, "src/extensions/prompt-construction/prompt-enrichment.ts"), "utf8")
+		// Handler bodies: text after each pi.on("context"... up to the next
+		// pi.on(" registration. Any context handler added to this file must
+		// consciously decide to apply the strip — hence the strict length assert.
+		const bodies = source
+			.split(/pi\.on\("context"[^\n]*\n/)
+			.slice(1)
+			.map((rest) => rest.split(/\n\s*pi\.on\("/)[0])
+		expect(bodies.length).toBe(2)
+		for (const body of bodies) {
+			expect(body).toContain("stripCrossModelThinking(")
+		}
+	})
+})

--- a/src/extensions/prompt-construction/strip-cross-model-thinking.ts
+++ b/src/extensions/prompt-construction/strip-cross-model-thinking.ts
@@ -1,0 +1,64 @@
+import type { OrchestratorMessages } from "../orchestration/continuation-nudge.js"
+
+/** Minimal shape of the active model needed for the cross-model check.
+ *  Structurally compatible with pi-ai's `Model` (provider/api/id). */
+export interface ActiveModelRef {
+	provider: string
+	api: string
+	id: string
+}
+
+/**
+ * Remove `thinking` content blocks from assistant messages produced by a
+ * different model than the currently active one.
+ *
+ * Why: after a user switches models mid-session, pi-ai's `transformMessages`
+ * converts the previous model's `thinking` blocks into plain assistant TEXT
+ * so the (cross-model) provider request stays valid. To the new model that
+ * converted text looks like assistant-authored chain-of-thought — an
+ * in-context example of "emit reasoning prose, then stop".
+ *
+ * Evidence (2026-08-19): a session in which the user switched glm-5.2-fp8 →
+ * kimi-k2.7 stalled for four consecutive turns (reasoning prose or
+ * reasoning-only, stop=stop, zero tool calls). Replaying the reconstructed
+ * 141-message context against kimi-k2.7 via the gateway reproduced the stall;
+ * replaying the same context with cross-model thinking blocks stripped made
+ * kimi-k2.7 call a tool immediately. Controls (glm-5.2-fp8, kimi-k3) called
+ * tools on the full context. See .kimchi/docs/plan-cross-model-thinking-strip.md.
+ *
+ * Same-model semantics mirror pi-ai's `isSameModel` in
+ * `transformMessages`: all three identifiers (provider, api, model id)
+ * must match for a block to be kept. Same-model thinking is preserved
+ * verbatim — signed/redacted thinking replay depends on it.
+ *
+ * Content-less edge: an assistant message that contained ONLY thinking
+ * blocks keeps its slot with an empty `content` array. pi-ai's
+ * `convertMessages` deterministically skips such messages ("Skip assistant
+ * messages that have no content and no tool calls") and synthesises results
+ * for orphaned tool calls, so no placeholder is needed here.
+ *
+ * Placement note: this transform is wired into the `context` handlers in
+ * `prompt-enrichment.ts`. `emitContext` composes handlers in extension
+ * registration order, and no context handler registered after
+ * prompt-enrichment (hide-thinking, tool-rendering, todos, ferment)
+ * creates `thinking` blocks — hide-thinking only rewrites `<think>`-tag
+ * TEXT for display restore — so the strip cannot be re-undone downstream.
+ */
+export function stripCrossModelThinking(
+	messages: OrchestratorMessages,
+	model: ActiveModelRef | undefined,
+): OrchestratorMessages {
+	// No active model (edge of session lifecycle): cannot compare provenance,
+	// leave messages untouched.
+	if (!model) return messages
+	let changed = false
+	const stripped = messages.map((msg) => {
+		if (msg.role !== "assistant") return msg
+		const isSameModel = msg.provider === model.provider && msg.api === model.api && msg.model === model.id
+		if (isSameModel) return msg
+		if (!msg.content.some((block) => block.type === "thinking")) return msg
+		changed = true
+		return { ...msg, content: msg.content.filter((block) => block.type !== "thinking") }
+	})
+	return changed ? stripped : messages
+}


### PR DESCRIPTION
## Linked issue

Closes #1063

## What does this PR do?

After a model switch, pi-ai converts the previous model's `thinking` blocks into plain assistant **text** so the cross-model request stays valid. The new model reads that converted text as assistant-authored chain-of-thought and mimics it — emitting reasoning prose and stopping instead of calling tools.

This surfaced in a real session: after switching glm-5.2-fp8 → kimi-k2.7, the model stalled for four consecutive turns (reasoning prose or reasoning-only, `stop`, zero tool calls), and continuation nudges did not recover it. Reproduction of the reconstructed 141-message context:

| Variant | Result |
|---|---|
| kimi-k2.7, full context (thinking leaked) | `stop`, no tool calls — stall |
| kimi-k2.7, thinking blocks stripped from history | `toolUse`, calls `read` — fixed |
| glm-5.2-fp8, full context | `toolUse`, calls `edit` |
| kimi-k3, full context | `toolUse`, calls `grep` |

The fix applies that exact validated transformation inside the harness: `stripCrossModelThinking(messages, model)` drops `thinking` blocks from assistant messages whose provider/api/model do not all match the active model (mirroring pi-ai's `isSameModel`). It runs in both `context` handlers in `prompt-enrichment.ts` (orchestrator + subagent). Same-model thinking is preserved verbatim (signed/redacted replay depends on it). A source-contract test ensures both handlers keep applying the strip.

Side effects worth noting: ~17k tokens of leaked chain-of-thought removed from the observed session's context; thinking-only cross-model assistant messages keep their slot with empty `content` (pi-ai deterministically skips them).

Follow-up: file an upstream pi-ai issue — converting cross-model thinking to plain assistant text is the root behavior; dropping/relabeling it upstream would eventually let this harness-side strip be retired.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`) — 9 new tests pass; 25 full-suite failures verified identical on master (pre-existing, permissions/ACP/web-fetch domains, unrelated)
- [x] Lint passes (`pnpm run check`) — typecheck + biome clean
- [x] Documentation updated if behavior changed — behavior change is invisible at the terminal layer; rationale is documented in the linked issue and inline in the module
