### PR TITLE
fix(hooks): Claude Code hook event mismatch + user-level hooks dropped

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -137,7 +137,7 @@ Supported events:
 
 - `PreToolUse`
 - `PostToolUse`
-- `PostToolUseFail` — runs only when a tool result is an error (`PostToolUse` still runs for all results)
+- `PostToolUseFailure` — runs only when a tool result is an error (`PostToolUse` still runs for all results)
 - `PostToolBatch` — synthesized once per turn after all tool executions in that turn finish
 - `SessionStart`
 - `PreCompact`

--- a/src/extensions/claude-code-hook-adapter/definition.test.ts
+++ b/src/extensions/claude-code-hook-adapter/definition.test.ts
@@ -23,7 +23,7 @@ describe("Claude Code hook discovery", () => {
 		rmSync(dir, { recursive: true, force: true })
 	})
 
-	it("does not load user Claude settings when cwd lacks .claude", () => {
+	it("loads user Claude settings even when cwd lacks .claude", () => {
 		const home = process.env.HOME ?? ""
 		const cwd = join(home, "work", "project")
 		mkdirSync(cwd, { recursive: true })
@@ -40,7 +40,23 @@ describe("Claude Code hook discovery", () => {
 
 		const resources = discoverClaudeCodeHookResources(cwd)
 
-		expect(resources).toEqual([])
+		// User-level settings.json always loads (real Claude Code loads user hooks regardless of project structure).
+		// settings.local.json at the home level is not a valid source (local scope is project-level only), so its Stop hook is NOT discovered.
+		expect(resources).toEqual([
+			{
+				adapterId: "claude-code",
+				async: false,
+				command: "load-context",
+				env: undefined,
+				eventName: "SessionStart",
+				id: "hooks.claude-code.user.session-start.0",
+				index: 0,
+				matcher: undefined,
+				path: join(home, ".claude", "settings.json"),
+				scope: "user",
+				timeoutMs: 60_000,
+			},
+		])
 	})
 })
 

--- a/src/extensions/claude-code-hook-adapter/definition.ts
+++ b/src/extensions/claude-code-hook-adapter/definition.ts
@@ -24,9 +24,8 @@ export function discoverClaudeCodeHookResources(cwd = process.cwd()) {
 function claudeCodeHookSources(cwd = process.cwd()): CommandHookSource[] {
 	const homeDir = homedir()
 	const projectDir = resolve(cwd)
-	if (!existsSync(join(projectDir, ".claude"))) return []
 	const sources: CommandHookSource[] = [{ scope: "user", path: join(homeDir, ".claude", "settings.json") }]
-	if (resolve(projectDir) !== resolve(homeDir)) {
+	if (existsSync(join(projectDir, ".claude")) && resolve(projectDir) !== resolve(homeDir)) {
 		sources.push(
 			{ scope: "project", path: join(projectDir, ".claude", "settings.json") },
 			{ scope: "local", path: join(projectDir, ".claude", "settings.local.json") },

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -480,11 +480,11 @@ describe("hook adapter command execution", () => {
 		expect(pi.sendUserMessage).not.toHaveBeenCalled()
 	})
 
-	it("runs PostToolUseFail hooks only for failed tool results", async () => {
+	it("runs PostToolUseFailure hooks only for failed tool results", async () => {
 		writeJson(join(dir, "home", ".claude", "settings.json"), {
 			hooks: {
 				PostToolUse: [{ hooks: [{ type: "command", command: "post-tool" }] }],
-				PostToolUseFail: [{ hooks: [{ type: "command", command: "post-tool-fail" }] }],
+				PostToolUseFailure: [{ hooks: [{ type: "command", command: "post-tool-fail" }] }],
 			},
 		})
 		const postHook = mockBlockingHook()
@@ -507,7 +507,7 @@ describe("hook adapter command execution", () => {
 		expect(mockSpawn).toHaveBeenCalledTimes(2)
 		expect(hookPayload(postHook).hook_event_name).toBe("PostToolUse")
 		const failPayload = hookPayload(failHook)
-		expect(failPayload.hook_event_name).toBe("PostToolUseFail")
+		expect(failPayload.hook_event_name).toBe("PostToolUseFailure")
 		expect(failPayload.is_error).toBe(true)
 
 		mockSpawn.mockClear()

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -342,7 +342,7 @@ async function runPostToolUse(
 	if (event.isError) {
 		result = mergeOptionalResults(
 			result,
-			await runMatchingHooks(definition, "PostToolUseFail", ctx, matcherCandidates(event.toolName), basePayload),
+			await runMatchingHooks(definition, "PostToolUseFailure", ctx, matcherCandidates(event.toolName), basePayload),
 		)
 	}
 	const skillName = skillNameFromReadPath(event)

--- a/src/extensions/hook-adapters/discovery.test.ts
+++ b/src/extensions/hook-adapters/discovery.test.ts
@@ -58,6 +58,18 @@ describe("hook adapter discovery", () => {
 		expect(hooks).toEqual([])
 	})
 
+	it("discovers user-level Claude Code hooks even when project cwd has no .claude directory", () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				PreToolUse: [{ hooks: [{ type: "command", command: "user-guard" }] }],
+			},
+		})
+
+		const hooks = discoverClaudeCodeHookResources(join(dir, "project"))
+
+		expect(hooks.map((hook) => hook.id)).toEqual(["hooks.claude-code.user.pre-tool-use.0"])
+	})
+
 	it("honors disableAllHooks in JSON hook configs", () => {
 		mkdirSync(join(dir, "project", ".claude"), { recursive: true })
 		writeJson(join(dir, "home", ".claude", "settings.json"), {

--- a/src/extensions/hook-adapters/discovery.ts
+++ b/src/extensions/hook-adapters/discovery.ts
@@ -6,7 +6,7 @@ export type HookAdapterScope = "user" | "project" | "local"
 export type CommandHookEventName =
 	| "PreToolUse"
 	| "PostToolUse"
-	| "PostToolUseFail"
+	| "PostToolUseFailure"
 	| "PostToolBatch"
 	| "SessionStart"
 	| "PreCompact"
@@ -29,7 +29,7 @@ export type CommandHookEventName =
 export const FULL_COMMAND_HOOK_EVENTS: readonly CommandHookEventName[] = [
 	"PreToolUse",
 	"PostToolUse",
-	"PostToolUseFail",
+	"PostToolUseFailure",
 	"PostToolBatch",
 	"SessionStart",
 	"PreCompact",


### PR DESCRIPTION
## Linked issue

Closes #1070

## What does this PR do?

Fixes two interop bugs in the Claude Code hook adapter:

1. **Event name mismatch** — renames `PostToolUseFail` → `PostToolUseFailure` to match real Claude Code. Hooks keyed `PostToolUseFailure` were silently dropped at discovery.

2. **User-level hooks dropped** — `claudeCodeHookSources()` now always includes the user-level source (`~/.claude/settings.json`). Previously it returned `[]` early when the project cwd had no `.claude/` dir, dropping user-level hooks that should always load.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed