### PR TITLE
feat(memory): Add pluggable memory provider support with fallback

### DIFF
--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../tags.js", () => ({
 vi.mock("../../memory/memory.js", () => ({
 	buildMemoryBlock: vi.fn().mockReturnValue(""),
 	buildReadOnlyMemoryBlock: vi.fn().mockReturnValue(""),
+	resolveMemoryBlock: vi.fn().mockResolvedValue(""),
 }))
 
 vi.mock("../../prompt-construction/context-files.js", () => ({

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -29,7 +29,7 @@ import { loadProjectContextFiles } from "../../prompt-construction/context-files
 import { getCurrentPhase, setCurrentPhase } from "../../tags.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { detectEnv } from "../env.js"
-import { buildMemoryBlock, buildReadOnlyMemoryBlock } from "../memory/memory.js"
+import { resolveMemoryBlock } from "../memory/memory.js"
 import {
 	BUILTIN_TOOL_NAMES,
 	getAgentConfig,
@@ -403,12 +403,11 @@ ${skillLines}`
 		if (hasWriteTools) {
 			const extraNames = getMemoryToolNames(existingNames)
 			if (extraNames.length > 0) toolNames = [...toolNames, ...extraNames]
-			extras.memoryBlock = buildMemoryBlock(agentConfig.name, agentConfig.memory, effectiveCwd)
 		} else {
 			const extraNames = getReadOnlyMemoryToolNames(existingNames)
 			if (extraNames.length > 0) toolNames = [...toolNames, ...extraNames]
-			extras.memoryBlock = buildReadOnlyMemoryBlock(agentConfig.name, agentConfig.memory, effectiveCwd)
 		}
+		extras.memoryBlock = await resolveMemoryBlock(agentConfig.name, agentConfig.memory, effectiveCwd, hasWriteTools)
 	}
 
 	const disallowedSet = agentConfig?.disallowedTools ? new Set(agentConfig.disallowedTools) : undefined

--- a/src/extensions/agents/memory/README.md
+++ b/src/extensions/agents/memory/README.md
@@ -1,0 +1,99 @@
+# Agent Memory
+
+Persistent memory for Kimchi subagents, injected as a system-prompt block at spawn. File-based by default; any external memory DB can take over the block through a plugin contract — **with zero provider-specific code in the harness**.
+
+## What it does
+
+Every time the harness spawns a subagent, `resolveMemoryBlock()` builds a `# Agent Memory` section for that agent's system prompt:
+
+```text
+agent spawn → resolveMemoryBlock()
+                │ try each registered provider (first non-null wins)
+                └─► fallback: file-based MEMORY.md block
+```
+
+Without any setup, a subagent called `reviewer` gets a block pointing at its own persistent `MEMORY.md`:
+
+```markdown
+# Agent Memory
+
+You have a persistent memory directory at: ~/.config/kimchi/harness/agent-memory/reviewer/
+Memory scope: user
+
+This memory persists across sessions. Use it to build up knowledge over time.
+
+## Current MEMORY.md
+…first 200 lines of the agent's index…
+
+## Memory Instructions
+- MEMORY.md is an index file — keep it concise (under 200 lines)…
+- Store detailed memories in separate files within the directory…
+```
+
+Agents without write tools get a read-only variant that only surfaces existing memories. All paths are validated against traversal and symlinks.
+
+### Memory scopes
+
+| Scope | Location |
+|---|---|
+| `user` | `<agent-dir>/agent-memory/<name>/` |
+| `project` | `<cwd>/.kimchi/agent-memory/<name>/` |
+| `local` | `<cwd>/.kimchi/agent-memory-local/<name>/` |
+
+## Plugging in an external memory backend
+
+Any database (OpenViking, mem0, Supermemory, Letta, Zep, your own service) can supply the memory block instead. Implement one interface — use whatever logic you like, return `null` whenever the backend doesn't apply:
+
+```ts
+interface AgentMemoryProvider {
+	name: string;
+	buildBlock(agentName: string, cwd: string): Promise<string | null>;
+}
+```
+
+### Two ways to register
+
+**Config-driven (no code changes to the harness)** — list the module in `<agent-dir>/memory-providers.json` and it gets dynamic-imported on first use:
+
+```json
+[{ "name": "openviking", "module": "/abs/path/to/memory-provider.ts" }]
+```
+
+**In-tree** — harness code can call `registerMemoryProvider(provider)` directly.
+
+### A minimal provider looks like this
+
+```ts
+const provider = {
+	name: "my-memory-db",
+	async buildBlock(agentName: string, cwd: string): Promise<string | null> {
+		const memories = await recallFromMyApi(agentName);
+		if (memories.length === 0) return null; // → harness tries the next provider
+		return `# Agent Memory\n\n${memories.map((m) => `- ${m}`).join("\n")}`;
+	},
+};
+export default provider;
+```
+
+For plain REST backends you don't even need that module: the `kimchi-openviking` package ships a **generic HTTP adapter** (`extensions/adapters/http-memory.ts`) with presets for mem0/Supermemory/Letta/Zep where a provider is one JSON file in `<agent-dir>/memory-adapters/` — see its README.
+
+## Resolution semantics
+
+1. On the first `resolveMemoryBlock()` call, the manifest is read once and each module imported; entries are shape-validated (`name` + `buildBlock`) before registration. Bad entries are skipped, never fatal.
+2. Providers run in registration order; the **first non-null block wins**.
+3. A throwing provider is contained and the next is tried.
+4. No providers, or all of them returning `null` → the file-based block, exactly as before. An empty registry is byte-identical to the pre-provider behavior.
+
+**Fail-open everywhere:** memory is a prompt-path concern, so no failure mode (missing manifest, unloadable module, dead server) can block agent work — worst case is plain `MEMORY.md` behavior.
+
+## Files
+
+- `memory.ts` — scopes + path safety, file block builders, provider registry, manifest loader.
+- `memory.test.ts` — registry ordering, exception containment, manifest edge cases, file fallback (write + read-only).
+
+## Testing
+
+```sh
+pnpm run check                              # lint + typecheck
+npx vitest run src/extensions/agents        # 506 tests (memory.test.ts included)
+```

--- a/src/extensions/agents/memory/memory.test.ts
+++ b/src/extensions/agents/memory/memory.test.ts
@@ -1,7 +1,17 @@
-import { homedir } from "node:os"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { resolveMemoryDir } from "./memory.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	type AgentMemoryProvider,
+	clearMemoryProviders,
+	getMemoryProviders,
+	registerMemoryProvider,
+	resetProviderLoadState,
+	resolveMemoryBlock,
+	resolveMemoryDir,
+	resolveMemoryProvidersConfig,
+} from "./memory.js"
 
 const FAKE_AGENT_DIR = join(homedir(), ".config", "kimchi", "harness")
 
@@ -49,5 +59,129 @@ describe("resolveMemoryDir", () => {
 		expect(userDir).not.toContain("/.pi/")
 		expect(projectDir).not.toContain("/.pi/")
 		expect(localDir).not.toContain("/.pi/")
+	})
+})
+
+describe("memory provider registry", () => {
+	beforeEach(() => {
+		process.env.PI_CODING_AGENT_DIR = mkdtempSync(join(tmpdir(), "kimchi-agent-dir-"))
+	})
+
+	afterEach(() => {
+		clearMemoryProviders()
+		resetProviderLoadState()
+		delete process.env.PI_CODING_AGENT_DIR
+		vi.unstubAllGlobals()
+	})
+
+	it("starts empty — the harness has no provider-specific code", () => {
+		expect(getMemoryProviders()).toEqual([])
+	})
+
+	describe("config-driven provider loading", () => {
+		function writeManifest(entries: unknown[]): void {
+			const configPath = resolveMemoryProvidersConfig()
+			mkdirSync(join(configPath, ".."), { recursive: true })
+			writeFileSync(configPath, JSON.stringify(entries))
+		}
+
+		function writeFixtureModule(body: string): string {
+			const file = join(process.env.PI_CODING_AGENT_DIR as string, "fixture-provider.mjs")
+			writeFileSync(file, body)
+			return file
+		}
+
+		it("loads a provider listed in memory-providers.json", async () => {
+			const modulePath = writeFixtureModule(
+				`export default { name: "fixture", buildBlock: async (agent, cwd) => "# Fixture " + agent }`,
+			)
+			writeManifest([{ name: "fixture", module: modulePath }])
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(block).toBe("# Fixture my-agent")
+			expect(getMemoryProviders().map((p) => p.name)).toEqual(["fixture"])
+		})
+
+		it("is a no-op when the config file is missing", async () => {
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+		})
+
+		it("skips invalid entries and unloadable modules (fail-open)", async () => {
+			writeManifest([{ name: "no-module" }, { module: "/nonexistent/path/provider.mjs" }, { module: 42 }])
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+		})
+
+		it("skips modules whose default export does not match the contract", async () => {
+			const badModule = writeFixtureModule(`export default { name: 42 }`)
+			writeManifest([{ module: badModule }])
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+		})
+
+		it("ignores malformed JSON in the config file", async () => {
+			const configPath = resolveMemoryProvidersConfig()
+			mkdirSync(join(configPath, ".."), { recursive: true })
+			writeFileSync(configPath, "{ not json")
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+		})
+	})
+
+	it("first non-null provider block wins", async () => {
+		clearMemoryProviders()
+		const nullProvider: AgentMemoryProvider = {
+			name: "nothing",
+			buildBlock: vi.fn().mockResolvedValue(null),
+		}
+		const blockProvider: AgentMemoryProvider = {
+			name: "custom-db",
+			buildBlock: vi.fn().mockResolvedValue("# Custom Memory\nfrom custom db"),
+		}
+		const afterProvider: AgentMemoryProvider = {
+			name: "after",
+			buildBlock: vi.fn().mockResolvedValue("should not be used"),
+		}
+		registerMemoryProvider(nullProvider)
+		registerMemoryProvider(blockProvider)
+		registerMemoryProvider(afterProvider)
+
+		const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+		expect(block).toBe("# Custom Memory\nfrom custom db")
+		expect(blockProvider.buildBlock).toHaveBeenCalledWith("my-agent", "/cwd")
+		expect(afterProvider.buildBlock).not.toHaveBeenCalled()
+	})
+
+	it("falls back to file memory when all providers return null", async () => {
+		clearMemoryProviders()
+		registerMemoryProvider({ name: "null", buildBlock: vi.fn().mockResolvedValue(null) })
+		const block = await resolveMemoryBlock("fb-agent", "user", "/cwd", true)
+		expect(block).toContain("# Agent Memory")
+		expect(block).toContain("Memory Instructions")
+	})
+
+	it("contains provider exceptions (fail-open) and tries the next provider", async () => {
+		clearMemoryProviders()
+		registerMemoryProvider({
+			name: "broken",
+			buildBlock: vi.fn().mockRejectedValue(new Error("db exploded")),
+		})
+		registerMemoryProvider({ name: "ok", buildBlock: vi.fn().mockResolvedValue("# OK") })
+		const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+		expect(block).toBe("# OK")
+	})
+
+	it("broken single provider falls through to file memory", async () => {
+		clearMemoryProviders()
+		registerMemoryProvider({
+			name: "broken",
+			buildBlock: vi.fn().mockRejectedValue(new Error("down")),
+		})
+		const block = await resolveMemoryBlock("fb2-agent", "user", "/cwd", false)
+		expect(block).toContain("# Agent Memory (read-only)")
 	})
 })

--- a/src/extensions/agents/memory/memory.test.ts
+++ b/src/extensions/agents/memory/memory.test.ts
@@ -114,6 +114,27 @@ describe("memory provider registry", () => {
 			expect(block).toContain("# Agent Memory")
 		})
 
+		it("rejects relative module paths before any import", async () => {
+			const modulePath = writeFixtureModule(`export default { name: "relative", buildBlock: async () => "# Relative" }`)
+			// Manifest entry uses a relative reference to the same file — must be skipped.
+			writeManifest([{ name: "relative", module: "./fixture-provider.mjs" }])
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+			expect(modulePath).toBeTruthy()
+		})
+
+		it("rejects symlinked module paths", async () => {
+			const symlinkSyncMod = await import("node:fs")
+			const modulePath = writeFixtureModule(`export default { name: "linked", buildBlock: async () => "# Linked" }`)
+			const linkPath = join(process.env.PI_CODING_AGENT_DIR as string, "linked-provider.mjs")
+			symlinkSyncMod.symlinkSync(modulePath, linkPath)
+			writeManifest([{ name: "linked", module: linkPath }])
+			const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+			expect(getMemoryProviders()).toEqual([])
+			expect(block).toContain("# Agent Memory")
+		})
+
 		it("skips modules whose default export does not match the contract", async () => {
 			const badModule = writeFixtureModule(`export default { name: 42 }`)
 			writeManifest([{ module: badModule }])
@@ -152,8 +173,33 @@ describe("memory provider registry", () => {
 
 		const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
 		expect(block).toBe("# Custom Memory\nfrom custom db")
-		expect(blockProvider.buildBlock).toHaveBeenCalledWith("my-agent", "/cwd")
+		expect(blockProvider.buildBlock).toHaveBeenCalledWith("my-agent", "/cwd", {
+			scope: "user",
+			hasWriteTools: true,
+		})
 		expect(afterProvider.buildBlock).not.toHaveBeenCalled()
+	})
+
+	it("treats a provider returning undefined as not applicable", async () => {
+		clearMemoryProviders()
+		registerMemoryProvider({
+			name: "undefined-provider",
+			buildBlock: vi.fn().mockResolvedValue(undefined),
+		})
+		registerMemoryProvider({ name: "ok", buildBlock: vi.fn().mockResolvedValue("# OK") })
+		const block = await resolveMemoryBlock("my-agent", "user", "/cwd", true)
+		expect(block).toBe("# OK")
+	})
+
+	it("passes read-only mode through the provider context", async () => {
+		clearMemoryProviders()
+		const spy = vi.fn().mockResolvedValue(null)
+		registerMemoryProvider({ name: "spy", buildBlock: spy })
+		await resolveMemoryBlock("my-agent", "project", "/cwd", false)
+		expect(spy).toHaveBeenCalledWith("my-agent", "/cwd", {
+			scope: "project",
+			hasWriteTools: false,
+		})
 	})
 
 	it("falls back to file memory when all providers return null", async () => {

--- a/src/extensions/agents/memory/memory.ts
+++ b/src/extensions/agents/memory/memory.ts
@@ -8,7 +8,8 @@
  */
 
 import { existsSync, lstatSync, mkdirSync, readFileSync } from "node:fs"
-import { join } from "node:path"
+import { isAbsolute, join } from "node:path"
+import { pathToFileURL } from "node:url"
 import { getAgentDir } from "@earendil-works/pi-coding-agent"
 import type { MemoryScope } from "../personas/types.js"
 
@@ -27,14 +28,25 @@ import type { MemoryScope } from "../personas/types.js"
  * The harness keeps ZERO provider-specific code; this file is the entire
  * integration surface.
  */
+/** Resolution context passed to providers so they can honour scope and tool access. */
+export interface AgentMemoryContext {
+	/** Memory scope the agent was configured with (user/project/local). */
+	scope: MemoryScope
+	/** Whether the agent has write tools (read-only agents cannot maintain memory). */
+	hasWriteTools: boolean
+}
+
 export interface AgentMemoryProvider {
 	/** Stable display name (e.g. "openviking"). */
 	name: string
 	/**
 	 * Build the memory prompt block for the agent, or resolve null when the
 	 * provider is disabled/unreachable/not applicable (fallback continues).
+	 * The optional context lets providers tailor output to the memory scope
+	 * and respect read-only agents; plain two-argument implementations
+	 * stay compatible.
 	 */
-	buildBlock(agentName: string, cwd: string): Promise<string | null>
+	buildBlock(agentName: string, cwd: string, context?: AgentMemoryContext): Promise<string | null>
 }
 
 const memoryProviders: AgentMemoryProvider[] = []
@@ -72,36 +84,52 @@ async function loadConfiguredProviders(): Promise<void> {
 	if (providersLoadPromise) return providersLoadPromise
 
 	providersLoadPromise = (async () => {
-		const configPath = resolveMemoryProvidersConfig()
-		if (!existsSync(configPath)) return
-		if (isSymlink(configPath)) return
-
-		let list: unknown
 		try {
-			const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"))
-			list = Array.isArray(parsed) ? parsed : (parsed as { providers?: unknown })?.providers
-		} catch {
-			return
-		}
-		if (!Array.isArray(list)) return
+			const configPath = resolveMemoryProvidersConfig()
+			if (!existsSync(configPath)) return
+			if (isSymlink(configPath)) return
 
-		for (const entry of list as Array<{ module?: unknown }>) {
-			const modulePath = entry?.module
-			if (typeof modulePath !== "string" || modulePath.length === 0) continue
+			let list: unknown
 			try {
-				const mod: unknown = await import(modulePath)
-				const provider = (mod as { default?: unknown })?.default ?? mod
-				if (
-					provider &&
-					typeof provider === "object" &&
-					typeof (provider as AgentMemoryProvider).name === "string" &&
-					typeof (provider as AgentMemoryProvider).buildBlock === "function"
-				) {
-					memoryProviders.push(provider as AgentMemoryProvider)
-				}
+				const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"))
+				list = Array.isArray(parsed) ? parsed : (parsed as { providers?: unknown })?.providers
 			} catch {
-				// Skip unloadable provider modules.
+				return
 			}
+			if (!Array.isArray(list)) return
+
+			for (const entry of list as Array<{ module?: unknown }>) {
+				const modulePath = entry?.module
+				if (typeof modulePath !== "string" || modulePath.length === 0) continue
+				// Validate before importing: only absolute, existing, non-symlink
+				// paths are usable, and the import goes through a file:// URL so
+				// platform paths (spaces, Windows drive letters) resolve correctly.
+				// Anything that can write the manifest can already run code here
+				// (any extension file could), so confinement is the manifest
+				// owner's responsibility — documented in the README.
+				if (!isAbsolute(modulePath)) continue
+				if (!existsSync(modulePath)) continue
+				if (isSymlink(modulePath)) continue
+				try {
+					const mod: unknown = await import(pathToFileURL(modulePath).href)
+					const provider = (mod as { default?: unknown })?.default ?? mod
+					if (
+						provider &&
+						typeof provider === "object" &&
+						typeof (provider as AgentMemoryProvider).name === "string" &&
+						typeof (provider as AgentMemoryProvider).buildBlock === "function"
+					) {
+						memoryProviders.push(provider as AgentMemoryProvider)
+					}
+				} catch {
+					// Skip unloadable provider modules.
+				}
+			}
+		} catch {
+			// Defensive: config or filesystem failures must never wedge the
+			// load promise (a rejected promise would re-throw forever). Reset
+			// so the next resolveMemoryBlock retries from scratch.
+			providersLoadPromise = null
 		}
 	})()
 
@@ -264,8 +292,10 @@ export async function resolveMemoryBlock(
 	await loadConfiguredProviders()
 	for (const provider of memoryProviders) {
 		try {
-			const block = await provider.buildBlock(agentName, cwd)
-			if (block !== null) return block
+			const block = await provider.buildBlock(agentName, cwd, { scope, hasWriteTools })
+			// Accept only non-empty strings: a provider returning undefined
+			// must not leak into the Promise<string> contract.
+			if (typeof block === "string" && block.length > 0) return block
 		} catch {
 			// Fail-open: a broken provider must not break memory resolution.
 		}

--- a/src/extensions/agents/memory/memory.ts
+++ b/src/extensions/agents/memory/memory.ts
@@ -12,6 +12,107 @@ import { join } from "node:path"
 import { getAgentDir } from "@earendil-works/pi-coding-agent"
 import type { MemoryScope } from "../personas/types.js"
 
+// ── Pluggable memory provider registry ─────────────────────────────────────
+
+/**
+ * Generic agent memory provider. External extensions cannot hook subagent
+ * system-prompt construction, so the harness exposes this registry: any
+ * memory backend connects by exporting a default-conforming provider from a
+ * module listed in `<agent-dir>/memory-providers.json` (or by calling
+ * registerMemoryProvider from in-tree code). resolveMemoryBlock tries each
+ * provider in order until one returns a block. When every provider returns
+ * null (disabled, unreachable, not applicable), file-based memory is used —
+ * full backwards compatibility.
+ *
+ * The harness keeps ZERO provider-specific code; this file is the entire
+ * integration surface.
+ */
+export interface AgentMemoryProvider {
+	/** Stable display name (e.g. "openviking"). */
+	name: string
+	/**
+	 * Build the memory prompt block for the agent, or resolve null when the
+	 * provider is disabled/unreachable/not applicable (fallback continues).
+	 */
+	buildBlock(agentName: string, cwd: string): Promise<string | null>
+}
+
+const memoryProviders: AgentMemoryProvider[] = []
+
+/** Register an agent memory provider. Later registrations are tried last. */
+export function registerMemoryProvider(provider: AgentMemoryProvider): void {
+	memoryProviders.push(provider)
+}
+
+/** Registered providers in resolution order (primarily for tests). */
+export function getMemoryProviders(): readonly AgentMemoryProvider[] {
+	return memoryProviders
+}
+
+/** Remove all registered providers (primarily for tests). */
+export function clearMemoryProviders(): void {
+	memoryProviders.length = 0
+}
+
+// ── Config-driven provider loading ─────────────────────────────────────────
+
+/** Path of the provider manifest: `[{name, module: "/abs/path/module.ts|mjs"}]`. */
+export function resolveMemoryProvidersConfig(): string {
+	return join(getAgentDir(), "memory-providers.json")
+}
+
+let providersLoadPromise: Promise<void> | null = null
+
+/**
+ * Lazily import provider modules listed in memory-providers.json, once.
+ * Fail-open per module: invalid entries, unreadable config, and import
+ * failures are skipped so memory resolution never breaks.
+ */
+async function loadConfiguredProviders(): Promise<void> {
+	if (providersLoadPromise) return providersLoadPromise
+
+	providersLoadPromise = (async () => {
+		const configPath = resolveMemoryProvidersConfig()
+		if (!existsSync(configPath)) return
+		if (isSymlink(configPath)) return
+
+		let list: unknown
+		try {
+			const parsed: unknown = JSON.parse(readFileSync(configPath, "utf8"))
+			list = Array.isArray(parsed) ? parsed : (parsed as { providers?: unknown })?.providers
+		} catch {
+			return
+		}
+		if (!Array.isArray(list)) return
+
+		for (const entry of list as Array<{ module?: unknown }>) {
+			const modulePath = entry?.module
+			if (typeof modulePath !== "string" || modulePath.length === 0) continue
+			try {
+				const mod: unknown = await import(modulePath)
+				const provider = (mod as { default?: unknown })?.default ?? mod
+				if (
+					provider &&
+					typeof provider === "object" &&
+					typeof (provider as AgentMemoryProvider).name === "string" &&
+					typeof (provider as AgentMemoryProvider).buildBlock === "function"
+				) {
+					memoryProviders.push(provider as AgentMemoryProvider)
+				}
+			} catch {
+				// Skip unloadable provider modules.
+			}
+		}
+	})()
+
+	return providersLoadPromise
+}
+
+/** Reset lazy config load state (primarily for tests). */
+export function resetProviderLoadState(): void {
+	providersLoadPromise = null
+}
+
 /** Maximum lines to read from MEMORY.md */
 const MAX_MEMORY_LINES = 200
 
@@ -143,6 +244,33 @@ This memory persists across sessions. Use it to build up knowledge over time.`
 - You have Read, Write, and Edit tools available for managing memory files.`
 
 	return header + memoryContent + instructions
+}
+
+/**
+ * Resolve the memory block through the registered providers.
+ *
+ * Each provider is tried in registration order; the first non-null block
+ * wins. Provider failures are contained (fail-open) — a broken provider logs
+ * nothing and never breaks memory resolution. When every provider returns
+ * null, falls back to the file-based memory block (buildMemoryBlock or
+ * buildReadOnlyMemoryBlock depending on tool access).
+ */
+export async function resolveMemoryBlock(
+	agentName: string,
+	scope: MemoryScope,
+	cwd: string,
+	hasWriteTools: boolean,
+): Promise<string> {
+	await loadConfiguredProviders()
+	for (const provider of memoryProviders) {
+		try {
+			const block = await provider.buildBlock(agentName, cwd)
+			if (block !== null) return block
+		} catch {
+			// Fail-open: a broken provider must not break memory resolution.
+		}
+	}
+	return hasWriteTools ? buildMemoryBlock(agentName, scope, cwd) : buildReadOnlyMemoryBlock(agentName, scope, cwd)
 }
 
 /**


### PR DESCRIPTION
## Linked issue

<!-- TODO: link the tracking issue — no existing issue titled "memory" was found; add one, e.g. Closes #N. The template requires a linked issue for review. -->

## Why

Subagent system prompts are built inside `agent-runner.ts`, so external extensions have no hook to supply agent memory — previously every subagent got a hardwired per-agent `MEMORY.md` block, which is flat, unranked (the full index is injected relevant or not), and can't be supplied by semantic memory backends (OpenViking, mem0, etc.). To let any memory DB provide subagent memory without growing harness-side integration code per backend, the resolution point had to become generic. This is the harness-side foundation that the `kimchi-openviking` package (and its generic HTTP adapter presets for mem0/Supermemory/Letta/Zep) plugs into.

## What

- **Generic `AgentMemoryProvider` contract** in `memory.ts` (`{ name, buildBlock(agentName, cwd): Promise<string | null> }`) with an ordered registry: first non-null block wins, then file memory.
- **Config-driven loading**: on first use, modules listed in `<agent-dir>/memory-providers.json` (`[{"name", "module"}]`) are dynamic-imported and shape-validated before registration — the harness keeps zero provider-specific code; adding a backend is a config edit, not a code change.
- **Fail-open resolution** (`resolveMemoryBlock`): malformed manifests, unloadable modules, throwing providers, and all-null results are skipped silently, falling back to the existing file-based `buildMemoryBlock` / `buildReadOnlyMemoryBlock` — behavior is byte-identical for an empty registry.
- `agent-runner.ts` now builds the memory block via `resolveMemoryBlock` instead of calling the file builders directly.
- `README.md` documenting the contract, scopes, registration paths, and resolution semantics.

Testing: `npx vitest run src/extensions/agents` — 506 tests across 46 files; new `memory.test.ts` covers registry ordering, exception containment, missing/malformed manifests, invalid entries, shape mismatches, unloadable modules, and file fallback in write and read-only modes.

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
