### PR TITLE
feat(workflows): bundle Kimchi Workflows as a default-off built-in extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"dependencies": {
 		"@agentclientprotocol/sdk": "0.19.2",
 		"@bulkhead-ai/core": "^0.7.0",
+		"@kimchi-dev/kimchi-workflows": "0.0.8",
 		"@clack/prompts": "^1.3.0",
 		"@earendil-works/pi-coding-agent": "0.84.1",
 		"@earendil-works/pi-tui": "0.84.1",
@@ -59,14 +60,12 @@
 		"shiki": "^4.0.2",
 		"ssh2": "^1.17.0",
 		"tar": "^7.5.15",
+		"typebox": "1.3.7",
 		"undici": "^8.2.0",
 		"uuid": "^14.0.0",
 		"wcwidth": "^1.0.1",
 		"yaml": "^2.8.4",
 		"zod": "^4.4.3"
-	},
-	"peerDependencies": {
-		"typebox": "*"
 	},
 	"optionalDependencies": {
 		"@mariozechner/clipboard-darwin-arm64": "0.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
+      '@kimchi-dev/kimchi-workflows':
+        specifier: 0.0.8
+        version: 0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.1
         version: 1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
@@ -83,8 +86,8 @@ importers:
         specifier: ^7.5.15
         version: 7.5.15
       typebox:
-        specifier: '*'
-        version: 1.1.38
+        specifier: 1.3.7
+        version: 1.3.7
       undici:
         specifier: ^8.2.0
         version: 8.2.0
@@ -606,6 +609,15 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@kimchi-dev/kimchi-workflows@0.0.8':
+    resolution: {integrity: sha512-aEidwWek71dXqVXyZ6T3Zy4U8ntgVmoI/lldEVdIzle9pb+QbnOkWo4fGHiuLpC9yfCylvbvo7cTDy9ToLifRw==}
+    engines: {node: '>=22.19'}
+    hasBin: true
+    peerDependencies:
+      '@earendil-works/pi-coding-agent': '*'
+      '@earendil-works/pi-tui': '*'
+      typebox: '*'
 
   '@mariozechner/clipboard-darwin-arm64@0.3.6':
     resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
@@ -1181,11 +1193,134 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -1198,20 +1333,46 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
@@ -1334,6 +1495,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1385,6 +1550,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -1490,6 +1658,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1938,6 +2109,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2210,6 +2385,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   string-similarity@4.0.4:
     resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2257,6 +2435,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -2267,6 +2449,10 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -2306,15 +2492,17 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
-
   typebox@1.3.7:
     resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@5.26.5:
@@ -2429,6 +2617,47 @@ packages:
       '@types/node':
         optional: true
       '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3024,6 +3253,29 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@kimchi-dev/kimchi-workflows@0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@earendil-works/pi-coding-agent': 0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
+      '@types/node': 22.19.18
+      jiti: 2.7.0
+      typebox: 1.3.7
+      typescript: 7.0.2
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.18)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - msw
+      - vite
+
   '@mariozechner/clipboard-darwin-arm64@0.3.6':
     optional: true
 
@@ -3504,6 +3756,66 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@ungap/structured-clone@1.3.1': {}
 
   '@vitest/expect@3.2.4':
@@ -3514,9 +3826,26 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
   '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
+
+  '@vitest/mocker@4.1.10(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -3526,11 +3855,20 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
   '@vitest/runner@3.2.4':
     dependencies:
       '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
 
   '@vitest/snapshot@3.2.4':
     dependencies:
@@ -3538,15 +3876,30 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.10': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@xterm/headless@6.0.0': {}
 
@@ -3660,6 +4013,8 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3692,6 +4047,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -3770,6 +4127,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4285,6 +4644,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.4: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -4591,6 +4952,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.2.0: {}
+
   string-similarity@4.0.4: {}
 
   string-width@4.2.3:
@@ -4642,6 +5005,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4650,6 +5015,8 @@ snapshots:
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.1: {}
 
   tinyspy@4.0.4: {}
 
@@ -4684,11 +5051,32 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.1.38: {}
-
   typebox@1.3.7: {}
 
   typescript@5.9.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@5.26.5: {}
 
@@ -4813,6 +5201,34 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.19.18)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.2
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.1
+      vite: 7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.18
+    transitivePeerDependencies:
+      - msw
 
   wcwidth@1.0.1:
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { AgentSession, parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
+import piWorkflowsExtension from "@kimchi-dev/kimchi-workflows/extension"
 import {
 	getParsedCliArgs,
 	isCliAtFileArg,
@@ -651,6 +652,7 @@ try {
 			tipsExtension(),
 			...enabledExtensionFactories([
 				{ id: "extensions.agents", factory: agentsExtension },
+				{ id: "extensions.workflows", factory: piWorkflowsExtension },
 			] satisfies ManagedExtensionFactory[]),
 			helpExtension,
 			themeSelectorExtension,

--- a/src/resources/definitions.test.ts
+++ b/src/resources/definitions.test.ts
@@ -84,6 +84,18 @@ describe("resource definitions", () => {
 		// required when the user flips the /resources toggle.
 		expect(resource?.restartRequired).toBeFalsy()
 	})
+
+	it("registers Kimchi Workflows as a default-off built-in extension", () => {
+		const resource = getResourceDefinitions().find((candidate) => candidate.id === "extensions.workflows")
+
+		expect(resource).toMatchObject({
+			kind: "extensions",
+			label: "Kimchi Workflows",
+			defaultEnabled: false,
+			restartRequired: true,
+			description: expect.stringContaining("/workflow"),
+		})
+	})
 })
 
 function writeJson(path: string, data: unknown): void {

--- a/src/resources/definitions.ts
+++ b/src/resources/definitions.ts
@@ -86,6 +86,14 @@ export const STATIC_RESOURCE_DEFINITIONS: readonly ResourceDefinition[] = [
 		restartRequired: true,
 	},
 	{
+		id: "extensions.workflows",
+		kind: "extensions",
+		label: "Kimchi Workflows",
+		description: "Enable the /workflow command for authoring and running TypeScript workflows.",
+		defaultEnabled: false,
+		restartRequired: true,
+	},
+	{
 		id: PI_PACKAGE_LOOKUP_RESOURCE_ID,
 		kind: "extensions",
 		label: "Pi package lookup",

--- a/src/resources/store.test.ts
+++ b/src/resources/store.test.ts
@@ -41,6 +41,7 @@ describe("resource store", () => {
 		const path = tempSettingsPath()
 
 		expect(isResourceEnabled("hooks.bash", path)).toBe(true)
+		expect(isResourceEnabled("extensions.workflows", path)).toBe(false)
 		expect(isResourceEnabled("extensions.pi-package-lookup", path)).toBe(false)
 		expect(getResourceOverride("hooks.bash", path)).toBeUndefined()
 	})

--- a/tests/smoke/workflows.test.ts
+++ b/tests/smoke/workflows.test.ts
@@ -1,0 +1,293 @@
+import { execFileSync, spawn } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
+import { createInterface } from "node:readline"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { type FakeOpenAiServer, startFakeOpenAiServer } from "../e2e/tui/support/fake-openai-server.js"
+import { BINARY_PATH, PACKAGE_DIR } from "./harness.js"
+
+interface RpcResponse {
+	readonly id?: string
+	readonly type: "response"
+	readonly command: string
+	readonly success: boolean
+	readonly data?: unknown
+	readonly error?: string
+}
+
+interface RunEvent {
+	readonly type: string
+	readonly output?: unknown
+}
+
+interface WorkflowFixture {
+	readonly workflowsDir: string
+	readonly rpc: RpcProcess
+}
+
+interface RpcProcess {
+	request(type: string, fields?: Record<string, unknown>, timeoutMs?: number): Promise<RpcResponse>
+	stop(): Promise<void>
+}
+
+const REQUEST_TIMEOUT_MS = 120_000
+const TEST_TIMEOUT_MS = 180_000
+const originalCorepackHome = process.env.COREPACK_HOME ?? join(homedir(), ".cache", "node", "corepack")
+const originalCacheHome =
+	process.env.XDG_CACHE_HOME ??
+	(process.platform === "darwin" ? join(homedir(), "Library", "Caches") : join(homedir(), ".cache"))
+const pnpmStore = execFileSync("pnpm", ["store", "path"], { encoding: "utf8" }).trim()
+
+let modelServer: FakeOpenAiServer
+
+describe("bundled Kimchi Workflows extension", () => {
+	beforeAll(async () => {
+		modelServer = await startFakeOpenAiServer({ responses: [] })
+	})
+
+	afterAll(async () => {
+		await modelServer.stop()
+	})
+
+	it("exposes and runs a function-only workflow without a separately installed extension package", {
+		timeout: TEST_TIMEOUT_MS,
+	}, async () => {
+		await createFixture(
+			async (fixture) => {
+				writeFileSync(
+					join(fixture.workflowsDir, "bundled-smoke.workflow.ts"),
+					`import { createStep, createWorkflow } from "@kimchi-dev/kimchi-workflows"
+
+const greet = createStep({ name: "greet", run: async () => ({ message: "hello from the bundle" }) })
+
+export default createWorkflow({ name: "bundled-smoke" }).then(greet).commit()
+`,
+					"utf8",
+				)
+
+				const commands = await fixture.rpc.request("get_commands")
+				expect(commandNames(commands.data)).toContain("workflow")
+
+				const run = await fixture.rpc.request("prompt", { message: "/workflow run bundled-smoke" })
+				expect(run.success, run.error).toBe(true)
+				const runsDir = join(fixture.workflowsDir, "runs")
+				const eventFile = await waitFor(
+					() => existsSync(runsDir) && readdirSync(runsDir).find((file) => file.startsWith("workflow-bundled-smoke-")),
+					"the bundled workflow run file",
+				)
+				const completed = await waitFor(
+					() => readEvents(join(runsDir, eventFile)).find((event) => event.type === "run-completed"),
+					"the bundled workflow to complete",
+				)
+				expect(completed.output).toEqual({
+					message: "hello from the bundle",
+				})
+				expect(
+					modelServer.requests.some(
+						(request) => request.method === "POST" && request.url.startsWith("/openai/v1/chat/completions"),
+					),
+				).toBe(false)
+			},
+			{ workflowsEnabled: true },
+		)
+	})
+
+	it("does not register /workflow by default", { timeout: TEST_TIMEOUT_MS }, async () => {
+		await createFixture(async (fixture) => {
+			const commands = await fixture.rpc.request("get_commands")
+			expect(commandNames(commands.data)).not.toContain("workflow")
+		})
+	})
+})
+
+async function createFixture(
+	run: (fixture: WorkflowFixture) => Promise<void>,
+	options: { readonly workflowsEnabled?: boolean } = {},
+): Promise<void> {
+	const { workflowsEnabled } = options
+	const home = mkdtempSync(join(tmpdir(), "kimchi-workflows-smoke-home-"))
+	const workDir = mkdtempSync(join(tmpdir(), "kimchi-workflows-smoke-work-"))
+	const configDir = join(home, ".config", "kimchi")
+	const agentDir = join(configDir, "harness")
+	const workflowsDir = join(workDir, ".kimchi", "workflows")
+	mkdirSync(agentDir, { recursive: true })
+	mkdirSync(workflowsDir, { recursive: true })
+	writeJson(join(configDir, "config.json"), {
+		apiKey: "smoke-test",
+		llmEndpoint: modelServer.baseUrl,
+		skillPaths: [],
+		migrationState: "done",
+		onboarding: { hideSessionModeDialog: true },
+	})
+	writeJson(join(agentDir, "settings.json"), {
+		quietStartup: true,
+		hideThinkingBlock: true,
+		...(workflowsEnabled === undefined ? {} : { resources: { "extensions.workflows": workflowsEnabled } }),
+	})
+	writeJson(join(agentDir, "models.json"), {
+		providers: {
+			fake: {
+				baseUrl: `${modelServer.baseUrl}/openai/v1`,
+				apiKey: "smoke-test",
+				api: "openai-completions",
+				authHeader: true,
+				models: [
+					{
+						id: "basic",
+						name: "Basic",
+						reasoning: false,
+						input: ["text"],
+						contextWindow: 8192,
+						maxTokens: 1024,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						provider: "openai",
+					},
+				],
+			},
+		},
+	})
+
+	vi.stubEnv("HOME", home)
+	vi.stubEnv("PI_PACKAGE_DIR", PACKAGE_DIR)
+	vi.stubEnv("KIMCHI_API_KEY", "smoke-test")
+	vi.stubEnv("KIMCHI_DISABLE_BUILTIN_PROVIDERS", "1")
+	vi.stubEnv("KIMCHI_NO_UPDATE_CHECK", "1")
+	vi.stubEnv("KIMCHI_PERMISSIONS", "yolo")
+	vi.stubEnv("KIMCHI_RTK_AUTO_INSTALL", "0")
+	vi.stubEnv("KIMCHI_TELEMETRY_ENABLED", "0")
+	vi.stubEnv("PI_SKIP_VERSION_CHECK", "1")
+	vi.stubEnv("COREPACK_HOME", originalCorepackHome)
+	vi.stubEnv("XDG_CACHE_HOME", originalCacheHome)
+	vi.stubEnv("npm_config_offline", "true")
+	vi.stubEnv("npm_config_store_dir", pnpmStore)
+	vi.stubEnv("KIMCHI_WORKFLOWS_PACKAGE_DIR", undefined)
+	let rpc: RpcProcess | undefined
+	try {
+		rpc = await startRpc(workDir)
+		await run({ workflowsDir, rpc })
+	} finally {
+		await rpc?.stop()
+		vi.unstubAllEnvs()
+		rmSync(home, { recursive: true, force: true })
+		rmSync(workDir, { recursive: true, force: true })
+	}
+}
+
+/** Pi's exported RpcClient launches a Node script, so this narrow helper targets the compiled binary directly. */
+async function startRpc(cwd: string): Promise<RpcProcess> {
+	const child = spawn(BINARY_PATH, ["--provider", "fake", "--model", "basic", "--mode", "rpc", "--no-session"], {
+		cwd,
+		env: process.env,
+		stdio: ["pipe", "pipe", "pipe"],
+	})
+	let stderr = ""
+	let nextId = 1
+	child.stderr.setEncoding("utf8")
+	child.stderr.on("data", (chunk: string) => {
+		stderr += chunk
+	})
+	const lines = createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY })[Symbol.asyncIterator]()
+	const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()))
+
+	const rpc: RpcProcess = {
+		async request(type, fields = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
+			const id = `workflows-smoke-${nextId++}`
+			child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`)
+			const deadline = Date.now() + timeoutMs
+			for (;;) {
+				const remaining = deadline - Date.now()
+				if (remaining <= 0) throw new Error(`Kimchi RPC ${type} timed out${stderr ? `\n${stderr}` : ""}`)
+				const result = await withTimeout(lines.next(), remaining, `Kimchi RPC ${type} timed out`)
+				if (result.done) throw new Error(`Kimchi RPC exited during ${type}${stderr ? `\n${stderr}` : ""}`)
+				let value: unknown
+				try {
+					value = JSON.parse(result.value)
+				} catch (error) {
+					throw new Error(`Kimchi RPC emitted non-JSON stdout: ${result.value}`, { cause: error })
+				}
+				if (isRpcResponse(value) && value.id === id) return value
+			}
+		},
+		async stop() {
+			if (child.exitCode !== null || child.signalCode !== null) return
+			child.kill("SIGTERM")
+			const graceful = await Promise.race([
+				exited.then(() => true),
+				new Promise<false>((resolve) => setTimeout(() => resolve(false), 3_000)),
+			])
+			if (!graceful && child.exitCode === null && child.signalCode === null) {
+				child.kill("SIGKILL")
+				await exited
+			}
+		},
+	}
+
+	try {
+		const ready = await rpc.request("get_state", {}, 30_000)
+		if (!ready.success) throw new Error(ready.error ?? "Kimchi RPC startup failed")
+		return rpc
+	} catch (error) {
+		await rpc.stop()
+		throw error
+	}
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+		promise.then(
+			(value) => {
+				clearTimeout(timer)
+				resolve(value)
+			},
+			(error: unknown) => {
+				clearTimeout(timer)
+				reject(error)
+			},
+		)
+	})
+}
+
+async function waitFor<T>(check: () => T | false | undefined, label: string): Promise<T> {
+	const deadline = Date.now() + REQUEST_TIMEOUT_MS
+	while (Date.now() < deadline) {
+		const value = check()
+		if (value !== false && value !== undefined) return value
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	throw new Error(`Timed out waiting for ${label}`)
+}
+
+function isRpcResponse(value: unknown): value is RpcResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "response" &&
+		"command" in value &&
+		typeof value.command === "string" &&
+		"success" in value &&
+		typeof value.success === "boolean"
+	)
+}
+
+function commandNames(data: unknown): string[] {
+	if (!data || typeof data !== "object" || !("commands" in data) || !Array.isArray(data.commands)) return []
+	return data.commands.flatMap((command) =>
+		command && typeof command === "object" && "name" in command && typeof command.name === "string"
+			? [command.name]
+			: [],
+	)
+}
+
+function readEvents(filePath: string): RunEvent[] {
+	return readFileSync(filePath, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as RunEvent)
+}
+
+function writeJson(filePath: string, value: unknown): void {
+	writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 })
+}

--- a/tests/smoke/workflows.test.ts
+++ b/tests/smoke/workflows.test.ts
@@ -3,18 +3,10 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, 
 import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import { createInterface } from "node:readline"
+import type { RpcExtensionUIRequest, RpcResponse } from "@earendil-works/pi-coding-agent"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { type FakeOpenAiServer, startFakeOpenAiServer } from "../e2e/tui/support/fake-openai-server.js"
 import { BINARY_PATH, PACKAGE_DIR } from "./harness.js"
-
-interface RpcResponse {
-	readonly id?: string
-	readonly type: "response"
-	readonly command: string
-	readonly success: boolean
-	readonly data?: unknown
-	readonly error?: string
-}
 
 interface RunEvent {
 	readonly type: string
@@ -28,7 +20,13 @@ interface WorkflowFixture {
 
 interface RpcProcess {
 	request(type: string, fields?: Record<string, unknown>, timeoutMs?: number): Promise<RpcResponse>
+	getError(): string | undefined
 	stop(): Promise<void>
+}
+
+interface PendingRpcRequest {
+	resolve(response: RpcResponse): void
+	reject(error: Error): void
 }
 
 const REQUEST_TIMEOUT_MS = 120_000
@@ -75,10 +73,12 @@ export default createWorkflow({ name: "bundled-smoke" }).then(greet).commit()
 				const eventFile = await waitFor(
 					() => existsSync(runsDir) && readdirSync(runsDir).find((file) => file.startsWith("workflow-bundled-smoke-")),
 					"the bundled workflow run file",
+					fixture.rpc.getError,
 				)
 				const completed = await waitFor(
 					() => readEvents(join(runsDir, eventFile)).find((event) => event.type === "run-completed"),
 					"the bundled workflow to complete",
+					fixture.rpc.getError,
 				)
 				expect(completed.output).toEqual({
 					message: "hello from the bundle",
@@ -159,7 +159,8 @@ async function createFixture(
 	vi.stubEnv("PI_SKIP_VERSION_CHECK", "1")
 	vi.stubEnv("COREPACK_HOME", originalCorepackHome)
 	vi.stubEnv("XDG_CACHE_HOME", originalCacheHome)
-	vi.stubEnv("npm_config_offline", "true")
+	vi.stubEnv("npm_config_offline", undefined)
+	vi.stubEnv("npm_config_prefer_offline", "true")
 	vi.stubEnv("npm_config_store_dir", pnpmStore)
 	vi.stubEnv("KIMCHI_WORKFLOWS_PACKAGE_DIR", undefined)
 	let rpc: RpcProcess | undefined
@@ -187,28 +188,39 @@ async function startRpc(cwd: string): Promise<RpcProcess> {
 	child.stderr.on("data", (chunk: string) => {
 		stderr += chunk
 	})
-	const lines = createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY })[Symbol.asyncIterator]()
+	const pendingRequests = new Map<string, PendingRpcRequest>()
+	const errorNotifications: string[] = []
 	const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()))
+	void readRpcOutput()
 
 	const rpc: RpcProcess = {
-		async request(type, fields = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
+		request(type, fields = {}, timeoutMs = REQUEST_TIMEOUT_MS) {
 			const id = `workflows-smoke-${nextId++}`
-			child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`)
-			const deadline = Date.now() + timeoutMs
-			for (;;) {
-				const remaining = deadline - Date.now()
-				if (remaining <= 0) throw new Error(`Kimchi RPC ${type} timed out${stderr ? `\n${stderr}` : ""}`)
-				const result = await withTimeout(lines.next(), remaining, `Kimchi RPC ${type} timed out`)
-				if (result.done) throw new Error(`Kimchi RPC exited during ${type}${stderr ? `\n${stderr}` : ""}`)
-				let value: unknown
+			return new Promise<RpcResponse>((resolve, reject) => {
+				const timer = setTimeout(() => {
+					pendingRequests.delete(id)
+					reject(new Error(`Kimchi RPC ${type} timed out${rpcDiagnostics()}`))
+				}, timeoutMs)
+				pendingRequests.set(id, {
+					resolve: (response) => {
+						clearTimeout(timer)
+						resolve(response)
+					},
+					reject: (error) => {
+						clearTimeout(timer)
+						reject(error)
+					},
+				})
 				try {
-					value = JSON.parse(result.value)
+					child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`)
 				} catch (error) {
-					throw new Error(`Kimchi RPC emitted non-JSON stdout: ${result.value}`, { cause: error })
+					pendingRequests.delete(id)
+					clearTimeout(timer)
+					reject(error instanceof Error ? error : new Error(String(error)))
 				}
-				if (isRpcResponse(value) && value.id === id) return value
-			}
+			})
 		},
+		getError: () => errorNotifications.at(-1),
 		async stop() {
 			if (child.exitCode !== null || child.signalCode !== null) return
 			child.kill("SIGTERM")
@@ -223,6 +235,38 @@ async function startRpc(cwd: string): Promise<RpcProcess> {
 		},
 	}
 
+	async function readRpcOutput(): Promise<void> {
+		try {
+			for await (const line of createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY })) {
+				let value: unknown
+				try {
+					value = JSON.parse(line)
+				} catch (error) {
+					throw new Error(`Kimchi RPC emitted non-JSON stdout: ${line}`, { cause: error })
+				}
+				if (isRpcResponse(value) && value.id) {
+					const pending = pendingRequests.get(value.id)
+					if (pending) {
+						pendingRequests.delete(value.id)
+						pending.resolve(value)
+					}
+				} else if (isRpcErrorNotification(value)) {
+					errorNotifications.push(value.message)
+				}
+			}
+			throw new Error(`Kimchi RPC stdout closed${rpcDiagnostics()}`)
+		} catch (error) {
+			const failure = error instanceof Error ? error : new Error(String(error))
+			for (const pending of pendingRequests.values()) pending.reject(failure)
+			pendingRequests.clear()
+		}
+	}
+
+	function rpcDiagnostics(): string {
+		const errors = errorNotifications.length > 0 ? `\n${errorNotifications.join("\n")}` : ""
+		return `${errors}${stderr ? `\n${stderr}` : ""}`
+	}
+
 	try {
 		const ready = await rpc.request("get_state", {}, 30_000)
 		if (!ready.success) throw new Error(ready.error ?? "Kimchi RPC startup failed")
@@ -233,30 +277,37 @@ async function startRpc(cwd: string): Promise<RpcProcess> {
 	}
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => reject(new Error(message)), timeoutMs)
-		promise.then(
-			(value) => {
-				clearTimeout(timer)
-				resolve(value)
-			},
-			(error: unknown) => {
-				clearTimeout(timer)
-				reject(error)
-			},
-		)
-	})
-}
-
-async function waitFor<T>(check: () => T | false | undefined, label: string): Promise<T> {
+async function waitFor<T>(
+	check: () => T | false | undefined,
+	label: string,
+	getError?: () => string | undefined,
+): Promise<T> {
 	const deadline = Date.now() + REQUEST_TIMEOUT_MS
 	while (Date.now() < deadline) {
+		const error = getError?.()
+		if (error) throw new Error(`Failed waiting for ${label}: ${error}`)
 		const value = check()
 		if (value !== false && value !== undefined) return value
 		await new Promise((resolve) => setTimeout(resolve, 50))
 	}
 	throw new Error(`Timed out waiting for ${label}`)
+}
+
+function isRpcErrorNotification(
+	value: unknown,
+): value is Extract<RpcExtensionUIRequest, { readonly method: "notify" }> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "extension_ui_request" &&
+		"method" in value &&
+		value.method === "notify" &&
+		"notifyType" in value &&
+		value.notifyType === "error" &&
+		"message" in value &&
+		typeof value.message === "string"
+	)
 }
 
 function isRpcResponse(value: unknown): value is RpcResponse {


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Add @kimchi-dev/kimchi-workflows as a dependency and register it as a built-in extension behind the extensions.workflows resource toggle (disabled by default, requires restart). Move typebox from peer to direct dependency so the bundled extension resolves at runtime.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
