### PR TITLE
Keep the CLI running when a child process closes its stdin early

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,9 @@ import { dispatchSubcommand } from "./commands/dispatch.js"
 // IMPORTANT: must be first local import — patches InteractiveMode.prototype
 // before any module can construct an InteractiveMode instance.
 import "./login-command-patch.js"
+// Patches InteractiveMode.prototype so a broken pipe (EPIPE/ECONNRESET) from a
+// child process does not crash the CLI. Load early for the same reason as above.
+import "./uncaught-epipe-patch.js"
 import "./paste-to-editor-patch.js"
 import {
 	DEFAULT_SKILL_PATHS,

--- a/src/extensions/hook-adapters/adapter.stdin-epipe.test.ts
+++ b/src/extensions/hook-adapters/adapter.stdin-epipe.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { runCommandHook } from "./adapter.js"
+
+// This suite uses the REAL child_process.spawn (no vi.mock), because the
+// behaviour under test only appears with a real child process and a real pipe.
+//
+// The hook runner writes the event payload to the child's stdin with
+// child.stdin.end(input). If the hook command ignores its stdin and exits
+// immediately while a large payload is still being flushed, the OS tears down
+// the read end of the pipe and the write fails with EPIPE ("broken pipe").
+// That error arrives asynchronously on the stdin stream. The runner attaches
+// an error handler to the ChildProcess (child.on("error")) but not to the
+// stdin stream, so the stream error has no handler and surfaces as a
+// process-level unhandled error, which can take down the process.
+//
+// Payload size matters: the write only backs up once it exceeds the OS pipe
+// buffer (about 64 KB on macOS), so a small payload never exposes the bug. We
+// use ~1 MB to make the broken-pipe write reliable.
+const LARGE_PAYLOAD_BYTES = 1_000_000
+
+let dir: string
+
+describe("hook adapter stdin write reliability", () => {
+	beforeEach(() => {
+		dir = join(tmpdir(), `kimchi-hook-epipe-${process.pid}-${Math.random().toString(16).slice(2)}`)
+		mkdirSync(dir, { recursive: true })
+	})
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("does not raise an unhandled stream error when a hook ignores a large stdin payload", async () => {
+		// A hook command that never reads stdin and exits immediately with success.
+		const hook = { command: "true", async: false, timeoutMs: 5000 }
+		const payload = {
+			hook_event_name: "PostToolUse",
+			// A big tool result is a realistic way for a hook event to carry a
+			// payload larger than the OS pipe buffer.
+			tool_output: "x".repeat(LARGE_PAYLOAD_BYTES),
+		}
+
+		// Capture any process-level unhandled error that the stdin write triggers.
+		// We temporarily take over the process handlers so a captured EPIPE does
+		// not crash the test worker, then restore the originals afterwards.
+		const captured: string[] = []
+		const onUncaught = (err: NodeJS.ErrnoException) => {
+			captured.push(`uncaughtException:${err?.code ?? err?.message ?? err}`)
+		}
+		const onRejection = (reason: unknown) => {
+			const err = reason as NodeJS.ErrnoException
+			captured.push(`unhandledRejection:${err?.code ?? err?.message ?? String(reason)}`)
+		}
+		const prevUncaught = process.listeners("uncaughtException")
+		const prevRejection = process.listeners("unhandledRejection")
+		process.removeAllListeners("uncaughtException")
+		process.removeAllListeners("unhandledRejection")
+		process.on("uncaughtException", onUncaught)
+		process.on("unhandledRejection", onRejection)
+
+		try {
+			const result = await runCommandHook(hook, payload, dir)
+			// The broken-pipe error arrives after the child closes, so give the
+			// event loop time to deliver it before asserting.
+			await new Promise((resolve) => setTimeout(resolve, 250))
+
+			expect(captured, `unhandled stream error(s): ${captured.join(", ")}`).toEqual([])
+			// A hook that exits 0 with no output yields an empty result.
+			expect(result).toEqual({})
+		} finally {
+			process.removeListener("uncaughtException", onUncaught)
+			process.removeListener("unhandledRejection", onRejection)
+			for (const listener of prevUncaught) process.on("uncaughtException", listener as never)
+			for (const listener of prevRejection) process.on("unhandledRejection", listener as never)
+		}
+	})
+})

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -1052,7 +1052,7 @@ function fakeChild() {
 	const stdoutHandlers: Array<(chunk: string) => void> = []
 	const stderrHandlers: Array<(chunk: string) => void> = []
 	const child = {
-		stdin: { end: vi.fn() },
+		stdin: { end: vi.fn(), on: vi.fn(() => child.stdin) },
 		stdout: {
 			setEncoding: vi.fn(),
 			on: vi.fn((event: string, handler: (chunk: string) => void) => {

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -211,6 +211,10 @@ export async function runCommandHook(
 			timeout.unref?.()
 			child.once("exit", clearKillTimer)
 			child.once("close", clearKillTimer)
+			// A hook that ignores its stdin and exits makes the write fail with a
+			// broken pipe (EPIPE). That is benign here, so swallow it rather than
+			// letting it surface as an unhandled stream error that crashes the process.
+			child.stdin.on("error", () => {})
 			child.stdin.end(input)
 			child.unref()
 		} catch {
@@ -273,6 +277,10 @@ function runBlockingCommandHook(
 				child.kill()
 				settle({})
 			}, hook.timeoutMs)
+			// A hook that ignores its stdin and exits makes the write fail with a
+			// broken pipe (EPIPE). That is benign here, so swallow it rather than
+			// letting it surface as an unhandled stream error that crashes the process.
+			child.stdin.on("error", () => {})
 			child.stdin.end(input)
 		} catch {
 			settle({})

--- a/src/extensions/ui.ts
+++ b/src/extensions/ui.ts
@@ -248,6 +248,10 @@ function runScript(
 	child.stderr.on("data", (d: Buffer) => {
 		stderr += d.toString()
 	})
+	// A statusline script that ignores its stdin and exits makes the write fail
+	// with a broken pipe (EPIPE). That is benign here, so swallow it rather than
+	// letting it surface as an unhandled stream error that crashes the process.
+	child.stdin.on("error", () => {})
 	child.stdin.write(JSON.stringify(payload))
 	child.stdin.end()
 

--- a/src/uncaught-epipe-patch.test.ts
+++ b/src/uncaught-epipe-patch.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest"
+import { installUncaughtEpipePatch } from "./uncaught-epipe-patch.js"
+
+describe("uncaught EPIPE patch", () => {
+	it("swallows broken-pipe errors without calling the original crash handler", () => {
+		const original = vi.fn()
+		const modeClass = { prototype: { uncaughtCrash: original } }
+
+		installUncaughtEpipePatch(modeClass)
+		modeClass.prototype.uncaughtCrash({ code: "EPIPE" })
+		modeClass.prototype.uncaughtCrash({ code: "ECONNRESET" })
+
+		expect(original).not.toHaveBeenCalled()
+	})
+
+	it("delegates all other errors to the original crash handler", () => {
+		const original = vi.fn()
+		const modeClass = { prototype: { uncaughtCrash: original } }
+
+		installUncaughtEpipePatch(modeClass)
+		const error = new Error("boom")
+		modeClass.prototype.uncaughtCrash(error)
+
+		expect(original).toHaveBeenCalledWith(error)
+	})
+
+	it("wraps the crash handler once on repeated installs", () => {
+		const original = vi.fn()
+		const modeClass = { prototype: { uncaughtCrash: original } }
+
+		installUncaughtEpipePatch(modeClass)
+		const wrapped = modeClass.prototype.uncaughtCrash
+		installUncaughtEpipePatch(modeClass)
+
+		expect(modeClass.prototype.uncaughtCrash).toBe(wrapped)
+	})
+})

--- a/src/uncaught-epipe-patch.test.ts
+++ b/src/uncaught-epipe-patch.test.ts
@@ -1,3 +1,4 @@
+import { InteractiveMode } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import { installUncaughtEpipePatch } from "./uncaught-epipe-patch.js"
 
@@ -33,5 +34,10 @@ describe("uncaught EPIPE patch", () => {
 		installUncaughtEpipePatch(modeClass)
 
 		expect(modeClass.prototype.uncaughtCrash).toBe(wrapped)
+	})
+
+	it("targets a method that still exists on the SDK, so an upstream rename fails here instead of silently disabling the guard", () => {
+		const proto = (InteractiveMode as unknown as { prototype: { uncaughtCrash?: unknown } }).prototype
+		expect(typeof proto.uncaughtCrash).toBe("function")
 	})
 })

--- a/src/uncaught-epipe-patch.ts
+++ b/src/uncaught-epipe-patch.ts
@@ -1,0 +1,57 @@
+/**
+ * Makes broken-pipe errors (EPIPE / ECONNRESET) from the process's uncaught
+ * exception path non-fatal.
+ *
+ * A child process that ignores its stdin and exits can make a write to its pipe
+ * fail asynchronously with EPIPE. When such an error reaches the SDK's uncaught
+ * exception handler it would otherwise call `uncaughtCrash`, which restores the
+ * terminal and exits the process. A broken pipe is benign and must not take the
+ * CLI down, so we drop it here and let every other error crash as before.
+ *
+ * This module is imported for side effects. It must be loaded **before** any
+ * `InteractiveMode` instance is constructed so the prototype patch takes effect.
+ * The SDK registers its handler as `(error) => this.uncaughtCrash(error)`, so
+ * wrapping the prototype method takes effect regardless of registration order.
+ */
+
+import { InteractiveMode } from "@earendil-works/pi-coding-agent"
+
+type UncaughtCrash = (this: unknown, error: unknown) => void
+
+interface PatchableInteractiveMode {
+	prototype: {
+		uncaughtCrash?: UncaughtCrash
+		_kimchiUncaughtEpipePatch?: boolean
+	}
+}
+
+function isBrokenPipeError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException | undefined)?.code
+	return code === "EPIPE" || code === "ECONNRESET"
+}
+
+/** Exported for testing: applies the prototype patch (idempotent re-apply is safe). */
+export function installUncaughtEpipePatch(
+	modeClass: PatchableInteractiveMode = InteractiveMode as unknown as PatchableInteractiveMode,
+): void {
+	const proto = modeClass.prototype
+	if (proto._kimchiUncaughtEpipePatch) return
+	const original = proto.uncaughtCrash
+	if (!original) {
+		// Surface a renamed/moved upstream method instead of silently leaving the
+		// broken-pipe guard inactive after an SDK upgrade.
+		console.warn("uncaught-epipe patch: InteractiveMode.uncaughtCrash not found, EPIPE guard inactive")
+		return
+	}
+
+	proto.uncaughtCrash = function patchedUncaughtCrash(this: unknown, error: unknown): void {
+		// A broken pipe from a child process that ignored its stdin is benign;
+		// return without crashing so the CLI keeps running.
+		if (isBrokenPipeError(error)) return
+		original.call(this, error)
+	}
+	proto._kimchiUncaughtEpipePatch = true
+}
+
+// Apply patch on module load
+installUncaughtEpipePatch()

--- a/src/uncaught-epipe-patch.ts
+++ b/src/uncaught-epipe-patch.ts
@@ -26,6 +26,11 @@ interface PatchableInteractiveMode {
 }
 
 function isBrokenPipeError(error: unknown): boolean {
+	// A broken pipe surfaces as EPIPE for a regular pipe, and as ECONNRESET when the
+	// child's stdio is backed by a socket pair. Both mean the reader went away, so we
+	// treat them as the same benign case. This is deliberately broad: keeping the CLI
+	// alive on a stray reset is better than crashing it, and the error cannot be
+	// reliably attributed to a specific writer at the uncaught-exception layer.
 	const code = (error as NodeJS.ErrnoException | undefined)?.code
 	return code === "EPIPE" || code === "ECONNRESET"
 }


### PR DESCRIPTION
## TL;DR
A child process that closes its stdin early could crash the whole CLI with a broken pipe (EPIPE). This change makes that case non-fatal so the session keeps running.

## Requirements
- Writing to a child process's stdin must not crash the CLI when the child ignores stdin and exits.
- A broken pipe (EPIPE/ECONNRESET) that reaches the top level must not take the process down.
- Every other error still crashes as before.

## Changes
- Handle the stdin error at each place the CLI writes to a child process (command hooks and the statusline script).
- Add a small top-level guard that treats a broken pipe as non-fatal and lets all other errors through unchanged, covering write sites without an explicit handler (such as the language-server pipe).
- Add tests: a real-process regression test for the hook path, plus unit tests for the guard, including one that fails if the SDK method it wraps is ever renamed.
