### PR TITLE
feat: daemon + daemon_control tools for session-surviving processes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ import claudeCodeHooksAdapter from "./extensions/claude-code-hook-adapter/index.
 import claudeCodeSkillsExtension from "./extensions/claude-code-skills/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import customizeStatusLineExtension from "./extensions/customize-status-line-command.js"
+import daemonExtension from "./extensions/daemon/index.js"
 import explorationGuardExtension from "./extensions/exploration-guard.js"
 import fermentExtension from "./extensions/ferment/index.js"
 import helpExtension from "./extensions/help.js"
@@ -568,6 +569,10 @@ try {
 			// continue/stop decision, other tool calls are hard-blocked with a
 			// steering reason; natural process exit releases the gate.
 			bashControlExtension,
+			// Session-surviving daemons: daemon + daemon_control tools.
+			// Deliberate last resort for services that must outlive the session —
+			// session_shutdown intentionally kills nothing here.
+			daemonExtension,
 			bashToolGuardExtension,
 			bashTimeoutGuidanceExtension,
 			hiddenToolGuidanceExtension,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,7 @@ import claudeCodeSkillsExtension from "./extensions/claude-code-skills/index.js"
 import clipboardImageExtension from "./extensions/clipboard-image.js"
 import customizeStatusLineExtension from "./extensions/customize-status-line-command.js"
 import daemonExtension from "./extensions/daemon/index.js"
+import { setExperimentalFeaturesEnabled } from "./extensions/experimental.js"
 import explorationGuardExtension from "./extensions/exploration-guard.js"
 import fermentExtension from "./extensions/ferment/index.js"
 import helpExtension from "./extensions/help.js"
@@ -262,6 +263,10 @@ try {
 		await main(originalArgs, { extensionFactories: [] })
 	} else {
 		const experimentalFeatures = isExperimentalFeaturesArg(originalArgs)
+		// Publish to the module-level flag so extensions (daemon tools,
+		// steering text) can gate on it — the CLI arg is stripped from the
+		// args that reach main(), so pi.getFlag can't discover it.
+		setExperimentalFeaturesEnabled(experimentalFeatures)
 		let config = loadConfig()
 
 		const envKey = process.env.KIMCHI_API_KEY || undefined
@@ -572,7 +577,8 @@ try {
 			// Session-surviving daemons: daemon + daemon_control tools.
 			// Deliberate last resort for services that must outlive the session —
 			// session_shutdown intentionally kills nothing here.
-			daemonExtension,
+			// EXPERIMENTAL: gated behind --enable-experimental-features.
+			...(experimentalFeatures ? [daemonExtension] : []),
 			bashToolGuardExtension,
 			bashTimeoutGuidanceExtension,
 			hiddenToolGuidanceExtension,

--- a/src/extensions/bash-background/index.ts
+++ b/src/extensions/bash-background/index.ts
@@ -20,7 +20,7 @@
  * handle. The registry is drained on `session_shutdown`.
  */
 import type { ExtensionAPI, SessionShutdownEvent, SessionStartEvent } from "@earendil-works/pi-coding-agent"
-import { BASH_TOOL_DESCRIPTION } from "../bash-tool-guard.js"
+import { bashToolDescription } from "../bash-tool-guard.js"
 import { createBackgroundBashToolDefinition } from "./bash-background-tool.js"
 import { createProcessRegistry } from "./process-registry.js"
 import { getSessionRegistry, setSessionRegistry } from "./session-registry.js"
@@ -52,7 +52,7 @@ export function bashBackgroundExtension(pi: ExtensionAPI): void {
 		})
 		const toolWithSteering = {
 			...tool,
-			description: BASH_TOOL_DESCRIPTION,
+			description: bashToolDescription(),
 			// The promptSnippet is the one-line "Execute bash commands..."
 			// summary used in the Available tools section. Keep the
 			// upstream/wrapped snippet so the system prompt still lists bash.

--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -3,9 +3,10 @@
  * Tests the event handler registration (session_start, input, turn_start, tool_call)
  * using a mock ExtensionAPI.
  */
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import bashToolGuardExtension, { BASH_TOOL_DESCRIPTION, STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
 import { BASH_TOOL_GUARD_EVENTS } from "./bash-tool-guard-events.js"
+import { setExperimentalFeaturesEnabled } from "./experimental.js"
 
 let mockMode: string | undefined = "default"
 let mockResourceEnabled = true
@@ -18,9 +19,16 @@ vi.mock("../resources/store.js", () => ({
 	isResourceEnabled: (id: string) => (id === "extensions.bash-tool-guard" ? mockResourceEnabled : true),
 }))
 
+beforeEach(() => {
+	// Description assertions compare against the full BASH_TOOL_DESCRIPTION;
+	// that text (with the daemon steer) is only served when the flag is on.
+	setExperimentalFeaturesEnabled(true)
+})
+
 afterEach(() => {
 	mockMode = "default"
 	mockResourceEnabled = true
+	setExperimentalFeaturesEnabled(false)
 })
 
 // Capture what session_start actually passes to createBashToolDefinition

--- a/src/extensions/bash-tool-guard.integration.test.ts
+++ b/src/extensions/bash-tool-guard.integration.test.ts
@@ -4,7 +4,7 @@
  * using a mock ExtensionAPI.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import bashToolGuardExtension, { BASH_TOOL_DESCRIPTION, STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
+import bashToolGuardExtension, { bashToolDescription, STEER_MESSAGE_TYPE } from "./bash-tool-guard.js"
 import { BASH_TOOL_GUARD_EVENTS } from "./bash-tool-guard-events.js"
 import { setExperimentalFeaturesEnabled } from "./experimental.js"
 
@@ -20,8 +20,8 @@ vi.mock("../resources/store.js", () => ({
 }))
 
 beforeEach(() => {
-	// Description assertions compare against the full BASH_TOOL_DESCRIPTION;
-	// that text (with the daemon steer) is only served when the flag is on.
+	// Description assertions compare against bashToolDescription(); that
+	// text (with the daemon steer) is only served when the flag is on.
 	setExperimentalFeaturesEnabled(true)
 })
 
@@ -832,7 +832,7 @@ describe("bashToolGuardExtension - description override", () => {
 		fireSessionStart(pi)
 
 		expect(pi.registeredTools.size).toBe(1)
-		expect(pi.registeredTools.get("bash")?.description).toBe(BASH_TOOL_DESCRIPTION)
+		expect(pi.registeredTools.get("bash")?.description).toBe(bashToolDescription())
 	})
 
 	it("preserves the upstream execute/renderCall/renderResult/parameters", () => {
@@ -865,6 +865,6 @@ describe("bashToolGuardExtension - description override", () => {
 		expect(capturedCwd).toBe("/repo-b")
 		const second = pi.registeredTools.get("bash")
 		expect(second).not.toBe(first)
-		expect(second?.description).toBe(BASH_TOOL_DESCRIPTION)
+		expect(second?.description).toBe(bashToolDescription())
 	})
 })

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -6,7 +6,7 @@
  * ExtensionAPI (session_start/tool_call handlers) live in
  * bash-tool-guard.integration.test.ts instead.
  */
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import {
 	applyDescriptionOverride,
 	BASH_TOOL_DESCRIPTION,
@@ -17,6 +17,12 @@ import {
 	classifyBashCommand,
 	toolDescriptionOverride,
 } from "./bash-tool-guard.js"
+import { setExperimentalFeaturesEnabled } from "./experimental.js"
+
+afterEach(() => {
+	// Module-level singleton — restore default so suites don't leak state.
+	setExperimentalFeaturesEnabled(false)
+})
 
 describe("classifyBashCommand — read patterns", () => {
 	it("flags `cat <file>`", () => {
@@ -855,8 +861,19 @@ describe("BASH_TOOL_DESCRIPTION", () => {
 })
 
 describe("toolDescriptionOverride", () => {
-	it("returns the override for the bash tool", () => {
+	it("returns the override for the bash tool when experimental features are enabled", () => {
+		setExperimentalFeaturesEnabled(true)
 		expect(toolDescriptionOverride("bash")).toBe(BASH_TOOL_DESCRIPTION)
+	})
+
+	it("strips the daemon sentence when experimental features are disabled", () => {
+		setExperimentalFeaturesEnabled(false)
+		const override = toolDescriptionOverride("bash")
+		if (!override) throw new Error("expected bash description override")
+		expect(override).not.toContain("`daemon`")
+		expect(override).toContain(
+			"Managed background (timeout/checkin_interval + bash_control) is killed when the session ends.",
+		)
 	})
 
 	it("returns undefined for non-bash tools", () => {
@@ -870,6 +887,7 @@ describe("toolDescriptionOverride", () => {
 
 describe("applyDescriptionOverride", () => {
 	it("overrides the description for bash", () => {
+		setExperimentalFeaturesEnabled(true)
 		const tool = { name: "bash", description: "old description" }
 		const result = applyDescriptionOverride(tool)
 		expect(result.description).toBe(BASH_TOOL_DESCRIPTION)

--- a/src/extensions/bash-tool-guard.test.ts
+++ b/src/extensions/bash-tool-guard.test.ts
@@ -6,14 +6,14 @@
  * ExtensionAPI (session_start/tool_call handlers) live in
  * bash-tool-guard.integration.test.ts instead.
  */
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
 	applyDescriptionOverride,
-	BASH_TOOL_DESCRIPTION,
 	type BashCategory,
 	type BashGuardBlockResult,
 	type BashGuardWarnResult,
 	BashToolGuard,
+	bashToolDescription,
 	classifyBashCommand,
 	toolDescriptionOverride,
 } from "./bash-tool-guard.js"
@@ -820,50 +820,55 @@ describe("BashToolGuard — semantic intent override (no tool name)", () => {
 // the system prompt block + session_start mutation.
 
 describe("BASH_TOOL_DESCRIPTION", () => {
+	// Content assertions run against the FULL description (with the daemon
+	// steer) — the public bashToolDescription() accessor with the flag on.
+	beforeEach(() => {
+		setExperimentalFeaturesEnabled(true)
+	})
 	it("describes what bash is for", () => {
-		expect(BASH_TOOL_DESCRIPTION).toMatch(/build|test|git|package/i)
+		expect(bashToolDescription()).toMatch(/build|test|git|package/i)
 	})
 
 	it("explicitly tells the model to use dedicated tools for file ops", () => {
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `read`")
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `edit`")
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `write`")
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `grep`")
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `find`")
-		expect(BASH_TOOL_DESCRIPTION).toContain("use `ls`")
+		expect(bashToolDescription()).toContain("use `read`")
+		expect(bashToolDescription()).toContain("use `edit`")
+		expect(bashToolDescription()).toContain("use `write`")
+		expect(bashToolDescription()).toContain("use `grep`")
+		expect(bashToolDescription()).toContain("use `find`")
+		expect(bashToolDescription()).toContain("use `ls`")
 	})
 
 	it("preserves the upstream truncation behaviour", () => {
 		// The output truncation contract is important — dropping it would
 		// change runtime semantics. Verify the truncation info survives.
-		expect(BASH_TOOL_DESCRIPTION).toMatch(/truncat/i)
+		expect(bashToolDescription()).toMatch(/truncat/i)
 	})
 
 	it("documents that cd does not persist between bash tool calls", () => {
-		expect(BASH_TOOL_DESCRIPTION).toContain("does NOT persist")
-		expect(BASH_TOOL_DESCRIPTION).toContain("cd <dir> && <command>")
+		expect(bashToolDescription()).toContain("does NOT persist")
+		expect(bashToolDescription()).toContain("cd <dir> && <command>")
 	})
 
 	it("warns against piping output through tail/head to hide it", () => {
-		expect(BASH_TOOL_DESCRIPTION).toMatch(/pipe.*tail.*head.*hide/i)
+		expect(bashToolDescription()).toMatch(/pipe.*tail.*head.*hide/i)
 	})
 
 	it("warns against backgrounding with nohup/disown/&", () => {
-		expect(BASH_TOOL_DESCRIPTION).toContain("nohup")
-		expect(BASH_TOOL_DESCRIPTION).toContain("disown")
-		expect(BASH_TOOL_DESCRIPTION).toContain("background")
+		expect(bashToolDescription()).toContain("nohup")
+		expect(bashToolDescription()).toContain("disown")
+		expect(bashToolDescription()).toContain("background")
 	})
 
 	it("suggests using long timeout and checkin_interval for long-running commands", () => {
-		expect(BASH_TOOL_DESCRIPTION).toMatch(/timeout=1800/)
-		expect(BASH_TOOL_DESCRIPTION).toMatch(/checkin_interval/)
+		expect(bashToolDescription()).toMatch(/timeout=1800/)
+		expect(bashToolDescription()).toMatch(/checkin_interval/)
 	})
 })
 
 describe("toolDescriptionOverride", () => {
 	it("returns the override for the bash tool when experimental features are enabled", () => {
 		setExperimentalFeaturesEnabled(true)
-		expect(toolDescriptionOverride("bash")).toBe(BASH_TOOL_DESCRIPTION)
+		expect(toolDescriptionOverride("bash")).toBe(bashToolDescription())
 	})
 
 	it("strips the daemon sentence when experimental features are disabled", () => {
@@ -890,7 +895,7 @@ describe("applyDescriptionOverride", () => {
 		setExperimentalFeaturesEnabled(true)
 		const tool = { name: "bash", description: "old description" }
 		const result = applyDescriptionOverride(tool)
-		expect(result.description).toBe(BASH_TOOL_DESCRIPTION)
+		expect(result.description).toBe(bashToolDescription())
 	})
 
 	it("does not mutate the input object", () => {

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -182,7 +182,11 @@ function backgroundSuggestion(): string {
  * rather than by mutating a `pi.getAllTools()` result — the registry
  * write is what actually reaches the rendered system prompt.
  */
-export const BASH_TOOL_DESCRIPTION = `
+// Private: the flag-aware `bashToolDescription()` below is the single
+// public entry point — everything (override + tests) must go through the
+// GATE-aware variant, never reach for the constant directly (the raw
+// const contains the experimental `daemon` mention).
+const BASH_TOOL_DESCRIPTION = `
 Execute a bash command for operations without a dedicated tool: build commands, test runners, git, package managers, system administration, shell scripting.
 
 DO NOT use bash for: reading files (use \`read\`), editing files (use \`edit\`), writing files (use \`write\`), searching file contents (use \`grep\`), finding files by pattern (use \`find\`), or listing directories (use \`ls\`) — dedicated tools are faster and unlock LSP context.

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -77,6 +77,7 @@ import {
 	type BashToolGuardBlockPayload,
 	type BashToolGuardWarnPayload,
 } from "./bash-tool-guard-events.js"
+import { isExperimentalFeaturesEnabled } from "./experimental.js"
 import { getPermissionMode } from "./permissions/mode-controller.js"
 import { parseCommandSegments, stripRtk } from "./permissions/taxonomy.js"
 
@@ -157,10 +158,21 @@ const BLOCK_REASON_BASE =
 const READ_SUGGESTION = "Use the read tool with the file path (and offset/limit for head/tail)."
 const EDIT_SUGGESTION = "Use the edit tool with old_string/new_string."
 const WRITE_SUGGESTION = "Use the edit tool for targeted changes or the write tool for full-file replacements."
-const BACKGROUND_SUGGESTION =
-	"Use the bash tool with a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60) for long-running commands, then drive them via bash_control. " +
-	"Do not background processes with `&`, `nohup`, or `disown` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. " +
-	"Managed background (bash + bash_control) is killed when the session ends; if the process must keep running after your session ends (e.g. a server someone connects to afterwards), use the `daemon` tool instead."
+const DAEMON_STEER =
+	"if the process must keep running after your session ends (e.g. a server someone connects to afterwards), use the `daemon` tool instead."
+const NO_DAEMON_STEER =
+	"managed background is killed at session end — if the service must outlive the session, restate that requirement to the user before finishing."
+
+function backgroundSuggestion(): string {
+	const daemon = isExperimentalFeaturesEnabled()
+	return (
+		"Use the bash tool with a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60) for long-running commands, then drive them via bash_control. " +
+		"Do not background processes with `&`, `nohup`, or `disown` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. " +
+		(daemon
+			? `Managed background (bash + bash_control) is killed when the session ends; ${DAEMON_STEER}`
+			: `Managed background is likewise killed at session end; ${NO_DAEMON_STEER}`)
+	)
+}
 
 /**
  * Replacement description for the bash tool. Keeps the original output
@@ -190,9 +202,23 @@ Each command runs in a fresh shell rooted at the session working directory; \`cd
  * can exercise it without a mock `pi` and so the override rules are
  * visible at a glance.
  */
+/**
+ * The bash description to use in the CURRENT environment. When the
+ * experimental daemon tools are disabled, strip the `daemon`-mentioning
+ * sentence from BASH_TOOL_DESCRIPTION so the model is never steered
+ * toward a tool that doesn't exist.
+ */
+export function bashToolDescription(): string {
+	if (isExperimentalFeaturesEnabled()) return BASH_TOOL_DESCRIPTION
+	return BASH_TOOL_DESCRIPTION.replace(
+		"Managed background (timeout/checkin_interval + bash_control) is killed when the session ends — use the `daemon` tool instead when, and only when, a process must keep running after your session ends (e.g. a server someone connects to afterwards).",
+		"Managed background (timeout/checkin_interval + bash_control) is killed when the session ends.",
+	)
+}
+
 export function toolDescriptionOverride(name: string): string | undefined {
 	if (name !== "bash") return undefined
-	return BASH_TOOL_DESCRIPTION
+	return bashToolDescription()
 }
 
 /**
@@ -292,7 +318,7 @@ function detectBackgrounding(command: string): BashClassification | null {
 		if (tool === "nohup") {
 			return {
 				category: "background",
-				suggestion: BACKGROUND_SUGGESTION,
+				suggestion: backgroundSuggestion(),
 				matchedSegment: tokens.join(" "),
 				tool: "nohup",
 			}
@@ -303,7 +329,7 @@ function detectBackgrounding(command: string): BashClassification | null {
 		if (tool === "disown") {
 			return {
 				category: "background",
-				suggestion: BACKGROUND_SUGGESTION,
+				suggestion: backgroundSuggestion(),
 				matchedSegment: tokens.join(" "),
 				tool: "disown",
 			}
@@ -315,7 +341,7 @@ function detectBackgrounding(command: string): BashClassification | null {
 	if (hasBackgroundOperator) {
 		return {
 			category: "background",
-			suggestion: BACKGROUND_SUGGESTION,
+			suggestion: backgroundSuggestion(),
 			matchedSegment: "& (background)",
 			tool: "&",
 		}

--- a/src/extensions/bash-tool-guard.ts
+++ b/src/extensions/bash-tool-guard.ts
@@ -159,7 +159,8 @@ const EDIT_SUGGESTION = "Use the edit tool with old_string/new_string."
 const WRITE_SUGGESTION = "Use the edit tool for targeted changes or the write tool for full-file replacements."
 const BACKGROUND_SUGGESTION =
 	"Use the bash tool with a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60) for long-running commands, then drive them via bash_control. " +
-	"Do not background processes with `&`, `nohup`, or `disown` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs."
+	"Do not background processes with `&`, `nohup`, or `disown` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. " +
+	"Managed background (bash + bash_control) is killed when the session ends; if the process must keep running after your session ends (e.g. a server someone connects to afterwards), use the `daemon` tool instead."
 
 /**
  * Replacement description for the bash tool. Keeps the original output
@@ -176,7 +177,7 @@ DO NOT use bash for: reading files (use \`read\`), editing files (use \`edit\`),
 
 DO NOT pipe output through \`tail\` or \`head\` to hide it — this buffers all output until the process ends, preventing real-time progress monitoring. Instead, let the bash tool stream output directly and set a realistic timeout. For long-running commands (builds, tests, training), set a long timeout (e.g. timeout=1800) and checkin_interval (e.g. 60), then drive the process via bash_control.
 
-DO NOT background processes with \`&\`, \`nohup\`, or \`disown\` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. Instead, set a long timeout on the bash command so it runs in the bash tool's background mode with proper process management.
+DO NOT background processes with \`&\`, \`nohup\`, or \`disown\` — they escape the bash tool's process lifecycle and become orphaned, consuming memory until the container OOMs. Instead, set a long timeout on the bash command so it runs in the bash tool's background mode with proper process management. Managed background (timeout/checkin_interval + bash_control) is killed when the session ends — use the \`daemon\` tool instead when, and only when, a process must keep running after your session ends (e.g. a server someone connects to afterwards).
 
 Returns stdout and stderr. Output is truncated to last 2000 lines or 50KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.
 

--- a/src/extensions/daemon/daemon-control-tool.test.ts
+++ b/src/extensions/daemon/daemon-control-tool.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the `daemon_control` tool definition.
+ *
+ * Real processes in a temp state dir (same rationale as spawn.test.ts):
+ * list / status / logs / stop round-trip through actual pids so the
+ * liveness check and group kill are exercised, with soft-error shapes
+ * (NOT thrown tool errors) asserted for unknown ids — that pattern is the
+ * mark_todo lesson: hard errors make the model retry-churn.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import { createDaemonControlToolDefinition, DAEMON_CONTROL_TOOL_DESCRIPTION } from "./daemon-control-tool.js"
+import { spawnDaemon } from "./spawn.js"
+import { isPidAlive, readDaemon } from "./state.js"
+
+const describePosix = process.platform === "win32" ? describe.skip : describe
+
+const fakeCtx = createContext()
+
+describe("daemon_control tool description (steering)", () => {
+	it("documents the four actions and disclaims bash_control overlap", () => {
+		for (const action of ['"list"', '"status"', '"logs"', '"stop"']) {
+			expect(DAEMON_CONTROL_TOOL_DESCRIPTION).toContain(action)
+		}
+		expect(DAEMON_CONTROL_TOOL_DESCRIPTION).toContain("NOT managed by bash_control")
+	})
+})
+
+describePosix("daemon_control tool execute (real processes)", () => {
+	let dir: string
+	const livePids: number[] = []
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "daemon-ctl-test-"))
+	})
+
+	afterEach(() => {
+		for (const pid of livePids) {
+			try {
+				process.kill(-pid, "SIGKILL")
+			} catch {
+				// Expectations may have stopped it already.
+			}
+		}
+		livePids.length = 0
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	function tool() {
+		return createDaemonControlToolDefinition({ stateDir: dir })
+	}
+
+	async function startSleeper(name: string): Promise<{ id: string; pid: number; logFile: string }> {
+		const outcome = await spawnDaemon({
+			command: "sleep 60",
+			cwd: dir,
+			name,
+			stateDir: dir,
+			crashGraceMs: 100,
+		})
+		if (!outcome.ok) throw new Error(`setup spawn failed: ${outcome.error}`)
+		livePids.push(outcome.record.pid)
+		return outcome.record
+	}
+
+	it("list shows live daemons and prunes dead ones", async () => {
+		const empty = await tool().execute("t1", { action: "list" }, undefined, undefined, fakeCtx)
+		expect(empty.content[0].type === "text" && empty.content[0].text).toContain("No live daemons")
+
+		const record = await startSleeper("listed")
+		const listed = await tool().execute("t2", { action: "list" }, undefined, undefined, fakeCtx)
+		const text = listed.content[0].type === "text" ? listed.content[0].text : ""
+		expect(text).toContain(record.id)
+		expect(text).toContain(String(record.pid))
+	})
+
+	it("status reports a running daemon", async () => {
+		const record = await startSleeper("checked")
+		const result = await tool().execute("t3", { action: "status", id: record.id }, undefined, undefined, fakeCtx)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("RUNNING")
+		expect(text).toContain(String(record.pid))
+	})
+
+	it("status on unknown id steers to list (soft, not a throw)", async () => {
+		const result = await tool().execute("t4", { action: "status", id: "ghost-123abc" }, undefined, undefined, fakeCtx)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("not recorded")
+		expect(text).toContain("list")
+		expect(result.details?.error).toBe("unknown-id")
+	})
+
+	it("logs tails the daemon's output file", async () => {
+		const outcome = await spawnDaemon({
+			command: "bash -c 'echo log-marker-xyzzy; exec sleep 60'",
+			cwd: dir,
+			name: "logger",
+			stateDir: dir,
+			crashGraceMs: 100,
+		})
+		if (!outcome.ok) throw new Error(`setup spawn failed: ${outcome.error}`)
+		livePids.push(outcome.record.pid)
+
+		// Bounded wait for the log line to land.
+		const deadline = Date.now() + 3000
+		let text = ""
+		while (Date.now() < deadline) {
+			const res = await tool().execute(
+				"t5",
+				{ action: "logs", id: outcome.record.id, max_bytes: 4096 },
+				undefined,
+				undefined,
+				fakeCtx,
+			)
+			text = res.content[0].type === "text" ? res.content[0].text : ""
+			if (text.includes("log-marker-xyzzy")) break
+			await new Promise((r) => setTimeout(r, 50))
+		}
+		expect(text).toContain("log-marker-xyzzy")
+	})
+
+	it("stop kills the daemon and removes its record", async () => {
+		const record = await startSleeper("stopped")
+		const result = await tool().execute("t6", { action: "stop", id: record.id }, undefined, undefined, fakeCtx)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("stopped")
+		expect(isPidAlive(record.pid)).toBe(false)
+		expect(readDaemon(dir, record.id)).toBeUndefined()
+	})
+
+	it("stop on unknown id is a soft report", async () => {
+		const result = await tool().execute("t7", { action: "stop", id: "ghost-123abc" }, undefined, undefined, fakeCtx)
+		expect(result.details?.error).toBe("unknown-id")
+	})
+
+	it("status/logs/stop without id return a clear error", async () => {
+		const result = await tool().execute("t8", { action: "status" }, undefined, undefined, fakeCtx)
+		expect(result.details?.error).toBe("missing-id")
+	})
+})

--- a/src/extensions/daemon/daemon-control-tool.test.ts
+++ b/src/extensions/daemon/daemon-control-tool.test.ts
@@ -86,6 +86,37 @@ describePosix("daemon_control tool execute (real processes)", () => {
 		expect(text).toContain(String(record.pid))
 	})
 
+	it("status on a dead daemon: reports not-running and KEEPS the record", async () => {
+		// Regression for review feedback: status must not prune dead
+		// records as a side effect — only `list` does that.
+		const outcome = await spawnDaemon({
+			command: "bash -c 'echo transient; exit 0'",
+			cwd: dir,
+			name: "transient",
+			stateDir: dir,
+			crashGraceMs: 0, // skip liveness check — it's SUPPOSED to exit
+		})
+		if (!outcome.ok) throw new Error(`setup spawn failed: ${outcome.error}`)
+		// Bounded wait for natural death.
+		const deadline = Date.now() + 3000
+		while (isPidAlive(outcome.record.pid) && Date.now() < deadline) {
+			await new Promise((r) => setTimeout(r, 50))
+		}
+		expect(isPidAlive(outcome.record.pid)).toBe(false)
+
+		const result = await tool().execute(
+			"t3b",
+			{ action: "status", id: outcome.record.id },
+			undefined,
+			undefined,
+			fakeCtx,
+		)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("not running")
+		// Record retained for the next `list` to prune (or investigate).
+		expect(readDaemon(dir, outcome.record.id)).toBeDefined()
+	})
+
 	it("status on unknown id steers to list (soft, not a throw)", async () => {
 		const result = await tool().execute("t4", { action: "status", id: "ghost-123abc" }, undefined, undefined, fakeCtx)
 		const text = result.content[0].type === "text" ? result.content[0].text : ""

--- a/src/extensions/daemon/daemon-control-tool.ts
+++ b/src/extensions/daemon/daemon-control-tool.ts
@@ -1,0 +1,164 @@
+/**
+ * `daemon_control` tool — inspect and stop detached daemons.
+ *
+ * Companion to the `daemon` tool (see `./daemon-tool.ts` for the design
+ * goal). Actions:
+ *
+ *   list    — all live daemons (dead records are pruned from the state
+ *             dir, so a reboot doesn't leave phantoms).
+ *   status  — one daemon: alive?, uptime, command, log path.
+ *   logs    — tail of the daemon's log file (bounded, default 8KB).
+ *   stop    — SIGTERM the process group, grace, SIGKILL; removes the
+ *             state record. Idempotent: an already-dead or unknown id is
+ *             reported softly, NOT thrown as a tool error (hard errors
+ *             cause error→retry churn — same lesson as mark_todo).
+ */
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+import { readLogTail, stopDaemon } from "./spawn.js"
+import { daemonStateDir, listDaemons, readDaemon } from "./state.js"
+
+const daemonControlSchema = Type.Object({
+	action: Type.Union([Type.Literal("list"), Type.Literal("status"), Type.Literal("logs"), Type.Literal("stop")], {
+		description:
+			"'list' shows all live daemons; 'status' checks one daemon's liveness; 'logs' tails its log file; 'stop' terminates it.",
+	}),
+	id: Type.Optional(
+		Type.String({
+			description: "Daemon id (returned by the daemon tool). Required for status/logs/stop.",
+		}),
+	),
+	max_bytes: Type.Optional(
+		Type.Number({
+			description: "Only valid with action 'logs'. Max bytes to return from the end of the log file (default 8192).",
+		}),
+	),
+})
+
+export const DAEMON_CONTROL_TOOL_NAME = "daemon_control"
+
+export const DAEMON_CONTROL_TOOL_DESCRIPTION = `Inspect or stop detached daemons started by the \`daemon\` tool.
+
+- action "list": show all live daemons (id, pid, uptime, command, log file). Dead records are cleaned up automatically.
+- action "status": check one daemon — alive?, uptime, command, log path.
+- action "logs": return the tail of the daemon's log file.
+- action "stop": terminate the daemon's whole process group and remove its record.
+
+Daemons are NOT managed by bash_control — those handles belong to the bash tool's session-scoped background mode, which is a different lifecycle (killed at session end).`
+
+export interface DaemonControlToolOptions {
+	stateDir?: string
+}
+
+function formatUptime(startedAt: string): string {
+	const ms = Date.now() - new Date(startedAt).getTime()
+	if (!Number.isFinite(ms) || ms < 0) return "unknown"
+	const s = Math.floor(ms / 1000)
+	if (s < 60) return `${s}s`
+	const m = Math.floor(s / 60)
+	if (m < 60) return `${m}m${s % 60}s`
+	const h = Math.floor(m / 60)
+	return `${h}h${m % 60}m`
+}
+
+export function createDaemonControlToolDefinition(
+	options: DaemonControlToolOptions = {},
+): ToolDefinition<typeof daemonControlSchema, Record<string, unknown>> {
+	const stateDir = options.stateDir ?? daemonStateDir()
+
+	return {
+		name: DAEMON_CONTROL_TOOL_NAME,
+		label: "daemon_control",
+		description: DAEMON_CONTROL_TOOL_DESCRIPTION,
+		promptSnippet: "check or stop detached daemons",
+		parameters: daemonControlSchema,
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const { action, id } = params
+
+			// ── list ────────────────────────────────────────────────────
+			if (action === "list") {
+				const live = listDaemons(stateDir)
+				if (live.length === 0) {
+					return {
+						content: [{ type: "text", text: "No live daemons." }],
+						details: { action, daemons: [] },
+					}
+				}
+				const lines = live.map(
+					({ record }) =>
+						`${record.id}  pid ${record.pid}  up ${formatUptime(record.startedAt)}\n  ${record.command}\n  log: ${record.logFile}`,
+				)
+				return {
+					content: [{ type: "text", text: `${live.length} live daemon(s):\n\n${lines.join("\n\n")}` }],
+					details: {
+						action,
+						daemons: live.map(({ record }) => ({ id: record.id, pid: record.pid, command: record.command })),
+					},
+				}
+			}
+
+			// status / logs / stop require an id
+			if (!id) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Error: action "${action}" requires an 'id' (from the daemon tool or daemon_control list).`,
+						},
+					],
+					details: { action, error: "missing-id" },
+				}
+			}
+			const record = readDaemon(stateDir, id)
+			if (!record) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Daemon '${id}' is not recorded (already stopped, or never started here). Run daemon_control action "list" to see live daemons.`,
+						},
+					],
+					details: { action, id, error: "unknown-id" },
+				}
+			}
+
+			// ── status ──────────────────────────────────────────────────
+			if (action === "status") {
+				const live = listDaemons(stateDir).some((e) => e.record.id === id)
+				return {
+					content: [
+						{
+							type: "text",
+							text:
+								`Daemon ${record.id}: ${live ? "RUNNING" : "not running"}\n` +
+								`  pid:      ${record.pid}\n  command:  ${record.command}\n  cwd:      ${record.cwd}\n` +
+								`  started:  ${record.startedAt} (up ${formatUptime(record.startedAt)})\n  log:      ${record.logFile}`,
+						},
+					],
+					details: { action, id, alive: live, pid: record.pid },
+				}
+			}
+
+			// ── logs ────────────────────────────────────────────────────
+			if (action === "logs") {
+				const tail = readLogTail(record.logFile, params.max_bytes ?? 8192)
+				return {
+					content: [
+						{
+							type: "text",
+							text: tail !== undefined ? tail : `(no log output yet — ${record.logFile} is missing or empty)`,
+						},
+					],
+					details: { action, id, logFile: record.logFile },
+				}
+			}
+
+			// ── stop ────────────────────────────────────────────────────
+			const { note } = await stopDaemon(record, stateDir)
+			return {
+				content: [{ type: "text", text: note }],
+				details: { action, id, pid: record.pid },
+			}
+		},
+	}
+}

--- a/src/extensions/daemon/daemon-control-tool.ts
+++ b/src/extensions/daemon/daemon-control-tool.ts
@@ -157,10 +157,27 @@ export function createDaemonControlToolDefinition(
 			}
 
 			// ── stop ────────────────────────────────────────────────────
-			const { note } = await stopDaemon(record, stateDir)
+			// Explicit branch, NOT a fallthrough — if a future action is added
+			// above but not handled, we must not silently STOP the daemon.
+			if (action === "stop") {
+				const { note } = await stopDaemon(record, stateDir)
+				return {
+					content: [{ type: "text", text: note }],
+					details: { action, id, pid: record.pid },
+				}
+			}
+
+			// Unreachable for the current schema (closed union) — but if a
+			// new action is ever added and its branch is missed, nag rather
+			// than fall into a destructive default.
 			return {
-				content: [{ type: "text", text: note }],
-				details: { action, id, pid: record.pid },
+				content: [
+					{
+						type: "text",
+						text: `Unknown daemon_control action "${action}". Valid actions: list, status, logs, stop.`,
+					},
+				],
+				details: { action, error: "unknown-action" },
 			}
 		},
 	}

--- a/src/extensions/daemon/daemon-control-tool.ts
+++ b/src/extensions/daemon/daemon-control-tool.ts
@@ -16,7 +16,7 @@
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import { readLogTail, stopDaemon } from "./spawn.js"
-import { daemonStateDir, listDaemons, readDaemon } from "./state.js"
+import { daemonStateDir, isPidAlive, listDaemons, readDaemon } from "./state.js"
 
 const daemonControlSchema = Type.Object({
 	action: Type.Union([Type.Literal("list"), Type.Literal("status"), Type.Literal("logs"), Type.Literal("stop")], {
@@ -29,7 +29,8 @@ const daemonControlSchema = Type.Object({
 		}),
 	),
 	max_bytes: Type.Optional(
-		Type.Number({
+		Type.Integer({
+			minimum: 1,
 			description: "Only valid with action 'logs'. Max bytes to return from the end of the log file (default 8192).",
 		}),
 	),
@@ -124,7 +125,9 @@ export function createDaemonControlToolDefinition(
 
 			// ── status ──────────────────────────────────────────────────
 			if (action === "status") {
-				const live = listDaemons(stateDir).some((e) => e.record.id === id)
+				// isPidAlive directly — listDaemons would prune dead records, a
+				// surprising side effect from a read-only status query.
+				const live = isPidAlive(record.pid)
 				return {
 					content: [
 						{

--- a/src/extensions/daemon/daemon-tool.test.ts
+++ b/src/extensions/daemon/daemon-tool.test.ts
@@ -92,6 +92,14 @@ describePosix("daemon tool execute (real processes)", () => {
 		expect(result.details?.error).toBe("invalid-name")
 	})
 
+	it("empty-string name falls back to the default daemon- prefix", async () => {
+		const result = await tool().execute("tc2b", { command: "sleep 5", name: "" }, undefined, undefined, fakeCtx(dir))
+		expect(result.details?.error).toBeUndefined()
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("Daemon started")
+		expect(text).not.toMatch(/id:\s+-[0-9a-f]{6}/)
+	})
+
 	it("empty command returns an error result", async () => {
 		const result = await tool().execute("tc3", { command: "  " }, undefined, undefined, fakeCtx(dir))
 		expect(result.details?.error).toBe("spawn-failed")

--- a/src/extensions/daemon/daemon-tool.test.ts
+++ b/src/extensions/daemon/daemon-tool.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for the `daemon` tool definition.
+ *
+ * Two test groups:
+ *  - steering: the tool description is load-bearing for keeping the model
+ *    OFF background-execution-by-default (constraint from the spec), so
+ *    key phrases are asserted explicitly.
+ *  - behaviour: execute() against real `sleep` processes in a temp state
+ *    dir, validating the success/error result shapes the model sees.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import { createDaemonToolDefinition, DAEMON_TOOL_DESCRIPTION } from "./daemon-tool.js"
+import { isPidAlive, readDaemon } from "./state.js"
+
+const describePosix = process.platform === "win32" ? describe.skip : describe
+
+const fakeCtx = (cwd: string) => createContext({ cwd })
+
+describe("daemon tool description (steering)", () => {
+	it("positions itself as last resort, not as a bash replacement", () => {
+		expect(DAEMON_TOOL_DESCRIPTION).toContain("KEEPS RUNNING after this session ends")
+		// Must steer AWAY for ordinary work — spec constraint "must not
+		// encourage the model to prefer background execution".
+		expect(DAEMON_TOOL_DESCRIPTION).toContain("Do NOT use for")
+		expect(DAEMON_TOOL_DESCRIPTION).toContain("natural end")
+		// Must own its lifecycle truth: no timeout, no streaming, no cleanup.
+		expect(DAEMON_TOOL_DESCRIPTION).toContain("no timeout")
+		// Points back at the managed path for everything else.
+		expect(DAEMON_TOOL_DESCRIPTION).toContain("bash_control")
+	})
+})
+
+describePosix("daemon tool execute (real processes)", () => {
+	let dir: string
+	const livePids: number[] = []
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "daemon-tool-test-"))
+	})
+
+	afterEach(() => {
+		for (const pid of livePids) {
+			try {
+				process.kill(-pid, "SIGKILL")
+			} catch {
+				// Teardown of an expectation that already killed it — fine.
+			}
+		}
+		livePids.length = 0
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	function tool() {
+		return createDaemonToolDefinition({ stateDir: dir, crashGraceMs: 100 })
+	}
+
+	it("starts a daemon and returns id/pid/log with management hint", async () => {
+		const result = await tool().execute(
+			"tc1",
+			{ command: "sleep 60", name: "webserver" },
+			undefined,
+			undefined,
+			fakeCtx(dir),
+		)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("Daemon started")
+		expect(text).toContain("webserver-")
+		expect(text).toContain("daemon_control")
+
+		const id = result.details?.id as string
+		const record = readDaemon(dir, id)
+		if (!record) throw new Error(`record for ${id} not found in state dir`)
+		livePids.push(record.pid)
+		expect(isPidAlive(record.pid)).toBe(true)
+	})
+
+	it("rejects invalid names with a soft error (no throw)", async () => {
+		const result = await tool().execute(
+			"tc2",
+			{ command: "sleep 5", name: "bad/../name" },
+			undefined,
+			undefined,
+			fakeCtx(dir),
+		)
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("Error:")
+		expect(result.details?.error).toBe("invalid-name")
+	})
+
+	it("empty command returns an error result", async () => {
+		const result = await tool().execute("tc3", { command: "  " }, undefined, undefined, fakeCtx(dir))
+		expect(result.details?.error).toBe("spawn-failed")
+	})
+
+	it("instant-crash command surfaces the failure with log tail", async () => {
+		const result = await tool().execute("tc4", { command: "exit 1" }, undefined, undefined, fakeCtx(dir))
+		const text = result.content[0].type === "text" ? result.content[0].text : ""
+		expect(text).toContain("exited immediately")
+		expect(result.details?.error).toBe("spawn-failed")
+	})
+})

--- a/src/extensions/daemon/daemon-tool.ts
+++ b/src/extensions/daemon/daemon-tool.ts
@@ -1,0 +1,106 @@
+/**
+ * `daemon` tool — start a detached process that outlives the session.
+ *
+ * DESIGN GOAL: this tool must be UNATTRACTIVE for ordinary work. The
+ * default for long-running commands is `bash` with a realistic timeout
+ * (and checkin_interval + bash_control for managed background). `daemon`
+ * is the deliberate last resort for one specific shape of problem: a
+ * service that an external party connects to AFTER the agent's session
+ * has ended — a web/DB server for the user, an emulator, a benchmark
+ * grader's target process. The description below is load-bearing for that
+ * steering; keep its restrictive tone when editing.
+ *
+ * Everything else is intentionally absent: no timeout/deadline param
+ * (daemons never get one), no output streaming (that would be bash's
+ * checkin loop), no automatic cleanup (that's the point).
+ */
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+import { spawnDaemon } from "./spawn.js"
+import { daemonStateDir, validateDaemonName } from "./state.js"
+
+const daemonSchema = Type.Object({
+	command: Type.String({
+		description:
+			"Bash command line to run as the daemon. Executed in place of the shell (no wrapper stays behind). Output is redirected to the daemon's log file — do '... >> log 2>&1' style plumbing inside the command only when the default log file location is unsuitable.",
+	}),
+	name: Type.Optional(
+		Type.String({
+			description:
+				"Short identifier for the daemon (alphanumerics/dash/underscore only, max 40 chars). Used as a prefix for its id and log files. Pick something meaningful like 'pypi-server' or 'dev-web'.",
+		}),
+	),
+})
+
+export const DAEMON_TOOL_NAME = "daemon"
+
+export const DAEMON_TOOL_DESCRIPTION = `Start a detached background process that KEEPS RUNNING after this session ends.
+
+Use ONLY for long-lived services that someone connects to after you finish:
+- web servers, APIs, databases, caches the user (or a grader) will query afterwards
+- emulators / VMs that must stay up for external access
+- anything whose whole purpose is to outlive you
+
+Do NOT use for: builds, installs, tests, downloads, training runs, or ANY command with a natural end — use \`bash\` with a realistic timeout for those (and checkin_interval + bash_control for managed background). Managed background is the right default; it gets progress checkins, a deadline auto-kill, and cleanup at session end. Daemons get NONE of those: no timeout, no streamed output, no automatic cleanup. They just run.
+
+After starting, verify the service actually works (e.g. curl it) and report the address to the user. Manage later via daemon_control (list / status / logs / stop).`
+
+export interface DaemonToolOptions {
+	/** Override the state dir (tests use a temp dir). */
+	stateDir?: string
+	/** Override the crash-grace window in ms (tests shrink this). */
+	crashGraceMs?: number
+}
+
+export function createDaemonToolDefinition(
+	options: DaemonToolOptions = {},
+): ToolDefinition<typeof daemonSchema, Record<string, unknown>> {
+	const stateDir = options.stateDir ?? daemonStateDir()
+
+	return {
+		name: DAEMON_TOOL_NAME,
+		label: "daemon",
+		description: DAEMON_TOOL_DESCRIPTION,
+		promptSnippet: "start a detached service that must outlive this session (manage via daemon_control)",
+		parameters: daemonSchema,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (params.name !== undefined) {
+				const nameError = validateDaemonName(params.name)
+				if (nameError) {
+					return {
+						content: [{ type: "text", text: `Error: ${nameError}` }],
+						details: { error: "invalid-name" },
+					}
+				}
+			}
+
+			const outcome = await spawnDaemon({
+				command: params.command,
+				cwd: ctx.cwd,
+				name: params.name,
+				stateDir,
+				crashGraceMs: options.crashGraceMs,
+			})
+
+			if (!outcome.ok) {
+				return {
+					content: [{ type: "text", text: `Error: ${outcome.error}` }],
+					details: { error: "spawn-failed" },
+				}
+			}
+
+			const { record } = outcome
+			return {
+				content: [
+					{
+						type: "text",
+						text:
+							`Daemon started.\n  id:       ${record.id}\n  pid:      ${record.pid}\n  command:  ${record.command}\n  log file: ${record.logFile}\n\n` +
+							`It is detached and will keep running after this session ends. Verify it works (e.g. curl / connect) and tell the user how to reach it. Manage with daemon_control: action "status" | "logs" | "stop", id "${record.id}".`,
+					},
+				],
+				details: { id: record.id, pid: record.pid, logFile: record.logFile },
+			}
+		},
+	}
+}

--- a/src/extensions/daemon/daemon-tool.ts
+++ b/src/extensions/daemon/daemon-tool.ts
@@ -22,7 +22,7 @@ import { daemonStateDir, validateDaemonName } from "./state.js"
 const daemonSchema = Type.Object({
 	command: Type.String({
 		description:
-			"Bash command line to run as the daemon. Executed in place of the shell (no wrapper stays behind). Output is redirected to the daemon's log file — do '... >> log 2>&1' style plumbing inside the command only when the default log file location is unsuitable.",
+			"Bash command line to run as the daemon (compound commands like 'a && b' are fine — the whole line runs in one shell). The returned pid is the process-group leader; a thin shell wrapper may remain if the command doesn't end in exec. Output is redirected to the daemon's log file automatically.",
 	}),
 	name: Type.Optional(
 		Type.String({
@@ -64,8 +64,11 @@ export function createDaemonToolDefinition(
 		promptSnippet: "start a detached service that must outlive this session (manage via daemon_control)",
 		parameters: daemonSchema,
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			if (params.name !== undefined) {
-				const nameError = validateDaemonName(params.name)
+			// Coerce empty-string name to undefined so it takes the default
+			// `daemon-` prefix instead of producing a `-a1b2c3`-style id.
+			const name = params.name === "" ? undefined : params.name
+			if (name !== undefined) {
+				const nameError = validateDaemonName(name)
 				if (nameError) {
 					return {
 						content: [{ type: "text", text: `Error: ${nameError}` }],
@@ -77,7 +80,7 @@ export function createDaemonToolDefinition(
 			const outcome = await spawnDaemon({
 				command: params.command,
 				cwd: ctx.cwd,
-				name: params.name,
+				name,
 				stateDir,
 				crashGraceMs: options.crashGraceMs,
 			})

--- a/src/extensions/daemon/index.test.ts
+++ b/src/extensions/daemon/index.test.ts
@@ -8,13 +8,19 @@
  * API gives no seam for it. Test what's testable without that seam:
  * registration wiring.
  */
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { createContext } from "../__mocks__/context.js"
 import { createExtensionApi } from "../__mocks__/extension-api.js"
+import { setExperimentalFeaturesEnabled } from "../experimental.js"
 import daemonExtension from "./index.js"
+
+afterEach(() => {
+	setExperimentalFeaturesEnabled(false)
+})
 
 describe("daemonExtension", () => {
 	it("registers daemon and daemon_control tools on session_start", () => {
+		setExperimentalFeaturesEnabled(true)
 		const { api, getHandler } = createExtensionApi()
 		const registerTool = vi.mocked(api.registerTool)
 
@@ -24,6 +30,17 @@ describe("daemonExtension", () => {
 		const names = registerTool.mock.calls.map(([tool]) => tool.name)
 		expect(names).toContain("daemon")
 		expect(names).toContain("daemon_control")
+	})
+
+	it("registers no tools when experimental features are disabled", () => {
+		setExperimentalFeaturesEnabled(false)
+		const { api, getHandler } = createExtensionApi()
+		const registerTool = vi.mocked(api.registerTool)
+
+		daemonExtension(api)
+		getHandler("session_start")({} as never, createContext())
+
+		expect(registerTool).not.toHaveBeenCalled()
 	})
 
 	it("registers a session_shutdown handler (honesty notice, no killing)", () => {

--- a/src/extensions/daemon/index.test.ts
+++ b/src/extensions/daemon/index.test.ts
@@ -11,7 +11,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { createContext } from "../__mocks__/context.js"
 import { createExtensionApi } from "../__mocks__/extension-api.js"
-import { setExperimentalFeaturesEnabled } from "../experimental.js"
+import { setExperimentalFeaturesEnabled, withExperimentalFeatures } from "../experimental.js"
 import daemonExtension from "./index.js"
 
 afterEach(() => {
@@ -61,5 +61,45 @@ describe("daemonExtension", () => {
 		// must never touch the UI.
 		getHandler("session_shutdown")({} as never, ctx)
 		expect(notify).not.toHaveBeenCalled()
+	})
+
+	describe("before_agent_start steering (long-lived services clause)", () => {
+		async function callBeforeAgentStart(
+			{ api, getHandler }: ReturnType<typeof createExtensionApi>,
+			ctxOverrides: Parameters<typeof createContext>[0],
+		): Promise<{ systemPrompt: string } | undefined> {
+			daemonExtension(api)
+			const handler = getHandler<unknown, { systemPrompt: string }>("before_agent_start")
+			const result = await handler({ systemPrompt: "BASE" } as never, createContext(ctxOverrides))
+			return result as { systemPrompt: string } | undefined
+		}
+
+		it("injects the daemon clause in headless sessions with the flag on", () =>
+			withExperimentalFeatures(true, async () => {
+				const result = await callBeforeAgentStart(createExtensionApi(), { hasUI: false })
+				expect(result?.systemPrompt).toContain("BASE")
+				expect(result?.systemPrompt).toContain("## Long-lived services")
+				expect(result?.systemPrompt).toContain("`daemon`")
+			}))
+
+		it("does NOT name the daemon tool when experimental features are disabled", () =>
+			withExperimentalFeatures(false, async () => {
+				const result = await callBeforeAgentStart(createExtensionApi(), { hasUI: false })
+				expect(result).toBeUndefined()
+			}))
+
+		it("stays silent when a UI is attached", () =>
+			withExperimentalFeatures(true, async () => {
+				const result = await callBeforeAgentStart(createExtensionApi(), { hasUI: true })
+				expect(result).toBeUndefined()
+			}))
+
+		it("stays silent in ferment-oneshot sessions", () =>
+			withExperimentalFeatures(true, async () => {
+				const fresh = createExtensionApi()
+				;(fresh.api as { getFlag?: (f: string) => unknown }).getFlag = () => true
+				const result = await callBeforeAgentStart(fresh, { hasUI: false })
+				expect(result).toBeUndefined()
+			}))
 	})
 })

--- a/src/extensions/daemon/index.test.ts
+++ b/src/extensions/daemon/index.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Extension-level tests for the daemon extension factory.
+ *
+ * The factory is thin: register both tools on session_start, and on
+ * session_shutdown notify (TUI only) when detached daemons are still
+ * running. The shutdown notice uses the REAL default state dir by
+ * default, which would leak `~/.config/kimchi` into tests — the current
+ * API gives no seam for it. Test what's testable without that seam:
+ * registration wiring.
+ */
+import { describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import { createExtensionApi } from "../__mocks__/extension-api.js"
+import daemonExtension from "./index.js"
+
+describe("daemonExtension", () => {
+	it("registers daemon and daemon_control tools on session_start", () => {
+		const { api, getHandler } = createExtensionApi()
+		const registerTool = vi.mocked(api.registerTool)
+
+		daemonExtension(api)
+		getHandler("session_start")({} as never, createContext())
+
+		const names = registerTool.mock.calls.map(([tool]) => tool.name)
+		expect(names).toContain("daemon")
+		expect(names).toContain("daemon_control")
+	})
+
+	it("registers a session_shutdown handler (honesty notice, no killing)", () => {
+		const { api } = createExtensionApi()
+		daemonExtension(api)
+		const on = vi.mocked(api.on)
+		const events = on.mock.calls.map(([event]) => event)
+		expect(events).toContain("session_shutdown")
+	})
+
+	it("session_shutdown is a no-op in headless sessions", () => {
+		const { api, getHandler } = createExtensionApi()
+		daemonExtension(api)
+		const ctx = createContext({ hasUI: false })
+		const notify = vi.mocked(ctx.ui.notify)
+
+		// State dir interference would only matter with a UI; headless
+		// must never touch the UI.
+		getHandler("session_shutdown")({} as never, ctx)
+		expect(notify).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/daemon/index.ts
+++ b/src/extensions/daemon/index.ts
@@ -10,6 +10,7 @@
  * servers on their machine.
  */
 import type { ExtensionAPI, SessionShutdownEvent } from "@earendil-works/pi-coding-agent"
+import { isExperimentalFeaturesEnabled } from "../experimental.js"
 import { createDaemonControlToolDefinition } from "./daemon-control-tool.js"
 import { createDaemonToolDefinition } from "./daemon-tool.js"
 import { daemonStateDir, listDaemons } from "./state.js"
@@ -23,6 +24,11 @@ function formatDaemonNotice(count: number, firstId: string): string {
 
 export default function daemonExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", () => {
+		// EXPERIMENTAL: tools require --enable-experimental-features. cli.ts
+		// already gates registration; this inner check is defense-in-depth
+		// for any path that wires the extension directly (subagent sessions,
+		// bespoke entry points).
+		if (!isExperimentalFeaturesEnabled()) return
 		pi.registerTool(createDaemonToolDefinition())
 		pi.registerTool(createDaemonControlToolDefinition())
 	})

--- a/src/extensions/daemon/index.ts
+++ b/src/extensions/daemon/index.ts
@@ -9,7 +9,7 @@
  * quits with daemons still running, say so rather than silently orphaning
  * servers on their machine.
  */
-import type { ExtensionAPI, SessionShutdownEvent } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, SessionShutdownEvent } from "@earendil-works/pi-coding-agent"
 import { isExperimentalFeaturesEnabled } from "../experimental.js"
 import { createDaemonControlToolDefinition } from "./daemon-control-tool.js"
 import { createDaemonToolDefinition } from "./daemon-tool.js"
@@ -22,7 +22,23 @@ function formatDaemonNotice(count: number, firstId: string): string {
 		: `${count} detached daemons still running (${firstId}, …) — they keep running after kimchi exits. Stop later with daemon_control.`
 }
 
+/** Headless steering: services that must outlive the session need `daemon`. */
+const LONG_LIVED_SERVICES_CLAUSE =
+	"## Long-lived services\n\nWhen the task requires a web server or other long-lived service that a grader or user will connect to AFTER you finish, use the `daemon` tool to start it — managed background (bash + bash_control) and `&`/`nohup` processes are killed when the session ends, so the service would be dead by the time anyone connects."
+
 export default function daemonExtension(pi: ExtensionAPI): void {
+	// Headless-only steering: without the clause, the model has no reason to
+	// suspect `daemon` exists and reaches for `&`/nohup (dead at exit).
+	// Kept HERE (not in the questionnaire extension, where it lived briefly):
+	// the daemon extension owns its discoverability, and the experimental
+	// gate means the clause only appears when the tools actually do.
+	pi.on("before_agent_start", (event, ctx: ExtensionContext) => {
+		if (ctx.hasUI) return
+		if (pi.getFlag?.("ferment-oneshot") === true) return
+		if (!isExperimentalFeaturesEnabled()) return
+		return { systemPrompt: `${event.systemPrompt}\n\n${LONG_LIVED_SERVICES_CLAUSE}` }
+	})
+
 	pi.on("session_start", () => {
 		// EXPERIMENTAL: tools require --enable-experimental-features. cli.ts
 		// already gates registration; this inner check is defense-in-depth

--- a/src/extensions/daemon/index.ts
+++ b/src/extensions/daemon/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Daemon extension entry point.
+ *
+ * Registers the `daemon` and `daemon_control` tools (see
+ * `./daemon-tool.ts` for the restrictive design goal). Unlike every other
+ * process-lifecycle extension in this repo, `session_shutdown` does NOT
+ * kill anything here — outliving the session is the entire contract. The
+ * only shutdown behavior is an interactive honesty notice: when the user
+ * quits with daemons still running, say so rather than silently orphaning
+ * servers on their machine.
+ */
+import type { ExtensionAPI, SessionShutdownEvent } from "@earendil-works/pi-coding-agent"
+import { createDaemonControlToolDefinition } from "./daemon-control-tool.js"
+import { createDaemonToolDefinition } from "./daemon-tool.js"
+import { daemonStateDir, listDaemons } from "./state.js"
+
+/** One line per live daemon, for the shutdown notice. */
+function formatDaemonNotice(count: number, firstId: string): string {
+	return count === 1
+		? `1 detached daemon still running (${firstId}) — it will keep running after kimchi exits. Stop it later with: kimchi, then daemon_control stop ${firstId}`
+		: `${count} detached daemons still running (${firstId}, …) — they keep running after kimchi exits. Stop later with daemon_control.`
+}
+
+export default function daemonExtension(pi: ExtensionAPI): void {
+	pi.on("session_start", () => {
+		pi.registerTool(createDaemonToolDefinition())
+		pi.registerTool(createDaemonControlToolDefinition())
+	})
+
+	pi.on("session_shutdown", (_event: SessionShutdownEvent, ctx) => {
+		if (!ctx.hasUI) return
+		try {
+			const live = listDaemons(daemonStateDir())
+			if (live.length === 0) return
+			ctx.ui.notify(formatDaemonNotice(live.length, live[0].record.id), "info")
+		} catch (err) {
+			// Never let a housekeeping notice break session teardown.
+			console.error("daemon shutdown notice failed:", err)
+		}
+	})
+}

--- a/src/extensions/daemon/spawn.test.ts
+++ b/src/extensions/daemon/spawn.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for detached daemon spawn/stop (`spawn.ts`).
+ *
+ * Uses REAL processes (`sleep` / `bash`) in a temp state dir: the core
+ * guarantees here — survival past the spawning shell, process-group
+ * identity, instant-crash detection, log capture — are meaningless behind
+ * a fake child_process. POSIX-only: Windows detachment semantics differ
+ * (`detached: true` without setsid) and the benchmark targets are Linux
+ * containers anyway; CI exercises the POSIX path.
+ *
+ * Cleanup: afterEach force-kills every recorded pid so a failing test
+ * can't leak sleeps into CI.
+ */
+
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { readLogTail, spawnDaemon, stopDaemon } from "./spawn.js"
+import { isPidAlive, listDaemons, readDaemon } from "./state.js"
+
+// All nested child-process work here is POSIX (kill, negative pid groups).
+const describePosix = process.platform === "win32" ? describe.skip : describe
+
+const SHORT_GRACE = 100
+
+describePosix("spawnDaemon / stopDaemon (real processes)", () => {
+	let dir: string
+	const livePids: number[] = []
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "daemon-spawn-test-"))
+	})
+
+	afterEach(() => {
+		for (const pid of livePids) {
+			try {
+				process.kill(-pid, "SIGKILL")
+			} catch {
+				// Already gone — fine for teardown.
+			}
+		}
+		livePids.length = 0
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("spawns a detached process that survives its spawning shell", async () => {
+		const outcome = await spawnDaemon({
+			command: "sleep 60",
+			cwd: dir,
+			name: "test-sleeper",
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+		livePids.push(outcome.record.pid)
+
+		const { record } = outcome
+		expect(record.id).toMatch(/^test-sleeper-[0-9a-f]{6}$/)
+		expect(isPidAlive(record.pid)).toBe(true)
+		// exec replaced the shell: the pid IS the daemon, and the daemon is
+		// its own process-group leader (detached: true → setsid).
+		expect(readFileSync(record.pidFile, "utf8")).toBe(String(record.pid))
+		const recordOnDisk = readDaemon(dir, record.id)
+		expect(recordOnDisk).toEqual(record)
+	})
+
+	it("detects instant crashes inside the grace window and surfaces the log", async () => {
+		const outcome = await spawnDaemon({
+			command: "echo boot-failed-message; exit 3",
+			cwd: dir,
+			name: "crasher",
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(false)
+		if (outcome.ok) return
+		expect(outcome.error).toContain("exited immediately")
+		expect(outcome.error).toContain("boot-failed-message")
+		// No record left behind for a failed spawn.
+		expect(listDaemons(dir)).toEqual([])
+	})
+
+	it("treats an empty command as missing", async () => {
+		const outcome = await spawnDaemon({
+			command: "",
+			cwd: dir,
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(false)
+		if (outcome.ok) return
+		expect(outcome.error).toContain("Empty command")
+	})
+
+	it("captures the daemon's output into its log file", async () => {
+		const outcome = await spawnDaemon({
+			command: "bash -c 'echo daemon-booted; exec sleep 60'",
+			cwd: dir,
+			name: "logger",
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+		livePids.push(outcome.record.pid)
+
+		// Wait for output with a hard cutoff — polling without a limit is a
+		// review-lessons violation and hangs CI when the daemon is broken.
+		const deadline = Date.now() + 3000
+		let tail: string | undefined
+		while (Date.now() < deadline) {
+			tail = readLogTail(outcome.record.logFile)
+			if (tail?.includes("daemon-booted")) break
+			await new Promise((r) => setTimeout(r, 50))
+		}
+		expect(tail).toContain("daemon-booted")
+	})
+
+	it("stopDaemon kills the whole process group (children included)", async () => {
+		// Grandchild demonstates the setsid problem in reverse: without a
+		// process GROUP kill, only the leader would die and `sleep` would
+		// leak. The daemon here spawns a child sleep of its own. Located via
+		// pgrep — shell $! expansion would fight the JSON/bash -c quoting
+		// layers in spawn().
+		const outcome = await spawnDaemon({
+			command: "bash -c 'sleep 333 & wait'",
+			cwd: dir,
+			name: "parent",
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+		livePids.push(outcome.record.pid)
+
+		// Bounded poll for the grandchild to appear in the process table.
+		const deadline = Date.now() + 3000
+		let childPid: number | undefined
+		while (Date.now() < deadline) {
+			const found = Number(
+				// -fx: match the full cmdline exactly so the parent's
+				// `bash -c 'sleep 333 & wait'` cmdline doesn't self-match.
+				(spawnSync("pgrep", ["-fx", "sleep 333"], { encoding: "utf8" }).stdout as string).trim().split("\n")[0],
+			)
+			if (found > 0) {
+				childPid = found
+				break
+			}
+			await new Promise((r) => setTimeout(r, 50))
+		}
+		expect(childPid).toBeGreaterThan(0)
+		if (childPid === undefined || childPid <= 0) throw new Error("grandchild pid not discovered")
+		expect(isPidAlive(childPid)).toBe(true)
+
+		const stop = await stopDaemon(outcome.record, dir)
+		expect(stop.stopped).toBe(true)
+		expect(isPidAlive(outcome.record.pid)).toBe(false)
+		// The grandchild dies too — negative-pid group kill, not leader-only.
+		expect(isPidAlive(childPid)).toBe(false)
+		// And the state record is gone.
+		expect(readDaemon(dir, outcome.record.id)).toBeUndefined()
+	})
+
+	it("stopDaemon is idempotent for an already-dead daemon", async () => {
+		const outcome = await spawnDaemon({
+			command: "sleep 60",
+			cwd: dir,
+			name: "short-lived",
+			stateDir: dir,
+			crashGraceMs: SHORT_GRACE,
+		})
+		expect(outcome.ok).toBe(true)
+		if (!outcome.ok) return
+		livePids.push(outcome.record.pid)
+
+		// Kill it out-of-band, then stop: soft report, not an error.
+		process.kill(-outcome.record.pid, "SIGKILL")
+		await new Promise((r) => setTimeout(r, 50))
+		const stop = await stopDaemon(outcome.record, dir)
+		expect(stop.stopped).toBe(false)
+		expect(stop.note).toContain("already not running")
+	})
+})

--- a/src/extensions/daemon/spawn.test.ts
+++ b/src/extensions/daemon/spawn.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -60,8 +60,9 @@ describePosix("spawnDaemon / stopDaemon (real processes)", () => {
 		const { record } = outcome
 		expect(record.id).toMatch(/^test-sleeper-[0-9a-f]{6}$/)
 		expect(isPidAlive(record.pid)).toBe(true)
-		// exec replaced the shell: the pid IS the daemon, and the daemon is
-		// its own process-group leader (detached: true → setsid).
+		// The pid is the process-group leader (detached: true → setsid). The
+		// command itself may exec-replace that leader or leave a thin shell
+		// wrapper behind — group kill behaves the same either way.
 		expect(readFileSync(record.pidFile, "utf8")).toBe(String(record.pid))
 		const recordOnDisk = readDaemon(dir, record.id)
 		expect(recordOnDisk).toEqual(record)
@@ -182,5 +183,16 @@ describePosix("spawnDaemon / stopDaemon (real processes)", () => {
 		const stop = await stopDaemon(outcome.record, dir)
 		expect(stop.stopped).toBe(false)
 		expect(stop.note).toContain("already not running")
+	})
+
+	it("readLogTail never emits mojibake when the cut splits a UTF-8 character", () => {
+		const logFile = join(dir, "utf8.log")
+		// 1000 ASCII bytes + two 3-byte chars, so the tail window starts
+		// mid-code-point for alignments that the fix must snap away from.
+		writeFileSync(logFile, `x'.repeat(1000)}€€✓✓`)
+		for (const maxBytes of [6, 7, 8, 9, 10]) {
+			const tail = readLogTail(logFile, maxBytes)
+			expect(tail).not.toContain("�")
+		}
 	})
 })

--- a/src/extensions/daemon/spawn.ts
+++ b/src/extensions/daemon/spawn.ts
@@ -17,12 +17,15 @@
  *      leader, reparented to init when kimchi exits.
  *
  * Spawn mechanics:
- *   spawn("bash", ["-c", "exec <command> >> <log> 2>&1"], { detached, stdio: "ignore" })
+ *   spawn("bash", ["-c", "exec bash -c \"<command>\" >> <log> 2>&1"], { detached, stdio: "ignore" })
  *
- * `exec` makes the shell REPLACE itself with the daemon so `child.pid` is
- * both the daemon pid AND its process-group id — `kill(-pid)` in stop()
- * reaches exactly the daemon tree, no wrapping shell left behind. stdout
- * and stderr are shell-redirected into the state-dir log file (stdio is
+ * The outer `exec` replaces the outer shell with ONE inner `bash -c`, so
+ * `child.pid` is the daemon's process-group id: `kill(-pid)` in stop()
+ * reaches exactly the daemon tree. If the user's command ends in `exec`
+ * (or is a single simple command) the inner bash may replace itself too,
+ * but for compound commands a thin inner-bash wrapper stays behind as the
+ * group leader — group kill behaves the same either way. stdout and
+ * stderr are shell-redirected into the state-dir log file (stdio is
  * ignored, so kimchi keeps no pipes open and `unref()` lets the node
  * process exit freely).
  *
@@ -64,7 +67,13 @@ export function readLogTail(logFile: string, maxBytes = 8192): string | undefine
 	if (!existsSync(logFile)) return undefined
 	try {
 		const buf = readFileSync(logFile)
-		const slice = buf.length > maxBytes ? buf.subarray(buf.length - maxBytes) : buf
+		let slice = buf.length > maxBytes ? buf.subarray(buf.length - maxBytes) : buf
+		// Snap the cut to a UTF-8 code-point boundary — slicing mid-sequence
+		// would write replacement characters (mojibake) at the start of the
+		// tail. Continuation bytes have the form 10xx xxxx; skip past them.
+		let start = 0
+		while (start < slice.length && (slice[start] & 0xc0) === 0x80) start++
+		if (start > 0) slice = slice.subarray(start)
 		return slice.toString("utf8")
 	} catch (err) {
 		console.error(`daemon: failed to read log ${logFile}:`, err)

--- a/src/extensions/daemon/spawn.ts
+++ b/src/extensions/daemon/spawn.ts
@@ -1,0 +1,184 @@
+/**
+ * Detached daemon spawn + stop.
+ *
+ * Lifecycle contract (the whole point of this module): a daemon spawned
+ * here OUTLIVES the kimchi session. It must escape every kill chain the
+ * harness has:
+ *
+ *   1. `ProcessRegistry.shutdown()` kills managed background processes on
+ *      `session_shutdown` via the upstream `exec` AbortController →
+ *      `killProcessTree` (SIGKILL to the process group). We never go
+ *      through upstream `ops.exec`, so the registry never sees us.
+ *   2. `killTrackedDetachedChildren()` fires on kimchi SIGHUP/SIGTERM and
+ *      kills every pid registered via `trackDetachedChildPid`. We never
+ *      call that function.
+ *   3. Nothing else reaps orphans: with `detached: true` node calls
+ *      `setsid` in the child, so the daemon becomes its own process-group
+ *      leader, reparented to init when kimchi exits.
+ *
+ * Spawn mechanics:
+ *   spawn("bash", ["-c", "exec <command> >> <log> 2>&1"], { detached, stdio: "ignore" })
+ *
+ * `exec` makes the shell REPLACE itself with the daemon so `child.pid` is
+ * both the daemon pid AND its process-group id — `kill(-pid)` in stop()
+ * reaches exactly the daemon tree, no wrapping shell left behind. stdout
+ * and stderr are shell-redirected into the state-dir log file (stdio is
+ * ignored, so kimchi keeps no pipes open and `unref()` lets the node
+ * process exit freely).
+ *
+ * Windows note: `detached: true` + `windowsHide` behaves differently (no
+ * setsid, no process groups); stop() falls back to `taskkill /T /F`.
+ * Verified on POSIX only — benchmark targets are Linux containers.
+ */
+import { spawn, spawnSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { type DaemonRecord, isPidAlive, makeDaemonId, registerDaemon, unregisterDaemon } from "./state.js"
+
+/** How long to wait after spawn before checking the daemon didn't die instantly. */
+const CRASH_GRACE_MS = 500
+
+/** Grace between SIGTERM and SIGKILL when stopping. */
+const STOP_TERM_GRACE_MS = 2000
+
+/** Default shell. POSIX-first; Windows support is best-effort. */
+const SHELL = process.platform === "win32" ? "cmd.exe" : "bash"
+const SHELL_ARGS = (cmd: string) => (process.platform === "win32" ? ["/c", cmd] : ["-c", cmd])
+
+export interface SpawnDaemonOptions {
+	command: string
+	cwd: string
+	name?: string
+	stateDir: string
+	/** Override for tests: crash-detection grace in ms. */
+	crashGraceMs?: number
+}
+
+export type SpawnDaemonOutcome = { ok: true; record: DaemonRecord } | { ok: false; error: string }
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Read the last `maxBytes` of a log file (or undefined when absent). */
+export function readLogTail(logFile: string, maxBytes = 8192): string | undefined {
+	if (!existsSync(logFile)) return undefined
+	try {
+		const buf = readFileSync(logFile)
+		const slice = buf.length > maxBytes ? buf.subarray(buf.length - maxBytes) : buf
+		return slice.toString("utf8")
+	} catch (err) {
+		console.error(`daemon: failed to read log ${logFile}:`, err)
+		return undefined
+	}
+}
+
+export async function spawnDaemon(opts: SpawnDaemonOptions): Promise<SpawnDaemonOutcome> {
+	const { command, cwd, name, stateDir } = opts
+	if (command.trim().length === 0) {
+		return { ok: false, error: "Empty command — nothing to daemonize." }
+	}
+	const id = makeDaemonId(name)
+	const logFile = `${stateDir}/${id}.log`
+	const pidFile = `${stateDir}/${id}.pid`
+
+	// Wrap the user's command behind `bash -c` so exec applies to ONE
+	// process: `exec <compound> >> log` would only exec+redirect the first
+	// segment and silently drop the rest. JSON.stringify double-quotes and
+	// escapes for safe single-arg shell embedding. Windows (cmd) has no
+	// exec/setsid semantics; run the command plainly there.
+	const wrapped =
+		process.platform === "win32"
+			? `${command} >> ${JSON.stringify(logFile)} 2>&1`
+			: `exec bash -c ${JSON.stringify(command)} >> ${JSON.stringify(logFile)} 2>&1`
+
+	const child = spawn(SHELL, SHELL_ARGS(wrapped), {
+		cwd,
+		// NOT process.env passthrough blind spot: daemons want the same env the
+		// user's shell would see; process.env is the sanest default here.
+		env: process.env,
+		detached: true,
+		stdio: "ignore",
+		windowsHide: true,
+	})
+	child.unref()
+
+	if (child.pid === undefined) {
+		return { ok: false, error: "Failed to spawn daemon: no pid assigned." }
+	}
+
+	const record: DaemonRecord = {
+		id,
+		pid: child.pid,
+		command,
+		cwd,
+		name,
+		startedAt: new Date().toISOString(),
+		logFile,
+		pidFile,
+	}
+	registerDaemon(stateDir, record)
+
+	// Crash-grace: give the daemon a moment to die if it's going to
+	// (port-in-use, missing binary, bad flags). The single most common
+	// "server started" lie is a command that exits inside the first second.
+	const grace = opts.crashGraceMs ?? CRASH_GRACE_MS
+	if (grace > 0) await sleep(grace)
+	if (!isPidAlive(child.pid)) {
+		const tail = readLogTail(logFile, 2048)
+		unregisterDaemon(stateDir, id)
+		return {
+			ok: false,
+			error:
+				`Daemon ${id} (pid ${child.pid}) exited immediately. The command probably failed at startup.` +
+				(tail ? `\n\n--- last output ---\n${tail.trimEnd()}` : ""),
+		}
+	}
+
+	return { ok: true, record }
+}
+
+/**
+ * Stop a daemon: SIGTERM the process group, grace, then SIGKILL. The
+ * daemon is a process-group leader (spawned detached), so -pid reaches
+ * the whole tree. Idempotent: a dead pid is reported, not an error.
+ */
+export async function stopDaemon(record: DaemonRecord, stateDir: string): Promise<{ stopped: boolean; note: string }> {
+	const { pid } = record
+	if (!isPidAlive(pid)) {
+		unregisterDaemon(stateDir, record.id)
+		return { stopped: false, note: `Daemon ${record.id} (pid ${pid}) was already not running. Record cleaned up.` }
+	}
+
+	if (process.platform === "win32") {
+		// No POSIX process groups; taskkill /T kills the tree.
+		spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], { stdio: "ignore" })
+	} else {
+		try {
+			process.kill(-pid, "SIGTERM")
+		} catch (err) {
+			// ESRCH on a disappearing group is fine — the liveness check above
+			// raced a natural exit.
+			console.error(`daemon: SIGTERM to group -${pid} failed:`, err)
+		}
+		const deadline = Date.now() + STOP_TERM_GRACE_MS
+		while (isPidAlive(pid) && Date.now() < deadline) {
+			await sleep(100)
+		}
+		if (isPidAlive(pid)) {
+			try {
+				process.kill(-pid, "SIGKILL")
+			} catch (err) {
+				console.error(`daemon: SIGKILL to group -${pid} failed:`, err)
+			}
+		}
+	}
+
+	unregisterDaemon(stateDir, record.id)
+	const stillAlive = isPidAlive(pid)
+	return stillAlive
+		? {
+				stopped: false,
+				note: `Sent SIGKILL to daemon ${record.id} (pid ${pid}) but it is still alive — manual intervention needed.`,
+			}
+		: { stopped: true, note: `Daemon ${record.id} (pid ${pid}) stopped. Log kept at ${record.logFile}.` }
+}

--- a/src/extensions/daemon/spawn.ts
+++ b/src/extensions/daemon/spawn.ts
@@ -17,7 +17,7 @@
  *      leader, reparented to init when kimchi exits.
  *
  * Spawn mechanics:
- *   spawn("bash", ["-c", "exec bash -c \"<command>\" >> <log> 2>&1"], { detached, stdio: "ignore" })
+ *   spawn("bash", ["-c", "exec bash -c '<command>' >> <log> 2>&1"], { detached, stdio: "ignore" })
  *
  * The outer `exec` replaces the outer shell with ONE inner `bash -c`, so
  * `child.pid` is the daemon's process-group id: `kill(-pid)` in stop()
@@ -34,7 +34,7 @@
  * Verified on POSIX only — benchmark targets are Linux containers.
  */
 import { spawn, spawnSync } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
+import { closeSync, existsSync, fstatSync, openSync, readSync } from "node:fs"
 import { type DaemonRecord, isPidAlive, makeDaemonId, registerDaemon, unregisterDaemon } from "./state.js"
 
 /** How long to wait after spawn before checking the daemon didn't die instantly. */
@@ -62,12 +62,35 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-/** Read the last `maxBytes` of a log file (or undefined when absent). */
+/**
+ * POSIX-safe single-quote escaping. Double-quote interpolation
+ * (JSON.stringify) is NOT safe for shell embedding: the outer shell
+ * expands $vars/backticks/$(…) inside double quotes before the inner
+ * bash receives them (e.g. `VAR=inner; echo "$VAR"` would log the
+ * OUTER shell's empty $VAR). Single quotes suppress all expansion; a
+ * literal `'` is closed, escaped, reopened (`'\''` → '"'"'`).
+ */
+function shellQuote(s: string): string {
+	return `'${s.replace(/'/g, `'"'"'`)}'`
+}
+
+/**
+ * Read the last `maxBytes` of a log file (or undefined when absent).
+ * Seeks to the tail rather than loading the whole file — daemon logs are
+ * unbounded, so `readFileSync` could pull gigabytes into memory.
+ */
 export function readLogTail(logFile: string, maxBytes = 8192): string | undefined {
 	if (!existsSync(logFile)) return undefined
+	let fd: number | undefined
 	try {
-		const buf = readFileSync(logFile)
-		let slice = buf.length > maxBytes ? buf.subarray(buf.length - maxBytes) : buf
+		fd = openSync(logFile, "r")
+		const size = fstatSync(fd).size
+		const from = Math.max(0, size - maxBytes)
+		const length = size - from
+		if (length <= 0) return ""
+		const buf = Buffer.alloc(length)
+		readSync(fd, buf, 0, length, from)
+		let slice = buf
 		// Snap the cut to a UTF-8 code-point boundary — slicing mid-sequence
 		// would write replacement characters (mojibake) at the start of the
 		// tail. Continuation bytes have the form 10xx xxxx; skip past them.
@@ -78,6 +101,8 @@ export function readLogTail(logFile: string, maxBytes = 8192): string | undefine
 	} catch (err) {
 		console.error(`daemon: failed to read log ${logFile}:`, err)
 		return undefined
+	} finally {
+		if (fd !== undefined) closeSync(fd)
 	}
 }
 
@@ -92,13 +117,14 @@ export async function spawnDaemon(opts: SpawnDaemonOptions): Promise<SpawnDaemon
 
 	// Wrap the user's command behind `bash -c` so exec applies to ONE
 	// process: `exec <compound> >> log` would only exec+redirect the first
-	// segment and silently drop the rest. JSON.stringify double-quotes and
-	// escapes for safe single-arg shell embedding. Windows (cmd) has no
-	// exec/setsid semantics; run the command plainly there.
+	// segment and silently drop the rest. shellQuote single-quotes —
+	// JSON.stringify (double quotes) is NOT safe here: the outer shell
+	// would expand $vars/backticks before the inner bash sees them.
+	// Windows (cmd) has no exec/setsid semantics; run plainly there.
 	const wrapped =
 		process.platform === "win32"
-			? `${command} >> ${JSON.stringify(logFile)} 2>&1`
-			: `exec bash -c ${JSON.stringify(command)} >> ${JSON.stringify(logFile)} 2>&1`
+			? `${command} >> "${logFile}" 2>&1`
+			: `exec bash -c ${shellQuote(command)} >> ${shellQuote(logFile)} 2>&1`
 
 	const child = spawn(SHELL, SHELL_ARGS(wrapped), {
 		cwd,
@@ -109,10 +135,18 @@ export async function spawnDaemon(opts: SpawnDaemonOptions): Promise<SpawnDaemon
 		stdio: "ignore",
 		windowsHide: true,
 	})
+
+	// `spawn` never rejects for a missing cwd/binary — it emits 'error'
+	// asynchronously instead. An unhandled 'error' would throw and kill
+	// the kimchi process; capture it and convert to a soft spawn failure.
+	let spawnError: Error | undefined
+	child.on("error", (err) => {
+		spawnError = err
+	})
 	child.unref()
 
 	if (child.pid === undefined) {
-		return { ok: false, error: "Failed to spawn daemon: no pid assigned." }
+		return { ok: false, error: `Failed to spawn daemon: ${spawnError?.message ?? "no pid assigned"}.` }
 	}
 
 	const record: DaemonRecord = {
@@ -135,11 +169,12 @@ export async function spawnDaemon(opts: SpawnDaemonOptions): Promise<SpawnDaemon
 	if (!isPidAlive(child.pid)) {
 		const tail = readLogTail(logFile, 2048)
 		unregisterDaemon(stateDir, id)
+		const reason = spawnError
+			? `Spawn failed: ${spawnError.message}`
+			: `Daemon ${id} (pid ${child.pid}) exited immediately. The command probably failed at startup.`
 		return {
 			ok: false,
-			error:
-				`Daemon ${id} (pid ${child.pid}) exited immediately. The command probably failed at startup.` +
-				(tail ? `\n\n--- last output ---\n${tail.trimEnd()}` : ""),
+			error: reason + (tail ? `\n\n--- last output ---\n${tail.trimEnd()}` : ""),
 		}
 	}
 
@@ -182,12 +217,15 @@ export async function stopDaemon(record: DaemonRecord, stateDir: string): Promis
 		}
 	}
 
-	unregisterDaemon(stateDir, record.id)
 	const stillAlive = isPidAlive(pid)
-	return stillAlive
-		? {
-				stopped: false,
-				note: `Sent SIGKILL to daemon ${record.id} (pid ${pid}) but it is still alive — manual intervention needed.`,
-			}
-		: { stopped: true, note: `Daemon ${record.id} (pid ${pid}) stopped. Log kept at ${record.logFile}.` }
+	if (stillAlive) {
+		// KEEP the record — the daemon is alive but unmanageable without it
+		// (unregistering here would orphan a running process group).
+		return {
+			stopped: false,
+			note: `Sent SIGKILL to daemon ${record.id} (pid ${pid}) but it is still alive — manual intervention needed. Record kept for another daemon_control stop attempt.`,
+		}
+	}
+	unregisterDaemon(stateDir, record.id)
+	return { stopped: true, note: `Daemon ${record.id} (pid ${pid}) stopped. Log kept at ${record.logFile}.` }
 }

--- a/src/extensions/daemon/spawn.ts
+++ b/src/extensions/daemon/spawn.ts
@@ -43,6 +43,14 @@ const CRASH_GRACE_MS = 500
 /** Grace between SIGTERM and SIGKILL when stopping. */
 const STOP_TERM_GRACE_MS = 2000
 
+/**
+ * Grace AFTER SIGKILL when stopping. SIGKILL is asynchronous from our
+ * point of view (kernel signal delivery + reaping), so a killed process
+ * can still fail kill(pid, 0) checks right after the signal. Waiting
+ * avoids reporting a GOOD stop as "manual intervention needed".
+ */
+const STOP_KILL_GRACE_MS = 1000
+
 /** Default shell. POSIX-first; Windows support is best-effort. */
 const SHELL = process.platform === "win32" ? "cmd.exe" : "bash"
 const SHELL_ARGS = (cmd: string) => (process.platform === "win32" ? ["/c", cmd] : ["-c", cmd])
@@ -213,6 +221,13 @@ export async function stopDaemon(record: DaemonRecord, stateDir: string): Promis
 				process.kill(-pid, "SIGKILL")
 			} catch (err) {
 				console.error(`daemon: SIGKILL to group -${pid} failed:`, err)
+			}
+			// Wait for the kernel to actually reap the process — an instant
+			// liveness check would race signal delivery and false-negative
+			// (report "still alive" for a process that is dying).
+			const killDeadline = Date.now() + STOP_KILL_GRACE_MS
+			while (isPidAlive(pid) && Date.now() < killDeadline) {
+				await sleep(50)
 			}
 		}
 	}

--- a/src/extensions/daemon/state.test.ts
+++ b/src/extensions/daemon/state.test.ts
@@ -21,7 +21,7 @@ import {
 	validateDaemonName,
 } from "./state.js"
 
-function makeRecord(overrides: Partial<DaemonRecord> = {}): DaemonRecord {
+function makeRecord(dir: string, overrides: Partial<DaemonRecord> = {}): DaemonRecord {
 	const id = overrides.id ?? "test-daemon-123abc"
 	return {
 		id,
@@ -30,8 +30,10 @@ function makeRecord(overrides: Partial<DaemonRecord> = {}): DaemonRecord {
 		cwd: "/tmp",
 		name: "test-daemon",
 		startedAt: new Date().toISOString(),
-		logFile: `/tmp/${id}.log`,
-		pidFile: `/tmp/${id}.pid`,
+		// Paths must live INSIDE the state dir — readDaemon's containment
+		// check (review round 2) rejects out-of-state-dir paths.
+		logFile: join(dir, `${id}.log`),
+		pidFile: join(dir, `${id}.pid`),
 		...overrides,
 	}
 }
@@ -89,7 +91,7 @@ describe("daemon state", () => {
 
 	describe("register/read/unregister round-trip", () => {
 		it("persists a record and reads it back", () => {
-			const record = makeRecord()
+			const record = makeRecord(dir)
 			registerDaemon(dir, record)
 			expect(readDaemon(dir, record.id)).toEqual(record)
 			// pid file written as plain text for humans
@@ -97,7 +99,7 @@ describe("daemon state", () => {
 		})
 
 		it("unregister removes json and pid files", () => {
-			const record = makeRecord()
+			const record = makeRecord(dir)
 			registerDaemon(dir, record)
 			unregisterDaemon(dir, record.id)
 			expect(readDaemon(dir, record.id)).toBeUndefined()
@@ -116,6 +118,32 @@ describe("daemon state", () => {
 			writeFileSync(join(dir, "thin-123abc.json"), JSON.stringify({ id: "thin-123abc" }), "utf8")
 			expect(readDaemon(dir, "thin-123abc")).toBeUndefined()
 		})
+
+		// Review round 2: records are trusted less — act-on values get
+		// hardened checks since they feed kill("-"pid) and file writes.
+		it("readDaemon rejects non-positive or non-integer pids", () => {
+			const bad = makeRecord(dir, { pid: 0 })
+			writeFileSync(join(dir, `${bad.id}.json`), JSON.stringify(bad), "utf8")
+			expect(readDaemon(dir, bad.id)).toBeUndefined()
+		})
+
+		it("readDaemon rejects records whose id does not match the filename", () => {
+			const record = makeRecord(dir)
+			writeFileSync(join(dir, "aliased-123abc.json"), JSON.stringify(record), "utf8")
+			expect(readDaemon(dir, "aliased-123abc")).toBeUndefined()
+		})
+
+		it("readDaemon rejects records with paths outside the state dir", () => {
+			const record = makeRecord(dir, { logFile: "../evil.log" })
+			// resolve("../evil.log") is fine inside the dir? No — relative
+			// paths are rejected outright; also test an absolute escape:
+			writeFileSync(join(dir, `${record.id}.json`), JSON.stringify(record), "utf8")
+			expect(readDaemon(dir, record.id)).toBeUndefined()
+
+			const absolute = makeRecord(dir, { logFile: "/etc/passwd" })
+			writeFileSync(join(dir, `${absolute.id}.json`), JSON.stringify(absolute), "utf8")
+			expect(readDaemon(dir, absolute.id)).toBeUndefined()
+		})
 	})
 
 	describe("isPidAlive", () => {
@@ -131,14 +159,14 @@ describe("daemon state", () => {
 
 	describe("listDaemons", () => {
 		it("returns live records", () => {
-			registerDaemon(dir, makeRecord())
+			registerDaemon(dir, makeRecord(dir))
 			const live = listDaemons(dir)
 			expect(live).toHaveLength(1)
 			expect(live[0].alive).toBe(true)
 		})
 
 		it("prunes dead-pid records from disk", () => {
-			registerDaemon(dir, makeRecord({ id: "dead-123abc", pid: 4194303 }))
+			registerDaemon(dir, makeRecord(dir, { id: "dead-123abc", pid: 4194303 }))
 			expect(listDaemons(dir)).toHaveLength(0)
 			// Pruned: a second read finds no record at all.
 			expect(readDaemon(dir, "dead-123abc")).toBeUndefined()

--- a/src/extensions/daemon/state.test.ts
+++ b/src/extensions/daemon/state.test.ts
@@ -63,9 +63,17 @@ describe("daemon state", () => {
 		it("rejects over-long names", () => {
 			expect(validateDaemonName("x".repeat(41))).toBeDefined()
 		})
+
+		it("rejects empty string (must not silently fall back to a '-'-prefixed id)", () => {
+			expect(validateDaemonName("")).toBeDefined()
+		})
 	})
 
 	describe("makeDaemonId", () => {
+		it("treats empty name as absent (defensive — tools coerce at the boundary)", () => {
+			expect(makeDaemonId("")).toMatch(/^daemon-[0-9a-f]{6}$/)
+		})
+
 		it("prefixes with the name and a 6-hex suffix", () => {
 			expect(makeDaemonId("web")).toMatch(/^web-[0-9a-f]{6}$/)
 		})

--- a/src/extensions/daemon/state.test.ts
+++ b/src/extensions/daemon/state.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for daemon state management (`state.ts`).
+ *
+ * Everything filesystem-scoped runs inside a real temp dir so the
+ * register/read/prune round-trip is exercised against the actual state
+ * layout (`.kimchi/daemons`-style JSON + pid files) without touching
+ * `~/.config/kimchi`.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+	type DaemonRecord,
+	isPidAlive,
+	listDaemons,
+	makeDaemonId,
+	readDaemon,
+	registerDaemon,
+	unregisterDaemon,
+	validateDaemonName,
+} from "./state.js"
+
+function makeRecord(overrides: Partial<DaemonRecord> = {}): DaemonRecord {
+	const id = overrides.id ?? "test-daemon-123abc"
+	return {
+		id,
+		pid: process.pid, // alive for the test run
+		command: "sleep 60",
+		cwd: "/tmp",
+		name: "test-daemon",
+		startedAt: new Date().toISOString(),
+		logFile: `/tmp/${id}.log`,
+		pidFile: `/tmp/${id}.pid`,
+		...overrides,
+	}
+}
+
+describe("daemon state", () => {
+	let dir: string
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "daemon-state-test-"))
+	})
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	describe("validateDaemonName", () => {
+		it("accepts alphanumerics, dash, underscore", () => {
+			expect(validateDaemonName("pypi-server_2")).toBeUndefined()
+			expect(validateDaemonName("a")).toBeUndefined()
+		})
+
+		it("rejects path separators, dots, spaces", () => {
+			expect(validateDaemonName("../escape")).toBeDefined()
+			expect(validateDaemonName("has space")).toBeDefined()
+			expect(validateDaemonName("has.dot")).toBeDefined()
+			expect(validateDaemonName("too/short-ish")).toBeDefined()
+		})
+
+		it("rejects over-long names", () => {
+			expect(validateDaemonName("x".repeat(41))).toBeDefined()
+		})
+	})
+
+	describe("makeDaemonId", () => {
+		it("prefixes with the name and a 6-hex suffix", () => {
+			expect(makeDaemonId("web")).toMatch(/^web-[0-9a-f]{6}$/)
+		})
+
+		it("falls back to 'daemon-' when no name given", () => {
+			expect(makeDaemonId(undefined)).toMatch(/^daemon-[0-9a-f]{6}$/)
+		})
+
+		it("generates unique ids", () => {
+			expect(makeDaemonId("web")).not.toBe(makeDaemonId("web"))
+		})
+	})
+
+	describe("register/read/unregister round-trip", () => {
+		it("persists a record and reads it back", () => {
+			const record = makeRecord()
+			registerDaemon(dir, record)
+			expect(readDaemon(dir, record.id)).toEqual(record)
+			// pid file written as plain text for humans
+			expect(readFileSync(record.pidFile, "utf8")).toBe(String(record.pid))
+		})
+
+		it("unregister removes json and pid files", () => {
+			const record = makeRecord()
+			registerDaemon(dir, record)
+			unregisterDaemon(dir, record.id)
+			expect(readDaemon(dir, record.id)).toBeUndefined()
+		})
+
+		it("readDaemon returns undefined for missing ids", () => {
+			expect(readDaemon(dir, "nope-123abc")).toBeUndefined()
+		})
+
+		it("readDaemon skips malformed JSON instead of throwing", () => {
+			writeFileSync(join(dir, "broken-123abc.json"), "{not json", "utf8")
+			expect(readDaemon(dir, "broken-123abc")).toBeUndefined()
+		})
+
+		it("readDaemon skips records with missing fields", () => {
+			writeFileSync(join(dir, "thin-123abc.json"), JSON.stringify({ id: "thin-123abc" }), "utf8")
+			expect(readDaemon(dir, "thin-123abc")).toBeUndefined()
+		})
+	})
+
+	describe("isPidAlive", () => {
+		it("reports the current process as alive", () => {
+			expect(isPidAlive(process.pid)).toBe(true)
+		})
+
+		it("reports an impossible pid as dead", () => {
+			// Pid 2^22-1 is beyond typical pid_max; on macOS max pid is 99998.
+			expect(isPidAlive(4194303)).toBe(false)
+		})
+	})
+
+	describe("listDaemons", () => {
+		it("returns live records", () => {
+			registerDaemon(dir, makeRecord())
+			const live = listDaemons(dir)
+			expect(live).toHaveLength(1)
+			expect(live[0].alive).toBe(true)
+		})
+
+		it("prunes dead-pid records from disk", () => {
+			registerDaemon(dir, makeRecord({ id: "dead-123abc", pid: 4194303 }))
+			expect(listDaemons(dir)).toHaveLength(0)
+			// Pruned: a second read finds no record at all.
+			expect(readDaemon(dir, "dead-123abc")).toBeUndefined()
+		})
+
+		it("handles an empty or missing state dir", () => {
+			expect(listDaemons(join(dir, "does-not-exist"))).toEqual([])
+		})
+	})
+})

--- a/src/extensions/daemon/state.ts
+++ b/src/extensions/daemon/state.ts
@@ -47,9 +47,12 @@ export function ensureStateDir(dir: string): void {
  * Validate a user-supplied daemon name. Only alphanumerics, dash, and
  * underscore — the name is interpolated into a filename, so path
  * separators or dots could escape the state dir (review-lessons rule 4).
+ * Empty string is INVALID — callers wanting "no name" must pass
+ * `undefined` (an explicit empty name would silently fall through to the
+ * default prefix and produce confusing `-a1b2c3`-style ids).
  */
 export function validateDaemonName(name: string): string | undefined {
-	if (name.length === 0) return undefined
+	if (name.length === 0) return "Daemon name cannot be empty (omit the parameter for the default name)."
 	if (name.length > 40) return "Daemon name too long (max 40 chars)."
 	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
 		return "Daemon name may only contain letters, digits, dash, and underscore."
@@ -60,7 +63,7 @@ export function validateDaemonName(name: string): string | undefined {
 /** Generate a daemon id: <name|daemon>-<6 hex chars>. */
 export function makeDaemonId(name: string | undefined): string {
 	const suffix = randomBytes(3).toString("hex")
-	return `${name ?? "daemon"}-${suffix}`
+	return `${name ? name : "daemon"}-${suffix}`
 }
 
 export function daemonRecordPath(dir: string, id: string): string {

--- a/src/extensions/daemon/state.ts
+++ b/src/extensions/daemon/state.ts
@@ -21,7 +21,7 @@
 import { randomBytes } from "node:crypto"
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { isAbsolute, join, normalize, resolve, sep } from "node:path"
 
 export interface DaemonRecord {
 	id: string
@@ -82,6 +82,18 @@ export function unregisterDaemon(dir: string, id: string): void {
 }
 
 /** Runtime-validated record read; undefined when missing or malformed. */
+/**
+ * True when `filePath` resolves to a location inside the daemon state
+ * dir. Guards against records that redirect future reads/writes to an
+ * arbitrary path (hand-edited or corrupted on disk).
+ */
+export function isSafeStatePath(dir: string, filePath: string): boolean {
+	if (!isAbsolute(filePath)) return false
+	const resolvedDir = resolve(normalize(dir)) + sep
+	const resolvedPath = resolve(normalize(filePath))
+	return resolvedPath.startsWith(resolvedDir)
+}
+
 export function readDaemon(dir: string, id: string): DaemonRecord | undefined {
 	const path = daemonRecordPath(dir, id)
 	if (!existsSync(path)) return undefined
@@ -104,6 +116,28 @@ export function readDaemon(dir: string, id: string): DaemonRecord | undefined {
 	) {
 		console.error(`daemon state: record ${id} missing required fields`)
 		return undefined
+	}
+	// Hardening beyond shape: reject values that would be dangerous to act on.
+	// - pid must be a positive integer. kill(0, …) targets the CURRENT
+	//   process group; -1 signals all processes we may signal — both would
+	//   be catastrophic in stop/status paths.
+	// - record id must match the filename it was loaded from — a tampered or
+	//   corrupted record otherwise launders itself through list/status.
+	// - log/pid files must stay inside the state dir; filenames are joins
+	//   on our side, but a hand-edited record could redirect a future write.
+	if (!Number.isInteger(r.pid) || r.pid <= 0) {
+		console.error(`daemon state: record ${id} has invalid pid ${r.pid}`)
+		return undefined
+	}
+	if (r.id !== id) {
+		console.error(`daemon state: record ${id} id mismatch (contains "${r.id}")`)
+		return undefined
+	}
+	for (const filePath of [r.logFile, r.pidFile]) {
+		if (!isSafeStatePath(dir, filePath)) {
+			console.error(`daemon state: record ${id} path escapes state dir: ${filePath}`)
+			return undefined
+		}
 	}
 	return {
 		id: r.id,

--- a/src/extensions/daemon/state.ts
+++ b/src/extensions/daemon/state.ts
@@ -1,0 +1,156 @@
+/**
+ * Daemon state directory.
+ *
+ * Daemons are detached processes that intentionally outlive the kimchi
+ * session (see `spec-daemon-tool-2026-08-20.md`). Because they survive the
+ * session, their bookkeeping can NOT live in the session-scoped
+ * ProcessRegistry (`src/extensions/bash-background/process-registry.ts`) —
+ * that is drained on `session_shutdown`. Instead each daemon gets a small
+ * JSON record on disk under `~/.config/kimchi/daemons/` (matching the
+ * config/store convention in `src/config.ts`):
+ *
+ *   <id>.json   — { id, pid, command, cwd, startedAt, logFile, pidFile }
+ *   <id>.log    — daemon stdout+stderr (shell-redirected at spawn)
+ *   <id>.pid    — pid as text (for humans/debugging; .json is authoritative)
+ *
+ * Records are validated on read (malformed files are skipped, not thrown)
+ * and `list` liveness-prunes entries whose pid is gone, so the directory
+ * is self-healing after reboots where pids get reused.
+ */
+
+import { randomBytes } from "node:crypto"
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export interface DaemonRecord {
+	id: string
+	pid: number
+	command: string
+	cwd: string
+	name?: string
+	startedAt: string
+	logFile: string
+	pidFile: string
+}
+
+/** Root of the daemon state directory. Overridable for tests. */
+export function daemonStateDir(): string {
+	return join(homedir(), ".config", "kimchi", "daemons")
+}
+
+export function ensureStateDir(dir: string): void {
+	mkdirSync(dir, { recursive: true })
+}
+
+/**
+ * Validate a user-supplied daemon name. Only alphanumerics, dash, and
+ * underscore — the name is interpolated into a filename, so path
+ * separators or dots could escape the state dir (review-lessons rule 4).
+ */
+export function validateDaemonName(name: string): string | undefined {
+	if (name.length === 0) return undefined
+	if (name.length > 40) return "Daemon name too long (max 40 chars)."
+	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+		return "Daemon name may only contain letters, digits, dash, and underscore."
+	}
+	return undefined
+}
+
+/** Generate a daemon id: <name|daemon>-<6 hex chars>. */
+export function makeDaemonId(name: string | undefined): string {
+	const suffix = randomBytes(3).toString("hex")
+	return `${name ?? "daemon"}-${suffix}`
+}
+
+export function daemonRecordPath(dir: string, id: string): string {
+	return join(dir, `${id}.json`)
+}
+
+export function registerDaemon(dir: string, record: DaemonRecord): void {
+	ensureStateDir(dir)
+	writeFileSync(daemonRecordPath(dir, record.id), JSON.stringify(record, null, 2))
+	writeFileSync(record.pidFile, String(record.pid))
+}
+
+export function unregisterDaemon(dir: string, id: string): void {
+	rmSync(daemonRecordPath(dir, id), { force: true })
+	rmSync(join(dir, `${id}.pid`), { force: true })
+}
+
+/** Runtime-validated record read; undefined when missing or malformed. */
+export function readDaemon(dir: string, id: string): DaemonRecord | undefined {
+	const path = daemonRecordPath(dir, id)
+	if (!existsSync(path)) return undefined
+	let raw: unknown
+	try {
+		raw = JSON.parse(readFileSync(path, "utf8"))
+	} catch (err) {
+		console.error(`daemon state: malformed record ${id}:`, err)
+		return undefined
+	}
+	if (typeof raw !== "object" || raw === null) return undefined
+	const r = raw as Record<string, unknown>
+	if (
+		typeof r.id !== "string" ||
+		typeof r.pid !== "number" ||
+		typeof r.command !== "string" ||
+		typeof r.logFile !== "string" ||
+		typeof r.pidFile !== "string" ||
+		typeof r.startedAt !== "string"
+	) {
+		console.error(`daemon state: record ${id} missing required fields`)
+		return undefined
+	}
+	return {
+		id: r.id,
+		pid: r.pid,
+		command: r.command,
+		cwd: typeof r.cwd === "string" ? r.cwd : "",
+		name: typeof r.name === "string" ? r.name : undefined,
+		startedAt: r.startedAt,
+		logFile: r.logFile,
+		pidFile: r.pidFile,
+	}
+}
+
+/** True when the pid exists (kill(pid, 0) is existence-check only). */
+export function isPidAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (err: unknown) {
+		// EPERM means the process exists but is owned by someone else — alive.
+		if (typeof err === "object" && err !== null && "code" in err && (err as { code?: string }).code === "EPERM") {
+			return true
+		}
+		return false
+	}
+}
+
+export interface DaemonListEntry {
+	record: DaemonRecord
+	alive: boolean
+}
+
+/**
+ * List all recorded daemons with liveness. Dead entries are pruned from
+ * the state dir (records AND pid files) so a reboot's pid reuse doesn't
+ * leave phantom daemons around.
+ */
+export function listDaemons(dir: string): DaemonListEntry[] {
+	if (!existsSync(dir)) return []
+	const out: DaemonListEntry[] = []
+	for (const file of readdirSync(dir)) {
+		if (!file.endsWith(".json")) continue
+		const record = readDaemon(dir, file.slice(0, -".json".length))
+		if (!record) continue
+		const alive = isPidAlive(record.pid)
+		if (!alive) {
+			unregisterDaemon(dir, record.id)
+			continue
+		}
+		out.push({ record, alive })
+	}
+	return out
+}

--- a/src/extensions/experimental.ts
+++ b/src/extensions/experimental.ts
@@ -22,3 +22,20 @@ export function setExperimentalFeaturesEnabled(value: boolean): void {
 export function isExperimentalFeaturesEnabled(): boolean {
 	return enabled
 }
+
+/**
+ * TEST-ONLY helper: run `fn` with the flag set to `value`, then restore
+ * the previous value — even when `fn` throws. Prefer this over bare
+ * `setExperimentalFeaturesEnabled` in tests; a failed assertion
+ * mid-test otherwise leaks flag state into the next test in the file
+ * (module-level singleton + vitest's in-process module graph).
+ */
+export async function withExperimentalFeatures<T>(value: boolean, fn: () => T | Promise<T>): Promise<T> {
+	const previous = enabled
+	enabled = value
+	try {
+		return await fn()
+	} finally {
+		enabled = previous
+	}
+}

--- a/src/extensions/experimental.ts
+++ b/src/extensions/experimental.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared experimental-features flag.
+ *
+ * `--enable-experimental-features` is parsed in `cli.ts` and STRIPPED
+ * before args reach `main()`, so extensions cannot discover it via
+ * `pi.getFlag`. This module is the bridge: cli.ts calls
+ * `setExperimentalFeaturesEnabled(...)` once at startup; any extension
+ * that needs to gate behavior on the flag reads
+ * `isExperimentalFeaturesEnabled()`.
+ *
+ * Module-level singleton by design — the flag is a process-launch
+ * decision, not session state. Subagent sessions share the process, so
+ * they inherit the same value (and they should: an experimental tool is
+ * either available in this build or not).
+ */
+let enabled = false
+
+export function setExperimentalFeaturesEnabled(value: boolean): void {
+	enabled = value
+}
+
+export function isExperimentalFeaturesEnabled(): boolean {
+	return enabled
+}

--- a/src/extensions/permissions/taxonomy.test.ts
+++ b/src/extensions/permissions/taxonomy.test.ts
@@ -21,6 +21,13 @@ describe("classifyTool", () => {
 		expect(classifyTool("bash")).toBe("execute")
 	})
 
+	it("classifies daemon tools as execute (same risk class as bash)", () => {
+		expect(classifyTool("daemon")).toBe("execute")
+		expect(classifyTool("daemon_control")).toBe("execute")
+		expect(isReadOnlyTool("daemon")).toBe(false)
+		expect(isReadOnlyTool("daemon_control")).toBe(false)
+	})
+
 	it("classifies workflow output tools as read-only without widening the submit namespace", () => {
 		expect(classifyTool("workflow_submit_result")).toBe("readOnly")
 		expect(classifyTool("workflow_submit_questions")).toBe("readOnly")

--- a/src/extensions/permissions/taxonomy.ts
+++ b/src/extensions/permissions/taxonomy.ts
@@ -12,6 +12,12 @@ const STATIC_CATEGORIES: Record<string, ToolCategory> = {
 	edit: "write",
 	write: "write",
 	bash: "execute",
+	// daemon + daemon_control spawn/manage session-surviving processes —
+	// same risk class as bash (execute), so they inherit the same
+	// permission-mode treatment. (bash_control is `unknown` upstream;
+	// daemon tools are classified explicitly rather than inheriting that.)
+	daemon: "execute",
+	daemon_control: "execute",
 	web_search: "readOnly",
 	web_fetch: "readOnly",
 	questionnaire: "readOnly",

--- a/src/extensions/questionnaire/questionnaire.test.ts
+++ b/src/extensions/questionnaire/questionnaire.test.ts
@@ -352,28 +352,6 @@ describe("questionnaire environment behavior", () => {
 		expect(result.systemPrompt).toContain("Do NOT end your turn with questions")
 	})
 
-	it("includes the daemon clause only when experimental features are enabled", () => {
-		const pi = makePi(["questionnaire"])
-		pi.getFlag = vi.fn(() => undefined)
-		questionnaireExtension(pi as unknown as ExtensionAPI)
-
-		// Flag OFF: the prompt must not name an unregistered tool.
-		setExperimentalFeaturesEnabled(false)
-		const off = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false }) as
-			| { systemPrompt: string }
-			| undefined
-		expect(off?.systemPrompt).not.toContain("Long-lived services")
-		expect(off?.systemPrompt).not.toContain("`daemon`")
-
-		// Flag ON: daemon steering steers headless agents to the tool.
-		setExperimentalFeaturesEnabled(true)
-		const on = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false }) as
-			| { systemPrompt: string }
-			| undefined
-		expect(on?.systemPrompt).toContain("Long-lived services")
-		expect(on?.systemPrompt).toContain("daemon")
-	})
-
 	it("does not inject when UI is attached (interactive session)", () => {
 		const pi = makePi(["questionnaire"])
 		questionnaireExtension(pi as unknown as ExtensionAPI)

--- a/src/extensions/questionnaire/questionnaire.test.ts
+++ b/src/extensions/questionnaire/questionnaire.test.ts
@@ -1,6 +1,13 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { setExperimentalFeaturesEnabled } from "../experimental.js"
 import questionnaireExtension, { formatAnswerText, normalizeQuestionType } from "./questionnaire.js"
+
+afterEach(() => {
+	// Module-level singleton — restore the default-off state so other
+	// suites aren't polluted by tests that flipped it.
+	setExperimentalFeaturesEnabled(false)
+})
 
 function registeredQuestionnaireTool() {
 	let tool:
@@ -343,10 +350,28 @@ describe("questionnaire environment behavior", () => {
 		expect(result.systemPrompt).toContain("Autonomous mode")
 		expect(result.systemPrompt).toContain("no human or judge")
 		expect(result.systemPrompt).toContain("Do NOT end your turn with questions")
-		// Long-lived service guidance — drives 'daemon' tool choice over
-		// session-scoped managed background in headless runs.
-		expect(result.systemPrompt).toContain("Long-lived services")
-		expect(result.systemPrompt).toContain("daemon")
+	})
+
+	it("includes the daemon clause only when experimental features are enabled", () => {
+		const pi = makePi(["questionnaire"])
+		pi.getFlag = vi.fn(() => undefined)
+		questionnaireExtension(pi as unknown as ExtensionAPI)
+
+		// Flag OFF: the prompt must not name an unregistered tool.
+		setExperimentalFeaturesEnabled(false)
+		const off = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false }) as
+			| { systemPrompt: string }
+			| undefined
+		expect(off?.systemPrompt).not.toContain("Long-lived services")
+		expect(off?.systemPrompt).not.toContain("`daemon`")
+
+		// Flag ON: daemon steering steers headless agents to the tool.
+		setExperimentalFeaturesEnabled(true)
+		const on = pi._beforeAgentStart?.({ systemPrompt: "BASE" }, { hasUI: false }) as
+			| { systemPrompt: string }
+			| undefined
+		expect(on?.systemPrompt).toContain("Long-lived services")
+		expect(on?.systemPrompt).toContain("daemon")
 	})
 
 	it("does not inject when UI is attached (interactive session)", () => {

--- a/src/extensions/questionnaire/questionnaire.test.ts
+++ b/src/extensions/questionnaire/questionnaire.test.ts
@@ -338,11 +338,15 @@ describe("questionnaire environment behavior", () => {
 			| { systemPrompt: string }
 			| undefined
 
-		expect(result).toBeDefined()
-		expect(result!.systemPrompt).toContain("BASE")
-		expect(result!.systemPrompt).toContain("Autonomous mode")
-		expect(result!.systemPrompt).toContain("no human or judge")
-		expect(result!.systemPrompt).toContain("Do NOT end your turn with questions")
+		if (!result) throw new Error("expected autonomous-mode prompt injection")
+		expect(result.systemPrompt).toContain("BASE")
+		expect(result.systemPrompt).toContain("Autonomous mode")
+		expect(result.systemPrompt).toContain("no human or judge")
+		expect(result.systemPrompt).toContain("Do NOT end your turn with questions")
+		// Long-lived service guidance — drives 'daemon' tool choice over
+		// session-scoped managed background in headless runs.
+		expect(result.systemPrompt).toContain("Long-lived services")
+		expect(result.systemPrompt).toContain("daemon")
 	})
 
 	it("does not inject when UI is attached (interactive session)", () => {

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -19,7 +19,6 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Text, truncateToWidth } from "@earendil-works/pi-tui"
 import { type Static, Type } from "typebox"
 
-import { isExperimentalFeaturesEnabled } from "../experimental.js"
 import { withBlocked } from "../herdr-events.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { withWorkingHidden } from "../ui.js"
@@ -193,14 +192,8 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 	pi.on("before_agent_start", (event, ctx: ExtensionContext) => {
 		if (ctx.hasUI) return
 		if (pi.getFlag?.("ferment-oneshot") === true) return
-		// The daemon steering refers to an experimental tool — omit it when
-		// --enable-experimental-features is off so the prompt never names an
-		// unregistered tool.
-		const daemonClause = isExperimentalFeaturesEnabled()
-			? `\n\n## Long-lived services\n\nWhen the task requires a web server or other long-lived service that a grader or user will connect to AFTER you finish, use the \`daemon\` tool to start it — managed background (bash + bash_control) and \`&\`/\`nohup\` processes are killed when the session ends, so the service would be dead by the time anyone connects.`
-			: ""
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.${daemonClause}`,
+			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.`,
 		}
 	})
 

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -19,6 +19,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Text, truncateToWidth } from "@earendil-works/pi-tui"
 import { type Static, Type } from "typebox"
 
+import { isExperimentalFeaturesEnabled } from "../experimental.js"
 import { withBlocked } from "../herdr-events.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { withWorkingHidden } from "../ui.js"
@@ -192,8 +193,14 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 	pi.on("before_agent_start", (event, ctx: ExtensionContext) => {
 		if (ctx.hasUI) return
 		if (pi.getFlag?.("ferment-oneshot") === true) return
+		// The daemon steering refers to an experimental tool — omit it when
+		// --enable-experimental-features is off so the prompt never names an
+		// unregistered tool.
+		const daemonClause = isExperimentalFeaturesEnabled()
+			? `\n\n## Long-lived services\n\nWhen the task requires a web server or other long-lived service that a grader or user will connect to AFTER you finish, use the \`daemon\` tool to start it — managed background (bash + bash_control) and \`&\`/\`nohup\` processes are killed when the session ends, so the service would be dead by the time anyone connects.`
+			: ""
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.\n\n## Long-lived services\n\nWhen the task requires a web server or other long-lived service that a grader or user will connect to AFTER you finish, use the \`daemon\` tool to start it — managed background (bash + bash_control) and \`&\`/\`nohup\` processes are killed when the session ends, so the service would be dead by the time anyone connects.`,
+			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.${daemonClause}`,
 		}
 	})
 

--- a/src/extensions/questionnaire/questionnaire.ts
+++ b/src/extensions/questionnaire/questionnaire.ts
@@ -193,7 +193,7 @@ export default function questionnaireExtension(pi: ExtensionAPI): void {
 		if (ctx.hasUI) return
 		if (pi.getFlag?.("ferment-oneshot") === true) return
 		return {
-			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.`,
+			systemPrompt: `${event.systemPrompt}\n\n## Autonomous mode\n\nYou are running in a non-interactive session with no human or judge to answer questions. Do NOT end your turn with questions or ask for confirmation — no one will respond. Make the safest reasonable decision based on the task description and proceed. If you encounter genuine ambiguity, state your assumption and continue working. Never end your turn waiting for input.\n\n## Long-lived services\n\nWhen the task requires a web server or other long-lived service that a grader or user will connect to AFTER you finish, use the \`daemon\` tool to start it — managed background (bash + bash_control) and \`&\`/\`nohup\` processes are killed when the session ends, so the service would be dead by the time anyone connects.`,
 		}
 	})
 


### PR DESCRIPTION
## Summary

Adds a \`daemon\` tool that spawns processes guaranteed to outlive the kimchi session, and \`daemon_control\` (list/status/logs/stop) to manage detached daemons across sessions.

**Motivation:** terminal-bench analysis found scored failures where the agent solved the task (\`pypi-server\`, \`kv-store-grpc\`) but the server it started was killed by \`ProcessRegistry\` session shutdown before the external grader connected. The old \`BASH_TOOL_DESCRIPTION\` flatly forbid \`nohup\`/\`disown\`, pushing the model into session-scoped managed background even for grader-facing services.

**Validation:** benchmark run on this branch (101 trials) — both target trials flipped to pass: \`pypi-server\` scored_fail → 1.0, \`kv-store-grpc\` scored_fail → 1.0. All 8 daemon-using trials used the tool correctly (long-lived services only, no misuse for ordinary work); \`stop\` was used once properly for QEMU reconfiguration in \`install-windows-3.11\`.

## Implementation

- **Spawn** (\`spawn.ts\`): \`spawn(..., {detached: true})\` + \`unref()\` via \`exec bash -c "<cmd>" >> log 2>&1\` — escapes all three kill chains (\`ProcessRegistry.shutdown\`, \`killTrackedDetachedChildren\`, orphan reaping). Single-unit \`bash -c\` wrapping so compound commands work under \`exec\`.
- **Crash grace** (500ms): instant startups that fail immediately are reported with the log tail so the model sees *why*.
- **Process group kill**: \`daemon_control stop\` SIGTERM→grace→SIGKILL to the negative pid, reaching the full daemon tree (verified with grandchildren in tests).
- **Cross-session state** in \`~/.config/kimchi/daemons/<id>.json\` + \`.log\` + \`.pid\`, schema-validated, self-healing pruning of dead records.
- **Restrictive steering**: \`daemon\` tool description deliberately unattractive for ordinary work ("Do NOT use for builds, tests, downloads, or ordinary long-running commands — use bash"); \`BASH_TOOL_DESCRIPTION\` nohup ban now points to \`daemon\` only when a process must outlive the session; autonomous-mode prompt gains a "Long-lived services" clause.

## Steering / no upstream changes

Pure extension (\`src/extensions/daemon/\`), registered in \`cli.ts\` after \`bashControlExtension\`. No \`patches/\` changes, no upstream modifications.

## Test plan

- 38 daemon tests: unit (state validation, id generation, soft-error shapes) + POSIX integration with real \`sleep\`/\`bash\` processes (process-group survival, crash-grace detection, log capture, group kill of grandchildren via \`pgrep -fx\`).
- Permissions taxonomy: \`daemon\`/\`daemon_control\` classified \`execute\` (same risk class as bash) with regression tests.
- Questionnaire autonomous-prompt assertion for the new clause.
- Full permissions suite (3183 tests) + daemon suite green; lint + typecheck clean.

## Visibility audit

Daemon tools are catalog-persistent like \`bash_control\`: survive idle and implementation-ferment profiles (registered toolset), hidden in planning profiles (same as bash_control), not in \`BUILTIN_ALLOW_TOOL_NAMES\` (classifier routes them in headless auto mode, same as bash). Subagent workers do not inherit them (matches bash_control).

Co-Authored-By: Kimchi <noreply@kimchi.dev>