### PR TITLE
feat(acp): expose skills as slash commands and preload them like TUI

### DIFF
--- a/src/extensions/agents/prompt/skill-loader.test.ts
+++ b/src/extensions/agents/prompt/skill-loader.test.ts
@@ -41,12 +41,34 @@ describe("preloadSkills", () => {
 })
 
 describe("listAvailableSkillNames", () => {
-	it("returns an array of skill objects with name and description", () => {
-		const skills = listAvailableSkillNames(process.cwd())
-		expect(Array.isArray(skills)).toBe(true)
-		for (const skill of skills) {
-			expect(typeof skill.name).toBe("string")
-			expect(typeof skill.description).toBe("string")
-		}
+	it("returns an array of skill objects with name, description, and filePath", () => {
+		const base = join(tmpdir(), `kimchi-list-skills-${Date.now()}`)
+		const cwd = join(base, "project")
+		const skillDir = join(cwd, ".pi", "agent", "skills", "listed-skill")
+		mkdirSync(skillDir, { recursive: true })
+		const skillPath = join(skillDir, "SKILL.md")
+		writeFileSync(skillPath, "---\nname: listed-skill\ndescription: listed\n---\nbody")
+
+		const skills = listAvailableSkillNames(cwd)
+		expect(skills).toContainEqual({
+			name: "listed-skill",
+			description: "listed",
+			filePath: skillPath,
+		})
+	})
+
+	it("resolves .config/ paths against the provided homeDir override", () => {
+		const home = join(tmpdir(), `kimchi-home-skills-${Date.now()}`)
+		const skillDir = join(home, ".config", "kimchi", "harness", "skills", "home-skill")
+		mkdirSync(skillDir, { recursive: true })
+		const skillPath = join(skillDir, "SKILL.md")
+		writeFileSync(skillPath, "---\nname: home-skill\ndescription: from home\n---\nbody")
+
+		const skills = listAvailableSkillNames("/tmp/anywhere", { homeDir: home })
+		expect(skills).toContainEqual({
+			name: "home-skill",
+			description: "from home",
+			filePath: skillPath,
+		})
 	})
 })

--- a/src/extensions/agents/prompt/skill-loader.ts
+++ b/src/extensions/agents/prompt/skill-loader.ts
@@ -17,33 +17,53 @@ export interface PreloadedSkill {
 	content: string
 }
 
+export interface ListAvailableSkillNamesOptions {
+	/** Override for os.homedir(), useful for tests. Defaults to homedir(). */
+	readonly homeDir?: string
+}
+
+/** One skill discovered by {@link listAvailableSkillNames}. */
+export interface SkillListEntry {
+	name: string
+	description: string
+	filePath: string
+}
+
 /**
- * Discover all available skill names and descriptions from DEFAULT_SKILL_PATHS.
- * Returns a compact list of { name, description } pairs for injection into
- * sub-agent prompts when skills === true (the default).
- *
- * User custom skills (from .kimchi/skills/) are included since
- * DEFAULT_SKILL_PATHS scans all standard locations.
+ * Resolve kimchi's DEFAULT_SKILL_PATHS for a cwd. Absolute paths are kept as-is;
+ * paths starting with ".config/" resolve under the user's home directory; all
+ * others resolve relative to cwd.
  */
-export function listAvailableSkillNames(cwd: string): { name: string; description: string }[] {
-	const resolvedPaths = DEFAULT_SKILL_PATHS.map((p) => {
+export function resolveSkillPaths(cwd: string, home = homedir()): string[] {
+	return DEFAULT_SKILL_PATHS.map((p) => {
 		if (isAbsolute(p)) {
 			return p
 		}
 		if (p.startsWith(".config/")) {
-			return join(homedir(), p)
+			return join(home, p)
 		}
 		return join(cwd, p)
 	})
+}
 
-	const allSkills = new Map<string, { name: string; description: string }>()
-	for (const dir of resolvedPaths) {
+/**
+ * Discover all available skill names and descriptions from DEFAULT_SKILL_PATHS.
+ * Returns a compact list of { name, description, filePath } pairs for injection
+ * into sub-agent prompts when skills === true (the default).
+ *
+ * User custom skills (from .kimchi/skills/) are included since
+ * DEFAULT_SKILL_PATHS scans all standard locations.
+ */
+export function listAvailableSkillNames(cwd: string, options: ListAvailableSkillNamesOptions = {}): SkillListEntry[] {
+	const allSkills = new Map<string, SkillListEntry>()
+	for (const dir of resolveSkillPaths(cwd, options.homeDir)) {
 		try {
 			const { skills } = loadSkillsFromDir({ dir, source: dir })
 			for (const skill of skills) {
 				allSkills.set(skill.name, {
 					name: skill.name,
 					description: skill.description ?? "",
+					filePath: skill.filePath,
 				})
 			}
 		} catch (err) {
@@ -67,16 +87,7 @@ export function listAvailableSkillNames(cwd: string): { name: string; descriptio
 export function preloadSkills(skillNames: string[], cwd: string): PreloadedSkill[] {
 	if (skillNames.length === 0) return []
 
-	// Build resolved absolute paths from DEFAULT_SKILL_PATHS
-	const resolvedPaths = DEFAULT_SKILL_PATHS.map((p) => {
-		if (isAbsolute(p)) {
-			return p
-		}
-		if (p.startsWith(".config/")) {
-			return join(homedir(), p)
-		}
-		return join(cwd, p)
-	})
+	const resolvedPaths = resolveSkillPaths(cwd)
 
 	// Collect all skills from all paths using pi's official loader
 	const allSkills = new Map<string, Skill>()

--- a/src/modes/acp/ext-methods/set-session-title.test.ts
+++ b/src/modes/acp/ext-methods/set-session-title.test.ts
@@ -28,6 +28,8 @@ class FakeAgentSession {
 		this.sessionId = sessionId
 	}
 
+	getToolDefinition = vi.fn((_name: string) => undefined)
+	setActiveToolsByName = vi.fn()
 	subscribe = () => () => {}
 	async bindExtensions(): Promise<void> {}
 	async prompt(): Promise<void> {}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -27,11 +27,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 vi.mock("../../cli-auth/index.js", () => ({
 	authenticateViaBrowser: vi.fn(),
 }))
-// Mock config writes so tests don't touch the real config file.
-vi.mock("../../config.js", () => ({
-	writeApiKey: vi.fn(),
-	clearApiKey: vi.fn(),
-}))
+// Mock config writes so tests don't touch the real config file, but keep
+// DEFAULT_SKILL_PATHS so skill discovery in the ACP server works.
+vi.mock("../../config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../config.js")>()
+	return {
+		...actual,
+		writeApiKey: vi.fn(),
+		clearApiKey: vi.fn(),
+	}
+})
 // Mock the model cache refresh so tests don't hit the network.
 vi.mock("../../models.js", () => ({
 	updateModelsConfig: vi.fn(),
@@ -81,6 +86,50 @@ function cleanPermissionEnv(): void {
 beforeEach(cleanPermissionEnv)
 afterEach(cleanPermissionEnv)
 
+/** Model shape used by FakeAgentSession's model registry. */
+interface FakeModel {
+	provider: string
+	id: string
+	name?: string
+	input?: string[]
+	contextWindow?: number
+}
+
+/** Options passed through `AgentSession.prompt()` to the fake. */
+interface PromptOpts {
+	images?: unknown[]
+}
+
+/** Record of one prompt call captured by FakeAgentSession. */
+interface PromptCall {
+	prompt: string
+	opts?: PromptOpts
+}
+
+/** Context-usage stats surfaced to emitUsageUpdate. */
+interface ContextUsage {
+	tokens: number | null
+	contextWindow: number
+	percent: number | null
+}
+
+/** Token and cost stats returned by `AgentSession.getSessionStats()`. */
+interface SessionStats {
+	tokens: {
+		input: number
+		output: number
+		cacheRead: number
+		cacheWrite: number
+		total: number
+	}
+	cost: number
+}
+
+/** One option entry inside a config option returned by the ACP server. */
+interface SelectOptionItem {
+	value: string
+}
+
 // Minimal fake of AgentSession surface used by KimchiAcpAgent. The factory seam
 // means we only need to stand in for the methods the ACP server actually calls:
 // sessionId, subscribe, prompt, abort, dispose. loadSession also reads
@@ -91,7 +140,7 @@ class FakeAgentSession {
 	private listeners = new Set<AgentSessionEventListener>()
 	disposed = false
 	aborted = false
-	model: { provider: string; id: string; name?: string; input?: string[]; contextWindow?: number } | undefined = {
+	model: FakeModel | undefined = {
 		provider: "test",
 		id: "test-model",
 		name: "Test Model",
@@ -112,22 +161,22 @@ class FakeAgentSession {
 		find: (provider: string, id: string) =>
 			this.modelRegistry.getAvailable().find((m) => m.provider === provider && m.id === id),
 	}
-	promptImpl: (text: string, opts?: { images?: unknown[] }) => Promise<void> = async () => {}
+	promptImpl: (text: string, opts?: PromptOpts) => Promise<void> = async () => {}
 	abortImpl: () => Promise<void> = async () => {}
 	bindExtensionsImpl: (_bindings: unknown) => Promise<void> = async () => {}
+	// Captures tool registration and activation state for parity assertions.
+	registeredTools: Map<string, unknown> = new Map()
+	activeToolNames: string[] = []
 	lastPromptImages?: unknown[]
-	promptCalls: Array<{ prompt: string; opts?: { images?: unknown[] } }> = []
+	promptCalls: PromptCall[] = []
 	// Context-usage stats surfaced to emitUsageUpdate. Tests override these
 	// to simulate provider-reported usage or the null/empty no-op path.
-	contextUsage: { tokens: number | null; contextWindow: number; percent: number | null } | undefined = {
+	contextUsage: ContextUsage | undefined = {
 		tokens: 50_000,
 		contextWindow: 200_000,
 		percent: 25,
 	}
-	sessionStats: {
-		tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }
-		cost: number
-	} = {
+	sessionStats: SessionStats = {
 		tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		cost: 0,
 	}
@@ -198,6 +247,18 @@ class FakeAgentSession {
 
 	async bindExtensions(bindings: unknown): Promise<void> {
 		await this.bindExtensionsImpl(bindings)
+	}
+
+	getToolDefinition(name: string): unknown {
+		return this.registeredTools.get(name)
+	}
+
+	getActiveToolNames(): string[] {
+		return [...this.activeToolNames]
+	}
+
+	setActiveToolsByName(names: string[]): void {
+		this.activeToolNames = [...names]
 	}
 
 	getContextUsage(): { tokens: number | null; contextWindow: number; percent: number | null } | undefined {
@@ -3131,9 +3192,9 @@ describe("newSession available commands", () => {
 		const updatePayload = update?.update as {
 			availableCommands: Array<Record<string, unknown>>
 		}
-		expect(updatePayload.availableCommands).toHaveLength(1)
+		expect(updatePayload.availableCommands.length).toBeGreaterThanOrEqual(1)
 
-		const cmd = updatePayload.availableCommands[0]
+		const cmd = updatePayload.availableCommands.find((c) => c.name === "bug")
 		expect(cmd).toMatchObject({
 			name: "bug",
 			description: expect.any(String),
@@ -3165,6 +3226,112 @@ describe("loadSession available commands", () => {
 		const cmdUpdate = updates.find((u) => u.update.sessionUpdate === "available_commands_update")
 		expect(cmdUpdate).toBeDefined()
 		expect(updates.find((u) => u.update.sessionUpdate === "user_message_chunk")).toBeDefined()
+	})
+})
+
+describe("newSession skill commands", () => {
+	function makeSkillDir(): { dir: string; skillName: string } {
+		const dir = mkdtempSync(join(tmpdir(), "acp-server-skills-"))
+		const skillName = "acp-test-skill"
+		const skillDir = join(dir, ".pi", "agent", "skills", skillName)
+		mkdirSync(skillDir, { recursive: true })
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: ${skillName}\ndescription: ACP test skill\n---\nAlways use strict types.`,
+			"utf-8",
+		)
+		return { dir, skillName }
+	}
+
+	it("advertises discovered skills as available commands", async () => {
+		const { dir, skillName } = makeSkillDir()
+		const fake = new FakeAgentSession("session-skill-cmd", dir)
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: dir, mcpServers: [] })
+
+		const update = updates.find((u) => u.update.sessionUpdate === "available_commands_update")
+		expect(update).toBeDefined()
+		const availableCommands = (update?.update as { availableCommands: Array<Record<string, unknown>> })
+			.availableCommands
+		const skillCmd = availableCommands.find((c) => c.name === `skill:${skillName}`)
+		expect(skillCmd).toMatchObject({
+			name: `skill:${skillName}`,
+			description: "ACP test skill",
+			input: { hint: expect.any(String) },
+		})
+	})
+
+	it("rewrites a skill command prompt to inject skill content", async () => {
+		const { dir, skillName } = makeSkillDir()
+		const fake = new FakeAgentSession("session-skill-invoke", dir)
+		fake.promptImpl = async () => {
+			fake.emit(agentEnd())
+		}
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: dir, mcpServers: [] })
+
+		await agent.prompt({
+			sessionId: "session-skill-invoke",
+			prompt: [{ type: "text", text: `/skill:${skillName} review this file` }],
+		})
+
+		expect(fake.promptCalls).toHaveLength(1)
+		const sentPrompt = fake.promptCalls[0]?.prompt
+		expect(sentPrompt).toContain("Invoking skill: acp-test-skill")
+		expect(sentPrompt).toContain("Always use strict types.")
+		expect(sentPrompt).toContain("review this file")
+	})
+
+	it("leaves non-skill prompts unchanged", async () => {
+		const { dir } = makeSkillDir()
+		const fake = new FakeAgentSession("session-skill-pass-through", dir)
+		fake.promptImpl = async () => {
+			fake.emit(agentEnd())
+		}
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: dir, mcpServers: [] })
+
+		await agent.prompt({
+			sessionId: "session-skill-pass-through",
+			prompt: [{ type: "text", text: "hello world" }],
+		})
+
+		expect(fake.promptCalls).toHaveLength(1)
+		expect(fake.promptCalls[0]?.prompt).toBe("hello world")
+	})
+
+	it("activates the Skill tool when it is registered", async () => {
+		const { dir } = makeSkillDir()
+		const fake = new FakeAgentSession("session-skill-tool", dir)
+		fake.registeredTools.set("Skill", { name: "Skill" })
+		fake.activeToolNames = ["read", "bash"]
+		const factory: AcpSessionFactory = async () => asSession(fake)
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: factory,
+		})
+		await agent.newSession({ cwd: dir, mcpServers: [] })
+
+		expect(fake.activeToolNames).toContain("Skill")
+		expect(fake.activeToolNames).toContain("read")
+		expect(fake.activeToolNames).toContain("bash")
 	})
 })
 
@@ -3394,7 +3561,7 @@ describe("setSessionConfigOption", () => {
 		// biome-ignore lint/suspicious/noExplicitAny: union type requires assertion
 		const selectOption = res.configOptions[0] as any
 		expect(selectOption.options).toHaveLength(4)
-		expect(selectOption.options.map((o: { value: string }) => o.value)).toEqual(PERMISSION_MODES)
+		expect(selectOption.options.map((o: SelectOptionItem) => o.value)).toEqual(PERMISSION_MODES)
 	})
 
 	describe("model config option", () => {

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -3291,6 +3291,8 @@ describe("newSession skill commands", () => {
 		expect(sentPrompt).toContain("Invoking skill: acp-test-skill")
 		expect(sentPrompt).toContain("Always use strict types.")
 		expect(sentPrompt).toContain("review this file")
+		expect(sentPrompt).not.toContain("description: ACP test skill")
+		expect(sentPrompt).not.toContain("---")
 	})
 
 	it("leaves non-skill prompts unchanged", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -748,7 +748,7 @@ export class KimchiAcpAgent implements Agent {
 
 		// If the prompt starts with `/skillname` and matches a skill advertised
 		// for this session, rewrite the turn to inject the skill content.
-		const skillRewrite = tryParseSkillCommand(text, entry.skillCommands)
+		const skillRewrite = await tryParseSkillCommand(text, entry.skillCommands)
 		if (skillRewrite) {
 			text = buildSkillCommandPrompt(skillRewrite)
 		}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -746,7 +746,7 @@ export class KimchiAcpAgent implements Agent {
 			.join("")
 			.trim()
 
-		// If the prompt starts with `/skillname` and matches a skill advertised
+		// If the prompt starts with `/skill:<name>` and matches a skill advertised
 		// for this session, rewrite the turn to inject the skill content.
 		const skillRewrite = await tryParseSkillCommand(text, entry.skillCommands)
 		if (skillRewrite) {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -94,6 +94,14 @@ import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { handleSetSessionTitle } from "./ext-methods/set-session-title.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
+import {
+	type AcpSkillInfo,
+	buildSkillAvailableCommands,
+	buildSkillCommandPrompt,
+	buildSkillListBlock,
+	discoverAcpSkillCommands,
+	tryParseSkillCommand,
+} from "./skill-commands.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./tool-calls/utils.js"
 import { asString, truncate } from "./utils.js"
@@ -191,6 +199,22 @@ type SessionRecord = {
 	 * ACP id, so collisions across compaction boundaries are disambiguated.
 	 */
 	toolCallIdMap: Map<string, string>
+	/**
+	 * Per-session skill commands advertised to the ACP client. Populated from
+	 * the session cwd during newSession/loadSession so command names can be
+	 * resolved and skill content injected when the user invokes one.
+	 */
+	skillCommands: Map<string, AcpSkillInfo>
+}
+
+/** Options for {@link KimchiAcpAgent.disposeSessionRecord}. */
+interface DisposeSessionRecordOpts {
+	alreadyUnsubscribed?: boolean
+}
+
+/** Options for {@link KimchiAcpAgent.retireToolCall}. */
+interface RetireToolCallOpts {
+	removeFromHidden?: boolean
 }
 
 export class KimchiAcpAgent implements Agent {
@@ -404,6 +428,7 @@ export class KimchiAcpAgent implements Agent {
 				contentIndexToBlockId: new Map(),
 				nextToolCallId: 0,
 				toolCallIdMap: new Map(),
+				skillCommands: new Map(discoverAcpSkillCommands(session.sessionManager.getCwd()).map((s) => [s.name, s])),
 			}
 			registerAcpPrompter(
 				sessionId,
@@ -453,6 +478,16 @@ export class KimchiAcpAgent implements Agent {
 				process.stderr.write(`acp ext error [${err.extensionPath}] ${err.event}: ${err.error}\n`)
 			},
 		})
+
+		// Activate the Skill tool if the claude-code-skills extension registered it.
+		// This gives ACP sessions the same model-driven skill loading that TUI has
+		// by default (skills === true).
+		if (session.getToolDefinition("Skill")) {
+			const active = new Set(session.getActiveToolNames())
+			if (!active.has("Skill")) {
+				session.setActiveToolsByName([...active, "Skill"])
+			}
+		}
 	}
 
 	async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
@@ -637,6 +672,7 @@ export class KimchiAcpAgent implements Agent {
 				contentIndexToBlockId: new Map(),
 				nextToolCallId: 0,
 				toolCallIdMap: new Map(),
+				skillCommands: new Map(discoverAcpSkillCommands(session.sessionManager.getCwd()).map((s) => [s.name, s])),
 			}
 			registerAcpPrompter(
 				sid,
@@ -705,10 +741,18 @@ export class KimchiAcpAgent implements Agent {
 				process.stderr.write(`acp prompt: dropping ${b.type} block (${reason})\n`)
 			}
 		}
-		const text = params.prompt
+		let text = params.prompt
 			.map((b: ContentBlock) => (b.type === "text" ? b.text : ""))
 			.join("")
 			.trim()
+
+		// If the prompt starts with `/skillname` and matches a skill advertised
+		// for this session, rewrite the turn to inject the skill content.
+		const skillRewrite = tryParseSkillCommand(text, entry.skillCommands)
+		if (skillRewrite) {
+			text = buildSkillCommandPrompt(skillRewrite)
+		}
+
 		// Extract image blocks from the prompt only if model supports vision.
 		const images: ImageContent[] = supportsImages
 			? params.prompt
@@ -840,10 +884,7 @@ export class KimchiAcpAgent implements Agent {
 		await this.disposeSessionRecord(entry, { alreadyUnsubscribed: true })
 	}
 
-	private async disposeSessionRecord(
-		entry: SessionRecord,
-		opts: { alreadyUnsubscribed?: boolean } = {},
-	): Promise<void> {
+	private async disposeSessionRecord(entry: SessionRecord, opts: DisposeSessionRecordOpts = {}): Promise<void> {
 		if (!opts.alreadyUnsubscribed) entry.unsubscribe()
 		// Emit session_shutdown to extensions and await all handlers before
 		// calling dispose(). dispose() is synchronous and returns void, so async
@@ -1308,7 +1349,7 @@ export class KimchiAcpAgent implements Agent {
 		record: SessionRecord,
 		turn: TurnContext,
 		piToolCallId: string,
-		opts: { removeFromHidden?: boolean } = {},
+		opts: RetireToolCallOpts = {},
 	): void {
 		record.toolCallIdMap.delete(piToolCallId)
 		turn.announcedToolCallIds.delete(piToolCallId)
@@ -1319,11 +1360,13 @@ export class KimchiAcpAgent implements Agent {
 	}
 
 	private sendAvailableCommandsUpdate(sessionId: string): void {
+		const record = this.sessions.get(sessionId)
+		const skillCommands = record ? buildSkillAvailableCommands(Array.from(record.skillCommands.values())) : []
 		this.send({
 			sessionId,
 			update: {
 				sessionUpdate: "available_commands_update",
-				availableCommands: AVAILABLE_COMMANDS,
+				availableCommands: [...AVAILABLE_COMMANDS, ...skillCommands],
 			},
 		})
 	}
@@ -1634,11 +1677,20 @@ async function createSessionSettings(cwd: string, options: RunAcpOptions) {
 	// sessions in one process, the last-configured session's value governs
 	// all of them (see setStreamIdleTimeoutOverride).
 	configureHttpIdleTimeout(() => settingsManager.getHttpIdleTimeoutMs())
+	// Cache the skill list block per session so we don't rediscover skills on
+	// every turn's system prompt rebuild.
+	let cachedSkillListBlock: string | undefined
 	const resourceLoader = new DefaultResourceLoader({
 		cwd,
 		agentDir: options.agentDir,
 		settingsManager,
 		extensionFactories: options.extensionFactories,
+		appendSystemPromptOverride: () => {
+			if (cachedSkillListBlock === undefined) {
+				cachedSkillListBlock = buildSkillListBlock(cwd)
+			}
+			return cachedSkillListBlock ? [cachedSkillListBlock] : []
+		},
 	})
 	await resourceLoader.reload()
 	return { settingsManager, resourceLoader }

--- a/src/modes/acp/skill-commands.test.ts
+++ b/src/modes/acp/skill-commands.test.ts
@@ -3,6 +3,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { beforeEach, describe, expect, it } from "vitest"
 
+function makeSkill(dir: string, name: string, description: string, body = "Skill body."): string {
+	const skillDir = join(dir, name)
+	mkdirSync(skillDir, { recursive: true })
+	const filePath = join(skillDir, "SKILL.md")
+	writeFileSync(filePath, `---\nname: ${name}\ndescription: ${description}\n---\n${body}`, "utf-8")
+	return filePath
+}
+
 import {
 	type AcpSkillInfo,
 	buildSkillAvailableCommands,
@@ -11,12 +19,6 @@ import {
 	discoverAcpSkillCommands,
 	tryParseSkillCommand,
 } from "./skill-commands.js"
-
-function makeSkill(dir: string, name: string, description: string, body = "Skill body."): void {
-	const skillDir = join(dir, name)
-	mkdirSync(skillDir, { recursive: true })
-	writeFileSync(join(skillDir, "SKILL.md"), `---\nname: ${name}\ndescription: ${description}\n---\n${body}`, "utf-8")
-}
 
 describe("discoverAcpSkillCommands", () => {
 	let tmpDir: string
@@ -92,21 +94,40 @@ describe("buildSkillAvailableCommands", () => {
 })
 
 describe("tryParseSkillCommand", () => {
-	const skills = new Map<string, AcpSkillInfo>([
-		["typescript-safety", { name: "typescript-safety", description: "", filePath: "" }],
-	])
-
-	it("returns undefined for text without the /skill: prefix", () => {
-		expect(tryParseSkillCommand("hello world", skills)).toBeUndefined()
-		expect(tryParseSkillCommand("/typescript-safety", skills)).toBeUndefined()
+	it("returns undefined for text without the /skill: prefix", async () => {
+		const skills = new Map<string, AcpSkillInfo>([
+			["typescript-safety", { name: "typescript-safety", description: "", filePath: "" }],
+		])
+		expect(await tryParseSkillCommand("hello world", skills)).toBeUndefined()
+		expect(await tryParseSkillCommand("/typescript-safety", skills)).toBeUndefined()
 	})
 
-	it("returns undefined for unknown command names", () => {
-		expect(tryParseSkillCommand("/skill:unknown", skills)).toBeUndefined()
+	it("returns undefined for unknown command names", async () => {
+		const skills = new Map<string, AcpSkillInfo>([
+			["typescript-safety", { name: "typescript-safety", description: "", filePath: "" }],
+		])
+		expect(await tryParseSkillCommand("/skill:unknown", skills)).toBeUndefined()
 	})
 
-	it("returns undefined when the skill file cannot be read", () => {
-		expect(tryParseSkillCommand("/skill:typescript-safety", skills)).toBeUndefined()
+	it("returns undefined when the skill file cannot be read", async () => {
+		const skills = new Map<string, AcpSkillInfo>([
+			["missing", { name: "missing", description: "", filePath: "/no/such/SKILL.md" }],
+		])
+		expect(await tryParseSkillCommand("/skill:missing", skills)).toBeUndefined()
+	})
+
+	it("strips YAML frontmatter from the injected skill content", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "acp-skill-frontmatter-"))
+		const filePath = makeSkill(dir, "frontmatter-skill", "Frontmatter test", "Use strict types.")
+		const skills = new Map<string, AcpSkillInfo>([
+			["frontmatter-skill", { name: "frontmatter-skill", description: "", filePath }],
+		])
+		const result = await tryParseSkillCommand("/skill:frontmatter-skill review this", skills)
+		expect(result).toBeDefined()
+		expect(result?.skillContent).toBe("Use strict types.")
+		expect(result?.skillContent).not.toContain("---")
+		expect(result?.skillContent).not.toContain("name: frontmatter-skill")
+		expect(result?.skillContent).not.toContain("description: Frontmatter test")
 	})
 })
 

--- a/src/modes/acp/skill-commands.test.ts
+++ b/src/modes/acp/skill-commands.test.ts
@@ -1,0 +1,150 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+	type AcpSkillInfo,
+	buildSkillAvailableCommands,
+	buildSkillCommandPrompt,
+	buildSkillListBlock,
+	discoverAcpSkillCommands,
+	tryParseSkillCommand,
+} from "./skill-commands.js"
+
+function makeSkill(dir: string, name: string, description: string, body = "Skill body."): void {
+	const skillDir = join(dir, name)
+	mkdirSync(skillDir, { recursive: true })
+	writeFileSync(join(skillDir, "SKILL.md"), `---\nname: ${name}\ndescription: ${description}\n---\n${body}`, "utf-8")
+}
+
+describe("discoverAcpSkillCommands", () => {
+	let tmpDir: string
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "acp-skills-"))
+	})
+
+	it("discovers native skills under DEFAULT_SKILL_PATHS relative to cwd", () => {
+		makeSkill(join(tmpDir, ".pi", "agent", "skills"), "test-pi", "Pi skill description")
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		expect(skills).toContainEqual(expect.objectContaining({ name: "test-pi", description: "Pi skill description" }))
+	})
+
+	it("discovers native skills under ~/.config/kimchi/harness/skills", () => {
+		makeSkill(join(tmpDir, ".config", "kimchi", "harness", "skills"), "test-harness", "Harness skill description")
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		expect(skills).toContainEqual(
+			expect.objectContaining({ name: "test-harness", description: "Harness skill description" }),
+		)
+	})
+
+	it("discovers Claude Code skills under .claude/skills", () => {
+		makeSkill(join(tmpDir, ".claude", "skills"), "test-claude", "Claude skill description")
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		expect(skills).toContainEqual(
+			expect.objectContaining({ name: "test-claude", description: "Claude skill description" }),
+		)
+	})
+
+	it("returns skills sorted by name", () => {
+		makeSkill(join(tmpDir, ".claude", "skills"), "zebra", "Zebra skill")
+		makeSkill(join(tmpDir, ".claude", "skills"), "alpha", "Alpha skill")
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		expect(skills.map((s) => s.name)).toEqual(["alpha", "zebra"])
+	})
+
+	it("later sources override earlier sources on name collision", () => {
+		makeSkill(join(tmpDir, ".pi", "agent", "skills"), "shared", "Pi version")
+		makeSkill(join(tmpDir, ".claude", "skills"), "shared", "Claude version")
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		const shared = skills.find((s) => s.name === "shared")
+		expect(shared?.description).toBe("Claude version")
+	})
+
+	it("returns an empty array when no skill directories exist", () => {
+		const skills = discoverAcpSkillCommands(tmpDir, { homeDir: tmpDir })
+		expect(skills).toEqual([])
+	})
+})
+
+describe("buildSkillAvailableCommands", () => {
+	it("builds ACP AvailableCommand entries with skill:<name> command names", () => {
+		const skills: AcpSkillInfo[] = [
+			{ name: "typescript-safety", description: "TypeScript safety patterns", filePath: "/x/SKILL.md" },
+		]
+		const commands = buildSkillAvailableCommands(skills)
+		expect(commands).toEqual([
+			{
+				name: "skill:typescript-safety",
+				description: "TypeScript safety patterns",
+				input: { hint: "Optional prompt to run with this skill loaded." },
+			},
+		])
+	})
+
+	it("falls back to a generated description when the skill has none", () => {
+		const skills: AcpSkillInfo[] = [{ name: "empty-desc", description: "", filePath: "/x/SKILL.md" }]
+		const commands = buildSkillAvailableCommands(skills)
+		expect(commands[0]?.description).toBe("Invoke the empty-desc skill")
+		expect(commands[0]?.name).toBe("skill:empty-desc")
+	})
+})
+
+describe("tryParseSkillCommand", () => {
+	const skills = new Map<string, AcpSkillInfo>([
+		["typescript-safety", { name: "typescript-safety", description: "", filePath: "" }],
+	])
+
+	it("returns undefined for text without the /skill: prefix", () => {
+		expect(tryParseSkillCommand("hello world", skills)).toBeUndefined()
+		expect(tryParseSkillCommand("/typescript-safety", skills)).toBeUndefined()
+	})
+
+	it("returns undefined for unknown command names", () => {
+		expect(tryParseSkillCommand("/skill:unknown", skills)).toBeUndefined()
+	})
+
+	it("returns undefined when the skill file cannot be read", () => {
+		expect(tryParseSkillCommand("/skill:typescript-safety", skills)).toBeUndefined()
+	})
+})
+
+describe("buildSkillListBlock", () => {
+	it("returns an empty string when no skills are discovered", () => {
+		const dir = mkdtempSync(join(tmpdir(), "acp-no-skills-"))
+		const block = buildSkillListBlock(dir, { homeDir: dir })
+		expect(block).toBe("")
+	})
+
+	it("lists discovered native and Claude Code skills with descriptions", () => {
+		const dir = mkdtempSync(join(tmpdir(), "acp-skill-list-"))
+		makeSkill(join(dir, ".pi", "agent", "skills"), "pi-skill", "Pi skill description")
+		makeSkill(join(dir, ".claude", "skills"), "claude-skill", "Claude skill description")
+
+		const block = buildSkillListBlock(dir)
+		expect(block).toContain("## Available Skills")
+		expect(block).toContain("Use the Skill tool")
+		expect(block).toContain("/skill:<name>")
+		expect(block).toContain("- **claude-skill**: Claude skill description")
+		expect(block).toContain("- **pi-skill**: Pi skill description")
+	})
+})
+
+describe("buildSkillCommandPrompt", () => {
+	it("prepends skill content and keeps remaining user text", () => {
+		const rewrite = {
+			skillName: "typescript-safety",
+			remainingText: "review this file",
+			skillContent: "Use strict types.",
+		}
+		const prompt = buildSkillCommandPrompt(rewrite)
+		expect(prompt).toBe("Invoking skill: typescript-safety\n\nUse strict types.\n\nreview this file")
+	})
+
+	it("returns only the skill content when no remaining text is provided", () => {
+		const rewrite = { skillName: "typescript-safety", remainingText: "", skillContent: "Use strict types." }
+		const prompt = buildSkillCommandPrompt(rewrite)
+		expect(prompt).toBe("Invoking skill: typescript-safety\n\nUse strict types.")
+	})
+})

--- a/src/modes/acp/skill-commands.ts
+++ b/src/modes/acp/skill-commands.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "node:fs"
+import { readFile } from "node:fs/promises"
 import type { AvailableCommand } from "@agentclientprotocol/sdk"
-import { loadSkillsFromDir } from "@earendil-works/pi-coding-agent"
+import { loadSkillsFromDir, stripFrontmatter } from "@earendil-works/pi-coding-agent"
 import { listAvailableSkillNames } from "../../extensions/agents/prompt/skill-loader.js"
 import { getClaudeCodeSkillResourcePaths } from "../../extensions/claude-code-skills/definition.js"
 
@@ -98,10 +98,10 @@ export interface SkillCommandRewrite {
  * Returns undefined if the text does not begin with `/skill:` or if the name
  * is not a known skill.
  */
-export function tryParseSkillCommand(
+export async function tryParseSkillCommand(
 	text: string,
 	skills: ReadonlyMap<string, AcpSkillInfo>,
-): SkillCommandRewrite | undefined {
+): Promise<SkillCommandRewrite | undefined> {
 	if (!text.startsWith("/skill:")) return undefined
 	const withoutPrefix = text.slice("/skill:".length)
 	const spaceIdx = withoutPrefix.search(/\s/)
@@ -112,13 +112,14 @@ export function tryParseSkillCommand(
 	const skill = skills.get(name)
 	if (!skill) return undefined
 
-	let skillContent: string
+	let rawContent: string
 	try {
-		skillContent = readFileSync(skill.filePath, "utf-8").trim()
+		rawContent = await readFile(skill.filePath, "utf-8")
 	} catch {
 		return undefined
 	}
 
+	const skillContent = stripFrontmatter(rawContent).trim()
 	return { skillName: skill.name, remainingText: remaining, skillContent }
 }
 

--- a/src/modes/acp/skill-commands.ts
+++ b/src/modes/acp/skill-commands.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs"
+import type { AvailableCommand } from "@agentclientprotocol/sdk"
+import { loadSkillsFromDir } from "@earendil-works/pi-coding-agent"
+import { listAvailableSkillNames } from "../../extensions/agents/prompt/skill-loader.js"
+import { getClaudeCodeSkillResourcePaths } from "../../extensions/claude-code-skills/definition.js"
+
+export interface AcpSkillInfo {
+	readonly name: string
+	readonly description: string
+	readonly filePath: string
+}
+
+export interface DiscoverAcpSkillCommandsOptions {
+	/** Override for os.homedir(), useful for tests. Defaults to homedir(). */
+	readonly homeDir?: string
+}
+
+/**
+ * Discover all skills that should be advertised as ACP slash commands for the
+ * given working directory. Native skills from DEFAULT_SKILL_PATHS and Claude
+ * Code skills under .claude/skills are both included; later sources override
+ * earlier ones on name collisions.
+ */
+export function discoverAcpSkillCommands(cwd: string, options: DiscoverAcpSkillCommandsOptions = {}): AcpSkillInfo[] {
+	const byName = new Map<string, AcpSkillInfo>()
+
+	for (const skill of listAvailableSkillNames(cwd, { homeDir: options.homeDir })) {
+		byName.set(skill.name, skill)
+	}
+
+	for (const skill of discoverClaudeCodeSkills(cwd)) {
+		byName.set(skill.name, skill)
+	}
+
+	return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function discoverClaudeCodeSkills(cwd: string): AcpSkillInfo[] {
+	const skills: AcpSkillInfo[] = []
+	for (const dir of getClaudeCodeSkillResourcePaths(cwd)) {
+		try {
+			const { skills: loaded } = loadSkillsFromDir({ dir, source: dir })
+			for (const skill of loaded) {
+				skills.push({
+					name: skill.name,
+					description: skill.description ?? "",
+					filePath: skill.filePath,
+				})
+			}
+		} catch {
+			// Directory missing or unreadable — skip silently.
+		}
+	}
+	return skills
+}
+
+function skillCommandName(skillName: string): string {
+	return `skill:${skillName}`
+}
+
+export function buildSkillAvailableCommands(skills: readonly AcpSkillInfo[]): AvailableCommand[] {
+	return skills.map((skill) => ({
+		name: skillCommandName(skill.name),
+		description: skill.description || `Invoke the ${skill.name} skill`,
+		input: {
+			hint: "Optional prompt to run with this skill loaded.",
+		},
+	}))
+}
+
+/**
+ * Build a compact markdown block listing available skills for injection into
+ * the system prompt. Returns an empty string when no skills are discovered.
+ */
+export function buildSkillListBlock(
+	cwd: string,
+	options: Pick<DiscoverAcpSkillCommandsOptions, "homeDir"> = {},
+): string {
+	const skills = discoverAcpSkillCommands(cwd, options)
+	if (skills.length === 0) return ""
+
+	const lines = skills.map((s) => `- **${s.name}**: ${s.description || `Use the ${s.name} skill.`}`)
+	return `## Available Skills
+
+Use the Skill tool to load a skill's full instructions when its description matches your task. You can also invoke a skill for the current turn by starting your message with \`/skill:<name>\`.
+
+${lines.join("\n")}`
+}
+
+export interface SkillCommandRewrite {
+	readonly skillName: string
+	readonly remainingText: string
+	readonly skillContent: string
+}
+
+/**
+ * Parse a prompt that starts with a skill command name (`/skill:<name>`).
+ * Returns undefined if the text does not begin with `/skill:` or if the name
+ * is not a known skill.
+ */
+export function tryParseSkillCommand(
+	text: string,
+	skills: ReadonlyMap<string, AcpSkillInfo>,
+): SkillCommandRewrite | undefined {
+	if (!text.startsWith("/skill:")) return undefined
+	const withoutPrefix = text.slice("/skill:".length)
+	const spaceIdx = withoutPrefix.search(/\s/)
+	const name = spaceIdx === -1 ? withoutPrefix : withoutPrefix.slice(0, spaceIdx)
+	const remaining = spaceIdx === -1 ? "" : withoutPrefix.slice(spaceIdx + 1).trimStart()
+
+	if (!name) return undefined
+	const skill = skills.get(name)
+	if (!skill) return undefined
+
+	let skillContent: string
+	try {
+		skillContent = readFileSync(skill.filePath, "utf-8").trim()
+	} catch {
+		return undefined
+	}
+
+	return { skillName: skill.name, remainingText: remaining, skillContent }
+}
+
+/**
+ * Build the effective prompt text for a skill command invocation. The skill
+ * content is injected as a clear prefix so the model applies it for this turn.
+ */
+export function buildSkillCommandPrompt(rewrite: SkillCommandRewrite): string {
+	const { skillName, remainingText, skillContent } = rewrite
+	const header = `Invoking skill: ${skillName}`
+	const prefix = [header, "", skillContent].join("\n")
+	return remainingText ? `${prefix}\n\n${remainingText}` : prefix
+}


### PR DESCRIPTION
## Summary

Expose Kimchi skills in ACP sessions: advertise them as available slash commands, let users invoke them with `/skill:<name>`, and preload a compact skill list into the system prompt so the model can request skills via the Skill tool.

## Changes

- `src/modes/acp/skill-commands.ts` (new)
  - Discovers native and Claude Code skills for the session cwd.
  - Builds ACP available commands named `skill:<name>`.
  - Rewrites `/skill:<name> ...` prompts to inject skill content.

- `src/modes/acp/server.ts`
  - Stores per-session skill commands and emits them in `available_commands_update`.
  - Appends a cached skill list block to the system prompt via `appendSystemPromptOverride`.
  - Activates the `Skill` tool after `bindExtensions` when it is registered.

- `src/extensions/agents/prompt/skill-loader.ts`
  - Extracted `SkillListEntry` interface and `resolveSkillPaths` helper.
  - Extended `listAvailableSkillNames` to return file paths and accept an optional `homeDir` override.

- Tests
  - Added `src/modes/acp/skill-commands.test.ts`.
  - Added ACP server tests for skill command advertisement, prompt rewriting, and Skill tool activation.
  - Added skill-loader tests for the new `filePath` return and `homeDir` option.

## Verification

- `pnpm run check` ✅
- `npx vitest run src/modes/acp/skill-commands.test.ts src/modes/acp/server.test.ts src/extensions/agents/prompt/skill-loader.test.ts` ✅ (206 passing; 1 pre-existing failure in image capability detection)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Related

LLM-3061
