### PR TITLE
test(billing): update e2e assertion for changed BYO inference warning

### DIFF
--- a/tests/e2e/tui/billing-warnings.test.ts
+++ b/tests/e2e/tui/billing-warnings.test.ts
@@ -147,7 +147,7 @@ test("explains BYO inference when the backend blocks a Community user", async ({
 			await waitForText(terminal, "inference to the harness", { full: true })
 			await waitForText(terminal, "To use Kimchi inference", { full: true })
 			await waitForText(terminal, "upgrade", { full: true })
-			await waitForText(terminal, "Coder.", { full: true })
+			await waitForText(terminal, "https://app.kimchi.dev/pricing", { full: true })
 			expect(fullText(terminal)).not.toContain("You ran out of credits")
 			expect(fullText(terminal)).not.toContain("Top up at")
 			expect(fullText(terminal)).not.toContain("You are using Community tier")


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Fix assertion in end to end test after UI changes

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
