### PR TITLE
fix(mcp-adapter): serve Kimchi-branded MCP OAuth callback pages

### DIFF
--- a/src/cli-auth/callback-server.preview.test.ts
+++ b/src/cli-auth/callback-server.preview.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Manual preview of the branded OAuth callback pages shown in the browser
+ * during Kimchi-account login (the same templates pi's subscription providers,
+ * e.g. OpenAI Codex, serve via the patched pi-ai renderer).
+ *
+ * Disabled by default. Run explicitly with:
+ *
+ *   KIMCHI_SHOW_OAUTH_PAGE=1 pnpm vitest run src/cli-auth/callback-server.preview.test.ts
+ *
+ * Starts two real callback servers — one serving the success page, one the
+ * error page — and prints the URLs to open in a browser. Each server closes
+ * after its callback is visited; the test completes once the success URL has
+ * been visited (or after the 5-minute callback timeout).
+ *
+ * Note: the success page has no auto-close script, so it stays open in the
+ * browser for inspection.
+ */
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { generateState, startCallbackServer } from "./callback-server.js"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe("cli-auth OAuth callback page preview", () => {
+	it.runIf(process.env.KIMCHI_SHOW_OAUTH_PAGE === "1")(
+		"serves the branded callback pages for manual browser inspection",
+		async () => {
+			vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
+
+			const successState = generateState()
+			const errorState = generateState()
+			const success = await startCallbackServer(successState)
+			const error = await startCallbackServer(errorState)
+
+			try {
+				console.log("\n  Open in your browser to view the branded callback pages:")
+				console.log(`    success: http://127.0.0.1:${success.port}/callback?token=demo-token&state=${successState}`)
+				console.log(
+					`    error:   http://127.0.0.1:${error.port}/callback?error=access_denied&error_description=The+user+denied+the+request&state=${errorState}`,
+				)
+				console.log("  Visit the error page first — each listener closes after serving its page once.")
+				console.log("  The test completes once the success URL is visited (5-minute timeout otherwise).\n")
+
+				const result = await success.result
+				console.log(`  Received token "${result.token}" — callback flow completed.`)
+				expect(result.token).toBe("demo-token")
+			} finally {
+				error.close()
+				success.close()
+			}
+		},
+		7 * 60 * 1000,
+	)
+})

--- a/src/cli-auth/callback-server.ts
+++ b/src/cli-auth/callback-server.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto"
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
-import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js"
+import { oauthErrorHtml, oauthSuccessHtml } from "../utils/oauth-page.js"
 
 const CALLBACK_PATH = "/callback"
 const CALLBACK_TIMEOUT_MS = 300_000 // 5 minutes

--- a/src/extensions/mcp-adapter/mcp-callback-server.preview.test.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.preview.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Manual preview of the OAuth callback page shown in the browser after an MCP
+ * server (Rovo, Slack, …) redirects back to the local listener.
+ *
+ * Disabled by default. Run explicitly with:
+ *
+ *   KIMCHI_SHOW_OAUTH_PAGE=1 pnpm vitest run src/extensions/mcp-adapter/mcp-callback-server.preview.test.ts
+ *
+ * The test starts the real callback server and prints the URLs to open in a
+ * browser. It stays up until the success URL is visited (or the 5-minute
+ * callback timeout from mcp-callback-server.ts elapses).
+ */
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// Mirrors DEFAULT_OAUTH_CALLBACK_PORT in mcp-oauth-provider.ts. When the port
+// is busy the callback server scans forward, so always use the printed URL.
+const PREVIEW_PORT = 19876
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe("MCP OAuth callback page preview", () => {
+	it.runIf(process.env.KIMCHI_SHOW_OAUTH_PAGE === "1")(
+		"serves the callback page for manual browser inspection",
+		async () => {
+			vi.resetModules()
+			vi.stubEnv("MCP_OAUTH_CALLBACK_PORT", String(PREVIEW_PORT))
+			vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
+			const callbackServer = await import("./mcp-callback-server.js")
+			const { getOAuthCallbackPort, OAUTH_CALLBACK_PATH } = await import("./mcp-oauth-provider.js")
+
+			try {
+				const { callbackPromise } = await callbackServer.prepareCallback("demo-state")
+				const base = `http://127.0.0.1:${getOAuthCallbackPort()}${OAUTH_CALLBACK_PATH}`
+
+				console.log("\n  Open in your browser to view the callback pages:")
+				console.log(`    success: ${base}?code=demo-code&state=demo-state`)
+				console.log(
+				`    error:   ${base}?error=access_denied&error_description=The+user+denied+the+request&state=anything`,
+			)
+				console.log("  The server shuts down once the success URL is visited (5-minute timeout otherwise).\n")
+
+				const code = await callbackPromise
+				console.log(`  Received authorization code "${code}" — callback flow completed.`)
+				expect(code).toBe("demo-code")
+			} finally {
+				await callbackServer.stopCallbackServer()
+			}
+		},
+		6 * 60 * 1000,
+	)
+})

--- a/src/extensions/mcp-adapter/mcp-callback-server.preview.test.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.preview.test.ts
@@ -41,8 +41,8 @@ describe("MCP OAuth callback page preview", () => {
 				console.log("\n  Open in your browser to view the callback pages:")
 				console.log(`    success: ${base}?code=demo-code&state=demo-state`)
 				console.log(
-				`    error:   ${base}?error=access_denied&error_description=The+user+denied+the+request&state=anything`,
-			)
+					`    error:   ${base}?error=access_denied&error_description=The+user+denied+the+request&state=anything`,
+				)
 				console.log("  The server shuts down once the success URL is visited (5-minute timeout otherwise).\n")
 
 				const code = await callbackPromise

--- a/src/extensions/mcp-adapter/mcp-callback-server.test.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.test.ts
@@ -7,7 +7,6 @@
  * (addressed via KIMCHI_OAUTH_TEMPLATE_DIR). Without that env var the callback
  * server must fall back to a minimal *unbranded* page — never a Pi-branded one.
  */
-import { createServer } from "node:http"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -18,19 +17,25 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
 // branded template rendered rather than the unbranded fallback.
 const KIMCHI_LOGO_ORANGE = "#FF521D"
 
-async function getFreePort(): Promise<number> {
-	const server = createServer()
-	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
-	const address = server.address()
-	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
-	if (!address || typeof address === "string") throw new Error("Could not allocate a local test port")
-	return address.port
-}
-
-async function loadCallbackServerForPort(port: number) {
+/**
+ * Import the callback server and build callback URLs from the port it actually
+ * bound. No port is pre-selected: the server's own scan-forward handles busy
+ * ports, and tests always read the bound port afterwards.
+ */
+async function loadCallbackServer() {
 	vi.resetModules()
-	vi.stubEnv("MCP_OAUTH_CALLBACK_PORT", String(port))
-	return import("./mcp-callback-server.js")
+	const callbackServer = await import("./mcp-callback-server.js")
+	const oauthProvider = await import("./mcp-oauth-provider.js")
+
+	function callbackUrl(params: Record<string, string>): URL {
+		const url = new URL(oauthProvider.OAUTH_CALLBACK_PATH, `http://127.0.0.1:${oauthProvider.getOAuthCallbackPort()}`)
+		for (const [key, value] of Object.entries(params)) {
+			url.searchParams.set(key, value)
+		}
+		return url
+	}
+
+	return { callbackServer, callbackUrl }
 }
 
 afterEach(() => {
@@ -39,14 +44,13 @@ afterEach(() => {
 
 describe("MCP OAuth callback page", () => {
 	it("serves the branded authorization-success page after the provider redirects back", async () => {
-		const port = await getFreePort()
 		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
-		const callbackServer = await loadCallbackServerForPort(port)
+		const { callbackServer, callbackUrl } = await loadCallbackServer()
 
 		try {
 			const { callbackPromise } = await callbackServer.prepareCallback("state-success")
 
-			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=test-code&state=state-success`)
+			const response = await fetch(callbackUrl({ code: "test-code", state: "state-success" }))
 			const body = await response.text()
 
 			expect(response.status).toBe(200)
@@ -64,9 +68,8 @@ describe("MCP OAuth callback page", () => {
 	})
 
 	it("serves the branded authorization-failure page when the provider reports an error", async () => {
-		const port = await getFreePort()
 		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
-		const callbackServer = await loadCallbackServerForPort(port)
+		const { callbackServer, callbackUrl } = await loadCallbackServer()
 
 		try {
 			const { callbackPromise } = await callbackServer.prepareCallback("state-error")
@@ -75,7 +78,11 @@ describe("MCP OAuth callback page", () => {
 			const rejection = expect(callbackPromise).rejects.toThrow("The user denied the authorization request")
 
 			const response = await fetch(
-				`http://127.0.0.1:${port}/mcp/oauth/callback?error=access_denied&error_description=The%20user%20denied%20the%20authorization%20request&state=state-error`,
+				callbackUrl({
+					error: "access_denied",
+					error_description: "The user denied the authorization request",
+					state: "state-error",
+				}),
 			)
 			const body = await response.text()
 
@@ -94,15 +101,14 @@ describe("MCP OAuth callback page", () => {
 	})
 
 	it("rejects the pending auth when the callback has a state but no authorization code", async () => {
-		const port = await getFreePort()
-		const callbackServer = await loadCallbackServerForPort(port)
+		const { callbackServer, callbackUrl } = await loadCallbackServer()
 
 		try {
 			const { callbackPromise } = await callbackServer.prepareCallback("state-no-code")
 			// Fail fast instead of waiting for the 5-minute callback timeout.
 			const rejection = expect(callbackPromise).rejects.toThrow("No authorization code provided")
 
-			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?state=state-no-code`)
+			const response = await fetch(callbackUrl({ state: "state-no-code" }))
 			const body = await response.text()
 
 			expect(response.status).toBe(400)
@@ -114,16 +120,19 @@ describe("MCP OAuth callback page", () => {
 	})
 
 	it("HTML-escapes provider-controlled error text", async () => {
-		const port = await getFreePort()
 		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
-		const callbackServer = await loadCallbackServerForPort(port)
+		const { callbackServer, callbackUrl } = await loadCallbackServer()
 
 		try {
 			const { callbackPromise } = await callbackServer.prepareCallback("state-xss")
 			const rejection = expect(callbackPromise).rejects.toThrow("alert(1)")
 
 			const response = await fetch(
-				`http://127.0.0.1:${port}/mcp/oauth/callback?error=access_denied&error_description=%3Cscript%3Ealert(1)%3C/script%3E&state=state-xss`,
+				callbackUrl({
+					error: "access_denied",
+					error_description: "<script>alert(1)</script>",
+					state: "state-xss",
+				}),
 			)
 			const body = await response.text()
 
@@ -137,14 +146,13 @@ describe("MCP OAuth callback page", () => {
 	})
 
 	it("falls back to a minimal unbranded page when KIMCHI_OAUTH_TEMPLATE_DIR is unset", async () => {
-		const port = await getFreePort()
 		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", "")
-		const callbackServer = await loadCallbackServerForPort(port)
+		const { callbackServer, callbackUrl } = await loadCallbackServer()
 
 		try {
 			const { callbackPromise } = await callbackServer.prepareCallback("state-fallback")
 
-			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=test-code&state=state-fallback`)
+			const response = await fetch(callbackUrl({ code: "test-code", state: "state-fallback" }))
 			const body = await response.text()
 
 			expect(response.status).toBe(200)

--- a/src/extensions/mcp-adapter/mcp-callback-server.test.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Tests for the OAuth callback page served to the browser after an MCP server
+ * (Rovo, Slack, …) redirects back to the local listener.
+ *
+ * The page is rendered by the shared Kimchi-branded renderer in
+ * `src/utils/oauth-page.ts` using the templates in resources/oauth/
+ * (addressed via KIMCHI_OAUTH_TEMPLATE_DIR). Without that env var the callback
+ * server must fall back to a minimal *unbranded* page — never a Pi-branded one.
+ */
+import { createServer } from "node:http"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+async function getFreePort(): Promise<number> {
+	const server = createServer()
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+	const address = server.address()
+	await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+	if (!address || typeof address === "string") throw new Error("Could not allocate a local test port")
+	return address.port
+}
+
+async function loadCallbackServerForPort(port: number) {
+	vi.resetModules()
+	vi.stubEnv("MCP_OAUTH_CALLBACK_PORT", String(port))
+	return import("./mcp-callback-server.js")
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs()
+})
+
+describe("MCP OAuth callback page", () => {
+	it("serves the branded authorization-success page after the provider redirects back", async () => {
+		const port = await getFreePort()
+		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
+		const callbackServer = await loadCallbackServerForPort(port)
+
+		try {
+			const { callbackPromise } = await callbackServer.prepareCallback("state-success")
+
+			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=test-code&state=state-success`)
+			const body = await response.text()
+
+			expect(response.status).toBe(200)
+			expect(response.headers.get("content-type")).toBe("text/html")
+			await expect(callbackPromise).resolves.toBe("test-code")
+			// `bg-svg` exists only in resources/oauth/success.html, and the substituted
+			// message proves the shared renderer produced the page.
+			expect(body).toContain("bg-svg")
+			expect(body).toContain("MCP Authorization Successful")
+			expect(body).not.toContain("Pi -")
+			expect(body).toMatchInlineSnapshot(`
+				"<!doctype html>
+				<html lang="en" class="dark">
+				<head>
+				  <meta charset="utf-8" />
+				  <meta name="viewport" content="width=device-width, initial-scale=1" />
+				  <title>MCP Authorization Successful</title>
+				  <style>
+				    *, *::before, *::after {
+				      box-sizing: border-box;
+				      margin: 0;
+				      padding: 0;
+				    }
+
+				    body {
+				      background-color: #0b0b0e;
+				      color: #fafafa;
+				      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+				      display: flex;
+				      align-items: center;
+				      justify-content: center;
+				      min-height: 100vh;
+				      padding: 24px;
+				      position: relative;
+				    }
+
+				    /* ── Background SVG ──────────────────────────────── */
+				    .bg-svg {
+				      position: fixed;
+				      inset: 0;
+				      width: 100%;
+				      height: 100%;
+				      pointer-events: none;
+				      z-index: 0;
+				    }
+
+				    /* ── Content ──────────────────────────────────────── */
+				    .content {
+				      position: relative;
+				      z-index: 2;
+				      display: flex;
+				      flex-direction: column;
+				      align-items: center;
+				      gap: 32px;
+				    }
+
+				    /* Logo */
+				    .logo-wrap {
+				      display: flex;
+				      align-items: center;
+				      opacity: 0;
+				      transform: translateY(-12px);
+				      animation: fadeUp 0.55s cubic-bezier(0.22, 1, 0.36, 1) 0.1s forwards;
+				    }
+
+				    .logo-wrap svg {
+				      height: 40px;
+				      width: auto;
+				      display: block;
+				    }
+
+				    /* Card */
+				    .card {
+				      background: rgba(28, 28, 36, 0.88);
+				      border: 1px solid rgba(234, 231, 226, 0.09);
+				      border-radius: 20px;
+				      padding: 44px 52px;
+				      width: 100%;
+				      max-width: 360px;
+				      text-align: center;
+				      backdrop-filter: blur(24px);
+				      -webkit-backdrop-filter: blur(24px);
+				      display: flex;
+				      flex-direction: column;
+				      gap: 14px;
+				      opacity: 0;
+				      transform: translateY(16px);
+				      animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.25s forwards;
+				    }
+
+				    .card h1 {
+				      font-size: 17px;
+				      font-weight: 600;
+				      letter-spacing: -0.01em;
+				      color: #fafafa;
+				      line-height: 1.3;
+				    }
+
+				    .card p {
+				      font-size: 13.5px;
+				      font-weight: 400;
+				      color: #a1a1aa;
+				      line-height: 1.6;
+				    }
+
+				    .card .details {
+				      margin-top: 8px;
+				      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+				      font-size: 12px;
+				      color: #a1a1aa;
+				      white-space: pre-wrap;
+				      word-break: break-word;
+				      text-align: left;
+				      background: rgba(0, 0, 0, 0.25);
+				      border-radius: 10px;
+				      padding: 12px 14px;
+				    }
+
+				    /* ── Animations ───────────────────────────────────── */
+				    @keyframes fadeUp {
+				      to {
+				        opacity: 1;
+				        transform: translateY(0);
+				      }
+				    }
+
+				    @keyframes popIn {
+				      to {
+				        opacity: 1;
+				        transform: scale(1);
+				      }
+				    }
+				  </style>
+				</head>
+				<body>
+
+				  <!-- SVG background gradient -->
+				  <svg class="bg-svg" viewBox="0 0 1440 916" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+				    <g clip-path="url(#clip0)">
+				      <rect width="1440" height="916" fill="#0A0A0D"></rect>
+				      <circle cx="1643.73" cy="-109" r="602.269" fill="url(#paint0)"></circle>
+				      <circle cx="1214.01" cy="1117.99" r="761.28" fill="url(#paint1)"></circle>
+				      <circle cx="639.798" cy="971.665" r="950.892" fill="url(#paint2)"></circle>
+				      <circle cx="840.81" cy="1199.83" r="629.662" fill="url(#paint3)"></circle>
+				    </g>
+				    <defs>
+				      <radialGradient id="paint0" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1643.73 -109) rotate(91.3362) scale(602.433)">
+				        <stop stop-color="#AC3D1A"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1214.01 1117.99) rotate(91.3362) scale(761.487)">
+				        <stop stop-color="#36C3C4"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(639.798 971.665) rotate(91.3362) scale(951.151)">
+				        <stop stop-color="#AC3D1A"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(840.81 1199.83) rotate(91.3362) scale(629.834)">
+				        <stop stop-color="#BD978E"></stop>
+				        <stop offset="0.889427" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <clipPath id="clip0">
+				        <rect width="1440" height="916" fill="white"></rect>
+				      </clipPath>
+				    </defs>
+				  </svg>
+
+				  <!-- Main content -->
+				  <div class="content">
+
+				    <!-- Kimchi wordmark -->
+				    <div class="logo-wrap">
+				      <svg width="471" height="104" viewBox="0 0 471 104" fill="none" xmlns="http://www.w3.org/2000/svg">
+				        <path d="M454.815 34.482L462.021 35.871L469.313 34.482V84.4004H454.815V34.482ZM462.021 29.3599C459.416 29.3599 457.275 28.6943 455.597 27.3632C453.976 25.9741 453.166 24.151 453.166 21.8939C453.166 19.5788 453.976 17.7557 455.597 16.4245C457.275 15.0355 459.416 14.341 462.021 14.341C464.683 14.341 466.825 15.0355 468.445 16.4245C470.066 17.7557 470.876 19.5788 470.876 21.8939C470.876 24.151 470.066 25.9741 468.445 27.3632C466.825 28.6943 464.683 29.3599 462.021 29.3599Z" fill="white"/>
+				        <path d="M391.715 17.5529H406.213V84.4002H391.715V17.5529ZM425.052 33.7004C429.74 33.7004 433.734 34.6554 437.032 36.5653C440.331 38.4174 442.849 41.0797 444.585 44.5523C446.322 48.0249 447.19 52.163 447.19 56.9668V84.4002H432.692V59.1372C432.692 54.6807 431.621 51.3238 429.48 49.0666C427.338 46.7516 424.242 45.5941 420.19 45.5941C417.354 45.5941 414.866 46.2307 412.724 47.504C410.641 48.7194 409.02 50.4267 407.863 52.626C406.763 54.8254 406.213 57.4587 406.213 60.5262L401.438 58.0086C402.075 52.7997 403.464 48.4011 405.606 44.8127C407.805 41.2244 410.583 38.4753 413.94 36.5653C417.297 34.6554 421.001 33.7004 425.052 33.7004Z" fill="white"/>
+				        <path d="M386.492 64.2595C385.913 68.4845 384.264 72.2175 381.544 75.4586C378.881 78.6997 375.438 81.2173 371.213 83.0115C366.988 84.8056 362.271 85.7027 357.062 85.7027C351.158 85.7027 345.95 84.632 341.435 82.4906C336.979 80.2913 333.477 77.2238 330.931 73.2882C328.442 69.3526 327.198 64.8383 327.198 59.7451C327.198 54.5941 328.442 50.0798 330.931 46.202C333.477 42.2664 336.979 39.199 341.435 36.9997C345.95 34.8004 351.158 33.7007 357.062 33.7007C362.271 33.7007 366.988 34.6267 371.213 36.4788C375.438 38.273 378.881 40.7906 381.544 44.0317C384.264 47.2149 385.913 50.9479 386.492 55.2308H371.994C371.242 51.8739 369.505 49.2984 366.785 47.5043C364.123 45.6522 360.882 44.7262 357.062 44.7262C353.994 44.7262 351.303 45.3339 348.988 46.5493C346.731 47.7068 344.995 49.4142 343.779 51.6714C342.564 53.8707 341.956 56.5619 341.956 59.7451C341.956 62.8705 342.564 65.5617 343.779 67.8189C344.995 70.0182 346.731 71.7256 348.988 72.941C351.303 74.0985 353.994 74.6773 357.062 74.6773C360.94 74.6773 364.21 73.7223 366.872 71.8124C369.592 69.9024 371.299 67.3848 371.994 64.2595H386.492Z" fill="white"/>
+				        <path d="M227.479 35.0029H241.977L245.102 53.8417V84.4005H230.604V51.6714L227.479 35.0029ZM262.725 33.7007C267.124 33.7007 270.886 34.6557 274.011 36.5656C277.137 38.4176 279.51 41.08 281.13 44.5526C282.809 48.0251 283.648 52.1633 283.648 56.9671V84.4005H269.15V59.1374C269.15 54.6809 268.166 51.3241 266.198 49.0669C264.288 46.7519 261.481 45.5943 257.777 45.5943C255.173 45.5943 252.915 46.231 251.005 47.5043C249.096 48.7197 247.62 50.427 246.578 52.6263C245.594 54.8256 245.102 57.459 245.102 60.5265L240.327 58.0088C240.906 52.7999 242.237 48.4013 244.321 44.813C246.404 41.2247 249.009 38.4755 252.134 36.5656C255.317 34.6557 258.848 33.7007 262.725 33.7007ZM301.184 33.7007C305.583 33.7007 309.345 34.6557 312.47 36.5656C315.653 38.4176 318.055 41.08 319.676 44.5526C321.354 48.0251 322.193 52.1633 322.193 56.9671V84.4005H307.695V59.1374C307.695 54.6809 306.712 51.3241 304.744 49.0669C302.834 46.7519 300.027 45.5943 296.323 45.5943C293.718 45.5943 291.461 46.231 289.551 47.5043C287.641 48.7197 286.165 50.427 285.124 52.6263C284.14 54.8256 283.648 57.459 283.648 60.5265L278.873 58.0088C279.452 52.7999 280.783 48.4013 282.866 44.813C284.95 41.2247 287.554 38.4755 290.68 36.5656C293.863 34.6557 297.364 33.7007 301.184 33.7007Z" fill="white"/>
+				        <path d="M206.993 34.482L214.199 35.871L221.491 34.482V84.4004H206.993V34.482ZM214.199 29.3599C211.594 29.3599 209.453 28.6943 207.774 27.3632C206.154 25.9741 205.344 24.151 205.344 21.8939C205.344 19.5788 206.154 17.7557 207.774 16.4245C209.453 15.0355 211.594 14.341 214.199 14.341C216.861 14.341 219.003 15.0355 220.623 16.4245C222.244 17.7557 223.054 19.5788 223.054 21.8939C223.054 24.151 222.244 25.9741 220.623 27.3632C219.003 28.6943 216.861 29.3599 214.199 29.3599Z" fill="white"/>
+				        <path d="M136.97 84.4004V19.2894H151.641V72.42L147.474 69.4683L187.756 19.2894H203.47L150.252 84.4004H136.97ZM168.049 52.5395L178.641 43.0767L204.425 84.4004H187.583L168.049 52.5395Z" fill="white"/>
+				        <circle cx="52" cy="52" r="52" fill="#FF521D"/>
+				        <path d="M68.4459 24.9438C69.8639 24.1762 71.6471 23.7178 73.4821 24.2163C73.8278 24.2966 74.1339 24.3916 74.4362 24.5024L75.9186 25.0464L75.5104 26.5727C75.3469 27.1827 75.202 27.723 75.0387 28.3325L74.6442 29.8042L73.1354 29.5972C73.0242 29.5819 72.9246 29.5753 72.8082 29.5747C72.2474 29.5865 71.7542 29.8645 71.2662 30.6772C70.8883 31.307 70.5939 32.1486 70.3815 33.1079C74.871 36.0331 77.8444 41.0994 77.8444 46.8638C77.8443 49.5292 77.2072 52.0505 76.0758 54.2798C71.5108 64.3996 54.1783 84.8815 23.4655 79.0083C21.8797 78.7048 20.9918 77.4165 20.902 76.1245C20.8141 74.8561 21.479 73.487 22.8981 72.8813C31.0698 69.394 35.5884 65.7091 38.5983 61.2329C41.6553 56.6866 43.2606 51.1907 45.3287 43.7251C46.7942 36.1645 53.4462 30.4547 61.4362 30.4546L61.8834 30.4604C62.4398 30.4755 62.9894 30.519 63.5309 30.5884C63.9515 29.7288 64.4424 28.8863 65.0211 28.0659L65.1745 27.8423C65.9623 26.731 67.1108 25.6667 68.4459 24.9438Z" fill="#18181A"/>
+				      </svg>
+				    </div>
+
+				    <!-- Success card -->
+				    <div class="card">
+				      <h1>MCP Authorization Successful</h1>
+				      <p>You can close this window and return to Kimchi.</p>
+				      
+				    </div>
+
+				  </div>
+
+				</body>
+				</html>
+				"
+			`)
+		} finally {
+			await callbackServer.stopCallbackServer()
+		}
+	})
+
+	it("serves the branded authorization-failure page when the provider reports an error", async () => {
+		const port = await getFreePort()
+		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
+		const callbackServer = await loadCallbackServerForPort(port)
+
+		try {
+			const { callbackPromise } = await callbackServer.prepareCallback("state-error")
+			// Attach the rejection assertion before the fetch: the server rejects the
+			// pending auth in a deferred setTimeout after sending the response.
+			const rejection = expect(callbackPromise).rejects.toThrow("The user denied the authorization request")
+
+			const response = await fetch(
+				`http://127.0.0.1:${port}/mcp/oauth/callback?error=access_denied&error_description=The%20user%20denied%20the%20authorization%20request&state=state-error`,
+			)
+			const body = await response.text()
+
+			expect(response.status).toBe(200)
+			await rejection
+			expect(body).toContain("bg-svg")
+			expect(body).toContain("MCP Authorization Failed")
+			expect(body).toContain("An error occurred during MCP authorization.")
+			expect(body).toContain("The user denied the authorization request")
+			expect(body).not.toContain("Pi -")
+			expect(body).toMatchInlineSnapshot(`
+				"<!doctype html>
+				<html lang="en" class="dark">
+				<head>
+				  <meta charset="utf-8" />
+				  <meta name="viewport" content="width=device-width, initial-scale=1" />
+				  <title>MCP Authorization Failed</title>
+				  <style>
+				    *, *::before, *::after {
+				      box-sizing: border-box;
+				      margin: 0;
+				      padding: 0;
+				    }
+
+				    body {
+				      background-color: #0b0b0e;
+				      color: #fafafa;
+				      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+				      display: flex;
+				      align-items: center;
+				      justify-content: center;
+				      min-height: 100vh;
+				      padding: 24px;
+				      position: relative;
+				    }
+
+				    /* ── Background SVG ──────────────────────────────── */
+				    .bg-svg {
+				      position: fixed;
+				      inset: 0;
+				      width: 100%;
+				      height: 100%;
+				      pointer-events: none;
+				      z-index: 0;
+				    }
+
+				    /* ── Content ──────────────────────────────────────── */
+				    .content {
+				      position: relative;
+				      z-index: 2;
+				      display: flex;
+				      flex-direction: column;
+				      align-items: center;
+				      gap: 32px;
+				    }
+
+				    /* Logo */
+				    .logo-wrap {
+				      display: flex;
+				      align-items: center;
+				      opacity: 0;
+				      transform: translateY(-12px);
+				      animation: fadeUp 0.55s cubic-bezier(0.22, 1, 0.36, 1) 0.1s forwards;
+				    }
+
+				    .logo-wrap svg {
+				      height: 40px;
+				      width: auto;
+				      display: block;
+				    }
+
+				    /* Card */
+				    .card {
+				      background: rgba(28, 28, 36, 0.88);
+				      border: 1px solid rgba(234, 231, 226, 0.09);
+				      border-radius: 20px;
+				      padding: 44px 52px;
+				      width: 100%;
+				      max-width: 360px;
+				      text-align: center;
+				      backdrop-filter: blur(24px);
+				      -webkit-backdrop-filter: blur(24px);
+				      display: flex;
+				      flex-direction: column;
+				      gap: 14px;
+				      opacity: 0;
+				      transform: translateY(16px);
+				      animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.25s forwards;
+				    }
+
+				    .card h1 {
+				      font-size: 17px;
+				      font-weight: 600;
+				      letter-spacing: -0.01em;
+				      color: #ef4444;
+				      line-height: 1.3;
+				    }
+
+				    .card p {
+				      font-size: 13.5px;
+				      font-weight: 400;
+				      color: #a1a1aa;
+				      line-height: 1.6;
+				    }
+
+				    .card .details {
+				      margin-top: 8px;
+				      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+				      font-size: 12px;
+				      color: #fca5a5;
+				      white-space: pre-wrap;
+				      word-break: break-word;
+				      text-align: left;
+				      background: rgba(239, 68, 68, 0.12);
+				      border-radius: 10px;
+				      padding: 12px 14px;
+				    }
+
+				    /* ── Animations ───────────────────────────────────── */
+				    @keyframes fadeUp {
+				      to {
+				        opacity: 1;
+				        transform: translateY(0);
+				      }
+				    }
+
+				    @keyframes popIn {
+				      to {
+				        opacity: 1;
+				        transform: scale(1);
+				      }
+				    }
+				  </style>
+				</head>
+				<body>
+
+				  <!-- SVG background gradient -->
+				  <svg class="bg-svg" viewBox="0 0 1440 916" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+				    <g clip-path="url(#clip0)">
+				      <rect width="1440" height="916" fill="#0A0A0D"></rect>
+				      <circle cx="1643.73" cy="-109" r="602.269" fill="url(#paint0)"></circle>
+				      <circle cx="1214.01" cy="1117.99" r="761.28" fill="url(#paint1)"></circle>
+				      <circle cx="639.798" cy="971.665" r="950.892" fill="url(#paint2)"></circle>
+				      <circle cx="840.81" cy="1199.83" r="629.662" fill="url(#paint3)"></circle>
+				    </g>
+				    <defs>
+				      <radialGradient id="paint0" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1643.73 -109) rotate(91.3362) scale(602.433)">
+				        <stop stop-color="#AC3D1A"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1214.01 1117.99) rotate(91.3362) scale(761.487)">
+				        <stop stop-color="#36C3C4"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(639.798 971.665) rotate(91.3362) scale(951.151)">
+				        <stop stop-color="#AC3D1A"></stop>
+				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <radialGradient id="paint3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(840.81 1199.83) rotate(91.3362) scale(629.834)">
+				        <stop stop-color="#BD978E"></stop>
+				        <stop offset="0.889427" stop-color="#0A0A0D" stop-opacity="0"></stop>
+				      </radialGradient>
+				      <clipPath id="clip0">
+				        <rect width="1440" height="916" fill="white"></rect>
+				      </clipPath>
+				    </defs>
+				  </svg>
+
+				  <!-- Main content -->
+				  <div class="content">
+
+				    <!-- Kimchi wordmark -->
+				    <div class="logo-wrap">
+				      <svg width="471" height="104" viewBox="0 0 471 104" fill="none" xmlns="http://www.w3.org/2000/svg">
+				        <path d="M454.815 34.482L462.021 35.871L469.313 34.482V84.4004H454.815V34.482ZM462.021 29.3599C459.416 29.3599 457.275 28.6943 455.597 27.3632C453.976 25.9741 453.166 24.151 453.166 21.8939C453.166 19.5788 453.976 17.7557 455.597 16.4245C457.275 15.0355 459.416 14.341 462.021 14.341C464.683 14.341 466.825 15.0355 468.445 16.4245C470.066 17.7557 470.876 19.5788 470.876 21.8939C470.876 24.151 470.066 25.9741 468.445 27.3632C466.825 28.6943 464.683 29.3599 462.021 29.3599Z" fill="white"/>
+				        <path d="M391.715 17.5529H406.213V84.4002H391.715V17.5529ZM425.052 33.7004C429.74 33.7004 433.734 34.6554 437.032 36.5653C440.331 38.4174 442.849 41.0797 444.585 44.5523C446.322 48.0249 447.19 52.163 447.19 56.9668V84.4002H432.692V59.1372C432.692 54.6807 431.621 51.3238 429.48 49.0666C427.338 46.7516 424.242 45.5941 420.19 45.5941C417.354 45.5941 414.866 46.2307 412.724 47.504C410.641 48.7194 409.02 50.4267 407.863 52.626C406.763 54.8254 406.213 57.4587 406.213 60.5262L401.438 58.0086C402.075 52.7997 403.464 48.4011 405.606 44.8127C407.805 41.2244 410.583 38.4753 413.94 36.5653C417.297 34.6554 421.001 33.7004 425.052 33.7004Z" fill="white"/>
+				        <path d="M386.492 64.2595C385.913 68.4845 384.264 72.2175 381.544 75.4586C378.881 78.6997 375.438 81.2173 371.213 83.0115C366.988 84.8056 362.271 85.7027 357.062 85.7027C351.158 85.7027 345.95 84.632 341.435 82.4906C336.979 80.2913 333.477 77.2238 330.931 73.2882C328.442 69.3526 327.198 64.8383 327.198 59.7451C327.198 54.5941 328.442 50.0798 330.931 46.202C333.477 42.2664 336.979 39.199 341.435 36.9997C345.95 34.8004 351.158 33.7007 357.062 33.7007C362.271 33.7007 366.988 34.6267 371.213 36.4788C375.438 38.273 378.881 40.7906 381.544 44.0317C384.264 47.2149 385.913 50.9479 386.492 55.2308H371.994C371.242 51.8739 369.505 49.2984 366.785 47.5043C364.123 45.6522 360.882 44.7262 357.062 44.7262C353.994 44.7262 351.303 45.3339 348.988 46.5493C346.731 47.7068 344.995 49.4142 343.779 51.6714C342.564 53.8707 341.956 56.5619 341.956 59.7451C341.956 62.8705 342.564 65.5617 343.779 67.8189C344.995 70.0182 346.731 71.7256 348.988 72.941C351.303 74.0985 353.994 74.6773 357.062 74.6773C360.94 74.6773 364.21 73.7223 366.872 71.8124C369.592 69.9024 371.299 67.3848 371.994 64.2595H386.492Z" fill="white"/>
+				        <path d="M227.479 35.0029H241.977L245.102 53.8417V84.4005H230.604V51.6714L227.479 35.0029ZM262.725 33.7007C267.124 33.7007 270.886 34.6557 274.011 36.5656C277.137 38.4176 279.51 41.08 281.13 44.5526C282.809 48.0251 283.648 52.1633 283.648 56.9671V84.4005H269.15V59.1374C269.15 54.6809 268.166 51.3241 266.198 49.0669C264.288 46.7519 261.481 45.5943 257.777 45.5943C255.173 45.5943 252.915 46.231 251.005 47.5043C249.096 48.7197 247.62 50.427 246.578 52.6263C245.594 54.8256 245.102 57.459 245.102 60.5265L240.327 58.0088C240.906 52.7999 242.237 48.4013 244.321 44.813C246.404 41.2247 249.009 38.4755 252.134 36.5656C255.317 34.6557 258.848 33.7007 262.725 33.7007ZM301.184 33.7007C305.583 33.7007 309.345 34.6557 312.47 36.5656C315.653 38.4176 318.055 41.08 319.676 44.5526C321.354 48.0251 322.193 52.1633 322.193 56.9671V84.4005H307.695V59.1374C307.695 54.6809 306.712 51.3241 304.744 49.0669C302.834 46.7519 300.027 45.5943 296.323 45.5943C293.718 45.5943 291.461 46.231 289.551 47.5043C287.641 48.7197 286.165 50.427 285.124 52.6263C284.14 54.8256 283.648 57.459 283.648 60.5265L278.873 58.0088C279.452 52.7999 280.783 48.4013 282.866 44.813C284.95 41.2247 287.554 38.4755 290.68 36.5656C293.863 34.6557 297.364 33.7007 301.184 33.7007Z" fill="white"/>
+				        <path d="M206.993 34.482L214.199 35.871L221.491 34.482V84.4004H206.993V34.482ZM214.199 29.3599C211.594 29.3599 209.453 28.6943 207.774 27.3632C206.154 25.9741 205.344 24.151 205.344 21.8939C205.344 19.5788 206.154 17.7557 207.774 16.4245C209.453 15.0355 211.594 14.341 214.199 14.341C216.861 14.341 219.003 15.0355 220.623 16.4245C222.244 17.7557 223.054 19.5788 223.054 21.8939C223.054 24.151 222.244 25.9741 220.623 27.3632C219.003 28.6943 216.861 29.3599 214.199 29.3599Z" fill="white"/>
+				        <path d="M136.97 84.4004V19.2894H151.641V72.42L147.474 69.4683L187.756 19.2894H203.47L150.252 84.4004H136.97ZM168.049 52.5395L178.641 43.0767L204.425 84.4004H187.583L168.049 52.5395Z" fill="white"/>
+				        <circle cx="52" cy="52" r="52" fill="#FF521D"/>
+				        <path d="M68.4459 24.9438C69.8639 24.1762 71.6471 23.7178 73.4821 24.2163C73.8278 24.2966 74.1339 24.3916 74.4362 24.5024L75.9186 25.0464L75.5104 26.5727C75.3469 27.1827 75.202 27.723 75.0387 28.3325L74.6442 29.8042L73.1354 29.5972C73.0242 29.5819 72.9246 29.5753 72.8082 29.5747C72.2474 29.5865 71.7542 29.8645 71.2662 30.6772C70.8883 31.307 70.5939 32.1486 70.3815 33.1079C74.871 36.0331 77.8444 41.0994 77.8444 46.8638C77.8443 49.5292 77.2072 52.0505 76.0758 54.2798C71.5108 64.3996 54.1783 84.8815 23.4655 79.0083C21.8797 78.7048 20.9918 77.4165 20.902 76.1245C20.8141 74.8561 21.479 73.487 22.8981 72.8813C31.0698 69.394 35.5884 65.7091 38.5983 61.2329C41.6553 56.6866 43.2606 51.1907 45.3287 43.7251C46.7942 36.1645 53.4462 30.4547 61.4362 30.4546L61.8834 30.4604C62.4398 30.4755 62.9894 30.519 63.5309 30.5884C63.9515 29.7288 64.4424 28.8863 65.0211 28.0659L65.1745 27.8423C65.9623 26.731 67.1108 25.6667 68.4459 24.9438Z" fill="#18181A"/>
+				      </svg>
+				    </div>
+
+				    <!-- Error card -->
+				    <div class="card">
+				      <h1>MCP Authorization Failed</h1>
+				      <p>An error occurred during MCP authorization.</p>
+				      <div class="details">The user denied the authorization request</div>
+				    </div>
+
+				  </div>
+
+				</body>
+				</html>
+				"
+			`)
+		} finally {
+			await callbackServer.stopCallbackServer()
+		}
+	})
+
+	it("HTML-escapes provider-controlled error text", async () => {
+		const port = await getFreePort()
+		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", resolve(repoRoot, "resources", "oauth"))
+		const callbackServer = await loadCallbackServerForPort(port)
+
+		try {
+			const { callbackPromise } = await callbackServer.prepareCallback("state-xss")
+			const rejection = expect(callbackPromise).rejects.toThrow("alert(1)")
+
+			const response = await fetch(
+				`http://127.0.0.1:${port}/mcp/oauth/callback?error=access_denied&error_description=%3Cscript%3Ealert(1)%3C/script%3E&state=state-xss`,
+			)
+			const body = await response.text()
+
+			expect(response.status).toBe(200)
+			await rejection
+			expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;")
+			expect(body).not.toContain("<script>alert(1)</script>")
+		} finally {
+			await callbackServer.stopCallbackServer()
+		}
+	})
+
+	it("falls back to a minimal unbranded page when KIMCHI_OAUTH_TEMPLATE_DIR is unset", async () => {
+		const port = await getFreePort()
+		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", "")
+		const callbackServer = await loadCallbackServerForPort(port)
+
+		try {
+			const { callbackPromise } = await callbackServer.prepareCallback("state-fallback")
+
+			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?code=test-code&state=state-fallback`)
+			const body = await response.text()
+
+			expect(response.status).toBe(200)
+			await expect(callbackPromise).resolves.toBe("test-code")
+			expect(body).toContain("MCP Authorization Successful")
+			expect(body).not.toContain("bg-svg")
+			expect(body).not.toContain("Pi -")
+		} finally {
+			await callbackServer.stopCallbackServer()
+		}
+	})
+})

--- a/src/extensions/mcp-adapter/mcp-callback-server.test.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.test.ts
@@ -14,6 +14,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
 
+// The Kimchi logo SVG in both templates uses this exact orange — proof the
+// branded template rendered rather than the unbranded fallback.
+const KIMCHI_LOGO_ORANGE = "#FF521D"
+
 async function getFreePort(): Promise<number> {
 	const server = createServer()
 	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
@@ -48,199 +52,12 @@ describe("MCP OAuth callback page", () => {
 			expect(response.status).toBe(200)
 			expect(response.headers.get("content-type")).toBe("text/html")
 			await expect(callbackPromise).resolves.toBe("test-code")
-			// `bg-svg` exists only in resources/oauth/success.html, and the substituted
-			// message proves the shared renderer produced the page.
 			expect(body).toContain("bg-svg")
-			expect(body).toContain("MCP Authorization Successful")
+			expect(body).toContain(KIMCHI_LOGO_ORANGE)
+			expect(body).toContain("<title>MCP Authorization Successful</title>")
+			expect(body).toContain("<h1>MCP Authorization Successful</h1>")
+			expect(body).toContain("You can close this window and return to Kimchi.")
 			expect(body).not.toContain("Pi -")
-			expect(body).toMatchInlineSnapshot(`
-				"<!doctype html>
-				<html lang="en" class="dark">
-				<head>
-				  <meta charset="utf-8" />
-				  <meta name="viewport" content="width=device-width, initial-scale=1" />
-				  <title>MCP Authorization Successful</title>
-				  <style>
-				    *, *::before, *::after {
-				      box-sizing: border-box;
-				      margin: 0;
-				      padding: 0;
-				    }
-
-				    body {
-				      background-color: #0b0b0e;
-				      color: #fafafa;
-				      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-				      display: flex;
-				      align-items: center;
-				      justify-content: center;
-				      min-height: 100vh;
-				      padding: 24px;
-				      position: relative;
-				    }
-
-				    /* ── Background SVG ──────────────────────────────── */
-				    .bg-svg {
-				      position: fixed;
-				      inset: 0;
-				      width: 100%;
-				      height: 100%;
-				      pointer-events: none;
-				      z-index: 0;
-				    }
-
-				    /* ── Content ──────────────────────────────────────── */
-				    .content {
-				      position: relative;
-				      z-index: 2;
-				      display: flex;
-				      flex-direction: column;
-				      align-items: center;
-				      gap: 32px;
-				    }
-
-				    /* Logo */
-				    .logo-wrap {
-				      display: flex;
-				      align-items: center;
-				      opacity: 0;
-				      transform: translateY(-12px);
-				      animation: fadeUp 0.55s cubic-bezier(0.22, 1, 0.36, 1) 0.1s forwards;
-				    }
-
-				    .logo-wrap svg {
-				      height: 40px;
-				      width: auto;
-				      display: block;
-				    }
-
-				    /* Card */
-				    .card {
-				      background: rgba(28, 28, 36, 0.88);
-				      border: 1px solid rgba(234, 231, 226, 0.09);
-				      border-radius: 20px;
-				      padding: 44px 52px;
-				      width: 100%;
-				      max-width: 360px;
-				      text-align: center;
-				      backdrop-filter: blur(24px);
-				      -webkit-backdrop-filter: blur(24px);
-				      display: flex;
-				      flex-direction: column;
-				      gap: 14px;
-				      opacity: 0;
-				      transform: translateY(16px);
-				      animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.25s forwards;
-				    }
-
-				    .card h1 {
-				      font-size: 17px;
-				      font-weight: 600;
-				      letter-spacing: -0.01em;
-				      color: #fafafa;
-				      line-height: 1.3;
-				    }
-
-				    .card p {
-				      font-size: 13.5px;
-				      font-weight: 400;
-				      color: #a1a1aa;
-				      line-height: 1.6;
-				    }
-
-				    .card .details {
-				      margin-top: 8px;
-				      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-				      font-size: 12px;
-				      color: #a1a1aa;
-				      white-space: pre-wrap;
-				      word-break: break-word;
-				      text-align: left;
-				      background: rgba(0, 0, 0, 0.25);
-				      border-radius: 10px;
-				      padding: 12px 14px;
-				    }
-
-				    /* ── Animations ───────────────────────────────────── */
-				    @keyframes fadeUp {
-				      to {
-				        opacity: 1;
-				        transform: translateY(0);
-				      }
-				    }
-
-				    @keyframes popIn {
-				      to {
-				        opacity: 1;
-				        transform: scale(1);
-				      }
-				    }
-				  </style>
-				</head>
-				<body>
-
-				  <!-- SVG background gradient -->
-				  <svg class="bg-svg" viewBox="0 0 1440 916" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-				    <g clip-path="url(#clip0)">
-				      <rect width="1440" height="916" fill="#0A0A0D"></rect>
-				      <circle cx="1643.73" cy="-109" r="602.269" fill="url(#paint0)"></circle>
-				      <circle cx="1214.01" cy="1117.99" r="761.28" fill="url(#paint1)"></circle>
-				      <circle cx="639.798" cy="971.665" r="950.892" fill="url(#paint2)"></circle>
-				      <circle cx="840.81" cy="1199.83" r="629.662" fill="url(#paint3)"></circle>
-				    </g>
-				    <defs>
-				      <radialGradient id="paint0" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1643.73 -109) rotate(91.3362) scale(602.433)">
-				        <stop stop-color="#AC3D1A"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1214.01 1117.99) rotate(91.3362) scale(761.487)">
-				        <stop stop-color="#36C3C4"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(639.798 971.665) rotate(91.3362) scale(951.151)">
-				        <stop stop-color="#AC3D1A"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(840.81 1199.83) rotate(91.3362) scale(629.834)">
-				        <stop stop-color="#BD978E"></stop>
-				        <stop offset="0.889427" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <clipPath id="clip0">
-				        <rect width="1440" height="916" fill="white"></rect>
-				      </clipPath>
-				    </defs>
-				  </svg>
-
-				  <!-- Main content -->
-				  <div class="content">
-
-				    <!-- Kimchi wordmark -->
-				    <div class="logo-wrap">
-				      <svg width="471" height="104" viewBox="0 0 471 104" fill="none" xmlns="http://www.w3.org/2000/svg">
-				        <path d="M454.815 34.482L462.021 35.871L469.313 34.482V84.4004H454.815V34.482ZM462.021 29.3599C459.416 29.3599 457.275 28.6943 455.597 27.3632C453.976 25.9741 453.166 24.151 453.166 21.8939C453.166 19.5788 453.976 17.7557 455.597 16.4245C457.275 15.0355 459.416 14.341 462.021 14.341C464.683 14.341 466.825 15.0355 468.445 16.4245C470.066 17.7557 470.876 19.5788 470.876 21.8939C470.876 24.151 470.066 25.9741 468.445 27.3632C466.825 28.6943 464.683 29.3599 462.021 29.3599Z" fill="white"/>
-				        <path d="M391.715 17.5529H406.213V84.4002H391.715V17.5529ZM425.052 33.7004C429.74 33.7004 433.734 34.6554 437.032 36.5653C440.331 38.4174 442.849 41.0797 444.585 44.5523C446.322 48.0249 447.19 52.163 447.19 56.9668V84.4002H432.692V59.1372C432.692 54.6807 431.621 51.3238 429.48 49.0666C427.338 46.7516 424.242 45.5941 420.19 45.5941C417.354 45.5941 414.866 46.2307 412.724 47.504C410.641 48.7194 409.02 50.4267 407.863 52.626C406.763 54.8254 406.213 57.4587 406.213 60.5262L401.438 58.0086C402.075 52.7997 403.464 48.4011 405.606 44.8127C407.805 41.2244 410.583 38.4753 413.94 36.5653C417.297 34.6554 421.001 33.7004 425.052 33.7004Z" fill="white"/>
-				        <path d="M386.492 64.2595C385.913 68.4845 384.264 72.2175 381.544 75.4586C378.881 78.6997 375.438 81.2173 371.213 83.0115C366.988 84.8056 362.271 85.7027 357.062 85.7027C351.158 85.7027 345.95 84.632 341.435 82.4906C336.979 80.2913 333.477 77.2238 330.931 73.2882C328.442 69.3526 327.198 64.8383 327.198 59.7451C327.198 54.5941 328.442 50.0798 330.931 46.202C333.477 42.2664 336.979 39.199 341.435 36.9997C345.95 34.8004 351.158 33.7007 357.062 33.7007C362.271 33.7007 366.988 34.6267 371.213 36.4788C375.438 38.273 378.881 40.7906 381.544 44.0317C384.264 47.2149 385.913 50.9479 386.492 55.2308H371.994C371.242 51.8739 369.505 49.2984 366.785 47.5043C364.123 45.6522 360.882 44.7262 357.062 44.7262C353.994 44.7262 351.303 45.3339 348.988 46.5493C346.731 47.7068 344.995 49.4142 343.779 51.6714C342.564 53.8707 341.956 56.5619 341.956 59.7451C341.956 62.8705 342.564 65.5617 343.779 67.8189C344.995 70.0182 346.731 71.7256 348.988 72.941C351.303 74.0985 353.994 74.6773 357.062 74.6773C360.94 74.6773 364.21 73.7223 366.872 71.8124C369.592 69.9024 371.299 67.3848 371.994 64.2595H386.492Z" fill="white"/>
-				        <path d="M227.479 35.0029H241.977L245.102 53.8417V84.4005H230.604V51.6714L227.479 35.0029ZM262.725 33.7007C267.124 33.7007 270.886 34.6557 274.011 36.5656C277.137 38.4176 279.51 41.08 281.13 44.5526C282.809 48.0251 283.648 52.1633 283.648 56.9671V84.4005H269.15V59.1374C269.15 54.6809 268.166 51.3241 266.198 49.0669C264.288 46.7519 261.481 45.5943 257.777 45.5943C255.173 45.5943 252.915 46.231 251.005 47.5043C249.096 48.7197 247.62 50.427 246.578 52.6263C245.594 54.8256 245.102 57.459 245.102 60.5265L240.327 58.0088C240.906 52.7999 242.237 48.4013 244.321 44.813C246.404 41.2247 249.009 38.4755 252.134 36.5656C255.317 34.6557 258.848 33.7007 262.725 33.7007ZM301.184 33.7007C305.583 33.7007 309.345 34.6557 312.47 36.5656C315.653 38.4176 318.055 41.08 319.676 44.5526C321.354 48.0251 322.193 52.1633 322.193 56.9671V84.4005H307.695V59.1374C307.695 54.6809 306.712 51.3241 304.744 49.0669C302.834 46.7519 300.027 45.5943 296.323 45.5943C293.718 45.5943 291.461 46.231 289.551 47.5043C287.641 48.7197 286.165 50.427 285.124 52.6263C284.14 54.8256 283.648 57.459 283.648 60.5265L278.873 58.0088C279.452 52.7999 280.783 48.4013 282.866 44.813C284.95 41.2247 287.554 38.4755 290.68 36.5656C293.863 34.6557 297.364 33.7007 301.184 33.7007Z" fill="white"/>
-				        <path d="M206.993 34.482L214.199 35.871L221.491 34.482V84.4004H206.993V34.482ZM214.199 29.3599C211.594 29.3599 209.453 28.6943 207.774 27.3632C206.154 25.9741 205.344 24.151 205.344 21.8939C205.344 19.5788 206.154 17.7557 207.774 16.4245C209.453 15.0355 211.594 14.341 214.199 14.341C216.861 14.341 219.003 15.0355 220.623 16.4245C222.244 17.7557 223.054 19.5788 223.054 21.8939C223.054 24.151 222.244 25.9741 220.623 27.3632C219.003 28.6943 216.861 29.3599 214.199 29.3599Z" fill="white"/>
-				        <path d="M136.97 84.4004V19.2894H151.641V72.42L147.474 69.4683L187.756 19.2894H203.47L150.252 84.4004H136.97ZM168.049 52.5395L178.641 43.0767L204.425 84.4004H187.583L168.049 52.5395Z" fill="white"/>
-				        <circle cx="52" cy="52" r="52" fill="#FF521D"/>
-				        <path d="M68.4459 24.9438C69.8639 24.1762 71.6471 23.7178 73.4821 24.2163C73.8278 24.2966 74.1339 24.3916 74.4362 24.5024L75.9186 25.0464L75.5104 26.5727C75.3469 27.1827 75.202 27.723 75.0387 28.3325L74.6442 29.8042L73.1354 29.5972C73.0242 29.5819 72.9246 29.5753 72.8082 29.5747C72.2474 29.5865 71.7542 29.8645 71.2662 30.6772C70.8883 31.307 70.5939 32.1486 70.3815 33.1079C74.871 36.0331 77.8444 41.0994 77.8444 46.8638C77.8443 49.5292 77.2072 52.0505 76.0758 54.2798C71.5108 64.3996 54.1783 84.8815 23.4655 79.0083C21.8797 78.7048 20.9918 77.4165 20.902 76.1245C20.8141 74.8561 21.479 73.487 22.8981 72.8813C31.0698 69.394 35.5884 65.7091 38.5983 61.2329C41.6553 56.6866 43.2606 51.1907 45.3287 43.7251C46.7942 36.1645 53.4462 30.4547 61.4362 30.4546L61.8834 30.4604C62.4398 30.4755 62.9894 30.519 63.5309 30.5884C63.9515 29.7288 64.4424 28.8863 65.0211 28.0659L65.1745 27.8423C65.9623 26.731 67.1108 25.6667 68.4459 24.9438Z" fill="#18181A"/>
-				      </svg>
-				    </div>
-
-				    <!-- Success card -->
-				    <div class="card">
-				      <h1>MCP Authorization Successful</h1>
-				      <p>You can close this window and return to Kimchi.</p>
-				      
-				    </div>
-
-				  </div>
-
-				</body>
-				</html>
-				"
-			`)
 		} finally {
 			await callbackServer.stopCallbackServer()
 		}
@@ -265,198 +82,32 @@ describe("MCP OAuth callback page", () => {
 			expect(response.status).toBe(200)
 			await rejection
 			expect(body).toContain("bg-svg")
-			expect(body).toContain("MCP Authorization Failed")
+			expect(body).toContain(KIMCHI_LOGO_ORANGE)
+			expect(body).toContain("<title>MCP Authorization Failed</title>")
+			expect(body).toContain("<h1>MCP Authorization Failed</h1>")
 			expect(body).toContain("An error occurred during MCP authorization.")
 			expect(body).toContain("The user denied the authorization request")
 			expect(body).not.toContain("Pi -")
-			expect(body).toMatchInlineSnapshot(`
-				"<!doctype html>
-				<html lang="en" class="dark">
-				<head>
-				  <meta charset="utf-8" />
-				  <meta name="viewport" content="width=device-width, initial-scale=1" />
-				  <title>MCP Authorization Failed</title>
-				  <style>
-				    *, *::before, *::after {
-				      box-sizing: border-box;
-				      margin: 0;
-				      padding: 0;
-				    }
+		} finally {
+			await callbackServer.stopCallbackServer()
+		}
+	})
 
-				    body {
-				      background-color: #0b0b0e;
-				      color: #fafafa;
-				      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-				      display: flex;
-				      align-items: center;
-				      justify-content: center;
-				      min-height: 100vh;
-				      padding: 24px;
-				      position: relative;
-				    }
+	it("rejects the pending auth when the callback has a state but no authorization code", async () => {
+		const port = await getFreePort()
+		const callbackServer = await loadCallbackServerForPort(port)
 
-				    /* ── Background SVG ──────────────────────────────── */
-				    .bg-svg {
-				      position: fixed;
-				      inset: 0;
-				      width: 100%;
-				      height: 100%;
-				      pointer-events: none;
-				      z-index: 0;
-				    }
+		try {
+			const { callbackPromise } = await callbackServer.prepareCallback("state-no-code")
+			// Fail fast instead of waiting for the 5-minute callback timeout.
+			const rejection = expect(callbackPromise).rejects.toThrow("No authorization code provided")
 
-				    /* ── Content ──────────────────────────────────────── */
-				    .content {
-				      position: relative;
-				      z-index: 2;
-				      display: flex;
-				      flex-direction: column;
-				      align-items: center;
-				      gap: 32px;
-				    }
+			const response = await fetch(`http://127.0.0.1:${port}/mcp/oauth/callback?state=state-no-code`)
+			const body = await response.text()
 
-				    /* Logo */
-				    .logo-wrap {
-				      display: flex;
-				      align-items: center;
-				      opacity: 0;
-				      transform: translateY(-12px);
-				      animation: fadeUp 0.55s cubic-bezier(0.22, 1, 0.36, 1) 0.1s forwards;
-				    }
-
-				    .logo-wrap svg {
-				      height: 40px;
-				      width: auto;
-				      display: block;
-				    }
-
-				    /* Card */
-				    .card {
-				      background: rgba(28, 28, 36, 0.88);
-				      border: 1px solid rgba(234, 231, 226, 0.09);
-				      border-radius: 20px;
-				      padding: 44px 52px;
-				      width: 100%;
-				      max-width: 360px;
-				      text-align: center;
-				      backdrop-filter: blur(24px);
-				      -webkit-backdrop-filter: blur(24px);
-				      display: flex;
-				      flex-direction: column;
-				      gap: 14px;
-				      opacity: 0;
-				      transform: translateY(16px);
-				      animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.25s forwards;
-				    }
-
-				    .card h1 {
-				      font-size: 17px;
-				      font-weight: 600;
-				      letter-spacing: -0.01em;
-				      color: #ef4444;
-				      line-height: 1.3;
-				    }
-
-				    .card p {
-				      font-size: 13.5px;
-				      font-weight: 400;
-				      color: #a1a1aa;
-				      line-height: 1.6;
-				    }
-
-				    .card .details {
-				      margin-top: 8px;
-				      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-				      font-size: 12px;
-				      color: #fca5a5;
-				      white-space: pre-wrap;
-				      word-break: break-word;
-				      text-align: left;
-				      background: rgba(239, 68, 68, 0.12);
-				      border-radius: 10px;
-				      padding: 12px 14px;
-				    }
-
-				    /* ── Animations ───────────────────────────────────── */
-				    @keyframes fadeUp {
-				      to {
-				        opacity: 1;
-				        transform: translateY(0);
-				      }
-				    }
-
-				    @keyframes popIn {
-				      to {
-				        opacity: 1;
-				        transform: scale(1);
-				      }
-				    }
-				  </style>
-				</head>
-				<body>
-
-				  <!-- SVG background gradient -->
-				  <svg class="bg-svg" viewBox="0 0 1440 916" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-				    <g clip-path="url(#clip0)">
-				      <rect width="1440" height="916" fill="#0A0A0D"></rect>
-				      <circle cx="1643.73" cy="-109" r="602.269" fill="url(#paint0)"></circle>
-				      <circle cx="1214.01" cy="1117.99" r="761.28" fill="url(#paint1)"></circle>
-				      <circle cx="639.798" cy="971.665" r="950.892" fill="url(#paint2)"></circle>
-				      <circle cx="840.81" cy="1199.83" r="629.662" fill="url(#paint3)"></circle>
-				    </g>
-				    <defs>
-				      <radialGradient id="paint0" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1643.73 -109) rotate(91.3362) scale(602.433)">
-				        <stop stop-color="#AC3D1A"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1214.01 1117.99) rotate(91.3362) scale(761.487)">
-				        <stop stop-color="#36C3C4"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(639.798 971.665) rotate(91.3362) scale(951.151)">
-				        <stop stop-color="#AC3D1A"></stop>
-				        <stop offset="1" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <radialGradient id="paint3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(840.81 1199.83) rotate(91.3362) scale(629.834)">
-				        <stop stop-color="#BD978E"></stop>
-				        <stop offset="0.889427" stop-color="#0A0A0D" stop-opacity="0"></stop>
-				      </radialGradient>
-				      <clipPath id="clip0">
-				        <rect width="1440" height="916" fill="white"></rect>
-				      </clipPath>
-				    </defs>
-				  </svg>
-
-				  <!-- Main content -->
-				  <div class="content">
-
-				    <!-- Kimchi wordmark -->
-				    <div class="logo-wrap">
-				      <svg width="471" height="104" viewBox="0 0 471 104" fill="none" xmlns="http://www.w3.org/2000/svg">
-				        <path d="M454.815 34.482L462.021 35.871L469.313 34.482V84.4004H454.815V34.482ZM462.021 29.3599C459.416 29.3599 457.275 28.6943 455.597 27.3632C453.976 25.9741 453.166 24.151 453.166 21.8939C453.166 19.5788 453.976 17.7557 455.597 16.4245C457.275 15.0355 459.416 14.341 462.021 14.341C464.683 14.341 466.825 15.0355 468.445 16.4245C470.066 17.7557 470.876 19.5788 470.876 21.8939C470.876 24.151 470.066 25.9741 468.445 27.3632C466.825 28.6943 464.683 29.3599 462.021 29.3599Z" fill="white"/>
-				        <path d="M391.715 17.5529H406.213V84.4002H391.715V17.5529ZM425.052 33.7004C429.74 33.7004 433.734 34.6554 437.032 36.5653C440.331 38.4174 442.849 41.0797 444.585 44.5523C446.322 48.0249 447.19 52.163 447.19 56.9668V84.4002H432.692V59.1372C432.692 54.6807 431.621 51.3238 429.48 49.0666C427.338 46.7516 424.242 45.5941 420.19 45.5941C417.354 45.5941 414.866 46.2307 412.724 47.504C410.641 48.7194 409.02 50.4267 407.863 52.626C406.763 54.8254 406.213 57.4587 406.213 60.5262L401.438 58.0086C402.075 52.7997 403.464 48.4011 405.606 44.8127C407.805 41.2244 410.583 38.4753 413.94 36.5653C417.297 34.6554 421.001 33.7004 425.052 33.7004Z" fill="white"/>
-				        <path d="M386.492 64.2595C385.913 68.4845 384.264 72.2175 381.544 75.4586C378.881 78.6997 375.438 81.2173 371.213 83.0115C366.988 84.8056 362.271 85.7027 357.062 85.7027C351.158 85.7027 345.95 84.632 341.435 82.4906C336.979 80.2913 333.477 77.2238 330.931 73.2882C328.442 69.3526 327.198 64.8383 327.198 59.7451C327.198 54.5941 328.442 50.0798 330.931 46.202C333.477 42.2664 336.979 39.199 341.435 36.9997C345.95 34.8004 351.158 33.7007 357.062 33.7007C362.271 33.7007 366.988 34.6267 371.213 36.4788C375.438 38.273 378.881 40.7906 381.544 44.0317C384.264 47.2149 385.913 50.9479 386.492 55.2308H371.994C371.242 51.8739 369.505 49.2984 366.785 47.5043C364.123 45.6522 360.882 44.7262 357.062 44.7262C353.994 44.7262 351.303 45.3339 348.988 46.5493C346.731 47.7068 344.995 49.4142 343.779 51.6714C342.564 53.8707 341.956 56.5619 341.956 59.7451C341.956 62.8705 342.564 65.5617 343.779 67.8189C344.995 70.0182 346.731 71.7256 348.988 72.941C351.303 74.0985 353.994 74.6773 357.062 74.6773C360.94 74.6773 364.21 73.7223 366.872 71.8124C369.592 69.9024 371.299 67.3848 371.994 64.2595H386.492Z" fill="white"/>
-				        <path d="M227.479 35.0029H241.977L245.102 53.8417V84.4005H230.604V51.6714L227.479 35.0029ZM262.725 33.7007C267.124 33.7007 270.886 34.6557 274.011 36.5656C277.137 38.4176 279.51 41.08 281.13 44.5526C282.809 48.0251 283.648 52.1633 283.648 56.9671V84.4005H269.15V59.1374C269.15 54.6809 268.166 51.3241 266.198 49.0669C264.288 46.7519 261.481 45.5943 257.777 45.5943C255.173 45.5943 252.915 46.231 251.005 47.5043C249.096 48.7197 247.62 50.427 246.578 52.6263C245.594 54.8256 245.102 57.459 245.102 60.5265L240.327 58.0088C240.906 52.7999 242.237 48.4013 244.321 44.813C246.404 41.2247 249.009 38.4755 252.134 36.5656C255.317 34.6557 258.848 33.7007 262.725 33.7007ZM301.184 33.7007C305.583 33.7007 309.345 34.6557 312.47 36.5656C315.653 38.4176 318.055 41.08 319.676 44.5526C321.354 48.0251 322.193 52.1633 322.193 56.9671V84.4005H307.695V59.1374C307.695 54.6809 306.712 51.3241 304.744 49.0669C302.834 46.7519 300.027 45.5943 296.323 45.5943C293.718 45.5943 291.461 46.231 289.551 47.5043C287.641 48.7197 286.165 50.427 285.124 52.6263C284.14 54.8256 283.648 57.459 283.648 60.5265L278.873 58.0088C279.452 52.7999 280.783 48.4013 282.866 44.813C284.95 41.2247 287.554 38.4755 290.68 36.5656C293.863 34.6557 297.364 33.7007 301.184 33.7007Z" fill="white"/>
-				        <path d="M206.993 34.482L214.199 35.871L221.491 34.482V84.4004H206.993V34.482ZM214.199 29.3599C211.594 29.3599 209.453 28.6943 207.774 27.3632C206.154 25.9741 205.344 24.151 205.344 21.8939C205.344 19.5788 206.154 17.7557 207.774 16.4245C209.453 15.0355 211.594 14.341 214.199 14.341C216.861 14.341 219.003 15.0355 220.623 16.4245C222.244 17.7557 223.054 19.5788 223.054 21.8939C223.054 24.151 222.244 25.9741 220.623 27.3632C219.003 28.6943 216.861 29.3599 214.199 29.3599Z" fill="white"/>
-				        <path d="M136.97 84.4004V19.2894H151.641V72.42L147.474 69.4683L187.756 19.2894H203.47L150.252 84.4004H136.97ZM168.049 52.5395L178.641 43.0767L204.425 84.4004H187.583L168.049 52.5395Z" fill="white"/>
-				        <circle cx="52" cy="52" r="52" fill="#FF521D"/>
-				        <path d="M68.4459 24.9438C69.8639 24.1762 71.6471 23.7178 73.4821 24.2163C73.8278 24.2966 74.1339 24.3916 74.4362 24.5024L75.9186 25.0464L75.5104 26.5727C75.3469 27.1827 75.202 27.723 75.0387 28.3325L74.6442 29.8042L73.1354 29.5972C73.0242 29.5819 72.9246 29.5753 72.8082 29.5747C72.2474 29.5865 71.7542 29.8645 71.2662 30.6772C70.8883 31.307 70.5939 32.1486 70.3815 33.1079C74.871 36.0331 77.8444 41.0994 77.8444 46.8638C77.8443 49.5292 77.2072 52.0505 76.0758 54.2798C71.5108 64.3996 54.1783 84.8815 23.4655 79.0083C21.8797 78.7048 20.9918 77.4165 20.902 76.1245C20.8141 74.8561 21.479 73.487 22.8981 72.8813C31.0698 69.394 35.5884 65.7091 38.5983 61.2329C41.6553 56.6866 43.2606 51.1907 45.3287 43.7251C46.7942 36.1645 53.4462 30.4547 61.4362 30.4546L61.8834 30.4604C62.4398 30.4755 62.9894 30.519 63.5309 30.5884C63.9515 29.7288 64.4424 28.8863 65.0211 28.0659L65.1745 27.8423C65.9623 26.731 67.1108 25.6667 68.4459 24.9438Z" fill="#18181A"/>
-				      </svg>
-				    </div>
-
-				    <!-- Error card -->
-				    <div class="card">
-				      <h1>MCP Authorization Failed</h1>
-				      <p>An error occurred during MCP authorization.</p>
-				      <div class="details">The user denied the authorization request</div>
-				    </div>
-
-				  </div>
-
-				</body>
-				</html>
-				"
-			`)
+			expect(response.status).toBe(400)
+			expect(body).toContain("<title>MCP Authorization Failed</title>")
+			await rejection
 		} finally {
 			await callbackServer.stopCallbackServer()
 		}
@@ -498,8 +149,9 @@ describe("MCP OAuth callback page", () => {
 
 			expect(response.status).toBe(200)
 			await expect(callbackPromise).resolves.toBe("test-code")
-			expect(body).toContain("MCP Authorization Successful")
+			expect(body).toContain("<title>MCP Authorization Successful</title>")
 			expect(body).not.toContain("bg-svg")
+			expect(body).not.toContain(KIMCHI_LOGO_ORANGE)
 			expect(body).not.toContain("Pi -")
 		} finally {
 			await callbackServer.stopCallbackServer()

--- a/src/extensions/mcp-adapter/mcp-callback-server.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.ts
@@ -97,6 +97,14 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 	if (!code) {
 		res.writeHead(400, { "Content-Type": "text/html" })
 		res.end(oauthErrorHtml(ERROR_MESSAGE, "No authorization code provided", ERROR_PAGE))
+		// Reject the pending auth so the flow fails fast instead of hanging until the timeout
+		if (pendingAuths.has(state)) {
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			const pending = pendingAuths.get(state)!
+			clearTimeout(pending.timeout)
+			pendingAuths.delete(state)
+			setTimeout(() => pending.reject(new Error("No authorization code provided")), 0)
+		}
 		return
 	}
 

--- a/src/extensions/mcp-adapter/mcp-callback-server.ts
+++ b/src/extensions/mcp-adapter/mcp-callback-server.ts
@@ -6,6 +6,7 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
+import { oauthErrorHtml, oauthSuccessHtml } from "../../utils/oauth-page.js"
 import {
 	getConfiguredOAuthCallbackPort,
 	getOAuthCallbackPort,
@@ -13,47 +14,14 @@ import {
 	setOAuthCallbackPort,
 } from "./mcp-oauth-provider.js"
 
-// HTML templates for callback responses
-const HTML_SUCCESS = `<!DOCTYPE html>
-<html>
-<head>
-  <title>Pi - Authorization Successful</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
-    .container { text-align: center; padding: 2rem; }
-    h1 { color: #4ade80; margin-bottom: 1rem; }
-    p { color: #aaa; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Authorization Successful</h1>
-    <p>You can close this window and return to Pi.</p>
-  </div>
-  <script>setTimeout(() => window.close(), 2000);</script>
-</body>
-</html>`
-
-const HTML_ERROR = (error: string) => `<!DOCTYPE html>
-<html>
-<head>
-  <title>Pi - Authorization Failed</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
-    .container { text-align: center; padding: 2rem; }
-    h1 { color: #f87171; margin-bottom: 1rem; }
-    p { color: #aaa; }
-    .error { color: #fca5a5; font-family: monospace; margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Authorization Failed</h1>
-    <p>An error occurred during authorization.</p>
-    <div class="error">${error}</div>
-  </div>
-</body>
-</html>`
+// Branded OAuth callback pages come from the shared renderer (templates in
+// resources/oauth/, via KIMCHI_OAUTH_TEMPLATE_DIR); it also HTML-escapes the
+// provider-controlled error text. Falls back to a minimal unbranded page when
+// the template dir is not configured.
+const SUCCESS_MESSAGE = "You can close this window and return to Kimchi."
+const SUCCESS_PAGE = { title: "MCP Authorization Successful", heading: "MCP Authorization Successful" }
+const ERROR_MESSAGE = "An error occurred during MCP authorization."
+const ERROR_PAGE = { title: "MCP Authorization Failed", heading: "MCP Authorization Failed" }
 
 /** Pending authorization request */
 interface PendingAuth {
@@ -104,7 +72,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 	if (!state) {
 		const errorMsg = "Missing required state parameter - potential CSRF attack"
 		res.writeHead(400, { "Content-Type": "text/html" })
-		res.end(HTML_ERROR(errorMsg))
+		res.end(oauthErrorHtml(ERROR_MESSAGE, errorMsg, ERROR_PAGE))
 		return
 	}
 
@@ -113,7 +81,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 		const errorMsg = errorDescription || error
 		// Send HTTP response first before rejecting promise
 		res.writeHead(200, { "Content-Type": "text/html" })
-		res.end(HTML_ERROR(errorMsg))
+		res.end(oauthErrorHtml(ERROR_MESSAGE, errorMsg, ERROR_PAGE))
 		// Reject promise after response is sent (defer to allow test to attach handler)
 		if (pendingAuths.has(state)) {
 			// biome-ignore lint/style/noNonNullAssertion: asserted above
@@ -128,7 +96,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 	// Require authorization code
 	if (!code) {
 		res.writeHead(400, { "Content-Type": "text/html" })
-		res.end(HTML_ERROR("No authorization code provided"))
+		res.end(oauthErrorHtml(ERROR_MESSAGE, "No authorization code provided", ERROR_PAGE))
 		return
 	}
 
@@ -136,7 +104,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 	if (!pendingAuths.has(state)) {
 		const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
 		res.writeHead(400, { "Content-Type": "text/html" })
-		res.end(HTML_ERROR(errorMsg))
+		res.end(oauthErrorHtml(ERROR_MESSAGE, errorMsg, ERROR_PAGE))
 		return
 	}
 
@@ -149,7 +117,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse): void {
 	pending.resolve(code)
 
 	res.writeHead(200, { "Content-Type": "text/html" })
-	res.end(HTML_SUCCESS)
+	res.end(oauthSuccessHtml(SUCCESS_MESSAGE, SUCCESS_PAGE))
 }
 
 /**

--- a/src/utils/oauth-page.test.ts
+++ b/src/utils/oauth-page.test.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js"
 
 const templateDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../resources/oauth")
@@ -9,19 +9,12 @@ const templateDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../reso
 // branded template rendered rather than the unbranded fallback.
 const KIMCHI_LOGO_ORANGE = "#FF521D"
 
-let originalTemplateDir: string | undefined
-
 beforeEach(() => {
-	originalTemplateDir = process.env.KIMCHI_OAUTH_TEMPLATE_DIR
-	process.env.KIMCHI_OAUTH_TEMPLATE_DIR = templateDir
+	vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", templateDir)
 })
 
 afterEach(() => {
-	if (originalTemplateDir === undefined) {
-		delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
-	} else {
-		process.env.KIMCHI_OAUTH_TEMPLATE_DIR = originalTemplateDir
-	}
+	vi.unstubAllEnvs()
 })
 
 describe("oauthSuccessHtml", () => {
@@ -67,7 +60,7 @@ describe("oauthErrorHtml", () => {
 
 describe("unbranded fallback", () => {
 	it("applies overrides when the template dir is not configured", () => {
-		delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+		vi.stubEnv("KIMCHI_OAUTH_TEMPLATE_DIR", "")
 
 		const html = oauthSuccessHtml("msg", {
 			title: "MCP Authorization Successful",

--- a/src/utils/oauth-page.test.ts
+++ b/src/utils/oauth-page.test.ts
@@ -1,0 +1,80 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.js"
+
+const templateDir = resolve(dirname(fileURLToPath(import.meta.url)), "../../resources/oauth")
+
+// The Kimchi logo SVG in both templates uses this exact orange — proof the
+// branded template rendered rather than the unbranded fallback.
+const KIMCHI_LOGO_ORANGE = "#FF521D"
+
+let originalTemplateDir: string | undefined
+
+beforeEach(() => {
+	originalTemplateDir = process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+	process.env.KIMCHI_OAUTH_TEMPLATE_DIR = templateDir
+})
+
+afterEach(() => {
+	if (originalTemplateDir === undefined) {
+		delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+	} else {
+		process.env.KIMCHI_OAUTH_TEMPLATE_DIR = originalTemplateDir
+	}
+})
+
+describe("oauthSuccessHtml", () => {
+	it("applies title/heading overrides on the branded page", () => {
+		const html = oauthSuccessHtml("You can close this window and return to Kimchi.", {
+			title: "MCP Authorization Successful",
+			heading: "MCP Authorization Successful",
+		})
+
+		expect(html).toContain(KIMCHI_LOGO_ORANGE)
+		expect(html).toContain("<title>MCP Authorization Successful</title>")
+		expect(html).toContain("<h1>MCP Authorization Successful</h1>")
+		expect(html).toContain("You can close this window and return to Kimchi.")
+	})
+
+	it("keeps the default authentication wording without overrides", () => {
+		const html = oauthSuccessHtml("done")
+
+		expect(html).toContain("<title>Authentication successful</title>")
+		expect(html).toContain("<h1>Authentication successful</h1>")
+	})
+})
+
+describe("oauthErrorHtml", () => {
+	it("applies overrides and HTML-escapes the details", () => {
+		const html = oauthErrorHtml("An error occurred during MCP authorization.", "<script>alert(1)</script>", {
+			title: "MCP Authorization Failed",
+			heading: "MCP Authorization Failed",
+		})
+
+		expect(html).toContain("<title>MCP Authorization Failed</title>")
+		expect(html).toContain("An error occurred during MCP authorization.")
+		expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;")
+		expect(html).not.toContain("<script>alert(1)</script>")
+	})
+
+	it("keeps the default authentication wording without overrides", () => {
+		const html = oauthErrorHtml("nope")
+
+		expect(html).toContain("<title>Authentication failed</title>")
+	})
+})
+
+describe("unbranded fallback", () => {
+	it("applies overrides when the template dir is not configured", () => {
+		delete process.env.KIMCHI_OAUTH_TEMPLATE_DIR
+
+		const html = oauthSuccessHtml("msg", {
+			title: "MCP Authorization Successful",
+			heading: "MCP Authorization Successful",
+		})
+
+		expect(html).toContain("<title>MCP Authorization Successful</title>")
+		expect(html).not.toContain(KIMCHI_LOGO_ORANGE)
+	})
+})

--- a/src/utils/oauth-page.ts
+++ b/src/utils/oauth-page.ts
@@ -1,4 +1,5 @@
-// Branded OAuth callback pages for the Kimchi-account browser login.
+// Branded OAuth callback pages shared by the browser-based auth flows
+// (Kimchi-account CLI login, MCP server OAuth authorization).
 //
 // This mirrors the renderer that `scripts/patch-pi-ai-oauth.js` injects into
 // pi-ai's `oauth-page.js`: both read the SAME templates from
@@ -74,19 +75,26 @@ function renderPage(options: PageOptions): string {
 </html>`
 }
 
-export function oauthSuccessHtml(message: string): string {
+/** Optional page wording for flows that need something other than the default
+ * authentication copy (e.g. MCP authorization callbacks). */
+export interface PageOverrides {
+	title?: string
+	heading?: string
+}
+
+export function oauthSuccessHtml(message: string, overrides: PageOverrides = {}): string {
 	return renderPage({
-		title: "Authentication successful",
-		heading: "Authentication successful",
+		title: overrides.title ?? "Authentication successful",
+		heading: overrides.heading ?? "Authentication successful",
 		message,
 		template: "success",
 	})
 }
 
-export function oauthErrorHtml(message: string, details?: string): string {
+export function oauthErrorHtml(message: string, details?: string, overrides: PageOverrides = {}): string {
 	return renderPage({
-		title: "Authentication failed",
-		heading: "Authentication failed",
+		title: overrides.title ?? "Authentication failed",
+		heading: overrides.heading ?? "Authentication failed",
 		message,
 		details,
 		template: "error",


### PR DESCRIPTION
## Linked issue

No linked issue — branding inconsistency surfaced during MCP OAuth testing (providers like Rovo/Slack land on the Pi-branded callback page after authorizing).

## What does this PR do?

MCP OAuth callbacks rendered hardcoded Pi-branded HTML (`Pi - Authorization Successful`). This PR:

- Routes `mcp-callback-server.ts` through the shared branded OAuth page renderer with MCP-specific wording ("MCP Authorization Successful" / "MCP Authorization Failed")
- Moves that renderer from `src/cli-auth/` to `src/utils/` since it now serves both auth flows; cli-auth pages keep their default "Authentication" wording
- Adds optional `{ title, heading }` overrides to `oauthSuccessHtml` / `oauthErrorHtml` (additive, existing call sites unchanged)
- Closes an HTML injection: provider-supplied `error_description` was interpolated unescaped in the old inline template; the shared renderer escapes it

## Testing

- New `mcp-callback-server.test.ts`: branded success/error page snapshots, HTML-escaping regression test, unbranded-fallback test
- New `src/utils/oauth-page.test.ts`: override behavior, default-wording regression, fallback
- New env-gated preview tests for both flows (`KIMCHI_SHOW_OAUTH_PAGE=1 pnpm vitest run <file>`) that start the real servers and print browser URLs for live inspection
- Typecheck and biome pass; affected suites pass (`cache-resolver.integration.test.ts` has pre-existing, environment-dependent local failures, identical with and without this change)

## Checklist

- [x] Tests pass locally (`pnpm run test`) — targeted suites; see note above
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed — N/A, no documented contract changes
