### PR TITLE
fix(mcp): resolveProbeName treats missing serverUrl as match

### DIFF
--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -712,4 +712,25 @@ describe("kimchi mcp probe", () => {
 			error: null,
 		})
 	})
+
+	it("uses the real name and does not clean up when the entry is from an incomplete OAuth flow", async () => {
+		// An OAuth flow that was started but never finished leaves an entry
+		// with only oauthState/codeVerifier — no serverUrl. Treating it as a
+		// URL mismatch would probe under a throwaway name whose OAuth tokens
+		// the finally block then deletes, leaving every subsequent probe with
+		// needsAuth: true. The real name must be reused so the flow can
+		// complete on the correct entry.
+		mockGetAuthEntry.mockReturnValue({ oauthState: "state-123" })
+		mockSupportsOAuth.mockReturnValue(true)
+		mockProbeTools.mockResolvedValue({ tools: [{ name: "secure_tool" }], needsAuth: false })
+
+		mockStdin(probeInput(OAUTH_SERVER))
+		const out = captureStdout()
+
+		const code = await runMcp(["probe", "--json"])
+		expect(code).toBe(0)
+		expect(out.json.error).toBeNull()
+		expect(mockProbeTools).toHaveBeenCalledWith(SERVER_NAME, OAUTH_SERVER)
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
 })

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -11,9 +11,10 @@
  * name for a *different* URL (e.g. the user edited the URL but kept the
  * name). If so, it probes under a throwaway `__probe_<uuid>` name and
  * cleans it up afterwards so the real server's stored tokens are never
- * overwritten. If no entry exists or the URL matches, the real name is used
- * so a repeat probe of an already-authorized server finds stored OAuth
- * tokens and skips the browser flow.
+ * overwritten. If no entry exists, the URL matches, or the entry is
+ * residue from an incomplete OAuth flow (no serverUrl), the real name is
+ * used — so a repeat probe of an already-authorized server finds stored
+ * OAuth tokens and an interrupted flow completes on the correct entry.
  *
  * Used by Kimchi Desktop's MCP server configuration UI to populate a
  * multiselect dropdown of available tools when the user picks
@@ -198,13 +199,22 @@ async function runProbe(args: string[]): Promise<number> {
  *
  * When no entry exists (new server) or the URL matches (repeat probe of an
  * authorized server), the real name is used so that stored tokens are found
- * and OAuth is skipped on repeat probes.
+ * and OAuth is skipped on repeat probes. An entry without a serverUrl is
+ * residue from an incomplete OAuth flow (only oauthState/codeVerifier were
+ * saved) — the real name is used so the flow can complete and save its
+ * tokens to the correct entry.
  */
 function resolveProbeName(name: string, definition: ServerEntry): string {
 	const existing = getAuthEntry(name)
 	// No stored entry: new server — use the real name so the first probe
 	// persists tokens under it and a repeat probe finds them.
 	if (!existing) return name
+	// No stored serverUrl: the entry is residue from an incomplete OAuth
+	// flow (only oauthState/codeVerifier were saved, no tokens). Use the
+	// real name so the flow can complete and save tokens to the correct
+	// entry — a throwaway name's tokens would be deleted by the finally
+	// cleanup, leaving every subsequent probe with needsAuth: true.
+	if (!existing.serverUrl) return name
 	// URL matches: repeat probe of an authorized server — reuse the name so
 	// stored tokens are found and the browser flow is skipped.
 	if (existing.serverUrl === definition.url) return name

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -26,11 +26,11 @@
  * Exit:   0 on success (including needs-auth), 1 on error
  */
 
-import { randomUUID } from "node:crypto"
 import { Type } from "typebox"
 import { Value } from "typebox/value"
-import { getAuthEntry, removeAuthEntry } from "../extensions/mcp-adapter/mcp-auth.js"
+import { removeAuthEntry } from "../extensions/mcp-adapter/mcp-auth.js"
 import { authenticate, supportsOAuth } from "../extensions/mcp-adapter/mcp-auth-flow.js"
+import { resolveProbeName } from "../extensions/mcp-adapter/resolve-probe-name.js"
 import { McpServerManager } from "../extensions/mcp-adapter/server-manager.js"
 import type { McpTool, ServerEntry } from "../extensions/mcp-adapter/types.js"
 
@@ -185,42 +185,6 @@ async function runProbe(args: string[]): Promise<number> {
 			removeAuthEntry(probeName)
 		}
 	}
-}
-
-/**
- * Decide which name to use as the OAuth token-store key during a probe.
- *
- * The token store is keyed by server name. If an auth entry already exists
- * under `name` for a *different* URL — e.g. the user edited the server's URL
- * but kept the name — probing with the real name would overwrite the real
- * server's stored credentials. To avoid that, fall back to a throwaway
- * `__probe_<uuid>` name whenever the stored URL does not match the probe's
- * URL; the caller cleans it up with {@link removeAuthEntry} in its `finally`.
- *
- * When no entry exists (new server) or the URL matches (repeat probe of an
- * authorized server), the real name is used so that stored tokens are found
- * and OAuth is skipped on repeat probes. An entry without a serverUrl is
- * residue from an incomplete OAuth flow (only oauthState/codeVerifier were
- * saved) — the real name is used so the flow can complete and save its
- * tokens to the correct entry.
- */
-function resolveProbeName(name: string, definition: ServerEntry): string {
-	const existing = getAuthEntry(name)
-	// No stored entry: new server — use the real name so the first probe
-	// persists tokens under it and a repeat probe finds them.
-	if (!existing) return name
-	// No stored serverUrl: the entry is residue from an incomplete OAuth
-	// flow (only oauthState/codeVerifier were saved, no tokens). Use the
-	// real name so the flow can complete and save tokens to the correct
-	// entry — a throwaway name's tokens would be deleted by the finally
-	// cleanup, leaving every subsequent probe with needsAuth: true.
-	if (!existing.serverUrl) return name
-	// URL matches: repeat probe of an authorized server — reuse the name so
-	// stored tokens are found and the browser flow is skipped.
-	if (existing.serverUrl === definition.url) return name
-	// Entry exists for a different URL — isolate the probe's credentials under
-	// a throwaway name so the real server's tokens are never overwritten.
-	return `__probe_${randomUUID()}`
 }
 
 function readStdin(): Promise<string> {

--- a/src/extensions/mcp-adapter/resolve-probe-name.test.ts
+++ b/src/extensions/mcp-adapter/resolve-probe-name.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockGetAuthEntry = vi.fn()
+
+vi.mock("./mcp-auth.js", () => ({
+	getAuthEntry: (...args: unknown[]) => mockGetAuthEntry(...args),
+}))
+
+import { resolveProbeName } from "./resolve-probe-name.js"
+
+const URL_SERVER = { url: "https://example.com/mcp" }
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe("resolveProbeName", () => {
+	it("uses the real name when no auth entry exists (new server)", () => {
+		mockGetAuthEntry.mockReturnValue(undefined)
+
+		expect(resolveProbeName("my-server", URL_SERVER)).toBe("my-server")
+		expect(mockGetAuthEntry).toHaveBeenCalledWith("my-server")
+	})
+
+	it("uses the real name when the entry is residue from an incomplete OAuth flow (no serverUrl)", () => {
+		// Only oauthState/codeVerifier were saved — no tokens, no serverUrl.
+		// The real name must be reused so the flow can complete and save
+		// tokens to the correct entry.
+		mockGetAuthEntry.mockReturnValue({ oauthState: "state-123", codeVerifier: "verifier-456" })
+
+		expect(resolveProbeName("my-server", URL_SERVER)).toBe("my-server")
+	})
+
+	it("uses the real name when the stored URL matches (repeat probe)", () => {
+		mockGetAuthEntry.mockReturnValue({ serverUrl: URL_SERVER.url, tokens: { accessToken: "tok" } })
+
+		expect(resolveProbeName("my-server", URL_SERVER)).toBe("my-server")
+	})
+
+	it("uses a throwaway name when the stored URL differs (server URL edited)", () => {
+		mockGetAuthEntry.mockReturnValue({ serverUrl: "https://old.example.com/mcp" })
+
+		const probeName = resolveProbeName("my-server", URL_SERVER)
+
+		expect(probeName).toMatch(/^__probe_[0-9a-f-]{36}$/)
+		expect(probeName).not.toBe("my-server")
+	})
+})

--- a/src/extensions/mcp-adapter/resolve-probe-name.ts
+++ b/src/extensions/mcp-adapter/resolve-probe-name.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from "node:crypto"
+import { getAuthEntry } from "./mcp-auth.js"
+import type { ServerEntry } from "./types.js"
+
+/**
+ * Decide which name to use as the OAuth token-store key during a probe.
+ *
+ * The token store is keyed by server name. If an auth entry already exists
+ * under `name` for a *different* URL — e.g. the user edited the server's
+ * URL but kept the name — probing with the real name would overwrite the
+ * real server's stored credentials. To avoid that, fall back to a
+ * throwaway `__probe_<uuid>` name; the caller cleans it up with
+ * removeAuthEntry() in its finally block, so the real server's tokens are
+ * never overwritten and the store never accumulates `__probe_*` entries.
+ *
+ * The real name is used in every other case:
+ * - No stored entry: new server. The first probe persists tokens under
+ *   the real name so a repeat probe finds them.
+ * - Stored entry without a serverUrl: residue from an incomplete OAuth
+ *   flow (only oauthState/codeVerifier were saved, no tokens). The real
+ *   name lets the flow complete and save its tokens to the correct entry —
+ *   a throwaway's tokens would be deleted by the caller's finally cleanup,
+ *   looping every subsequent probe on needsAuth.
+ * - Stored URL matches: repeat probe of an authorized server. Stored
+ *   tokens are found and the browser flow is skipped.
+ */
+export function resolveProbeName(name: string, definition: ServerEntry): string {
+	const existing = getAuthEntry(name)
+	// No stored entry: new server — use the real name so the first probe
+	// persists tokens under it and a repeat probe finds them.
+	if (!existing) return name
+	// No stored serverUrl: the entry is residue from an incomplete OAuth
+	// flow (only oauthState/codeVerifier were saved, no tokens). Use the
+	// real name so the flow can complete and save tokens to the correct
+	// entry — a throwaway name's tokens would be deleted by the caller's
+	// finally cleanup, leaving every subsequent probe with needsAuth: true.
+	if (!existing.serverUrl) return name
+	// URL matches: repeat probe of an authorized server — reuse the name so
+	// stored tokens are found and the browser flow is skipped.
+	if (existing.serverUrl === definition.url) return name
+	// Entry exists for a different URL — isolate the probe's credentials
+	// under a throwaway name so the real server's tokens are never
+	// overwritten.
+	return `__probe_${randomUUID()}`
+}

--- a/src/modes/acp/ext-methods/mcp.test.ts
+++ b/src/modes/acp/ext-methods/mcp.test.ts
@@ -270,6 +270,21 @@ describe("handleProbeMcpServer", () => {
 		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
 	})
 
+	it("uses the real serverName when the auth entry is from an incomplete OAuth flow", async () => {
+		const manager = makeManager()
+		mockSupportsOAuth.mockReturnValue(false)
+		mockProbeTools.mockResolvedValue({ tools: [], needsAuth: false, error: null })
+		// Incomplete OAuth flow residue: only oauthState/codeVerifier were
+		// saved — no serverUrl. The real name must be reused so the flow can
+		// complete and save tokens to the correct entry.
+		mockGetAuthEntry.mockReturnValue({ oauthState: "state-123", codeVerifier: "verifier-456" })
+
+		await handleProbeMcpServer(manager, { server: urlServer, serverName: "my-server" })
+
+		expect(mockProbeTools).toHaveBeenCalledWith("my-server", urlServer)
+		expect(mockRemoveAuthEntry).not.toHaveBeenCalled()
+	})
+
 	it("cleans up throwaway auth entries even when probeTools throws", async () => {
 		const manager = makeManager()
 		mockSupportsOAuth.mockReturnValue(false)

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -5,10 +5,10 @@
 // the dependencies it needs (manager, params) and returns a plain record
 // suitable for the ACP wire.
 
-import { randomUUID } from "node:crypto"
 import { RequestError } from "@agentclientprotocol/sdk"
-import { getAuthEntry, removeAuthEntry } from "../../../extensions/mcp-adapter/mcp-auth.js"
+import { removeAuthEntry } from "../../../extensions/mcp-adapter/mcp-auth.js"
 import { authenticate, getAuthStatus, supportsOAuth } from "../../../extensions/mcp-adapter/mcp-auth-flow.js"
+import { resolveProbeName } from "../../../extensions/mcp-adapter/resolve-probe-name.js"
 import type { McpServerManager } from "../../../extensions/mcp-adapter/server-manager.js"
 import type { ProbeResult, ServerEntry } from "../../../extensions/mcp-adapter/types.js"
 
@@ -140,28 +140,4 @@ export async function handleProbeMcpServer(
 			removeAuthEntry(probeName)
 		}
 	}
-}
-
-/**
- * Decide which name to use as the OAuth token-store key during a probe.
- *
- * If an auth entry already exists under `name` for a *different* URL —
- * e.g. the user edited the server's URL but kept the name — fall back to
- * a throwaway `__probe_*` name so the real server's tokens are never
- * overwritten. When no entry exists (new server) or the URL matches
- * (repeat probe), the real name is used so stored tokens are found.
- * An entry without a stored `serverUrl` is residue from an incomplete
- * OAuth flow (only `oauthState`/`codeVerifier` were saved) — the real
- * name is used so the flow completes and its tokens land on the correct
- * entry.
- */
-function resolveProbeName(name: string, definition: ServerEntry): string {
-	const existing = getAuthEntry(name)
-	if (!existing) return name
-	// No stored serverUrl means the entry is from an incomplete OAuth flow
-	// (only oauthState/codeVerifier were saved). Use the real name so the
-	// flow can complete and save tokens to the correct entry.
-	if (!existing.serverUrl) return name
-	if (existing.serverUrl === definition.url) return name
-	return `__probe_${randomUUID()}`
 }

--- a/src/modes/acp/ext-methods/mcp.ts
+++ b/src/modes/acp/ext-methods/mcp.ts
@@ -150,10 +150,18 @@ export async function handleProbeMcpServer(
  * a throwaway `__probe_*` name so the real server's tokens are never
  * overwritten. When no entry exists (new server) or the URL matches
  * (repeat probe), the real name is used so stored tokens are found.
+ * An entry without a stored `serverUrl` is residue from an incomplete
+ * OAuth flow (only `oauthState`/`codeVerifier` were saved) — the real
+ * name is used so the flow completes and its tokens land on the correct
+ * entry.
  */
 function resolveProbeName(name: string, definition: ServerEntry): string {
 	const existing = getAuthEntry(name)
 	if (!existing) return name
+	// No stored serverUrl means the entry is from an incomplete OAuth flow
+	// (only oauthState/codeVerifier were saved). Use the real name so the
+	// flow can complete and save tokens to the correct entry.
+	if (!existing.serverUrl) return name
 	if (existing.serverUrl === definition.url) return name
 	return `__probe_${randomUUID()}`
 }


### PR DESCRIPTION
## Problem

When an OAuth flow was started but never completed (only `oauthState` and `codeVerifier` saved, no `tokens` or `serverUrl`), `resolveProbeName` saw `existing.serverUrl` (undefined) !== `definition.url` and used a throwaway `__probe_*` name.

The OAuth flow then saved tokens under `__probe_*`, which the `finally` block deleted — so the real server name never got tokens. Every subsequent probe for that server failed with `needsAuth: true`.

## Fix

Treat a missing `serverUrl` as a match (incomplete OAuth flow) so the real server name is used and tokens are saved to the correct entry.

```diff
 function resolveProbeName(name: string, definition: ServerEntry): string {
 	const existing = getAuthEntry(name)
 	if (!existing) return name
-	if (existing.serverUrl === definition.url) return name
+	// No stored serverUrl means the entry is from an incomplete OAuth flow
+	// (only oauthState/codeVerifier were saved). Use the real name so the
+	// flow can complete and save tokens to the correct entry.
+	if (!existing.serverUrl) return name
+	if (existing.serverUrl === definition.url) return name
 	return `__probe_${randomUUID()}`
 }
```

## Testing

- All 29 existing tests pass
- Manually verified: removed stored Slack OAuth credentials, clicked Connect in Kimchi Studio → tokens saved correctly under `slack/`, Refresh works without re-authenticating

Co-Authored-By: Kimchi <noreply@kimchi.dev>