### PR TITLE
fix(prompt): delete debug env vars instead of setting undefined

### DIFF
--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1139,3 +1139,68 @@ describe("continuation nudge turn_end handler", () => {
 		expect(result).toBeUndefined()
 	})
 })
+
+describe("debug prompts cleanup", () => {
+	beforeEach(() => {
+		delete process.env.KIMCHI_DEBUG_PROMPTS
+		delete process.env.KIMCHI_DEBUG_SESSION
+	})
+
+	afterEach(() => {
+		delete process.env.KIMCHI_DEBUG_PROMPTS
+		delete process.env.KIMCHI_DEBUG_SESSION
+	})
+
+	function buildExtensionWithDebugFlag(debugPrompts: boolean) {
+		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown> | unknown>()
+		const pi = {
+			appendEntry: vi.fn(),
+			registerFlag: () => {},
+			registerCommand: () => {},
+			on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => {
+				handlers.set(event, handler)
+			},
+			getAllTools: () => [],
+			getActiveTools: () => [],
+			getFlag: (name: string) => (name === "debug-prompts" ? debugPrompts : undefined),
+		} as unknown as ExtensionAPI
+		promptEnrichmentExtension([])(pi)
+		return {
+			beforeAgentStart: handlers.get("before_agent_start"),
+		}
+	}
+
+	it("does not re-enable debug mode on a second turn when the flag is off", async () => {
+		const { beforeAgentStart } = buildExtensionWithDebugFlag(false)
+		if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+		const ctx = createContext({ hasUI: false })
+
+		// First turn: flag is off, env vars are unset.
+		await beforeAgentStart({}, ctx)
+
+		// Second turn: flag is still off. With the buggy cleanup, the first
+		// turn would have left KIMCHI_DEBUG_SESSION as the string "undefined",
+		// which is truthy and would re-enable debug mode here.
+		await beforeAgentStart({}, ctx)
+
+		expect(process.env.KIMCHI_DEBUG_PROMPTS).toBeUndefined()
+		expect(process.env.KIMCHI_DEBUG_SESSION).toBeUndefined()
+	})
+
+	it("writes debug files and sets env vars when the flag is on", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-debug-prompts-"))
+		try {
+			const { beforeAgentStart } = buildExtensionWithDebugFlag(true)
+			if (!beforeAgentStart) throw new Error("before_agent_start handler was not registered")
+
+			const ctx = createContext({ cwd: dir, hasUI: false })
+			await beforeAgentStart({}, ctx)
+
+			expect(process.env.KIMCHI_DEBUG_PROMPTS).toBe("1")
+			expect(process.env.KIMCHI_DEBUG_SESSION).toBeDefined()
+		} finally {
+			rmSync(dir, { recursive: true, force: true })
+		}
+	})
+})

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -599,8 +599,8 @@ export default function (skillPaths: string[]) {
 					ctx.ui.notify(`[debug-prompts] ${filePath}`, "info")
 				}
 			} else {
-				process.env.KIMCHI_DEBUG_PROMPTS = undefined
-				process.env.KIMCHI_DEBUG_SESSION = undefined
+				delete process.env.KIMCHI_DEBUG_PROMPTS
+				delete process.env.KIMCHI_DEBUG_SESSION
 			}
 
 			return { systemPrompt }


### PR DESCRIPTION
## Problem

Debug prompt mode was leaking on after being disabled. Once a session processed a turn without `--debug-prompts`, the cleanup code did:

```ts
process.env.KIMCHI_DEBUG_PROMPTS = undefined
process.env.KIMCHI_DEBUG_SESSION = undefined
```

In Node.js this writes the **string** `"undefined"`, which is truthy. The handler later checks `process.env.KIMCHI_DEBUG_SESSION` truthily, so on the next turn (or a subagent/new session in the same process) the leaked string re-enabled debug prompt dumps even though the flag was off.

## Fix

Use `delete process.env.X` to actually remove the variables.

## Verification

- Added a regression test that calls `before_agent_start` twice with the flag off and asserts the env vars stay unset.
- `pnpm run test src/extensions/prompt-construction/prompt-enrichment.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`

Fixes the debug-prompts leak introduced in #262 (`0cec4a50`).
