### PR TITLE
feat(telemetry): inject traceparent header into model requests

### DIFF
--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -317,6 +317,65 @@ describe("telemetryExtension integration", () => {
 		expect(headers["X-Session-Id"]).toBeTruthy()
 		expect(headers["X-Turn-Index"]).toBe("4")
 	})
+
+	it("before_provider_headers injects W3C traceparent derived from session id", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const event = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		const sessionId = event.headers["X-Session-Id"]
+		const traceparent = event.headers.traceparent
+		expect(traceparent).toBeDefined()
+		const [version, traceId, spanId, flags] = traceparent.split("-")
+		expect(version).toBe("00")
+		expect(traceId).toBe(sessionId.replace(/-/g, "").toLowerCase())
+		expect(traceId).toMatch(/^[0-9a-f]{32}$/)
+		expect(spanId).toMatch(/^[0-9a-f]{16}$/)
+		expect(flags).toBe("01")
+	})
+
+	it("before_provider_headers generates a fresh span id on each request", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const event1 = { headers: {} as Record<string, string> }
+		const event2 = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event1)
+		getHandler(handlers, "before_provider_headers")(event2)
+
+		const spanId1 = event1.headers.traceparent.split("-")[2]
+		const spanId2 = event2.headers.traceparent.split("-")[2]
+		expect(spanId1).not.toBe(spanId2)
+	})
+
+	it("before_provider_headers preserves an existing traceparent header", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const existingTraceparent = "00-11111111111111111111111111111111-2222222222222222-01"
+		const event = { headers: { traceparent: existingTraceparent } as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(event.headers.traceparent).toBe(existingTraceparent)
+	})
+
+	it("before_provider_headers preserves an existing traceparent header regardless of case", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const existingTraceparent = "00-11111111111111111111111111111111-2222222222222222-01"
+		const event = { headers: { Traceparent: existingTraceparent } as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(event.headers.Traceparent).toBe(existingTraceparent)
+		expect(event.headers.traceparent).toBeUndefined()
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto"
+
 import type { Message } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import type { TelemetryConfig } from "../../config.js"
@@ -740,6 +742,23 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			event.headers["X-Session-Id"] = telemetryCtx.telemetryId
 			// 0 means "before first turn" (sentinel); backend should treat it accordingly.
 			event.headers["X-Turn-Index"] = String(telemetryCtx.turnIndex)
+
+			// Inject W3C Trace Context (if not already present) derived from
+			// the session id so that downstream distributed tracing spans
+			// join the same trace. Header names are case-insensitive, so
+			// check all keys rather than a single property name.
+			// Example:
+			//   session id: 85a2d4f5-9f9f-49fb-890e-522a10e4a1e8
+			//   trace id:   85a2d4f59f9f49fb890e522a10e4a1e8
+			//   span id:    <new random 16-hex value per request>
+			const hasTraceparent = Object.keys(event.headers).some((name) => name.toLowerCase() === "traceparent")
+			if (!hasTraceparent) {
+				const traceId = telemetryCtx.telemetryId.replace(/-/g, "").toLowerCase()
+				if (traceId.length === 32) {
+					const spanId = randomBytes(8).toString("hex")
+					event.headers.traceparent = `00-${traceId}-${spanId}-01`
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->
Added a W3C [traceparent](https://www.w3.org/TR/trace-context/) header to outgoing model requests. This enables telemetry tools to correlate distributed traces with Kimchi sessions via session id.

This PR is an extension of https://github.com/getkimchi/kimchi/pull/1005, where session id injection was added.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
