### PR TITLE
fix(skills): contribute configured skill paths via resources_discover

### DIFF
--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -347,6 +347,20 @@ describe("prompt enrichment Claude Code skills", () => {
 		expect(result).toEqual({ skillPaths: [projectSkillPath] })
 	})
 
+	it("contributes configured absolute skill paths through resources_discover so /skill: can invoke them", async () => {
+		const cwd = join(dir, "project")
+		const configuredSkills = join(dir, "opt", "skills")
+		writeSkill(join(configuredSkills, "agent-browser", "SKILL.md"), {
+			description: "Drive a browser.",
+		})
+		const { resourcesDiscover } = buildPromptExtensionWithHandlers([configuredSkills])
+		if (!resourcesDiscover) throw new Error("resources_discover handler was not registered")
+
+		const result = resourcesDiscover({ type: "resources_discover", cwd, reason: "startup" }, undefined)
+
+		expect(result).toEqual({ skillPaths: [configuredSkills] })
+	})
+
 	it("injects Kimchi project skills without configured paths", async () => {
 		const cwd = join(dir, "project", "src")
 		writeSkill(join(dir, "project", ".kimchi", "skills", "typescript-safety", "SKILL.md"), {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -495,9 +495,15 @@ export default function (skillPaths: string[]) {
 		let cachedGitRemote: string | undefined | null = null
 
 		pi.on("resources_discover", (event) => {
-			const skillPaths = getKimchiProjectSkillPaths(event.cwd)
-			if (skillPaths.length === 0) return undefined
-			return { skillPaths }
+			// Contribute user-configured skill paths (e.g. /opt/kimchi/skills) in
+			// addition to project .kimchi/skills, so they register with pi's
+			// resource loader and become invocable via /skill:<name> — the
+			// before_agent_start system-prompt list below is a separate pipeline.
+			const discoveredSkillPaths = Array.from(
+				new Set([...getKimchiProjectSkillPaths(event.cwd), ...getConfiguredSkillResourcePaths(event.cwd, skillPaths)]),
+			)
+			if (discoveredSkillPaths.length === 0) return undefined
+			return { skillPaths: discoveredSkillPaths }
 		})
 
 		pi.on("before_agent_start", async (event, ctx) => {


### PR DESCRIPTION
Configured skillPaths (e.g. /opt/kimchi/skills) were only injected into the system-prompt skills list (before_agent_start) but never registered with pi's resource loader, so they were invisible to /skill:<name> invocation, autocomplete, and /resources. The resources_discover handler now merges getConfiguredSkillResourcePaths with .kimchi/skills project paths.

## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
