### PR TITLE
fix(mcp): OAuth strictPort, skipAuth probe flag, and double-connect removal

### DIFF
--- a/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.test.ts
@@ -209,4 +209,58 @@ describe("MCP OAuth callback lifecycle", () => {
 			rmSync(authDir, { recursive: true, force: true })
 		}
 	})
+
+	it("uses non-strict port binding for dynamic registration (no clientId), scanning for a free port when busy", async () => {
+		const port = await getFreePort()
+		const { authDir, authStore, callbackServer, flow, oauthProvider, openBrowser } = await loadAuthFlowForPort(port)
+
+		// Occupy the preferred callback port so the server must scan forward
+		const blocker = createServer()
+		await new Promise<void>((resolve, reject) => {
+			blocker.once("error", reject)
+			blocker.listen(port, "127.0.0.1", resolve)
+		})
+
+		try {
+			const authPromise = flow.authenticate("slack", "https://slack.example.test/mcp")
+			await vi.waitFor(() => expect(openBrowser).toHaveBeenCalledOnce())
+
+			// Server should be running on the next free port (port + 1)
+			const actualPort = oauthProvider.getOAuthCallbackPort()
+			expect(actualPort).toBe(port + 1)
+			expect(callbackServer.isCallbackServerRunning()).toBe(true)
+
+			const state = await authStore.getOAuthState("slack")
+			if (!state) throw new Error("Missing Slack OAuth state")
+			await sendCallback(actualPort, oauthProvider.OAUTH_CALLBACK_PATH, state, "slack-code")
+			await expect(authPromise).resolves.toBe("authenticated")
+		} finally {
+			await flow.shutdownOAuth()
+			await new Promise<void>((resolve) => blocker.close(() => resolve()))
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
+
+	it("uses strict port binding for pre-registered clients (clientId set), failing when the port is busy", async () => {
+		const port = await getFreePort()
+		const { authDir, flow } = await loadAuthFlowForPort(port)
+
+		// Occupy the preferred callback port
+		const blocker = createServer()
+		await new Promise<void>((resolve, reject) => {
+			blocker.once("error", reject)
+			blocker.listen(port, "127.0.0.1", resolve)
+		})
+
+		try {
+			const definition = { url: "https://slack.example.test/mcp", oauth: { clientId: "pre-registered-id" } }
+			await expect(flow.authenticate("slack", "https://slack.example.test/mcp", definition)).rejects.toThrow(
+				/already in use/,
+			)
+		} finally {
+			await flow.shutdownOAuth()
+			await new Promise<void>((resolve) => blocker.close(() => resolve()))
+			rmSync(authDir, { recursive: true, force: true })
+		}
+	})
 })

--- a/src/extensions/mcp-adapter/mcp-auth-flow.ts
+++ b/src/extensions/mcp-adapter/mcp-auth-flow.ts
@@ -132,7 +132,13 @@ export async function startAuth(
 	try {
 		// Start the callback server and register ownership in one serialized operation.
 		// This prevents shutdown from closing the listener between those two steps.
-		const preparedCallback = await prepareCallback(oauthState, { strictPort: true })
+		// Pre-registered clients (with a configured clientId) must bind the exact
+		// redirect URI port registered with the OAuth server. Dynamic registration
+		// (RFC 7591) sends the redirect URI at registration time, so the port can
+		// vary — RFC 8252 §7.3 requires authorization servers to accept any port
+		// for loopback redirect URIs.
+		const strictPort = !!config.clientId
+		const preparedCallback = await prepareCallback(oauthState, { strictPort })
 		callbackPromise = preparedCallback.callbackPromise
 		void callbackPromise.catch(() => {})
 

--- a/src/extensions/mcp-adapter/server-manager.test.ts
+++ b/src/extensions/mcp-adapter/server-manager.test.ts
@@ -337,3 +337,79 @@ describe("withTimeout (indirectly via probeTools)", () => {
 		expect(mockClose).toHaveBeenCalled()
 	})
 })
+
+describe("McpServerManager.probeTools SSE fallback", () => {
+	beforeEach(() => {
+		mockConnect.mockReset()
+		mockListTools.mockReset()
+		mockClose.mockReset()
+		mockSetNotificationHandler.mockReset()
+		vi.mocked(supportsOAuth).mockReset()
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		mockClose.mockResolvedValue(undefined)
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("falls back to SSE when StreamableHTTP connect fails with non-auth error", async () => {
+		// First connect (StreamableHTTP) fails, second (SSE) succeeds
+		mockConnect.mockRejectedValueOnce(new Error("Invalid content type")).mockResolvedValueOnce(undefined)
+		mockListTools.mockResolvedValue({ tools: [{ name: "sse_tool" }], nextCursor: undefined })
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("sse-server", {
+			url: "https://mcp.example.com/sse",
+		})
+
+		expect(result.tools).toHaveLength(1)
+		expect(result.tools[0].name).toBe("sse_tool")
+		expect(result.needsAuth).toBe(false)
+		expect(mockConnect).toHaveBeenCalledTimes(2)
+	})
+
+	it("returns error when both StreamableHTTP and SSE fail", async () => {
+		mockConnect.mockRejectedValue(new Error("Connection refused"))
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("dual-fail", {
+			url: "https://mcp.example.com/sse",
+		})
+
+		expect(result.tools).toEqual([])
+		expect(result.needsAuth).toBe(false)
+		expect(result.error).toBe("Connection refused")
+		expect(mockConnect).toHaveBeenCalledTimes(2)
+	})
+
+	it("returns needsAuth when SSE fallback throws UnauthorizedError", async () => {
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		mockConnect
+			.mockRejectedValueOnce(new Error("Invalid content type"))
+			.mockRejectedValueOnce(new UnauthorizedError("Unauthorized"))
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("oauth-sse", {
+			url: "https://mcp.example.com/sse",
+			auth: "oauth",
+		})
+
+		expect(result.needsAuth).toBe(true)
+		expect(result.error).toBeNull()
+		expect(mockConnect).toHaveBeenCalledTimes(2)
+	})
+
+	it("does not fall back to SSE for stdio servers", async () => {
+		mockConnect.mockRejectedValue(new Error("spawn failed"))
+
+		const manager = new McpServerManager()
+		const result = await manager.probeTools("stdio-fail", {
+			command: "nonexistent-binary",
+		})
+
+		expect(result.tools).toEqual([])
+		expect(result.error).toBe("spawn failed")
+		expect(mockConnect).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/extensions/mcp-adapter/server-manager.test.ts
+++ b/src/extensions/mcp-adapter/server-manager.test.ts
@@ -118,9 +118,8 @@ describe("McpServerManager.probeTools", () => {
 		expect(result.tools).toEqual([])
 		expect(result.needsAuth).toBe(true)
 		expect(result.error).toBeNull()
-		// client.close is NOT called here because the UnauthorizedError is thrown
-		// during createTransport (createHttpTransport's internal test client),
-		// before probeTools' own client is connected — so there's nothing to close.
+		// UnauthorizedError skips the SSE fallback and returns needsAuth directly.
+		// The finally block closes the client and transport.
 	})
 
 	it("returns error string when connect throws a non-OAuth error", async () => {

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -98,7 +98,7 @@ export class McpServerManager {
 	}
 
 	private async createConnection(name: string, definition: ServerDefinition): Promise<ServerConnection> {
-		const client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
+		let client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
 		let transport: Transport | undefined
 
 		try {
@@ -125,9 +125,11 @@ export class McpServerManager {
 				await client.close().catch(() => {})
 				await transport?.close().catch(() => {})
 
+				if (!transport) throw error
+
 				return {
 					client,
-					transport: transport as Transport,
+					transport,
 					definition,
 					tools: [],
 					resources: [],
@@ -139,10 +141,13 @@ export class McpServerManager {
 
 			// SSE fallback for HTTP servers: if StreamableHTTP connect fails with a
 			// non-auth error, retry with the legacy SSE transport.
-			if (definition.url && transport) {
+			if (definition.url && transport && !(error instanceof UnauthorizedError)) {
+				await transport.close().catch(() => {})
+				await client.close().catch(() => {})
+				transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
+				client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
+
 				try {
-					await transport.close().catch(() => {})
-					transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
 					await client.connect(transport)
 					this.attachAdapterNotificationHandlers(name, client)
 
@@ -161,10 +166,10 @@ export class McpServerManager {
 				} catch (sseError) {
 					if (sseError instanceof UnauthorizedError && supportsOAuth(definition)) {
 						await client.close().catch(() => {})
-						await transport?.close().catch(() => {})
+						await transport.close().catch(() => {})
 						return {
 							client,
-							transport: transport as Transport,
+							transport,
 							definition,
 							tools: [],
 							resources: [],
@@ -174,7 +179,7 @@ export class McpServerManager {
 						}
 					}
 					await client.close().catch(() => {})
-					await transport?.close().catch(() => {})
+					await transport.close().catch(() => {})
 					throw sseError
 				}
 			}
@@ -388,7 +393,7 @@ export class McpServerManager {
 		// tools/list) — it gets a single 60s budget from start to finish.
 		const deadline = Date.now() + totalBudgetMs
 
-		const client = new Client({ name: `pi-mcp-probe-${name}`, version: "1.0.0" })
+		let client = new Client({ name: `pi-mcp-probe-${name}`, version: "1.0.0" })
 		let transport: Transport | undefined
 
 		try {
@@ -411,9 +416,12 @@ export class McpServerManager {
 			// SSE fallback for HTTP servers: if StreamableHTTP connect fails with a
 			// non-auth error, retry with the legacy SSE transport.
 			if (definition.url && !(error instanceof UnauthorizedError)) {
+				await transport.close().catch(() => {})
+				await client.close().catch(() => {})
+				transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
+				client = new Client({ name: `pi-mcp-probe-${name}`, version: "1.0.0" })
+
 				try {
-					await transport.close().catch(() => {})
-					transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
 					const result = await this.connectAndList(client, transport, name, deadline)
 					return result
 				} catch (sseError) {

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -406,14 +406,8 @@ export class McpServerManager {
 		try {
 			transport = await this.createTransport(name, definition)
 		} catch (error) {
-			if (error instanceof UnauthorizedError) {
-				return { tools: [], needsAuth: true, error: null }
-			}
-			return {
-				tools: [],
-				needsAuth: false,
-				error: error instanceof Error ? error.message : String(error),
-			}
+			if (error instanceof UnauthorizedError) return this.authProbeResult()
+			return this.errorProbeResult(error)
 		}
 
 		try {
@@ -432,25 +426,13 @@ export class McpServerManager {
 					const result = await this.connectAndList(client, transport, name, deadline)
 					return result
 				} catch (sseError) {
-					if (sseError instanceof UnauthorizedError) {
-						return { tools: [], needsAuth: true, error: null }
-					}
-					return {
-						tools: [],
-						needsAuth: false,
-						error: sseError instanceof Error ? sseError.message : String(sseError),
-					}
+					if (sseError instanceof UnauthorizedError) return this.authProbeResult()
+					return this.errorProbeResult(sseError)
 				}
 			}
 
-			if (error instanceof UnauthorizedError) {
-				return { tools: [], needsAuth: true, error: null }
-			}
-			return {
-				tools: [],
-				needsAuth: false,
-				error: error instanceof Error ? error.message : String(error),
-			}
+			if (error instanceof UnauthorizedError) return this.authProbeResult()
+			return this.errorProbeResult(error)
 		} finally {
 			await client.close().catch(() => {})
 			await transport?.close().catch(() => {})
@@ -480,6 +462,24 @@ export class McpServerManager {
 		}))
 
 		return { tools: probeTools, needsAuth: false, error: null }
+	}
+
+	/**
+	 * Build a ProbeResult indicating the server requires authentication.
+	 */
+	private authProbeResult(): ProbeResult {
+		return { tools: [], needsAuth: true, error: null }
+	}
+
+	/**
+	 * Build a ProbeResult from an error, extracting a human-readable message.
+	 */
+	private errorProbeResult(error: unknown): ProbeResult {
+		return {
+			tools: [],
+			needsAuth: false,
+			error: error instanceof Error ? error.message : String(error),
+		}
 	}
 }
 

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -103,11 +103,7 @@ export class McpServerManager {
 
 		try {
 			transport = await this.createTransport(name, definition)
-			await client.connect(transport)
-			this.attachAdapterNotificationHandlers(name, client)
-
-			// Discover tools and resources
-			const [tools, resources] = await Promise.all([this.fetchAllTools(client), this.fetchAllResources(client)])
+			const { tools, resources } = await this.connectAndDiscover(client, transport, name)
 
 			return {
 				client,
@@ -127,16 +123,7 @@ export class McpServerManager {
 
 				if (!transport) throw error
 
-				return {
-					client,
-					transport,
-					definition,
-					tools: [],
-					resources: [],
-					lastUsedAt: Date.now(),
-					inFlight: 0,
-					status: "needs-auth",
-				}
+				return this.buildNeedsAuthConnection(client, transport, definition)
 			}
 
 			// SSE fallback for HTTP servers: if StreamableHTTP connect fails with a
@@ -148,10 +135,7 @@ export class McpServerManager {
 				client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
 
 				try {
-					await client.connect(transport)
-					this.attachAdapterNotificationHandlers(name, client)
-
-					const [tools, resources] = await Promise.all([this.fetchAllTools(client), this.fetchAllResources(client)])
+					const { tools, resources } = await this.connectAndDiscover(client, transport, name)
 
 					return {
 						client,
@@ -167,16 +151,7 @@ export class McpServerManager {
 					if (sseError instanceof UnauthorizedError && supportsOAuth(definition)) {
 						await client.close().catch(() => {})
 						await transport.close().catch(() => {})
-						return {
-							client,
-							transport,
-							definition,
-							tools: [],
-							resources: [],
-							lastUsedAt: Date.now(),
-							inFlight: 0,
-							status: "needs-auth",
-						}
+						return this.buildNeedsAuthConnection(client, transport, definition)
 					}
 					await client.close().catch(() => {})
 					await transport.close().catch(() => {})
@@ -187,6 +162,41 @@ export class McpServerManager {
 			await client.close().catch(() => {})
 			await transport?.close().catch(() => {})
 			throw error
+		}
+	}
+
+	/**
+	 * Connect a client to a transport and fetch tools + resources.
+	 * Shared by createConnection() for both StreamableHTTP and SSE attempts.
+	 */
+	private async connectAndDiscover(
+		client: Client,
+		transport: Transport,
+		name: string,
+	): Promise<{ tools: McpTool[]; resources: McpResource[] }> {
+		await client.connect(transport)
+		this.attachAdapterNotificationHandlers(name, client)
+		const [tools, resources] = await Promise.all([this.fetchAllTools(client), this.fetchAllResources(client)])
+		return { tools, resources }
+	}
+
+	/**
+	 * Build a ServerConnection in the needs-auth state.
+	 */
+	private buildNeedsAuthConnection(
+		client: Client,
+		transport: Transport,
+		definition: ServerDefinition,
+	): ServerConnection {
+		return {
+			client,
+			transport,
+			definition,
+			tools: [],
+			resources: [],
+			lastUsedAt: Date.now(),
+			inFlight: 0,
+			status: "needs-auth",
 		}
 	}
 
@@ -237,10 +247,7 @@ export class McpServerManager {
 		return { url, requestInit, authProvider }
 	}
 
-	private async createHttpTransport(
-		definition: ServerDefinition & { url: string },
-		serverName: string,
-	): Promise<Transport> {
+	private createHttpTransport(definition: ServerDefinition & { url: string }, serverName: string): Transport {
 		const { url, requestInit, authProvider } = this.buildHttpConfig(definition, serverName)
 		return new StreamableHTTPClientTransport(url, { requestInit, authProvider })
 	}

--- a/src/extensions/mcp-adapter/server-manager.ts
+++ b/src/extensions/mcp-adapter/server-manager.ts
@@ -99,9 +99,10 @@ export class McpServerManager {
 
 	private async createConnection(name: string, definition: ServerDefinition): Promise<ServerConnection> {
 		const client = new Client({ name: `pi-mcp-${name}`, version: "1.0.0" })
-		const transport = await this.createTransport(name, definition)
+		let transport: Transport | undefined
 
 		try {
+			transport = await this.createTransport(name, definition)
 			await client.connect(transport)
 			this.attachAdapterNotificationHandlers(name, client)
 
@@ -121,13 +122,12 @@ export class McpServerManager {
 		} catch (error) {
 			// Check for UnauthorizedError - server requires OAuth
 			if (error instanceof UnauthorizedError && supportsOAuth(definition)) {
-				// Clean up both client and transport before reporting needs-auth.
 				await client.close().catch(() => {})
-				await transport.close().catch(() => {})
+				await transport?.close().catch(() => {})
 
 				return {
 					client,
-					transport,
+					transport: transport as Transport,
 					definition,
 					tools: [],
 					resources: [],
@@ -137,17 +137,62 @@ export class McpServerManager {
 				}
 			}
 
-			// Clean up both client and transport on any error
+			// SSE fallback for HTTP servers: if StreamableHTTP connect fails with a
+			// non-auth error, retry with the legacy SSE transport.
+			if (definition.url && transport) {
+				try {
+					await transport.close().catch(() => {})
+					transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
+					await client.connect(transport)
+					this.attachAdapterNotificationHandlers(name, client)
+
+					const [tools, resources] = await Promise.all([this.fetchAllTools(client), this.fetchAllResources(client)])
+
+					return {
+						client,
+						transport,
+						definition,
+						tools,
+						resources,
+						lastUsedAt: Date.now(),
+						inFlight: 0,
+						status: "connected",
+					}
+				} catch (sseError) {
+					if (sseError instanceof UnauthorizedError && supportsOAuth(definition)) {
+						await client.close().catch(() => {})
+						await transport?.close().catch(() => {})
+						return {
+							client,
+							transport: transport as Transport,
+							definition,
+							tools: [],
+							resources: [],
+							lastUsedAt: Date.now(),
+							inFlight: 0,
+							status: "needs-auth",
+						}
+					}
+					await client.close().catch(() => {})
+					await transport?.close().catch(() => {})
+					throw sseError
+				}
+			}
+
 			await client.close().catch(() => {})
-			await transport.close().catch(() => {})
+			await transport?.close().catch(() => {})
 			throw error
 		}
 	}
 
-	private async createHttpTransport(
+	/**
+	 * Build the shared HTTP transport config (URL, headers, auth provider)
+	 * used by both StreamableHTTP and SSE transports.
+	 */
+	private buildHttpConfig(
 		definition: ServerDefinition & { url: string },
 		serverName: string,
-	): Promise<Transport> {
+	): { url: URL; requestInit: Record<string, unknown> | undefined; authProvider: McpOAuthProvider | undefined } {
 		const url = new URL(definition.url)
 
 		// Build headers first (including any bearer token)
@@ -168,7 +213,6 @@ export class McpServerManager {
 		// For OAuth servers, create an auth provider
 		let authProvider: McpOAuthProvider | undefined
 		if (supportsOAuth(definition)) {
-			// Extract OAuth config (handles both object and false cases)
 			const oauthConfig =
 				definition.oauth === false
 					? {}
@@ -185,34 +229,24 @@ export class McpServerManager {
 			})
 		}
 
-		// Try StreamableHTTP first (modern MCP servers)
-		const streamableTransport = new StreamableHTTPClientTransport(url, {
-			requestInit,
-			authProvider,
-		})
+		return { url, requestInit, authProvider }
+	}
 
-		try {
-			// Create a test client to verify the transport works
-			const testClient = new Client({ name: "pi-mcp-probe", version: "2.1.2" })
-			await testClient.connect(streamableTransport)
-			await testClient.close().catch(() => {})
-			// Close probe transport before creating fresh one
-			await streamableTransport.close().catch(() => {})
+	private async createHttpTransport(
+		definition: ServerDefinition & { url: string },
+		serverName: string,
+	): Promise<Transport> {
+		const { url, requestInit, authProvider } = this.buildHttpConfig(definition, serverName)
+		return new StreamableHTTPClientTransport(url, { requestInit, authProvider })
+	}
 
-			// StreamableHTTP works - create fresh transport for actual use
-			return new StreamableHTTPClientTransport(url, { requestInit, authProvider })
-		} catch (error) {
-			// StreamableHTTP failed, close and try SSE fallback
-			await streamableTransport.close().catch(() => {})
-
-			// If this was an UnauthorizedError, don't try SSE - the server needs auth
-			if (error instanceof UnauthorizedError) {
-				throw error
-			}
-
-			// SSE is the legacy transport
-			return new SSEClientTransport(url, { requestInit, authProvider })
-		}
+	/**
+	 * Create an SSE transport for HTTP servers that don't support StreamableHTTP.
+	 * Shares the same config (URL, headers, auth provider) as the StreamableHTTP transport.
+	 */
+	private createSseTransport(definition: ServerDefinition & { url: string }, serverName: string): Transport {
+		const { url, requestInit, authProvider } = this.buildHttpConfig(definition, serverName)
+		return new SSEClientTransport(url, { requestInit, authProvider })
 	}
 
 	private async fetchAllTools(client: Client): Promise<McpTool[]> {
@@ -355,7 +389,7 @@ export class McpServerManager {
 		const deadline = Date.now() + totalBudgetMs
 
 		const client = new Client({ name: `pi-mcp-probe-${name}`, version: "1.0.0" })
-		let transport: Transport
+		let transport: Transport | undefined
 
 		try {
 			transport = await this.createTransport(name, definition)
@@ -371,20 +405,29 @@ export class McpServerManager {
 		}
 
 		try {
-			await withTimeout(client.connect(transport), deadline)
-			this.attachAdapterNotificationHandlers(name, client)
-
-			const tools = await withTimeout(this.fetchAllTools(client), deadline)
-			const probeTools: ProbeMcpTool[] = tools.map((t) => ({
-				name: t.name,
-				title: t.title,
-				description: t.description,
-				inputSchema: t.inputSchema,
-				annotations: t.annotations,
-			}))
-
-			return { tools: probeTools, needsAuth: false, error: null }
+			const result = await this.connectAndList(client, transport, name, deadline)
+			return result
 		} catch (error) {
+			// SSE fallback for HTTP servers: if StreamableHTTP connect fails with a
+			// non-auth error, retry with the legacy SSE transport.
+			if (definition.url && !(error instanceof UnauthorizedError)) {
+				try {
+					await transport.close().catch(() => {})
+					transport = this.createSseTransport(definition as ServerEntry & { url: string }, name)
+					const result = await this.connectAndList(client, transport, name, deadline)
+					return result
+				} catch (sseError) {
+					if (sseError instanceof UnauthorizedError) {
+						return { tools: [], needsAuth: true, error: null }
+					}
+					return {
+						tools: [],
+						needsAuth: false,
+						error: sseError instanceof Error ? sseError.message : String(sseError),
+					}
+				}
+			}
+
 			if (error instanceof UnauthorizedError) {
 				return { tools: [], needsAuth: true, error: null }
 			}
@@ -395,8 +438,33 @@ export class McpServerManager {
 			}
 		} finally {
 			await client.close().catch(() => {})
-			await transport.close().catch(() => {})
+			await transport?.close().catch(() => {})
 		}
+	}
+
+	/**
+	 * Connect a client to a transport, fetch tools, and return a ProbeResult.
+	 * Shared by probeTools() for both StreamableHTTP and SSE attempts.
+	 */
+	private async connectAndList(
+		client: Client,
+		transport: Transport,
+		name: string,
+		deadline: number,
+	): Promise<ProbeResult> {
+		await withTimeout(client.connect(transport), deadline)
+		this.attachAdapterNotificationHandlers(name, client)
+
+		const tools = await withTimeout(this.fetchAllTools(client), deadline)
+		const probeTools: ProbeMcpTool[] = tools.map((t) => ({
+			name: t.name,
+			title: t.title,
+			description: t.description,
+			inputSchema: t.inputSchema,
+			annotations: t.annotations,
+		}))
+
+		return { tools: probeTools, needsAuth: false, error: null }
 	}
 }
 

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -106,6 +106,7 @@ export async function handleProbeMcpServer(
 	// stored tokens are never overwritten. See `resolveProbeName` below.
 	const probeName = resolveProbeName(serverName, server)
 	const usedThrowaway = probeName !== serverName
+	const skipAuth = params.skipAuth === true
 
 	try {
 		// For OAuth-capable URL servers, authenticate FIRST before probing.
@@ -114,7 +115,12 @@ export async function handleProbeMcpServer(
 		// overwritten and the callback fails. By authenticating first, the
 		// stored tokens are available when probeTools connects, so it skips
 		// auth entirely.
-		if (supportsOAuth(server) && server.url) {
+		//
+		// When skipAuth is true, skip the explicit authenticate() call and
+		// let probeTools() handle it: stored access tokens or refresh tokens
+		// are tried by the SDK internally; if both fail, probeTools() returns
+		// { needsAuth: true } without opening a browser.
+		if (!skipAuth && supportsOAuth(server) && server.url) {
 			const authStatus = await getAuthStatus(probeName, server.url)
 			if (authStatus !== "authenticated") {
 				try {

--- a/src/modes/acp/probe-mcp-server.test.ts
+++ b/src/modes/acp/probe-mcp-server.test.ts
@@ -262,6 +262,94 @@ describe("KimchiAcpAgent extMethod probe_mcp_server OAuth", () => {
 	})
 })
 
+describe("KimchiAcpAgent extMethod probe_mcp_server skipAuth", () => {
+	beforeEach(() => {
+		vi.mocked(supportsOAuth).mockReturnValue(false)
+		vi.mocked(authenticate).mockReset()
+		vi.mocked(getAuthEntry).mockReturnValue(undefined)
+		vi.mocked(getAuthStatus).mockReset()
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
+	})
+
+	it("skips authenticate() and probes directly when skipAuth is true", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
+			server: serverEntry,
+			serverName: "my-server",
+			skipAuth: true,
+		})
+
+		expect(result.tools).toHaveLength(1)
+		expect(vi.mocked(authenticate)).not.toHaveBeenCalled()
+		expect(vi.mocked(getAuthStatus)).not.toHaveBeenCalled()
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+		expect(manager.probeTools).toHaveBeenCalledWith("my-server", serverEntry)
+	})
+
+	it("returns needsAuth without opening browser when skipAuth is true and tokens are invalid", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const needsAuthResult: ProbeResult = { tools: [], needsAuth: true, error: null }
+		const manager = makeFakeMcpServerManager(needsAuthResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("expired")
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
+			server: serverEntry,
+			serverName: "my-server",
+			skipAuth: true,
+		})
+
+		expect(result.needsAuth).toBe(true)
+		expect(result.error).toBeNull()
+		expect(vi.mocked(authenticate)).not.toHaveBeenCalled()
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+	})
+
+	it("still authenticates when skipAuth is false", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
+		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
+
+		const agent = makeAgent(manager)
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
+			server: serverEntry,
+			serverName: "my-server",
+			skipAuth: false,
+		})
+
+		expect(result.tools).toHaveLength(1)
+		expect(vi.mocked(authenticate)).toHaveBeenCalledWith("my-server", "https://example.com/mcp", serverEntry)
+		expect(manager.probeTools).toHaveBeenCalledTimes(1)
+	})
+
+	it("still authenticates when skipAuth is omitted", async () => {
+		const serverEntry: ServerEntry = { url: "https://example.com/mcp" }
+		const probeResult: ProbeResult = { tools: [{ name: "tool1" }], needsAuth: false, error: null }
+		const manager = makeFakeMcpServerManager(probeResult)
+		vi.mocked(supportsOAuth).mockReturnValue(true)
+		vi.mocked(getAuthStatus).mockResolvedValue("not_authenticated")
+		vi.mocked(authenticate).mockResolvedValue("authenticated" as never)
+
+		const agent = makeAgent(manager)
+		await agent.extMethod(AVAILABLE_EXT_METHODS.probe_mcp_server, {
+			server: serverEntry,
+			serverName: "my-server",
+		})
+
+		expect(vi.mocked(authenticate)).toHaveBeenCalledWith("my-server", "https://example.com/mcp", serverEntry)
+	})
+})
+
 describe("KimchiAcpAgent extMethod probe_mcp_server validation", () => {
 	it("rejects non-object server param", async () => {
 		const agent = makeAgent(makeFakeMcpServerManager({ tools: [], needsAuth: false, error: null }))


### PR DESCRIPTION
## Summary

Three fixes for MCP OAuth flows (LLM-3052):

### 1. strictPort conditional in `startAuth()`

`startAuth()` always passed `{ strictPort: true }` to `prepareCallback()`, which made the callback server fail on a busy port 19876 for all OAuth flows — including dynamic registration where the port can vary.

Changed to `strictPort: !!config.clientId`:
- **Dynamic registration** (no `clientId`): `strictPort: false` — callback server scans forward for a free port. Per [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252.html#section-7.3), authorization servers MUST accept any port for loopback redirect URIs.
- **Pre-registered client** (`clientId` set): `strictPort: true` — redirect URI is fixed at the registered port.

### 2. `skipAuth` flag in `handleProbeMcpServer`

When `true`, skips the interactive `authenticate()` call and goes straight to `probeTools()`. The SDK handles token refresh internally during `connect()`; if that fails, `probeTools()` returns `{ needsAuth: true }` without opening a browser. Default `false` preserves backwards compatibility.

This lets Studio's "Refresh" button (`skipAuth: true`) do a read-only probe without triggering a browser-based auth flow, while "Connect"/"Retry" (`skipAuth: false`) keeps the existing interactive auth behavior.

### 3. Remove double-connect in `createHttpTransport()`

`createHttpTransport()` did a test connect (creating a `Client`, calling `connect()`, then closing) before creating a fresh transport for the real connect. This consumed refresh tokens and corrupted auth state — the SDK's `_authThenStart()` → `auth()` → `refreshAuthorization()` ran during the test connect, and the real connect failed because the token was already consumed.

The fix:
- `createHttpTransport()` now just creates and returns a `StreamableHTTPClientTransport` directly
- SSE fallback moved to `probeTools()` and `createConnection()`, which retry with `SSEClientTransport` on non-auth errors
- Extracted `buildHttpConfig()` and `createSseTransport()` helpers to share config between transports
- Extracted `connectAndList()` helper in `probeTools()` to avoid duplication between StreamableHTTP and SSE attempts

## Test coverage

- `mcp-auth-flow.test.ts`: 2 new tests — dynamic registration scans for free port when busy; pre-registered client fails on busy port
- `probe-mcp-server.test.ts`: 4 new tests — `skipAuth: true` skips auth and probes directly; `skipAuth: true` with invalid tokens returns `needsAuth` without browser; `skipAuth: false` and omitted both authenticate as before
- `server-manager.test.ts`: updated comment on `UnauthorizedError` test to reflect new code path

All 46 tests pass (`mcp-auth-flow`, `server-manager`, `probe-mcp-server`, `mcp-oauth-callback` smoke).

## Jira

[LLM-3052](https://castai.atlassian.net/browse/LLM-3052)

Co-Authored-By: Kimchi <noreply@kimchi.dev>