### PR TITLE
fix(login): switch Kimchi account via /login without restart

### DIFF
--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -209,9 +209,10 @@ export async function syncKimchiAuth(modelRegistry: ModelRegistryLike, token: st
 
 	if (!modelRegistry.getApiKeyForProvider) return
 	const unresolvedProviders: string[] = []
+	const expectedKey = token || undefined
 	for (const providerId of getKimchiProviderIds(modelRegistry)) {
 		const resolvedKey = await modelRegistry.getApiKeyForProvider(providerId)
-		if (token ? resolvedKey !== token : resolvedKey !== undefined) {
+		if (resolvedKey !== expectedKey) {
 			unresolvedProviders.push(providerId)
 		}
 	}

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -216,7 +216,10 @@ export async function syncKimchiAuth(modelRegistry: ModelRegistryLike, token: st
 		}
 	}
 	if (unresolvedProviders.length > 0) {
-		throw new Error(`Pi did not activate the updated credentials for: ${unresolvedProviders.join(", ")}`)
+		// This can happen when Kimchi was started with `--api-key`. That key stays in memory and takes
+		// priority over auth.json, so logging in or out updates the file while the running session keeps
+		// using the command-line key.
+		throw new Error(`Kimchi did not activate the updated credentials for: ${unresolvedProviders.join(", ")}`)
 	}
 }
 
@@ -552,7 +555,7 @@ async function showOAuthLoginDialogWithExtensionUI(
 ): Promise<boolean> {
 	const authStorage = (ctx.modelRegistry as ModelRegistryLike).authStorage
 	if (!authStorage?.login) {
-		ctx.ui.notify(`${providerName} subscription login is unavailable in this Pi version. Use /login.`, "error")
+		ctx.ui.notify(`${providerName} subscription login is unavailable in this Kimchi version. Use /login.`, "error")
 		return false
 	}
 	const login = authStorage.login.bind(authStorage)

--- a/src/extensions/login/flow.ts
+++ b/src/extensions/login/flow.ts
@@ -18,6 +18,7 @@ import {
 	syncProviderModels,
 	updateModelsConfig,
 } from "../../models.js"
+import { syncPiAuth } from "../../pi-auth.js"
 import { refreshBillingStatusFromConfig } from "../billing/status.js"
 
 export const KIMCHI_PROVIDER_ID = "kimchi-dev"
@@ -75,12 +76,8 @@ export function formatBrowserLoginMessage(url: string): string {
 
 type AuthSelectorProvider = ConstructorParameters<typeof OAuthSelectorComponent>[1][number]
 type AuthStatus = ReturnType<PiModelRegistry["getProviderAuthStatus"]>
-type ProviderConfigInput = NonNullable<Parameters<PiModelRegistry["registerProvider"]>[1]>
+
 interface AuthStorageLike {
-	set(provider: string, credential: unknown): void
-	get(provider: string): unknown
-	remove?(provider: string): void
-	logout?(provider: string): void
 	getOAuthProviders?(): Array<{ id: string; name: string; usesCallbackServer?: boolean }>
 	login?(
 		provider: string,
@@ -110,10 +107,9 @@ interface ModelRegistryLike<TModel extends ProviderModelLike = ProviderModelLike
 	getProvider?(
 		providerId: string,
 	): { id?: string; name?: string; auth?: { oauth?: { name?: string; login?: unknown } } } | undefined
-	registerProvider?(providerId: string, config: ProviderConfigInput): void
-	unregisterProvider?(providerId: string): void
-	getRegisteredProviderConfig?(providerId: string): ProviderConfigInput | undefined
 	getRegisteredProviderIds?(): readonly string[]
+	/** Resolve the credential Pi will use for a provider. */
+	getApiKeyForProvider?(providerId: string): Promise<string | undefined>
 }
 
 export function createLoginChoiceSelector(options: {
@@ -188,25 +184,6 @@ async function refreshKimchiModels(
 	await updateModelsConfig(resolve(agentDir, "models.json"), token, { endpoint, ...options })
 }
 
-export function setKimchiAuthToken(
-	modelRegistry: ModelRegistryLike,
-	token: string,
-	credentialType: "api_key" | "oauth" = "api_key",
-): void {
-	const credential =
-		credentialType === "oauth"
-			? { type: "oauth" as const, access: token, refresh: "", expires: Number.MAX_SAFE_INTEGER }
-			: { type: "api_key" as const, key: token }
-
-	for (const providerId of getKimchiProviderIds(modelRegistry)) {
-		if (modelRegistry.authStorage) {
-			modelRegistry.authStorage.set(providerId, credential)
-		} else {
-			registerProviderApiKey(modelRegistry, providerId, token)
-		}
-	}
-}
-
 export function getKimchiProviderIds(modelRegistry: ModelRegistryLike): Set<string> {
 	return new Set([
 		KIMCHI_PROVIDER_ID,
@@ -217,13 +194,30 @@ export function getKimchiProviderIds(modelRegistry: ModelRegistryLike): Set<stri
 	])
 }
 
-function registerProviderApiKey(modelRegistry: ModelRegistryLike, providerId: string, token: string): void {
-	const registerProvider = modelRegistry.registerProvider?.bind(modelRegistry)
-	if (!registerProvider) return
-	registerProvider(providerId, {
-		...modelRegistry.getRegisteredProviderConfig?.(providerId),
-		apiKey: token,
-	})
+/** Persist Kimchi credentials for every provider in models.json and refresh Pi's
+ * current registry. Pi's AuthStorage notices the auth.json revision change, so the
+ * same running session resolves the new key without reaching into private runtime
+ * fields or requiring a restart. */
+export async function syncKimchiAuth(modelRegistry: ModelRegistryLike, token: string): Promise<void> {
+	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
+	if (!agentDir) {
+		throw new Error("KIMCHI_CODING_AGENT_DIR is missing; Kimchi credentials cannot be synchronized")
+	}
+
+	await syncPiAuth(resolve(agentDir, "auth.json"), resolve(agentDir, "models.json"), token)
+	await modelRegistry.refresh()
+
+	if (!modelRegistry.getApiKeyForProvider) return
+	const unresolvedProviders: string[] = []
+	for (const providerId of getKimchiProviderIds(modelRegistry)) {
+		const resolvedKey = await modelRegistry.getApiKeyForProvider(providerId)
+		if (token ? resolvedKey !== token : resolvedKey !== undefined) {
+			unresolvedProviders.push(providerId)
+		}
+	}
+	if (unresolvedProviders.length > 0) {
+		throw new Error(`Pi did not activate the updated credentials for: ${unresolvedProviders.join(", ")}`)
+	}
 }
 
 export interface KimchiBrowserLoginHost {
@@ -244,24 +238,6 @@ export interface KimchiBrowserLoginOptions {
 export interface KimchiApiKeyLoginOptions {
 	apiKey: string
 	endpoint: string
-}
-
-function restoreKimchiAuth(modelRegistry: ModelRegistryLike, previousCredentials: Map<string, unknown>): void {
-	for (const [providerId, previousCredential] of previousCredentials) {
-		if (!modelRegistry.authStorage) {
-			if (previousCredential) {
-				modelRegistry.registerProvider?.(providerId, previousCredential as ProviderConfigInput)
-			} else {
-				modelRegistry.unregisterProvider?.(providerId)
-			}
-			continue
-		}
-		if (previousCredential !== undefined) {
-			modelRegistry.authStorage.set(providerId, previousCredential)
-		} else {
-			modelRegistry.authStorage.remove?.(providerId)
-		}
-	}
 }
 
 function formatKimchiTokenError(error: unknown, options: { saved: boolean }): string {
@@ -298,24 +274,17 @@ async function configureKimchiToken(
 		return false
 	}
 
-	const previousCredentials = new Map(
-		[...getKimchiProviderIds(host.modelRegistry)].map((providerId) => [
-			providerId,
-			host.modelRegistry.authStorage
-				? host.modelRegistry.authStorage.get(providerId)
-				: host.modelRegistry.getRegisteredProviderConfig?.(providerId),
-		]),
-	)
-	setKimchiAuthToken(host.modelRegistry, token)
+	// Metadata authentication succeeded (or browser login is using cached metadata),
+	// so make config.json and Pi's auth.json agree before refreshing the live registry.
+	// If the process stops between these writes, startup sync repairs auth.json from
+	// config.json on the next launch.
+	options.persistConfig?.()
+	let authSynchronized = false
 	try {
-		await host.modelRegistry.refresh()
+		await syncKimchiAuth(host.modelRegistry, token)
+		authSynchronized = true
 	} catch (error) {
 		refreshError ??= error
-		if (options.strictFreshDiscovery) {
-			restoreKimchiAuth(host.modelRegistry, previousCredentials)
-			host.showError?.(formatKimchiTokenError(error, { saved: false }))
-			return false
-		}
 	}
 
 	let providerModels: ProviderModelLike[] = []
@@ -324,19 +293,12 @@ async function configureKimchiToken(
 	} catch (error) {
 		refreshError ??= error
 	}
-	if (providerModels.length > 0) {
-		options.persistConfig?.()
+	if (authSynchronized && providerModels.length > 0) {
 		void refreshBillingStatusFromConfig({ mode: "forced" })
 		const selectedModel = providerModels.find((m) => m.id === KIMCHI_DEFAULT_MODEL_ID) ?? providerModels[0]
 		await host.setModel?.(selectedModel)
 		host.addFeedback?.(formatKimchiLoginSuccessMessage(selectedModel.id))
 		return true
-	}
-
-	if (options.strictFreshDiscovery) {
-		restoreKimchiAuth(host.modelRegistry, previousCredentials)
-		host.showError?.("Kimchi API-key login found no available Kimchi models. No changes were saved.")
-		return false
 	}
 
 	if (refreshError) {

--- a/src/extensions/login/index.test.ts
+++ b/src/extensions/login/index.test.ts
@@ -2,8 +2,9 @@ import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agen
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import loginExtension from "./index.js"
 
-const { loadConfigMock } = vi.hoisted(() => ({
+const { loadConfigMock, refreshBillingStatusFromConfigMock } = vi.hoisted(() => ({
 	loadConfigMock: vi.fn(),
+	refreshBillingStatusFromConfigMock: vi.fn(),
 }))
 
 vi.mock("../../config.js", () => ({
@@ -12,7 +13,7 @@ vi.mock("../../config.js", () => ({
 }))
 
 vi.mock("../billing/status.js", () => ({
-	refreshBillingStatusFromConfig: vi.fn(),
+	refreshBillingStatusFromConfig: refreshBillingStatusFromConfigMock,
 }))
 
 // Keep the real chatCompletionsApi (URL builder + scheme normalization) so baseUrl assertions
@@ -79,5 +80,19 @@ describe("loginExtension", () => {
 			name: "OpenAI Codex",
 			auth: { oauth: { name: "OpenAI (ChatGPT Plus/Pro)" } },
 		})
+	})
+
+	it("refreshes billing when an authenticated session starts", () => {
+		loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint: undefined })
+		const on = vi.fn()
+
+		loginExtension({ on, registerProvider: vi.fn() } as unknown as ExtensionAPI)
+		loadConfigMock.mockReturnValue({ apiKey: "configured-api-key", customLlmEndpoint: undefined })
+
+		const sessionStart = on.mock.calls.find(([event]) => event === "session_start")?.[1]
+		sessionStart({}, { modelRegistry: { getAll: () => [] } })
+
+		expect(refreshBillingStatusFromConfigMock).toHaveBeenCalledOnce()
+		expect(refreshBillingStatusFromConfigMock).toHaveBeenCalledWith({ mode: "forced" })
 	})
 })

--- a/src/extensions/login/index.test.ts
+++ b/src/extensions/login/index.test.ts
@@ -2,13 +2,11 @@ import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agen
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import loginExtension from "./index.js"
 
-const { clearApiKeyMock, loadConfigMock } = vi.hoisted(() => ({
-	clearApiKeyMock: vi.fn(),
+const { loadConfigMock } = vi.hoisted(() => ({
 	loadConfigMock: vi.fn(),
 }))
 
 vi.mock("../../config.js", () => ({
-	clearApiKey: clearApiKeyMock,
 	loadConfig: loadConfigMock,
 	writeApiKey: vi.fn(),
 }))
@@ -81,32 +79,5 @@ describe("loginExtension", () => {
 			name: "OpenAI Codex",
 			auth: { oauth: { name: "OpenAI (ChatGPT Plus/Pro)" } },
 		})
-	})
-
-	it("logs out every internal Kimchi provider when the single Kimchi entry is selected", () => {
-		loadConfigMock.mockReturnValue({ apiKey: "", customLlmEndpoint: undefined })
-		const on = vi.fn()
-		const originalLogout = vi.fn()
-		const authStorage = { logout: originalLogout }
-		const modelRegistry = {
-			authStorage,
-			getAll: () => [
-				{ id: "sol", provider: "kimchi-dev" },
-				{ id: "sol", provider: "kimchi-dev/openai" },
-				{ id: "claude", provider: "kimchi-dev/anthropic" },
-			],
-		}
-
-		loginExtension({ on, registerProvider: vi.fn() } as unknown as ExtensionAPI)
-		const sessionStart = on.mock.calls[0]?.[1]
-		sessionStart({}, { modelRegistry })
-		authStorage.logout("kimchi-dev")
-
-		expect(originalLogout.mock.calls.map(([provider]) => provider)).toEqual([
-			"kimchi-dev",
-			"kimchi-dev/openai",
-			"kimchi-dev/anthropic",
-		])
-		expect(clearApiKeyMock).toHaveBeenCalledOnce()
 	})
 })

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -2,12 +2,10 @@ import { resolve } from "node:path"
 import { registerBunOAuthFlows } from "@earendil-works/pi-ai/bun-oauth"
 import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex"
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
+import { loadConfig, writeApiKey } from "../../config.js"
 import { chatCompletionsApi, updateModelsConfig, validateApiKey } from "../../models.js"
 import { refreshBillingStatusFromConfig } from "../billing/status.js"
-import { getKimchiProviderIds, KIMCHI_PROVIDER_ID, setKimchiAuthToken } from "./flow.js"
-
-const KIMCHI_LOGOUT_PATCHED = Symbol("kimchi.logoutPatched")
+import { KIMCHI_PROVIDER_ID } from "./flow.js"
 
 export default function loginExtension(pi: ExtensionAPI): void {
 	const agentDir = process.env.KIMCHI_CODING_AGENT_DIR
@@ -17,36 +15,6 @@ export default function loginExtension(pi: ExtensionAPI): void {
 	// Builtin providers are disabled globally; explicitly restore the approved subscription provider.
 	registerBunOAuthFlows()
 	pi.registerProvider(openaiCodexProvider())
-
-	pi.on("session_start", (_event, ctx) => {
-		// Re-read config every session start (not once at load): the API key can change mid-process
-		// after a `/login` writes it, and each new session must pick up the latest key. This is a
-		// separate read from the load-time customLlmEndpoint lookup below — do not dedupe them.
-		const configKey = loadConfig().apiKey
-		if (configKey) {
-			setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
-			void refreshBillingStatusFromConfig({ mode: "forced" })
-		}
-
-		const authStorage = (ctx.modelRegistry as { authStorage?: { logout(provider: string): void } }).authStorage
-		if (!authStorage) return
-		const patchedAuthStorage = authStorage as typeof authStorage & { [KIMCHI_LOGOUT_PATCHED]?: boolean }
-		if (patchedAuthStorage[KIMCHI_LOGOUT_PATCHED]) return
-
-		const originalLogout = patchedAuthStorage.logout.bind(patchedAuthStorage)
-		patchedAuthStorage.logout = (provider: string) => {
-			if (provider === KIMCHI_PROVIDER_ID) {
-				for (const providerId of getKimchiProviderIds(ctx.modelRegistry)) {
-					originalLogout(providerId)
-				}
-				clearApiKey()
-				void refreshBillingStatusFromConfig({ mode: "forced" })
-				return
-			}
-			originalLogout(provider)
-		}
-		patchedAuthStorage[KIMCHI_LOGOUT_PATCHED] = true
-	})
 
 	// Apply a custom llmEndpoint as an in-memory baseUrl override for the kimchi-dev provider.
 	// This routes chat requests to the override even when the metadata refresh falls back to the

--- a/src/extensions/login/index.ts
+++ b/src/extensions/login/index.ts
@@ -54,6 +54,10 @@ export default function loginExtension(pi: ExtensionAPI): void {
 	// This runs on every session_start because sub-providers may not exist yet
 	// at initial load (they're created by updateModelsConfig from the metadata API).
 	pi.on("session_start", (_event, ctx) => {
+		if (loadConfig().apiKey) {
+			void refreshBillingStatusFromConfig({ mode: "forced" })
+		}
+
 		const subProviders = new Set(
 			ctx.modelRegistry
 				.getAll()

--- a/src/extensions/login/startup-auth.test.ts
+++ b/src/extensions/login/startup-auth.test.ts
@@ -17,9 +17,14 @@ const modelsMock = vi.hoisted(() => ({
 	isTransientModelsError: vi.fn((error: unknown) => (error as { transient?: boolean })?.transient === true),
 }))
 
+const piAuthMock = vi.hoisted(() => ({
+	syncPiAuth: vi.fn(),
+}))
+
 vi.mock("../../cli-auth/index.js", () => authMock)
 vi.mock("../../config.js", () => configMock)
 vi.mock("../../models.js", () => modelsMock)
+vi.mock("../../pi-auth.js", () => piAuthMock)
 
 import {
 	createStartupAuthGate,
@@ -51,7 +56,7 @@ function createHarness(
 	options: {
 		state?: StartupAuthGateState
 		availableInitially?: boolean
-		addModelOnAuthSet?: boolean
+		addModelOnAuthSync?: boolean
 		overlayActiveInitially?: boolean
 		onCancel?: ReturnType<typeof vi.fn>
 		afterSessionStart?: SessionStartHandler
@@ -69,18 +74,12 @@ function createHarness(
 	const availableModels: Array<{ id: string; provider: string }> = options.availableInitially
 		? [{ id: "kimi-k2.6", provider: "kimchi-dev" }]
 		: []
-	const authStorage = {
-		set: vi.fn((provider: string) => {
-			if (provider === "kimchi-dev" && options.addModelOnAuthSet !== false && availableModels.length === 0) {
-				availableModels.push({ id: "kimi-k2.6", provider: "kimchi-dev" })
-			}
-		}),
-		get: vi.fn(),
-		getOAuthProviders: vi.fn(() => []),
-		login: vi.fn(),
-	}
+	piAuthMock.syncPiAuth.mockImplementation(async (_authPath: string, _modelsPath: string, apiKey: string) => {
+		if (apiKey && options.addModelOnAuthSync !== false && availableModels.length === 0) {
+			availableModels.push({ id: "kimi-k2.6", provider: "kimchi-dev" })
+		}
+	})
 	const modelRegistry = {
-		authStorage,
 		refresh: vi.fn(),
 		getAll: vi.fn(() => availableModels),
 		getAvailable: vi.fn(() => availableModels),
@@ -140,7 +139,7 @@ function createHarness(
 		input: (data: string) => activeComponent?.handleInput?.(data),
 		terminalInput: (data: string) => terminalInputHandler?.(data),
 		settle: async () => {
-			for (let i = 0; i < 4; i += 1) await Promise.resolve()
+			for (let i = 0; i < 10; i += 1) await Promise.resolve()
 		},
 		waitForCustomPrompts: async (count: number) => {
 			for (let i = 0; i < 50; i += 1) {
@@ -157,6 +156,7 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-startup-auth-test")
 	authMock.authenticateViaBrowser.mockReset()
 	authMock.authenticateViaBrowser.mockResolvedValue({ token: "kimchi-token" })
 	let savedConfigKey = ""
@@ -169,6 +169,8 @@ beforeEach(() => {
 	modelsMock.updateModelsConfig.mockReset()
 	modelsMock.updateModelsConfig.mockResolvedValue({ models: [] })
 	modelsMock.syncProviderModels.mockReset()
+	piAuthMock.syncPiAuth.mockReset()
+	piAuthMock.syncPiAuth.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
@@ -214,10 +216,11 @@ describe("startup auth gate", () => {
 
 		expect(authMock.authenticateViaBrowser).toHaveBeenCalledOnce()
 		expect(configMock.writeApiKey).toHaveBeenCalledWith("kimchi-token")
-		expect(harness.modelRegistry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-			type: "api_key",
-			key: "kimchi-token",
-		})
+		expect(piAuthMock.syncPiAuth).toHaveBeenCalledWith(
+			"/tmp/kimchi-startup-auth-test/auth.json",
+			"/tmp/kimchi-startup-auth-test/models.json",
+			"kimchi-token",
+		)
 		expect(harness.api.setModel).toHaveBeenCalledWith({ id: "kimi-k2.6", provider: "kimchi-dev" })
 		expect(harness.state.authenticated).toBe(true)
 	})
@@ -296,7 +299,7 @@ describe("startup auth gate", () => {
 			savedConfigKey = key
 		})
 		const onCancel = vi.fn()
-		const harness = createHarness({ addModelOnAuthSet: false, onCancel })
+		const harness = createHarness({ addModelOnAuthSync: false, onCancel })
 
 		try {
 			const started = harness.start()
@@ -338,7 +341,7 @@ describe("startup auth gate", () => {
 		})
 		modelsMock.updateModelsConfig.mockRejectedValue(transientError)
 		const onCancel = vi.fn()
-		const harness = createHarness({ addModelOnAuthSet: false, onCancel })
+		const harness = createHarness({ addModelOnAuthSync: false, onCancel })
 
 		try {
 			const started = harness.start()
@@ -387,7 +390,7 @@ describe("startup auth gate", () => {
 		await harness.settle()
 
 		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
-		expect(harness.modelRegistry.authStorage.set).not.toHaveBeenCalled()
+		expect(piAuthMock.syncPiAuth).not.toHaveBeenCalled()
 
 		harness.setOverlay(false)
 		harness.terminalInput("x")
@@ -426,18 +429,17 @@ describe("startup auth gate", () => {
 		expect(onCancel).toHaveBeenCalledWith(harness.ctx)
 	})
 
-	it("preserves master behavior by seeding saved config keys as oauth credentials", async () => {
+	it("synchronizes a saved config key into Pi auth before checking available models", async () => {
 		configMock.loadConfig.mockReturnValue({ apiKey: "saved-config-token" })
 		const harness = createHarness()
 
 		await harness.start()
 
-		expect(harness.modelRegistry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-			type: "oauth",
-			access: "saved-config-token",
-			refresh: "",
-			expires: Number.MAX_SAFE_INTEGER,
-		})
+		expect(piAuthMock.syncPiAuth).toHaveBeenCalledWith(
+			"/tmp/kimchi-startup-auth-test/auth.json",
+			"/tmp/kimchi-startup-auth-test/models.json",
+			"saved-config-token",
+		)
 		expect(harness.ctx.ui.custom).not.toHaveBeenCalled()
 	})
 

--- a/src/extensions/login/startup-auth.ts
+++ b/src/extensions/login/startup-auth.ts
@@ -10,8 +10,8 @@ import {
 	isKimchiProvider,
 	performKimchiApiKeyLoginViaExtensionUI,
 	performKimchiBrowserLoginWithDialog,
-	setKimchiAuthToken,
 	showSubscriptionLoginWithExtensionUI,
+	syncKimchiAuth,
 } from "./flow.js"
 
 const STARTUP_AUTH_OVERLAY_WAIT_KEY = "kimchi-startup-auth-overlay-wait"
@@ -55,22 +55,16 @@ export function shouldShowStartupAuthGate(input: {
 	return true
 }
 
-export function seedKimchiAuthFromConfig(ctx: ExtensionContext): void {
-	seedKimchiAuthFromConfigAndReturnKey(ctx)
-}
-
-function seedKimchiAuthFromConfigAndReturnKey(ctx: ExtensionContext): string {
-	const configKey = loadConfig().apiKey
-	if (configKey) {
-		setKimchiAuthToken(ctx.modelRegistry, configKey, "oauth")
-	}
-	return configKey
-}
-
 export async function hasUsableAuth(ctx: ExtensionContext): Promise<boolean> {
-	const configKey = seedKimchiAuthFromConfigAndReturnKey(ctx)
+	const configKey = loadConfig().apiKey
+	let kimchiAuthSynchronized = configKey.length === 0
 	try {
-		await ctx.modelRegistry.refresh()
+		if (configKey) {
+			await syncKimchiAuth(ctx.modelRegistry, configKey)
+			kimchiAuthSynchronized = true
+		} else {
+			await ctx.modelRegistry.refresh()
+		}
 	} catch {
 		// Broken models.json is reported by upstream startup warnings. Treat it
 		// as unauthenticated here so the user gets a login path instead of Ferment.
@@ -79,7 +73,7 @@ export async function hasUsableAuth(ctx: ExtensionContext): Promise<boolean> {
 		const availableModels = ctx.modelRegistry.getAvailable()
 		if (availableModels.length === 0) return false
 		if (availableModels.some((model) => !isKimchiProvider(model.provider))) return true
-		return configKey.length > 0
+		return configKey.length > 0 && kimchiAuthSynchronized
 	} catch {
 		return false
 	}

--- a/src/login-command-patch.test.ts
+++ b/src/login-command-patch.test.ts
@@ -5,8 +5,11 @@ import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest"
 import * as configModule from "./config.js"
 import * as loginPatch from "./login-command-patch.js"
 import * as modelsModule from "./models.js"
+import * as piAuthModule from "./pi-auth.js"
 
 const { oauthDelegate, warningDelegate } = loginPatch
+
+let synchronizedApiKey = ""
 
 vi.mock("@earendil-works/pi-ai/compat", async () => {
 	const actual = await vi.importActual("@earendil-works/pi-ai/compat")
@@ -25,7 +28,12 @@ beforeEach(() => {
 	// Auth tests should be independent of the developer machine's real config.
 	vi.spyOn(configModule, "loadConfig").mockReturnValue({ apiKey: "" } as ReturnType<typeof configModule.loadConfig>)
 	vi.spyOn(configModule, "writeApiKey").mockImplementation(() => {})
+	vi.spyOn(configModule, "clearApiKey").mockImplementation(() => {})
 	vi.spyOn(modelsModule, "updateModelsConfig").mockResolvedValue({ models: [] })
+	synchronizedApiKey = ""
+	vi.spyOn(piAuthModule, "syncPiAuth").mockImplementation(async (_authPath, _modelsPath, apiKey) => {
+		synchronizedApiKey = apiKey
+	})
 })
 
 afterEach(() => {
@@ -42,11 +50,10 @@ function makeFakeModelRegistry() {
 	const getAllMock = vi.fn().mockReturnValue([])
 	const getAvailableMock = vi.fn().mockReturnValue([])
 	return {
-		authStorage: {
-			set: vi.fn(),
-			get: vi.fn(),
-			remove: vi.fn(),
-		},
+		getAuth: vi.fn(async () =>
+			synchronizedApiKey ? { auth: { apiKey: synchronizedApiKey, headers: {} }, env: {} } : undefined,
+		),
+		logout: vi.fn().mockResolvedValue(undefined),
 		refresh: vi.fn(),
 		getModels: getAllMock,
 		getAvailableSnapshot: getAvailableMock,
@@ -67,6 +74,8 @@ function makeFakeInteractiveMode(registry: ReturnType<typeof makeFakeModelRegist
 		showLoginDialog: vi.fn().mockResolvedValue(undefined),
 		showExtensionInput: vi.fn(),
 		getLoginProviderOptions: vi.fn().mockReturnValue([]),
+		getLogoutProviderOptions: vi.fn().mockResolvedValue([]),
+		updateAvailableProviderCount: vi.fn().mockResolvedValue(undefined),
 		chatContainer: {
 			addChild: vi.fn((child: unknown) => children.push(child)),
 			children,
@@ -155,10 +164,11 @@ it("intercepts the user-facing /login command and runs Kimchi browser auth", asy
 	expect(fakeIm.showSelector).toHaveBeenCalledOnce()
 	expect(authSpy).toHaveBeenCalledOnce()
 	expect(fakeIm.showStatus).toHaveBeenCalledWith("Opening browser for Kimchi login...")
-	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-		type: "api_key",
-		key: "test-token-123",
-	})
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-login-test/auth.json",
+		"/tmp/kimchi-login-test/models.json",
+		"test-token-123",
+	)
 	expect(registry.refresh).toHaveBeenCalledOnce()
 	expect(fakeIm.session.setModel).toHaveBeenCalledWith({
 		id: "kimi-k2.6",
@@ -189,10 +199,11 @@ it("does not reuse a saved Kimchi key for explicit /login", async () => {
 	expect(fakeIm.showStatus).toHaveBeenCalledWith("Opening browser for Kimchi login...")
 	expect(fakeIm.showStatus).not.toHaveBeenCalledWith("Refreshing Kimchi models with existing login...")
 	expect(configModule.writeApiKey).toHaveBeenCalledWith("fresh-token")
-	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-		type: "api_key",
-		key: "fresh-token",
-	})
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"fresh-token",
+	)
 	expect(fakeIm.session.setModel).toHaveBeenCalledWith({
 		id: "kimi-k2.6",
 		provider: "kimchi-dev",
@@ -283,7 +294,7 @@ it("shows error when browser auth fails", async () => {
 	await selectCurrentLoginOption(fakeIm)
 
 	expect(fakeIm.showError).toHaveBeenCalledWith("Kimchi login failed: Browser closed")
-	expect(registry.authStorage.set).not.toHaveBeenCalled()
+	expect(piAuthModule.syncPiAuth).not.toHaveBeenCalled()
 })
 
 it("prompts for Kimchi API key and endpoint with the default endpoint", async () => {
@@ -319,10 +330,11 @@ it("prompts for Kimchi API key and endpoint with the default endpoint", async ()
 			endpoint: "https://llm.kimchi.dev",
 		},
 	)
-	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-		type: "api_key",
-		key: "api-key-123",
-	})
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-123",
+	)
 	expect(fakeIm.session.setModel).toHaveBeenCalledWith({
 		id: "kimi-k2.6",
 		provider: "kimchi-dev",
@@ -356,10 +368,11 @@ it("uses a custom Kimchi endpoint for API-key model discovery and config persist
 	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-456", undefined, {
 		llmEndpoint: "https://custom.example/",
 	})
-	expect(registry.authStorage.set).toHaveBeenCalledWith("kimchi-dev", {
-		type: "api_key",
-		key: "api-key-456",
-	})
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-456",
+	)
 	expect(fakeIm.session.setModel).toHaveBeenCalledWith({ id: "custom-model", provider: "kimchi-dev" })
 })
 
@@ -386,8 +399,7 @@ it("does not persist API-key login when model discovery rejects an invalid key",
 		"Invalid API key. Please check your key and try again. No changes were saved.",
 	)
 	expect(configModule.writeApiKey).not.toHaveBeenCalled()
-	expect(registry.authStorage.set).not.toHaveBeenCalled()
-	expect(registry.authStorage.remove).not.toHaveBeenCalled()
+	expect(piAuthModule.syncPiAuth).not.toHaveBeenCalled()
 	expect(registry.refresh).not.toHaveBeenCalled()
 	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
@@ -412,20 +424,14 @@ it("does not persist API-key login when the endpoint is unreachable", async () =
 		"Kimchi endpoint is unreachable or temporarily unavailable (Failed to fetch models: network down). Check the endpoint and try again. No changes were saved.",
 	)
 	expect(configModule.writeApiKey).not.toHaveBeenCalled()
-	expect(registry.authStorage.set).not.toHaveBeenCalled()
-	expect(registry.authStorage.remove).not.toHaveBeenCalled()
+	expect(piAuthModule.syncPiAuth).not.toHaveBeenCalled()
 	expect(registry.refresh).not.toHaveBeenCalled()
 	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
 
-it("rolls back every Kimchi provider credential when registry refresh rejects", async () => {
-	const previousRootCredential = { type: "api_key", key: "previous-root-key" }
-	const previousSubProviderCredential = { type: "api_key", key: "previous-sub-provider-key" }
+it("keeps the validated API key persisted when registry refresh rejects", async () => {
 	const registry = makeFakeModelRegistry()
 	registry.getAll.mockReturnValue([{ id: "kimi-k2.6", provider: "kimchi-dev/castai" }])
-	registry.authStorage.get.mockImplementation((providerId: string) =>
-		providerId === "kimchi-dev" ? previousRootCredential : previousSubProviderCredential,
-	)
 	registry.refresh.mockRejectedValue(new Error("registry refresh failed"))
 
 	const fakeIm = makeFakeInteractiveMode(registry)
@@ -438,27 +444,22 @@ it("rolls back every Kimchi provider credential when registry refresh rejects", 
 	await waitForMockCall(fakeIm.showError)
 
 	expect(fakeIm.showError).toHaveBeenCalledWith(
-		"Kimchi model refresh failed: registry refresh failed. No changes were saved.",
+		"Kimchi model refresh failed: registry refresh failed. Your API key was saved; wait a moment and try again.",
 	)
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(1, "kimchi-dev", {
-		type: "api_key",
-		key: "api-key-123",
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-123",
+	)
+	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-123", undefined, {
+		llmEndpoint: "https://llm.kimchi.dev",
 	})
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(2, "kimchi-dev/castai", {
-		type: "api_key",
-		key: "api-key-123",
-	})
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(3, "kimchi-dev", previousRootCredential)
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(4, "kimchi-dev/castai", previousSubProviderCredential)
-	expect(configModule.writeApiKey).not.toHaveBeenCalled()
 })
 
-it("rolls back API-key auth when fresh discovery succeeds but no Kimchi models become available", async () => {
+it("keeps the validated API key persisted when no Kimchi models become available", async () => {
 	vi.stubEnv("KIMCHI_CODING_AGENT_DIR", "/tmp/kimchi-api-login-test")
 
-	const previousCredential = { type: "api_key", key: "previous-key" }
 	const registry = makeFakeModelRegistry()
-	registry.authStorage.get.mockReturnValue(previousCredential)
 	registry.getAvailable.mockReturnValue([{ id: "gpt-4", provider: "openai" }])
 
 	const fakeIm = makeFakeInteractiveMode(registry)
@@ -471,14 +472,16 @@ it("rolls back API-key auth when fresh discovery succeeds but no Kimchi models b
 	await waitForMockCall(fakeIm.showError)
 
 	expect(fakeIm.showError).toHaveBeenCalledWith(
-		"Kimchi API-key login found no available Kimchi models. No changes were saved.",
+		"Kimchi login did not configure any available models. Your API key was saved; try again.",
 	)
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(1, "kimchi-dev", {
-		type: "api_key",
-		key: "api-key-123",
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"api-key-123",
+	)
+	expect(configModule.writeApiKey).toHaveBeenCalledWith("api-key-123", undefined, {
+		llmEndpoint: "https://llm.kimchi.dev",
 	})
-	expect(registry.authStorage.set).toHaveBeenNthCalledWith(2, "kimchi-dev", previousCredential)
-	expect(configModule.writeApiKey).not.toHaveBeenCalled()
 	expect(fakeIm.session.setModel).not.toHaveBeenCalled()
 })
 
@@ -640,24 +643,82 @@ it("does not crash when registry.getAvailable throws after subscription login", 
 	syncSpy.mockRestore()
 })
 
-it("passes through to original showOAuthSelector for 'logout' mode", async () => {
-	// Stub oauthDelegate.original so the logout delegation path is exercised
-	// without calling into the real upstream implementation (which requires a
-	// fully constructed InteractiveMode with private methods).
+it("clears every persisted Kimchi credential from the running session on logout", async () => {
+	const registry = makeFakeModelRegistry()
+	registry.getAll.mockReturnValue([
+		{ id: "sol", provider: "kimchi-dev" },
+		{ id: "claude", provider: "kimchi-dev/anthropic" },
+	])
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.getLogoutProviderOptions.mockResolvedValue([
+		{ id: "kimchi-dev", name: "Kimchi", authType: "api_key", status: { configured: true } },
+	])
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "logout")
+	fakeIm.selectorComponent.handleInput("\n")
+	await waitForMockCall(fakeIm.showStatus)
+
+	expect(configModule.clearApiKey).toHaveBeenCalledOnce()
+	expect(piAuthModule.syncPiAuth).toHaveBeenCalledWith(
+		"/tmp/kimchi-api-login-test/auth.json",
+		"/tmp/kimchi-api-login-test/models.json",
+		"",
+	)
+	expect(registry.refresh).toHaveBeenCalledOnce()
+	expect(registry.logout).not.toHaveBeenCalled()
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("Logged out of Kimchi")
+})
+
+it("preserves upstream logout behavior for non-Kimchi providers", async () => {
+	const registry = makeFakeModelRegistry()
+	const fakeIm = makeFakeInteractiveMode(registry)
+	fakeIm.getLogoutProviderOptions.mockResolvedValue([
+		{ id: "openai-codex", name: "OpenAI Codex", authType: "oauth", status: { configured: true } },
+	])
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "logout")
+	fakeIm.selectorComponent.handleInput("\n")
+	await waitForMockCall(registry.logout)
+
+	expect(registry.logout).toHaveBeenCalledWith("openai-codex", { signal: expect.any(AbortSignal) })
+	expect(configModule.clearApiKey).not.toHaveBeenCalled()
+	expect(piAuthModule.syncPiAuth).not.toHaveBeenCalled()
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("Logged out of OpenAI Codex")
+})
+
+it("delegates logout to upstream when required selector internals are unavailable", async () => {
 	const stub = vi.fn().mockResolvedValue(undefined)
 	const saved = oauthDelegate.original
 	oauthDelegate.original = stub
 
 	try {
 		const fakeIm = makeFakeInteractiveMode(makeFakeModelRegistry())
+		fakeIm.showSelector = undefined
+
 		// biome-ignore lint/suspicious/noExplicitAny: not present in public type
 		const patched = (InteractiveMode.prototype as any).showOAuthSelector
 		await patched.call(fakeIm, "logout")
+
 		expect(stub).toHaveBeenCalledOnce()
 		expect(stub).toHaveBeenCalledWith("logout")
 	} finally {
 		oauthDelegate.original = saved
 	}
+})
+
+it("reports when there are no stored credentials to remove", async () => {
+	const fakeIm = makeFakeInteractiveMode(makeFakeModelRegistry())
+
+	// biome-ignore lint/suspicious/noExplicitAny: not present in public type
+	const patched = (InteractiveMode.prototype as any).showOAuthSelector
+	await patched.call(fakeIm, "logout")
+
+	expect(fakeIm.showStatus).toHaveBeenCalledWith("No stored credentials to remove.")
+	expect(fakeIm.showSelector).not.toHaveBeenCalled()
 })
 
 it("suppresses stale startup no-model warning after startup auth selected a model", () => {

--- a/src/login-command-patch.ts
+++ b/src/login-command-patch.ts
@@ -7,12 +7,15 @@
  */
 
 import {
+	CredentialSynchronizationError,
 	InteractiveMode,
 	ModelRegistry,
 	type ModelRuntime,
 	OAuthSelectorComponent,
 } from "@earendil-works/pi-coding-agent"
 import { Spacer, Text } from "@earendil-works/pi-tui"
+import { clearApiKey } from "./config.js"
+import { refreshBillingStatusFromConfig } from "./extensions/billing/status.js"
 import {
 	createLoginChoiceSelector,
 	formatBrowserLoginMessage,
@@ -22,45 +25,27 @@ import {
 	performKimchiApiKeyLogin,
 	performKimchiBrowserLogin,
 	prePopulateSubscriptionModels,
+	syncKimchiAuth,
 } from "./extensions/login/flow.js"
 
 // ---------------------------------------------------------------------------
 // Intercept the upstream login flow to add the Kimchi browser auth choice
 // ---------------------------------------------------------------------------
 
-interface AuthStorage {
-	set(provider: string, credential: unknown): void
-	get(provider: string): unknown
-}
-
 interface ModelLike {
 	id: string
 	provider: string
 }
 
-/** Shape the login patch expects from `session.modelRuntime`. At runtime this is a
- * `ModelRuntime`; the patch wraps it in a `ModelRegistry` before passing it to the
- * flow functions that call `getAll()`. The local interface mirrors the subset of
- * `ModelRuntime` that the patch code accesses directly (e.g. `authStorage`). */
-interface SessionModelRuntime extends ModelRuntime {
-	authStorage: AuthStorage
-}
-
 interface SessionLike {
-	modelRuntime: SessionModelRuntime
+	modelRuntime: ModelRuntime
 	setModel(model: ModelLike): Promise<void>
 }
 
 /** Wraps `session.modelRuntime` (a `ModelRuntime`) in a `ModelRegistry` so the login
- * flow can call `getAll()`. `ModelRegistry` delegates `getAll`→`getModels` and
- * `getAvailable`→`getAvailableSnapshot`, but does not expose `authStorage`; copy it
- * from the runtime when present so the flow's credential-storage path still works. */
-function asLoginRegistry(runtime: SessionModelRuntime): ModelRegistry {
-	const registry = new ModelRegistry(runtime)
-	if (runtime.authStorage) {
-		;(registry as { authStorage?: AuthStorage }).authStorage = runtime.authStorage
-	}
-	return registry
+ * flow can use the public extension-facing registry API. */
+function asLoginRegistry(runtime: ModelRuntime): ModelRegistry {
+	return new ModelRegistry(runtime)
 }
 
 type ChatContainerLike = {
@@ -81,6 +66,8 @@ type LoginModeLike = {
 	showLoginDialog?: (providerId: string, providerName: string) => Promise<void>
 	showExtensionInput?: (title: string, placeholder?: string) => Promise<string | undefined>
 	getLoginProviderOptions?: (authType: "oauth" | "api_key") => AuthSelectorProvider[]
+	getLogoutProviderOptions?: () => Promise<AuthSelectorProvider[]>
+	updateAvailableProviderCount?: () => Promise<void>
 	session: SessionLike
 	ui?: UiLike
 }
@@ -316,7 +303,72 @@ async function patchedShowOAuthSelector(this: InteractiveMode, mode: "login" | "
 		showLoginChoiceSelector(this)
 		return
 	}
-	return oauthDelegate.original.call(this, mode)
+	return showLogoutSelector(this)
+}
+
+async function showLogoutSelector(im: InteractiveMode): Promise<void> {
+	const modeLike = im as unknown as LoginModeLike
+	if (!modeLike.showSelector || !modeLike.getLogoutProviderOptions || !modeLike.session?.modelRuntime) {
+		await oauthDelegate.original.call(im, "logout")
+		return
+	}
+
+	let providerOptions: AuthSelectorProvider[]
+	try {
+		providerOptions = await modeLike.getLogoutProviderOptions()
+	} catch (error) {
+		im.showError(`Could not read stored credentials: ${error instanceof Error ? error.message : String(error)}`)
+		return
+	}
+	if (providerOptions.length === 0) {
+		modeLike.showStatus?.("No stored credentials to remove.")
+		return
+	}
+
+	modeLike.showSelector((done) => {
+		const selector = new OAuthSelectorComponent(
+			"logout",
+			providerOptions,
+			async (providerId) => {
+				done()
+				const providerOption = providerOptions.find((provider) => provider.id === providerId)
+				if (!providerOption) return
+
+				try {
+					if (isKimchiProvider(providerOption.id)) {
+						clearApiKey()
+						await syncKimchiAuth(asLoginRegistry(modeLike.session.modelRuntime), "")
+						void refreshBillingStatusFromConfig({ mode: "forced" })
+						await modeLike.updateAvailableProviderCount?.()
+						modeLike.showStatus?.("Logged out of Kimchi")
+						return
+					}
+
+					await modeLike.session.modelRuntime.logout(providerOption.id, {
+						signal: AbortSignal.timeout(15_000),
+					})
+					await modeLike.updateAvailableProviderCount?.()
+					const message =
+						providerOption.authType === "oauth"
+							? `Logged out of ${providerOption.name}`
+							: `Removed stored API key for ${providerOption.name}. Environment variables and models.json config are unchanged.`
+					modeLike.showStatus?.(message)
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error)
+					im.showError(
+						error instanceof CredentialSynchronizationError
+							? `Credentials removed for ${providerOption.name}, but local model state could not be synchronized: ${message}`
+							: `Logout failed: ${message}`,
+					)
+				}
+			},
+			() => {
+				done()
+				modeLike.ui?.requestRender()
+			},
+		)
+		return { component: selector, focus: selector }
+	})
 }
 
 async function patchedHandleLoginCommand(this: InteractiveMode, providerRef?: string) {

--- a/src/pi-auth.test.ts
+++ b/src/pi-auth.test.ts
@@ -36,6 +36,17 @@ function provider(models: ReturnType<typeof model>[]) {
 }
 
 describe("syncPiAuth", () => {
+	it("reports the missing models configuration when storing a Kimchi key", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-"))
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+		const modelsPath = join(dir, "models.json")
+
+		await expect(syncPiAuth(authPath, modelsPath, "kimchi-key")).rejects.toThrow(
+			`Models configuration is missing at ${modelsPath}`,
+		)
+	})
+
 	it("creates Pi auth storage on first run", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-"))
 		tempDirs.push(dir)

--- a/src/pi-auth.test.ts
+++ b/src/pi-auth.test.ts
@@ -172,4 +172,43 @@ describe("syncPiAuth", () => {
 			new Set(["kimchi-dev", "kimchi-dev/new-provider"]),
 		)
 	})
+
+	it("rejects when a --api-key runtime override prevents Kimchi from activating the synchronized credential", async () => {
+		vi.stubEnv("KIMCHI_DISABLE_BUILTIN_PROVIDERS", "1")
+		vi.stubEnv("KIMCHI_API_KEY", undefined)
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-stale-runtime-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", dir)
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+		const modelsPath = join(dir, "models.json")
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				"kimchi-dev": { type: "api_key", key: "old-account-token" },
+			}),
+		)
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: { "kimchi-dev": provider([model("kimchi-model")]) },
+			}),
+		)
+
+		const runtime = await ModelRuntime.create({
+			authPath,
+			modelsPath,
+			allowModelNetwork: false,
+			refreshOnCreate: false,
+		})
+		const registry = new ModelRegistry(runtime)
+		await runtime.setRuntimeApiKey("kimchi-dev", "stale-runtime-token")
+
+		await expect(syncKimchiAuth(registry, "new-account-token")).rejects.toThrow(
+			"Kimchi did not activate the updated credentials for: kimchi-dev",
+		)
+		expect(JSON.parse(readFileSync(authPath, "utf-8"))).toMatchObject({
+			"kimchi-dev": { type: "api_key", key: "new-account-token" },
+		})
+		expect(await registry.getApiKeyForProvider("kimchi-dev")).toBe("stale-runtime-token")
+	})
 })

--- a/src/pi-auth.test.ts
+++ b/src/pi-auth.test.ts
@@ -1,14 +1,39 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, describe, expect, it } from "vitest"
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { syncKimchiAuth } from "./extensions/login/flow.js"
 import { syncPiAuth } from "./pi-auth.js"
 
 const tempDirs: string[] = []
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+	vi.unstubAllEnvs()
 })
+
+function model(id: string) {
+	return {
+		id,
+		name: id,
+		reasoning: false,
+		input: ["text"],
+		contextWindow: 1000,
+		maxTokens: 100,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	}
+}
+
+function provider(models: ReturnType<typeof model>[]) {
+	return {
+		baseUrl: "https://example.invalid/openai/v1",
+		apiKey: "$KIMCHI_API_KEY",
+		api: "openai-completions",
+		authHeader: true,
+		models,
+	}
+}
 
 describe("syncPiAuth", () => {
 	it("creates Pi auth storage on first run", async () => {
@@ -76,5 +101,75 @@ describe("syncPiAuth", () => {
 		expect(JSON.parse(readFileSync(authPath, "utf-8"))).toEqual({
 			ollama: { type: "api_key", key: "keep" },
 		})
+	})
+
+	it("does not rewrite auth storage when Kimchi credentials are unchanged", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-"))
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+		const modelsPath = join(dir, "models.json")
+		const originalAuth = JSON.stringify({
+			anthropic: { type: "api_key", key: "keep-me" },
+			"kimchi-dev": { type: "api_key", key: "kimchi-key" },
+		})
+		writeFileSync(authPath, originalAuth)
+		writeFileSync(modelsPath, JSON.stringify({ providers: { "kimchi-dev": {} } }))
+		const fixedTime = new Date("2000-01-01T00:00:00.000Z")
+		utimesSync(authPath, fixedTime, fixedTime)
+		const originalMtime = statSync(authPath).mtimeMs
+
+		await syncPiAuth(authPath, modelsPath, "kimchi-key")
+
+		expect(readFileSync(authPath, "utf-8")).toBe(originalAuth)
+		expect(statSync(authPath).mtimeMs).toBe(originalMtime)
+		expect(statSync(authPath).mode & 0o777).toBe(0o600)
+	})
+
+	it("switches the active key in the same Pi runtime, including newly discovered sub-providers", async () => {
+		vi.stubEnv("KIMCHI_DISABLE_BUILTIN_PROVIDERS", "1")
+		vi.stubEnv("KIMCHI_API_KEY", undefined)
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-runtime-"))
+		vi.stubEnv("KIMCHI_CODING_AGENT_DIR", dir)
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+		const modelsPath = join(dir, "models.json")
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				"kimchi-dev": { type: "api_key", key: "old-account-token" },
+			}),
+		)
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: { "kimchi-dev": provider([model("old-model")]) },
+			}),
+		)
+
+		const runtime = await ModelRuntime.create({
+			authPath,
+			modelsPath,
+			allowModelNetwork: false,
+			refreshOnCreate: false,
+		})
+		const registry = new ModelRegistry(runtime)
+		expect(await registry.getApiKeyForProvider("kimchi-dev")).toBe("old-account-token")
+
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-dev": provider([model("new-root-model")]),
+					"kimchi-dev/new-provider": provider([model("new-sub-provider-model")]),
+				},
+			}),
+		)
+		await syncKimchiAuth(registry, "new-account-token")
+
+		expect(await registry.getApiKeyForProvider("kimchi-dev")).toBe("new-account-token")
+		expect(await registry.getApiKeyForProvider("kimchi-dev/new-provider")).toBe("new-account-token")
+		expect(new Set(registry.getAll().map(({ provider }) => provider))).toEqual(
+			new Set(["kimchi-dev", "kimchi-dev/new-provider"]),
+		)
 	})
 })

--- a/src/pi-auth.ts
+++ b/src/pi-auth.ts
@@ -28,6 +28,9 @@ export async function syncPiAuth(authPath: string, modelsPath: string, apiKey: s
 		}
 
 		if (apiKey) {
+			if (!existsSync(modelsPath)) {
+				throw new Error(`Models configuration is missing at ${modelsPath}`)
+			}
 			const models = JSON.parse(readFileSync(modelsPath, "utf-8")) as {
 				providers?: Record<string, unknown>
 			}

--- a/src/pi-auth.ts
+++ b/src/pi-auth.ts
@@ -1,5 +1,6 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { isDeepStrictEqual } from "node:util"
 import { lock } from "proper-lockfile"
 
 const KIMCHI_PROVIDER = "kimchi-dev"
@@ -17,11 +18,13 @@ export async function syncPiAuth(authPath: string, modelsPath: string, apiKey: s
 	mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 })
 	const release = await lock(authPath, { realpath: false, retries: 10 })
 	try {
-		if (!apiKey && !existsSync(authPath)) return
-		if (!existsSync(authPath)) writeFileSync(authPath, "{}\n", { encoding: "utf-8", mode: 0o600 })
-		const credentials = JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>
-		for (const providerId of Object.keys(credentials)) {
-			if (isKimchiProvider(providerId)) delete credentials[providerId]
+		const authExists = existsSync(authPath)
+		if (!apiKey && !authExists) return
+
+		const credentials = authExists ? (JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>) : {}
+		const nextCredentials = { ...credentials }
+		for (const providerId of Object.keys(nextCredentials)) {
+			if (isKimchiProvider(providerId)) delete nextCredentials[providerId]
 		}
 
 		if (apiKey) {
@@ -29,11 +32,16 @@ export async function syncPiAuth(authPath: string, modelsPath: string, apiKey: s
 				providers?: Record<string, unknown>
 			}
 			for (const providerId of Object.keys(models.providers ?? {}).filter(isKimchiProvider)) {
-				credentials[providerId] = { type: "api_key", key: apiKey }
+				nextCredentials[providerId] = { type: "api_key", key: apiKey }
 			}
 		}
 
-		writeFileSync(authPath, `${JSON.stringify(credentials, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 })
+		if (authExists && isDeepStrictEqual(credentials, nextCredentials)) {
+			chmodSync(authPath, 0o600)
+			return
+		}
+
+		writeFileSync(authPath, `${JSON.stringify(nextCredentials, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 })
 		chmodSync(authPath, 0o600)
 	} finally {
 		await release()


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Running /login in an active session and signing in with a different Kimchi account reported success, but the session kept using the previous account's credential until restart. The login flow expected a non-existent authStorage on the Pi 0.84.1 ModelRuntime and fell back to registerProvider(), which does not override the stale Kimchi credential already stored in auth.json.

Replace the dead authStorage path with syncKimchiAuth(): reuse the startup syncPiAuth() reconciliation to rewrite Kimchi credentials in auth.json, refresh the running ModelRegistry (Pi's AuthStorage picks up the file revision change), and verify via getApiKeyForProvider() that every Kimchi provider - root plus models.json sub-providers - resolves the new key, throwing when it does not.

- pi-auth: skip the auth.json rewrite (and forced AuthStorage reload) when Kimchi credentials are unchanged, preserving mtime; keep the 0o600 permission heal on the skip path
- flow: drop the setKimchiAuthToken/restoreKimchiAuth rollback; persist config.json before syncing auth.json (startup sync repairs a crash-window mismatch) and report "key saved; try again" on failure
- login-command-patch: handle /login logout for Kimchi providers by clearing config.json and stripping Kimchi entries from auth.json in the running session; non-Kimchi providers delegate to ModelRuntime.logout(); fall back to the upstream selector when the required internals are unavailable
- login extension: remove session_start credential seeding and the authStorage.logout monkey-patch, both superseded by syncKimchiAuth
- startup-auth: hasUsableAuth requires the sync to succeed, so a transient sync failure surfaces the login gate instead of a broken session

Regression coverage includes a real ModelRuntime integration test that reproduces the bug report exactly: old-account-token -> syncKimchiAuth -> new-account-token resolves in the same runtime, including a newly discovered sub-provider.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
