### PR TITLE
fix(telemetry): emit CLI version in session attributes

### DIFF
--- a/src/extensions/telemetry/handlers/session.test.ts
+++ b/src/extensions/telemetry/handlers/session.test.ts
@@ -158,6 +158,7 @@ describe("handleSessionShutdown", () => {
 		expect(typeChangedAttrs.session_type).toBe("ferment")
 		expect(typeChangedAttrs.previous_session_type).toBe("coding")
 		expect(typeChangedAttrs.ferment_id).toBe("f-drift")
+		expect(typeChangedAttrs["telemetry.cli_version"]).toBeDefined()
 
 		const endRecord = allRecords.find((r) => r.eventName === "session.end")
 		expect(endRecord).toBeDefined()

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -232,6 +232,7 @@ describe("telemetryExtension integration", () => {
 			session_type: "coding",
 			source: "cli",
 			"telemetry.arch": expect.any(String),
+			"telemetry.cli_version": expect.any(String),
 			"telemetry.host_os": expect.any(String),
 			"telemetry.is_wsl": expect.any(String),
 			"telemetry.os": expect.any(String),

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -4,6 +4,7 @@ import { getMe } from "../../api/me.js"
 import type { TelemetryConfig } from "../../config.js"
 import { IS_ACP_MODE } from "../../modes/acp/state.js"
 import { getOsMetadata } from "../../utils/os-metadata.js"
+import { getVersion } from "../../utils.js"
 import { getActiveFerment } from "../ferment/index.js"
 import { type CumulativeState, collectMetrics, createCumulativeState } from "./accumulator.js"
 import { getAcpAttributes, getPiSessionAttributes } from "./handlers/utils.js"
@@ -176,6 +177,7 @@ export class TelemetryContext {
 				previous_session_type: this.lastSessionType,
 				source,
 				ferment_id: ferment?.id ?? "",
+				"telemetry.cli_version": getVersion(),
 			})
 			this.logBuffer.push(buildLogRecord(this.telemetryId, "session.type_changed", changeAttrs))
 		}
@@ -200,6 +202,7 @@ export class TelemetryContext {
 			source: IS_ACP_MODE ? "acp" : "cli",
 			session_type: getSessionType(),
 			model: this.currentModel,
+			"telemetry.cli_version": getVersion(),
 			...getAcpAttributes(),
 			...(ctx ? getPiSessionAttributes(ctx) : {}),
 		}


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Add telemetry.cli_version (from getVersion()) to the base session attributes and to session.type_changed attributes, so emitted telemetry records identify the CLI version that produced them.


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
