### PR TITLE
feat(teleport): autocomplete for /teleport 's flags

### DIFF
--- a/src/extensions/teleport/commands/args.test.ts
+++ b/src/extensions/teleport/commands/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { parseSyncArgs, parseTeleportArgs } from "./args.js"
+import { getTeleportArgumentCompletions, parseSyncArgs, parseTeleportArgs } from "./args.js"
 
 describe("parseTeleportArgs", () => {
 	it("returns empty when no args are passed", () => {
@@ -73,6 +73,125 @@ describe("parseTeleportArgs", () => {
 
 	it("rejects a stray --", () => {
 		expect(() => parseTeleportArgs("name --")).toThrow(/Unexpected `--`/)
+	})
+})
+
+describe("getTeleportArgumentCompletions", () => {
+	it("returns all flags for a non-dash, non-empty prefix (discoverable while typing a name)", () => {
+		const result = getTeleportArgumentCompletions("my-session")
+		expect(result).not.toBeNull()
+		expect(result).toHaveLength(8)
+		const labels = result?.map((c) => c.label)
+		expect(labels).toContain("--workspace")
+		expect(labels).toContain("--git-repo")
+		expect(labels).toContain("--skip-session")
+	})
+
+	it("returns all flags for a non-dash partial like 'task-1'", () => {
+		const result = getTeleportArgumentCompletions("task-1")
+		expect(result).not.toBeNull()
+		expect(result).toHaveLength(8)
+	})
+
+	it("returns discovery items on an empty prefix", () => {
+		const result = getTeleportArgumentCompletions("")
+		expect(result).not.toBeNull()
+		expect(result).toHaveLength(3)
+		const labels = result?.map((c) => c.label)
+		expect(labels).toEqual(["my-feature", "--allow-dirty", "--force"])
+	})
+
+	it("returns discovery items on a whitespace-only prefix", () => {
+		const result = getTeleportArgumentCompletions("   ")
+		expect(result).not.toBeNull()
+		expect(result).toHaveLength(3)
+		const labels = result?.map((c) => c.label)
+		expect(labels).toEqual(["my-feature", "--allow-dirty", "--force"])
+	})
+
+	it("returns all flags when prefix is just --", () => {
+		const result = getTeleportArgumentCompletions("--")
+		expect(result).not.toBeNull()
+		expect(result).toHaveLength(8)
+		const labels = result?.map((c) => c.label)
+		expect(labels).toContain("--allow-dirty")
+		expect(labels).toContain("--force")
+		expect(labels).toContain("--workspace")
+		expect(labels).toContain("--git-repo")
+		expect(labels).toContain("--branch")
+		expect(labels).toContain("--no-git-token")
+		expect(labels).toContain("--no-compact-hint")
+		expect(labels).toContain("--skip-session")
+	})
+
+	it("filters by --all to --allow-dirty", () => {
+		const result = getTeleportArgumentCompletions("--all")
+		expect(result).toEqual([
+			{ value: "--allow-dirty", label: "--allow-dirty", description: "Proceed with uncommitted changes" },
+		])
+	})
+
+	it("filters by --force to exactly --force", () => {
+		const result = getTeleportArgumentCompletions("--force")
+		expect(result).toEqual([
+			{ value: "--force", label: "--force", description: "Override the 5 GB workspace size limit" },
+		])
+	})
+
+	it("filters by --no to both --no-* flags", () => {
+		const result = getTeleportArgumentCompletions("--no")
+		expect(result).not.toBeNull()
+		const labels = result?.map((c) => c.label)
+		expect(labels).toContain("--no-git-token")
+		expect(labels).toContain("--no-compact-hint")
+	})
+
+	it("returns null when no flag matches", () => {
+		expect(getTeleportArgumentCompletions("--xyz")).toBeNull()
+		expect(getTeleportArgumentCompletions("--zzzz")).toBeNull()
+	})
+
+	it("is case-insensitive", () => {
+		const result = getTeleportArgumentCompletions("--FORCE")
+		expect(result).toEqual([
+			{ value: "--force", label: "--force", description: "Override the 5 GB workspace size limit" },
+		])
+	})
+
+	it("emits a trailing space for value flags", () => {
+		const result = getTeleportArgumentCompletions("--workspace")
+		expect(result).toEqual([
+			{ value: "--workspace ", label: "--workspace", description: "Reuse an existing workspace (id or name)" },
+		])
+	})
+
+	it("emits a trailing space for --git-repo", () => {
+		const result = getTeleportArgumentCompletions("--git-repo")
+		expect(result).toEqual([
+			{
+				value: "--git-repo ",
+				label: "--git-repo",
+				description: "Clone from a git URL instead of rsyncing local files",
+			},
+		])
+	})
+
+	it("emits a trailing space for --branch", () => {
+		const result = getTeleportArgumentCompletions("--branch")
+		expect(result).toEqual([
+			{ value: "--branch ", label: "--branch", description: "Branch to check out (requires --git-repo)" },
+		])
+	})
+
+	it("does not emit a trailing space for boolean flags", () => {
+		const result = getTeleportArgumentCompletions("--skip-session")
+		expect(result).toEqual([
+			{
+				value: "--skip-session",
+				label: "--skip-session",
+				description: "Start remote agent fresh without uploading session history",
+			},
+		])
 	})
 })
 

--- a/src/extensions/teleport/commands/args.ts
+++ b/src/extensions/teleport/commands/args.ts
@@ -12,8 +12,87 @@ export interface TeleportArgs {
 
 const SESSION_NAME_RE = /^[A-Za-z0-9\-_]+$/
 
-const FLAGS_WITH_VALUE = new Set(["--workspace", "--git-repo", "--branch"])
-const BOOLEAN_FLAGS = new Set(["--no-git-token", "--no-compact-hint", "--skip-session"])
+/**
+ * Single source of truth for /teleport flag metadata. The parser derives its
+ * value/boolean `Set`s from this array, and the autocomplete function reads the
+ * descriptions from it — so a new flag added here is immediately parsed and
+ * surfaced in the completion picker without touching a second location.
+ */
+export interface TeleportFlag {
+	/** Long form, e.g. "--allow-dirty". */
+	name: string
+	/** True for flags that take a value (`--workspace <id>`), false for booleans. */
+	takesValue: boolean
+	/** Short description shown in the autocomplete picker. */
+	description: string
+}
+
+export const TELEPORT_FLAGS: readonly TeleportFlag[] = [
+	{ name: "--workspace", takesValue: true, description: "Reuse an existing workspace (id or name)" },
+	{ name: "--git-repo", takesValue: true, description: "Clone from a git URL instead of rsyncing local files" },
+	{ name: "--branch", takesValue: true, description: "Branch to check out (requires --git-repo)" },
+	{ name: "--allow-dirty", takesValue: false, description: "Proceed with uncommitted changes" },
+	{ name: "--force", takesValue: false, description: "Override the 5 GB workspace size limit" },
+	{ name: "--no-git-token", takesValue: false, description: "Skip the git credentials prompt" },
+	{ name: "--no-compact-hint", takesValue: false, description: "Skip the pre-teleport compaction hint" },
+	{
+		name: "--skip-session",
+		takesValue: false,
+		description: "Start remote agent fresh without uploading session history",
+	},
+]
+
+const FLAGS_WITH_VALUE = new Set(TELEPORT_FLAGS.filter((f) => f.takesValue).map((f) => f.name))
+const BOOLEAN_FLAGS = new Set(TELEPORT_FLAGS.filter((f) => !f.takesValue).map((f) => f.name))
+
+/** Completion item returned by `getTeleportArgumentCompletions`. */
+export interface TeleportCompletion {
+	value: string
+	label: string
+	description?: string
+}
+
+/**
+ * Shown on an empty prefix (right after `/teleport `) so users immediately
+ * discover the positional session name and the two most common flags without
+ * having to type `--`. Once the user starts typing, these fall away and the
+ * standard dash-prefix flag filtering takes over.
+ */
+const TELEPORT_DISCOVERY_COMPLETIONS: readonly TeleportCompletion[] = [
+	{ value: "my-feature", label: "my-feature", description: "Sample session name (or type your own)" },
+	{ value: "--allow-dirty", label: "--allow-dirty", description: "Proceed with uncommitted changes" },
+	{ value: "--force", label: "--force", description: "Override the 5 GB workspace size limit" },
+]
+
+/**
+ * Suggest `/teleport` completions for the autocomplete picker.
+ *
+ * Three behaviors:
+ * 1. **Empty prefix** (`/teleport `) — returns only the three discovery
+ *    items (`my-feature`, `--allow-dirty`, `--force`) so users learn the most
+ *    common forms exist without being overwhelmed.
+ * 2. **Dash prefix** (`--<partial>`) — filters all 8 flags by case-insensitive
+ *    prefix. Value flags emit a trailing space so the cursor lands inside the
+ *    argument, mirroring `/ferment`'s `"switch "` / `"revise "` completions.
+ * 3. **Non-dash, non-empty** — returns all flags unfiltered so they're
+ *    discoverable while the user types a session name.
+ */
+export function getTeleportArgumentCompletions(prefix: string): TeleportCompletion[] | null {
+	const trimmed = prefix.trimStart()
+	if (trimmed === "") return [...TELEPORT_DISCOVERY_COMPLETIONS]
+
+	const allFlags: TeleportCompletion[] = TELEPORT_FLAGS.map((f) => ({
+		value: f.takesValue ? `${f.name} ` : f.name,
+		label: f.name,
+		description: f.description,
+	}))
+
+	if (!trimmed.startsWith("-")) return allFlags
+
+	const lower = trimmed.toLowerCase()
+	const matches = allFlags.filter((f) => f.label.toLowerCase().startsWith(lower))
+	return matches.length > 0 ? matches : null
+}
 
 /**
  * Parse `/teleport [name] [--workspace ID] [--git-repo URL] [--branch B]

--- a/src/extensions/teleport/index.test.ts
+++ b/src/extensions/teleport/index.test.ts
@@ -41,6 +41,19 @@ describe("teleportExtension", () => {
 		expect(pi.registerCommand).toHaveBeenCalledTimes(5)
 	})
 
+	it("registers the teleport command with flag completions and an enriched description", () => {
+		const pi = makePi()
+		teleportExtension(pi)
+		const calls = (pi.registerCommand as ReturnType<typeof vi.fn>).mock.calls
+		const teleportCall = calls.find(([name]) => name === "teleport")
+		expect(teleportCall).toBeDefined()
+		const config = teleportCall?.[1] as { description: string; getArgumentCompletions: unknown; handler: unknown }
+		expect(typeof config.getArgumentCompletions).toBe("function")
+		expect(config.description).toContain("--allow-dirty")
+		expect(config.description).toContain("--force")
+		expect(config.description).toContain("[name]")
+	})
+
 	it("registers commands on macOS", () => {
 		osTypeMock.mockReturnValue("Darwin")
 		const pi = makePi()

--- a/src/extensions/teleport/index.ts
+++ b/src/extensions/teleport/index.ts
@@ -2,6 +2,7 @@ import os from "node:os"
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
 import { isInSandboxCluster } from "../../utils/sandbox.js"
+import { getTeleportArgumentCompletions } from "./commands/args.js"
 import { TeleportRefusal } from "./commands/errors.js"
 import { runRemoteSessions } from "./commands/remote-sessions.js"
 import { runSshConfig } from "./commands/ssh-config.js"
@@ -45,7 +46,9 @@ export default function teleportExtension(pi: ExtensionAPI): void {
 		return
 	}
 	pi.registerCommand("teleport", {
-		description: "Open a kimchi PTY session in a sandbox workspace",
+		description:
+			"Teleport to a remote workspace: /teleport [name], /teleport --allow-dirty, /teleport --force, /teleport --workspace <id>, /teleport --git-repo <url> --branch <branch>",
+		getArgumentCompletions: (prefix) => getTeleportArgumentCompletions(prefix),
 		handler: makeHandler(runTeleport),
 	})
 	pi.registerCommand("terminal", {


### PR DESCRIPTION
## Summary

The `/teleport` command was registered without a `getArgumentCompletions` callback, so typing `/teleport --<partial>` showed no flag suggestions — unlike `/ferment`, `/phase`, `/tags`, and `/todos` which all register completions. Additionally, the command `description` was a bare one-liner that didn't surface available flags in the slash-command picker.

## Changes

- **`args.ts`**: Introduced `TELEPORT_FLAGS` descriptor array as the single source of truth for flag metadata (name, `takesValue`, description). The parser's existing `FLAGS_WITH_VALUE` / `BOOLEAN_FLAGS` Sets are now derived from it, keeping parsing behavior unchanged. Added `getTeleportArgumentCompletions()` with three behaviors:
  1. **Empty prefix** (`/teleport `) — returns 3 discovery items (`my-feature`, `--allow-dirty`, `--force`) so users immediately learn the most common forms exist
  2. **Dash prefix** (`--<partial>`) — filters all 8 flags by case-insensitive prefix; value flags emit a trailing space so the cursor lands inside the argument
  3. **Non-dash, non-empty** — returns all 8 flags unfiltered so they're discoverable while the user types a session name
- **`index.ts`**: Wired up `getArgumentCompletions` on the teleport command registration and enriched the `description` to enumerate key flags, mirroring `/ferment`'s style
- **Tests**: 12 new unit tests for the completion function + assertion that `getArgumentCompletions` is registered with the enriched description

## Test plan

- [x] `pnpm test -- src/extensions/teleport/commands/args.test.ts src/extensions/teleport/index.test.ts` — 49/49 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm exec biome check` — clean
- [x] Manual smoke test: `/teleport ` shows 3 discovery items; `/teleport --` shows all 8 flags; `/teleport --fo` filters to `--force`