### PR TITLE
Plannotator plan-review integration + event-driven review architecture

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -4,6 +4,14 @@
 # generic changes to https://github.com/earendil-works/pi before the next upgrade.
 # Retains Kimchi CLI/provider defaults, extension-triggered prompt handling,
 # forced compaction, model selection, extension UI helpers, and compact visuals.
+# Also fixes two issues that block third-party npm extensions (e.g. plannotator):
+#   - Type2 ReferenceError: Bun's bundler renames Google GenAI's `Type` enum to
+#     `Type2` (collision with typebox's `Type`); the pi-ai compat module re-exports
+#     `Type` from typebox, but the bundled getter references the broken `Type2`
+#     binding. A Proxy overrides `.Type` with the typebox namespace directly.
+#   - Flag conflict crash: when an npm extension registers a flag that kimchi
+#     already provides (e.g. `--plan`), the conflict is downgraded from a hard
+#     error to a warning (kimchi built-in extensions load first and win).
 # Removal: delete each hunk once the pinned Pi release exposes equivalent APIs
 # or Kimchi no longer needs the branded behavior.
 #
@@ -548,3 +556,104 @@ index 42e655de0fee8081a31cb588426edd30992d893c..4f33b15d036dd0f24f5e03f3712d3e9b
                  this.showStatus(`Session exported to: ${filePath}`);
              }
              else {
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -29,6 +29,20 @@
+ import { createSyntheticSourceInfo } from "../source-info.js";
+ import { time } from "../timings.js";
+ /** Modules available to extensions via virtualModules (for compiled Bun binary) */
++// When Bun bundles the binary it renames Google GenAI's `Type` enum to `Type2`
++// (collision with typebox's `Type`). The pi-ai compat module re-exports `Type`
++// from typebox via `export { Type } from "typebox"`, but the bundled getter
++// for `.Type` references the broken `Type2` binding, producing
++// `ReferenceError: Type2 is not defined` when an extension accesses it.
++// This Proxy overrides `.Type` with the typebox namespace directly —
++// the same object pi-ai re-exports.
++const _bundledPiAiCompatSafe = new Proxy(_bundledPiAiCompat, {
++    get(target, prop, receiver) {
++        if (prop === "Type")
++            return _bundledTypebox.Type;
++        return Reflect.get(target, prop, receiver);
++    },
++});
+ const VIRTUAL_MODULES = {
+     typebox: _bundledTypebox,
+     "typebox/compile": _bundledTypeboxCompile,
+@@ -41,15 +55,23 @@
+     // Extensions resolve the pi-ai root to the compat entrypoint (a strict
+     // superset of the core entrypoint): existing extensions using the old
+     // global API keep working at runtime until compat is removed.
+-    "@earendil-works/pi-ai": _bundledPiAiCompat,
+-    "@earendil-works/pi-ai/compat": _bundledPiAiCompat,
++    //
++    // Bun's bundler renames Google GenAI's `Type` enum to `Type2` (collision
++    // with typebox's `Type`), but the renamed `Type2` binding is not
++    // accessible from the getter that `_bundledPiAiCompat.Type` triggers,
++    // producing `ReferenceError: Type2 is not defined` when an extension
++    // accesses `.Type` (e.g. `Type.Object(...)`). The Proxy intercepts `Type`
++    // and returns the typebox namespace directly — it is the same object
++    // pi-ai re-exports via `export { Type } from "typebox"`.
++    "@earendil-works/pi-ai": _bundledPiAiCompatSafe,
++    "@earendil-works/pi-ai/compat": _bundledPiAiCompatSafe,
+     "@earendil-works/pi-ai/oauth": _bundledPiAiOauth,
+     "@earendil-works/pi-ai/providers/all": _bundledPiAiProviders,
+     "@earendil-works/pi-coding-agent": _bundledPiCodingAgent,
+     "@mariozechner/pi-agent-core": _bundledPiAgentCore,
+     "@mariozechner/pi-tui": _bundledPiTui,
+-    "@mariozechner/pi-ai": _bundledPiAiCompat,
+-    "@mariozechner/pi-ai/compat": _bundledPiAiCompat,
++    "@mariozechner/pi-ai": _bundledPiAiCompatSafe,
++    "@mariozechner/pi-ai/compat": _bundledPiAiCompatSafe,
+     "@mariozechner/pi-ai/oauth": _bundledPiAiOauth,
+     "@mariozechner/pi-ai/providers/all": _bundledPiAiProviders,
+     "@mariozechner/pi-coding-agent": _bundledPiCodingAgent,
+diff --git a/dist/core/resource-loader.js b/dist/core/resource-loader.js
+--- a/dist/core/resource-loader.js
++++ b/dist/core/resource-loader.js
+@@ -458,9 +458,16 @@
+     addExtensionConflictDiagnostics(extensionsResult) {
+         // Detect extension conflicts (tools, commands, flags with same names from different extensions)
+         // Keep all extensions loaded. Conflicts are reported as diagnostics, and precedence is handled by load order.
++        // Tool conflicts are hard errors; flag conflicts are warnings (kimchi
++        // built-in extensions load first and win at runtime).
+         const conflicts = this.detectExtensionConflicts(extensionsResult.extensions);
+         for (const conflict of conflicts) {
+-            extensionsResult.errors.push({ path: conflict.path, error: conflict.message });
++            if (conflict.severity === "warning") {
++                extensionsResult.warnings ??= [];
++                extensionsResult.warnings.push({ path: conflict.path, message: conflict.message });
++            } else {
++                extensionsResult.errors.push({ path: conflict.path, error: conflict.message });
++            }
+         }
+     }
+     mapSkillPath(resource, metadataByPath) {
+@@ -841,7 +848,7 @@
+         const toolOwners = new Map();
+         const flagOwners = new Map();
+         for (const ext of extensions) {
+-            // Check tools
++            // Check tools — hard errors (genuinely ambiguous at runtime)
+             for (const toolName of ext.tools.keys()) {
+                 const existingOwner = toolOwners.get(toolName);
+                 if (existingOwner && existingOwner !== ext.path) {
+@@ -854,13 +861,16 @@
+                     toolOwners.set(toolName, ext.path);
+                 }
+             }
+-            // Check flags
++            // Check flags — warnings only (first registration wins at runtime;
++            // kimchi built-in extensions load first, so clashes from npm
++            // extensions are benign)
+             for (const flagName of ext.flags.keys()) {
+                 const existingOwner = flagOwners.get(flagName);
+                 if (existingOwner && existingOwner !== ext.path) {
+                     conflicts.push({
+                         path: ext.path,
+-                        message: `Flag "--${flagName}" conflicts with ${existingOwner}`,
++                        severity: "warning",
++                        message: `Flag "--${flagName}" conflicts with ${existingOwner}; kimchi's registration takes precedence.`,
+                     });
+                 }
+                 else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: 1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930
+    hash: d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
   '@earendil-works/pi-tui@0.84.1':
     hash: 311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.84.1(patch_hash=d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
@@ -338,24 +338,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.3':
     resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.3':
     resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.3':
     resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.3':
     resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
@@ -3082,7 +3086,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.1
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
       '@kimchi-dev/kimchi-workflows':
         specifier: 0.0.8
-        version: 0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.7.1
         version: 1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
@@ -3257,9 +3257,9 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@kimchi-dev/kimchi-workflows@0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@kimchi-dev/kimchi-workflows@0.0.8(@earendil-works/pi-coding-agent@0.84.1(patch_hash=d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3))(@earendil-works/pi-tui@0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5))(@opentelemetry/api@1.9.0)(typebox@1.3.7)(vite@7.3.3(@types/node@22.19.18)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@earendil-works/pi-coding-agent': 0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent': 0.84.1(patch_hash=d3074927a86746b8c663af0b071a0ec301579ca4016b50bb1f162a8ec99fa36d)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
       '@types/node': 22.19.18
       jiti: 2.7.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,7 @@ import permissionsExtension from "./extensions/permissions/index.js"
 import { writeKimchiKeybindingDefaults } from "./extensions/permissions/keybindings.js"
 import { installPiNativeCompatibilityShim } from "./extensions/pi-package-lookup/native-compat.js"
 import piiRedactionExtension from "./extensions/pii-redaction/index.js"
+import plannotatorExtension from "./extensions/plannotator/index.js"
 import pluginPackageHooksAdapter from "./extensions/plugin-package-hook-adapter/index.js"
 import promptEnrichmentExtension from "./extensions/prompt-construction/prompt-enrichment.js"
 import promptSummaryExtension from "./extensions/prompt-summary.js"
@@ -637,6 +638,7 @@ try {
 			// by each package's own resource toggle (see pluginPackageHookSources).
 			pluginPackageHooksAdapter,
 			kimchiHooksAdapter,
+			plannotatorExtension,
 			permissionsExtension,
 			resourcesExtension,
 			resourceToolBlockerExtension,

--- a/src/extensions/__mocks__/mini-event-bus.ts
+++ b/src/extensions/__mocks__/mini-event-bus.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest"
+
+/**
+ * Creates a mini event-bus mock for `pi.events` that actually delivers
+ * `emit` calls to registered `on` handlers. Many test harnesses need this
+ * because the plan-review bus routes decisions through `events.emit` →
+ * `events.on`; a dead `vi.fn()` stub swallows every delivery.
+ *
+ * Returns the `events` object plus an `emit` spy for assertion.
+ */
+export function createMiniEventBus(): {
+	events: {
+		emit: ReturnType<typeof vi.fn>
+		on: ReturnType<typeof vi.fn>
+	}
+	emit: ReturnType<typeof vi.fn>
+} {
+	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+	const emit = vi.fn((channel: string, data: unknown) => {
+		for (const handler of eventHandlers.get(channel) ?? []) handler(data)
+	})
+	const on = vi.fn((channel: string, handler: (data: unknown) => unknown) => {
+		const list = eventHandlers.get(channel) ?? []
+		list.push(handler)
+		eventHandlers.set(channel, list)
+		return () => {
+			const idx = list.indexOf(handler)
+			if (idx !== -1) list.splice(idx, 1)
+		}
+	})
+	return { events: { emit, on }, emit }
+}

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -668,30 +668,6 @@ describe("runAgent — Plan agent plan persistence", () => {
 		expect(existsSync(result.planPath as string)).toBe(true)
 	})
 
-	it("falls back to parsing the tool-result text when details are missing", async () => {
-		const savedPath = join(tempCwd, ".kimchi", "plans", "plan-x.md")
-		const session = makeFakeSession({
-			promptAction: async (emit) => {
-				;(session.messages as unknown[]).push({
-					role: "toolResult",
-					toolName: "submit_plan",
-					content: [{ type: "text", text: `Plan submitted and saved to ${savedPath}.` }],
-					details: undefined,
-				})
-				emit({ type: "message_start" })
-				emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "done" } })
-				emit({ type: "turn_end" })
-			},
-		})
-		mockSession(session)
-
-		const result = await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "plan it", {
-			pi: pi as unknown as RunOptions["pi"],
-		})
-
-		expect(result.planPath).toBe(savedPath)
-	})
-
 	it("returns undefined planPath when the Plan agent made no submit_plan call", async () => {
 		const session = makeFakeSession({
 			promptAction: async (emit) => {

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import dapExtension from "../../dap.js"
@@ -620,10 +620,18 @@ describe("runAgent — Plan agent plan persistence", () => {
 		vi.clearAllMocks()
 	})
 
-	it("saves the plan file when a Plan agent emits PLAN_COMPLETE", async () => {
-		const planText = "# My Plan\n\nDo the thing.\n\n<!-- PLAN_COMPLETE -->\n"
+	function makePlanToolsSession(planText: string, planPath: string) {
+		// Closure body runs after makeFakeSession returns (during prompt()), so
+		// `session` is defined by then. Pushes the worker's submit_plan tool
+		// result onto session messages — this is what extractSubmitPlanPath reads.
 		const session = makeFakeSession({
 			promptAction: async (emit) => {
+				;(session.messages as unknown[]).push({
+					role: "toolResult",
+					toolName: "submit_plan",
+					content: [{ type: "text", text: `Plan submitted and saved to ${planPath}.` }],
+					details: { submitted: true, planPath },
+				})
 				emit({ type: "message_start" })
 				emit({
 					type: "message_update",
@@ -632,43 +640,79 @@ describe("runAgent — Plan agent plan persistence", () => {
 				emit({ type: "turn_end" })
 			},
 		})
+		return session
+	}
+
+	function mockSession(session: unknown) {
 		mockCreateAgentSession.mockResolvedValue({
-			session: session as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			session: session as Awaited<ReturnType<typeof createAgentSession>>["session"],
 			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
 				ReturnType<typeof createAgentSession>
 			>["extensionsResult"],
 		})
+	}
+
+	it("surfaces planPath when the Plan agent submitted via submit_plan", async () => {
+		const planText = "# My Plan\n\nDo the thing.\n"
+		const savedPath = join(tempCwd, ".kimchi", "plans", "plan-my-plan.md")
+		mkdirSync(dirname(savedPath), { recursive: true })
+		writeFileSync(savedPath, planText, "utf-8")
+		const session = makePlanToolsSession(planText, savedPath)
+		mockSession(session)
 
 		const result = await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "plan it", {
 			pi: pi as unknown as RunOptions["pi"],
 		})
 
-		expect(result.planPath).toBeDefined()
-		const planPath = result.planPath as string
-		expect(existsSync(planPath)).toBe(true)
-		const content = readFileSync(planPath, "utf-8")
-		expect(content).toContain("Do the thing.")
-		expect(content).not.toContain("<!-- PLAN_COMPLETE -->")
+		expect(result.planPath).toBe(savedPath)
+		expect(existsSync(result.planPath as string)).toBe(true)
 	})
 
-	it("does not save a plan when a non-Plan agent emits PLAN_COMPLETE", async () => {
-		const planText = "Some text\n\n<!-- PLAN_COMPLETE -->\n"
+	it("falls back to parsing the tool-result text when details are missing", async () => {
+		const savedPath = join(tempCwd, ".kimchi", "plans", "plan-x.md")
 		const session = makeFakeSession({
 			promptAction: async (emit) => {
-				emit({ type: "message_start" })
-				emit({
-					type: "message_update",
-					assistantMessageEvent: { type: "text_delta", delta: planText },
+				;(session.messages as unknown[]).push({
+					role: "toolResult",
+					toolName: "submit_plan",
+					content: [{ type: "text", text: `Plan submitted and saved to ${savedPath}.` }],
+					details: undefined,
 				})
+				emit({ type: "message_start" })
+				emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "done" } })
 				emit({ type: "turn_end" })
 			},
 		})
-		mockCreateAgentSession.mockResolvedValue({
-			session: session as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
-			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
-				ReturnType<typeof createAgentSession>
-			>["extensionsResult"],
+		mockSession(session)
+
+		const result = await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "plan it", {
+			pi: pi as unknown as RunOptions["pi"],
 		})
+
+		expect(result.planPath).toBe(savedPath)
+	})
+
+	it("returns undefined planPath when the Plan agent made no submit_plan call", async () => {
+		const session = makeFakeSession({
+			promptAction: async (emit) => {
+				emit({ type: "message_start" })
+				emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "# Draft plan\n" } })
+				emit({ type: "turn_end" })
+			},
+		})
+		mockSession(session)
+
+		const result = await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "Plan", "plan it", {
+			pi: pi as unknown as RunOptions["pi"],
+		})
+
+		expect(result.planPath).toBeUndefined()
+	})
+
+	it("does not surface planPath for a non-Plan agent even if it calls submit_plan", async () => {
+		const savedPath = join(tempCwd, ".kimchi", "plans", "plan-gp.md")
+		const session = makePlanToolsSession("# My Plan\n\nDo the thing.\n", savedPath)
+		mockSession(session)
 
 		const result = await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "General-Purpose", "plan it", {
 			pi: pi as unknown as RunOptions["pi"],

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -17,12 +17,6 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
 import { readTelemetryConfig } from "../../../config.js"
-import {
-	derivePlanTitle,
-	savePlanMarkdown,
-	slugifyPlanName,
-	stripPlanCompletionMarkers,
-} from "../../../shared/planning/plan-markdown.js"
 import { getAvailableModels } from "../../../startup-context.js"
 import { runAsAgentWorker } from "../../agent-worker-context.js"
 import bashDefaultTimeoutExtension, { createSubagentBashClampExtension } from "../../bash-default-timeout.js"
@@ -277,6 +271,30 @@ function collectResponseText(session: AgentSession) {
 		}
 	})
 	return { getText: () => text, unsubscribe }
+}
+
+/**
+ * Find the worker session's submit_plan tool result and return the saved plan
+ * path. Prefers the structured `details` payload (`{ submitted: true, planPath }`);
+ * falls back to the tool-result text ("Plan submitted and saved to <path>.") in
+ * case details were lost through session serialization.
+ */
+function extractSubmitPlanPath(session: AgentSession): string | undefined {
+	for (let i = session.messages.length - 1; i >= 0; i--) {
+		const msg = session.messages[i]
+		if (msg.role !== "toolResult" || msg.toolName !== "submit_plan") continue
+		const details = msg.details as { submitted?: boolean; planPath?: unknown } | undefined
+		if (details?.submitted === true && typeof details.planPath === "string" && details.planPath) {
+			return details.planPath
+		}
+		const text = msg.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n")
+		const match = /^Plan submitted and saved to (.+)\.$/m.exec(text)
+		if (match?.[1]) return match[1]
+	}
+	return undefined
 }
 
 function getLastAssistantText(session: AgentSession): string {
@@ -811,20 +829,14 @@ ${skillLines}`
 
 	const responseText = collector.getText().trim() || getLastAssistantText(session)
 
-	// When a Plan agent emits a completion marker, the harness saves the plan
-	// to .kimchi/plans/<slug>.md regardless of permission mode — delegated
-	// Plan agents run outside plan permission mode so the turn_end handler in
-	// permissions/index.ts does not fire for them.
+	// A Plan agent completes by calling the submit_plan tool, which saves the
+	// plan itself (see permissions/index.ts) and terminates the turn. Extract
+	// the saved path from the tool result so the parent orchestrator can
+	// surface it. Stays undefined for non-Plan agents and when no submit_plan
+	// call happened.
 	let planPath: string | undefined
-	if (type === "Plan" && responseText.includes("<!-- PLAN_COMPLETE -->")) {
-		const planText = stripPlanCompletionMarkers(responseText)
-		const slug = slugifyPlanName(derivePlanTitle(planText))
-		try {
-			planPath = savePlanMarkdown({ cwd: effectiveCwd, name: slug, planText })
-		} catch (err) {
-			const detail = err instanceof Error ? err.message : String(err)
-			console.error(`agent-runner: failed to save plan file: ${detail}`)
-		}
+	if (type === "Plan") {
+		planPath = extractSubmitPlanPath(session)
 	}
 
 	return {

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -275,9 +275,9 @@ function collectResponseText(session: AgentSession) {
 
 /**
  * Find the worker session's submit_plan tool result and return the saved plan
- * path. Prefers the structured `details` payload (`{ submitted: true, planPath }`);
- * falls back to the tool-result text ("Plan submitted and saved to <path>.") in
- * case details were lost through session serialization.
+ * path from the structured `details` payload (`{ submitted: true, planPath }`).
+ * pi-mono preserves `details` on stored tool-result messages, so this is the
+ * sole extraction path.
  */
 function extractSubmitPlanPath(session: AgentSession): string | undefined {
 	for (let i = session.messages.length - 1; i >= 0; i--) {
@@ -287,12 +287,6 @@ function extractSubmitPlanPath(session: AgentSession): string | undefined {
 		if (details?.submitted === true && typeof details.planPath === "string" && details.planPath) {
 			return details.planPath
 		}
-		const text = msg.content
-			.filter((c): c is { type: "text"; text: string } => c.type === "text")
-			.map((c) => c.text)
-			.join("\n")
-		const match = /^Plan submitted and saved to (.+)\.$/m.exec(text)
-		if (match?.[1]) return match[1]
 	}
 	return undefined
 }

--- a/src/extensions/agents/personas/default-agents.ts
+++ b/src/extensions/agents/personas/default-agents.ts
@@ -139,13 +139,10 @@ multiple options apply; single for one choice.
 
 STEP 3 — use the \`questionnaire\` tool to confirm criteria with the user.
 
-STEP 5 — draft the plan directly in your response, then end with one of these markers
-on its own line:
-  <!-- PLAN_COMPLETE -->
-  or simply:
-  <done>
-The harness saves the plan to \`.kimchi/plans/<slug>.md\` automatically when the marker appears.
-Do NOT include markers on incomplete drafts, while assumptions remain unresolved, or
+STEP 5 — call the \`submit_plan\` tool with the full plan as the \`plan\` parameter.
+Your turn ends when the tool returns. The harness saves the submitted plan to
+\`.kimchi/plans/<slug>.md\` automatically.
+Do NOT call \`submit_plan\` on incomplete drafts, while assumptions remain unresolved, or
 when asking clarifying questions.
 
 # Tool Usage

--- a/src/extensions/agents/prompt/prompts.test.ts
+++ b/src/extensions/agents/prompt/prompts.test.ts
@@ -238,7 +238,8 @@ During **build** phase:
 
 		// Plan-Agent-specific tool bindings (override the shared planning process).
 		expect(output).toContain("`questionnaire`")
-		expect(output).toContain("harness saves the plan")
+		expect(output).toContain("`submit_plan`")
+		expect(output).toContain("harness saves the submitted plan")
 
 		// The shared planning process must be embedded verbatim. Asserting on the
 		// imported constant means any legitimate tweak to the shared process is

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -63,6 +63,11 @@ function registerFermentExtension(runtime?: FermentRuntime, flagValues: Record<s
 	const commands = new Map<string, CommandHandler>()
 	const shortcuts = new Map<string, { description?: string; handler: ShortcutHandler }>()
 	const registeredFlags = new Set<string>()
+	// Real mini event-bus: the plan-review request/decision flow routes through
+	// events.emit → events.on channels; a vi.fn() stub would swallow every
+	// delivery, leaving TUI outcomes unable to reach the decision handler.
+	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+
 	const pi = {
 		on: (event: string, handler: EventHandler) => {
 			// `handlers` keeps the first registration per event for tests that fetch a
@@ -91,7 +96,20 @@ function registerFermentExtension(runtime?: FermentRuntime, flagValues: Record<s
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
-		events: { emit: vi.fn(), on: vi.fn(() => () => {}) },
+		events: {
+			emit: vi.fn((channel: string, data: unknown) => {
+				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
+			}),
+			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
+				const list = eventHandlers.get(channel) ?? []
+				list.push(handler)
+				eventHandlers.set(channel, list)
+				return () => {
+					const idx = list.indexOf(handler)
+					if (idx !== -1) list.splice(idx, 1)
+				}
+			}),
+		},
 	} as unknown as ExtensionAPI
 
 	fermentExtension(pi, runtime)

--- a/src/extensions/ferment/index.test.ts
+++ b/src/extensions/ferment/index.test.ts
@@ -8,6 +8,7 @@ import { FermentEventStore } from "../../ferment/event-store.js"
 import { clearFermentCache, FermentStorage } from "../../ferment/store.js"
 import type { Ferment } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
+import { createMiniEventBus } from "../__mocks__/mini-event-bus.js"
 import { globalTipRegistry } from "../tips/registry.js"
 import fermentExtension from "./index.js"
 import { clearAllLifecycleGuards } from "./lifecycle-obligation-guard.js"
@@ -63,10 +64,7 @@ function registerFermentExtension(runtime?: FermentRuntime, flagValues: Record<s
 	const commands = new Map<string, CommandHandler>()
 	const shortcuts = new Map<string, { description?: string; handler: ShortcutHandler }>()
 	const registeredFlags = new Set<string>()
-	// Real mini event-bus: the plan-review request/decision flow routes through
-	// events.emit → events.on channels; a vi.fn() stub would swallow every
-	// delivery, leaving TUI outcomes unable to reach the decision handler.
-	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+	const { events } = createMiniEventBus()
 
 	const pi = {
 		on: (event: string, handler: EventHandler) => {
@@ -96,20 +94,7 @@ function registerFermentExtension(runtime?: FermentRuntime, flagValues: Record<s
 		appendEntry: vi.fn(),
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
-		events: {
-			emit: vi.fn((channel: string, data: unknown) => {
-				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
-			}),
-			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
-				const list = eventHandlers.get(channel) ?? []
-				list.push(handler)
-				eventHandlers.set(channel, list)
-				return () => {
-					const idx = list.indexOf(handler)
-					if (idx !== -1) list.splice(idx, 1)
-				}
-			}),
-		},
+		events,
 	} as unknown as ExtensionAPI
 
 	fermentExtension(pi, runtime)

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -191,46 +191,55 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 			// Fire-and-forget: emit a decision when the TUI resolves.
 			// The decision handler below acts on whichever surface decides first.
-			void reviewPromise.then((outcome) => {
-				unsubscribeDismiss()
-				if (!outcome) {
-					// No decision UI was presented (non-TUI or dismissed without a
-					// choice): clear the pending review and restore tools, but keep
-					// the persisted proposal for a later resume. planReviewRunning
-					// must reset here — no decision is emitted, so the decision
-					// handler never runs for this outcome.
-					runtime.clearPendingPlanReview(review.fermentId)
-					applyFermentRuntimeToolProfile(pi, runtime)
+			void reviewPromise
+				.then((outcome) => {
+					unsubscribeDismiss()
+					if (!outcome) {
+						// No decision UI was presented (non-TUI or dismissed without a
+						// choice): clear the pending review and restore tools, but keep
+						// the persisted proposal for a later resume. planReviewRunning
+						// must reset here — no decision is emitted, so the decision
+						// handler never runs for this outcome.
+						runtime.clearPendingPlanReview(review.fermentId)
+						applyFermentRuntimeToolProfile(pi, runtime)
+						planReviewRunning = false
+						return
+					}
+					if (outcome.kind === "cancelled") {
+						emitPlanReviewDecision(pi, {
+							decision: "rework",
+							source: "kimchi-tui",
+							planReviewSource: "ferment",
+							fermentId: review.fermentId,
+						})
+						return
+					}
+					if (outcome.kind === "start" || outcome.kind === "start_auto") {
+						emitPlanReviewDecision(pi, {
+							decision: "execute",
+							source: "kimchi-tui",
+							planReviewSource: "ferment",
+							fermentId: review.fermentId,
+							auto: outcome.kind === "start_auto",
+						})
+					} else if (outcome.kind === "feedback") {
+						emitPlanReviewDecision(pi, {
+							decision: "feedback",
+							feedback: outcome.text,
+							source: "kimchi-tui",
+							planReviewSource: "ferment",
+							fermentId: review.fermentId,
+						})
+					}
+				})
+				.catch(() => {
+					// If the TUI review promise rejects (unexpected error, not a
+					// plannotator-driven dismiss), clean up the dismiss listener and
+					// reset planReviewRunning so a failed popup doesn't leave ferment
+					// stuck waiting forever.
+					unsubscribeDismiss()
 					planReviewRunning = false
-					return
-				}
-				if (outcome.kind === "cancelled") {
-					emitPlanReviewDecision(pi, {
-						decision: "rework",
-						source: "kimchi-tui",
-						planReviewSource: "ferment",
-						fermentId: review.fermentId,
-					})
-					return
-				}
-				if (outcome.kind === "start" || outcome.kind === "start_auto") {
-					emitPlanReviewDecision(pi, {
-						decision: "execute",
-						source: "kimchi-tui",
-						planReviewSource: "ferment",
-						fermentId: review.fermentId,
-						auto: outcome.kind === "start_auto",
-					})
-				} else if (outcome.kind === "feedback") {
-					emitPlanReviewDecision(pi, {
-						decision: "feedback",
-						feedback: outcome.text,
-						source: "kimchi-tui",
-						planReviewSource: "ferment",
-						fermentId: review.fermentId,
-					})
-				}
-			})
+				})
 		} finally {
 			// planReviewRunning stays true until the decision handler clears it.
 			// The TUI prompt is fire-and-forget — the finally runs immediately.

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -17,9 +17,10 @@ import * as EntryTriggerRegistry from "../../shared/planning/entry-trigger-regis
 import {
 	consumePlanReviewContext,
 	emitPlanReviewDecision,
-	emitPlanReviewRequest,
 	onPlanReviewDecision,
+	onPlanReviewRequest,
 	type PlanReviewDecisionPayload,
+	type PlanReviewRequestPayload,
 } from "../../shared/planning/plan-review-bus.js"
 import * as PromptSupplementRegistry from "../../shared/planning/prompt-supplement-registry.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -163,19 +164,6 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 		planReviewRunning = true
 		try {
-			// Emit plan-review request — TUI popup and plannotator both listen.
-			// Fire-and-forget: the TUI review is shown below without awaiting,
-			// and plannotator's browser opens via the adapter. First decision wins.
-			emitPlanReviewRequest(
-				pi,
-				{
-					planContent: review.planMarkdown,
-					source: "ferment",
-					fermentId: review.fermentId,
-				},
-				{ ctx, planText: review.planMarkdown, fermentId: review.fermentId },
-			)
-
 			// promptPlanReview is TUI-only and returns undefined without prompting
 			// in other modes — only activate the herdr blocked pair when it will
 			// actually wait on the user (see herdr-events.ts PROTOCOL).
@@ -299,6 +287,21 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 				void runPendingPlanReview(triggerCtx, review)
 			}, 0)
 		}
+	})
+
+	// When propose_ferment_scoping emits a plan-review request (source=ferment),
+	// trigger the TUI popup. propose_ferment_scoping already set the pending
+	// review and persisted the proposal — this just shows the review UI.
+	onPlanReviewRequest(pi, (payload: PlanReviewRequestPayload) => {
+		if (payload.source !== "ferment") return
+		if (!ctx) return
+		const review = runtime.getCurrentPendingPlanReview()
+		if (!review || planReviewRunning) return
+		clearPlanReviewTimer()
+		planReviewTimer = setTimeout(() => {
+			planReviewTimer = undefined
+			void runPendingPlanReview(ctx!, review)
+		}, 0)
 	})
 
 	pi.on("session_start", (_event, _ctx) => {

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -353,6 +353,27 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	})
 
 	pi.on("agent_end", async (_event, ctx) => {
+		// Present a pending plan review when the turn ends. Reviews can exist
+		// without an in-turn emission (restored state, direct set), so this
+		// block emits the request — storing the review context the decision
+		// handler consumes — then schedules the popup directly. The
+		// planReviewTimer/planReviewRunning guards ensure we never re-emit or
+		// re-schedule when the in-turn proposal already opened (or queued) the
+		// same review, which would double-open plannotator's browser.
+		const review = runtime.getCurrentPendingPlanReview()
+		if (!planReviewRunning && !planReviewTimer && review) {
+			emitPlanReviewRequest(
+				pi,
+				{ planContent: review.planMarkdown, source: "ferment", fermentId: review.fermentId },
+				{ ctx, planText: review.planMarkdown, fermentId: review.fermentId },
+			)
+			clearPlanReviewTimer()
+			planReviewTimer = setTimeout(() => {
+				planReviewTimer = undefined
+				void runPendingPlanReview(ctx, review)
+			}, 0)
+		}
+
 		// Drain any remaining pending compactions at agent_end (catches the case
 		// where the ferment completes within a single agent run and the turn_end
 		// handler already cleared most pending entries).

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -326,15 +326,6 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	})
 
 	pi.on("agent_end", async (_event, ctx) => {
-		const review = runtime.getCurrentPendingPlanReview()
-		if (!planReviewRunning && review) {
-			clearPlanReviewTimer()
-			planReviewTimer = setTimeout(() => {
-				planReviewTimer = undefined
-				void runPendingPlanReview(ctx, review)
-			}, 0)
-		}
-
 		// Drain any remaining pending compactions at agent_end (catches the case
 		// where the ferment completes within a single agent run and the turn_end
 		// handler already cleared most pending entries).

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -17,6 +17,7 @@ import * as EntryTriggerRegistry from "../../shared/planning/entry-trigger-regis
 import {
 	consumePlanReviewContext,
 	emitPlanReviewDecision,
+	emitPlanReviewRequest,
 	onPlanReviewDecision,
 	onPlanReviewRequest,
 	type PlanReviewDecisionPayload,
@@ -163,11 +164,19 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		if (!isCurrentPendingReview(review)) return
 
 		planReviewRunning = true
+		// Unsubscribed when this review resolves; otherwise one listener would
+		// accumulate on the shared event bus for every review ever presented.
+		// `dismissReview` is assigned lazily by the prompt via onDismissRegister.
+		let dismissReview: (() => void) | undefined
+		const unsubscribeDismiss = onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+			if (payload.planReviewSource !== "ferment") return
+			if (payload.source !== "plannotator") return
+			dismissReview?.()
+		})
 		try {
 			// promptPlanReview is TUI-only and returns undefined without prompting
 			// in other modes — only activate the herdr blocked pair when it will
 			// actually wait on the user (see herdr-events.ts PROTOCOL).
-			let dismissReview: (() => void) | undefined
 			const reviewPromise =
 				ctx.mode === "tui"
 					? withBlocked(pi.events, "Ferment plan review", () =>
@@ -180,17 +189,22 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 						)
 					: promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
 
-			// Dismiss the TUI popup if plannotator decides first
-			onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
-				if (payload.planReviewSource !== "ferment") return
-				if (payload.source !== "plannotator") return
-				dismissReview?.()
-			})
-
 			// Fire-and-forget: emit a decision when the TUI resolves.
 			// The decision handler below acts on whichever surface decides first.
 			void reviewPromise.then((outcome) => {
-				if (!outcome || outcome.kind === "cancelled") {
+				unsubscribeDismiss()
+				if (!outcome) {
+					// No decision UI was presented (non-TUI or dismissed without a
+					// choice): clear the pending review and restore tools, but keep
+					// the persisted proposal for a later resume. planReviewRunning
+					// must reset here — no decision is emitted, so the decision
+					// handler never runs for this outcome.
+					runtime.clearPendingPlanReview(review.fermentId)
+					applyFermentRuntimeToolProfile(pi, runtime)
+					planReviewRunning = false
+					return
+				}
+				if (outcome.kind === "cancelled") {
 					emitPlanReviewDecision(pi, {
 						decision: "rework",
 						source: "kimchi-tui",
@@ -205,6 +219,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 						source: "kimchi-tui",
 						planReviewSource: "ferment",
 						fermentId: review.fermentId,
+						auto: outcome.kind === "start_auto",
 					})
 				} else if (outcome.kind === "feedback") {
 					emitPlanReviewDecision(pi, {
@@ -238,6 +253,10 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 			if (!scopeOutcome.ok) {
 				reviewCtx.ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
 				return
+			}
+			if (payload.auto) {
+				runtime.setContinuationPolicy("automated")
+				requestSharedStatusLineRender()
 			}
 			runtime.clearPendingPlanReview(fermentId)
 			applyFermentRuntimeToolProfile(pi, runtime)
@@ -281,11 +300,15 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	setPendingPlanReviewTrigger((triggerCtx) => {
 		const review = runtime.getCurrentPendingPlanReview()
 		if (!planReviewRunning && review) {
-			clearPlanReviewTimer()
-			planReviewTimer = setTimeout(() => {
-				planReviewTimer = undefined
-				void runPendingPlanReview(triggerCtx, review)
-			}, 0)
+			// Always emit — subscribers self-select. The onPlanReviewRequest
+			// listener below schedules runPendingPlanReview via planReviewTimer.
+			// In non-TUI, promptPlanReview returns undefined → clear-only branch
+			// restores tools without deleting the persisted proposal.
+			emitPlanReviewRequest(
+				pi,
+				{ planContent: review.planMarkdown, source: "ferment", fermentId: review.fermentId },
+				{ ctx: triggerCtx, planText: review.planMarkdown, fermentId: review.fermentId },
+			)
 		}
 	})
 
@@ -294,13 +317,14 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	// review and persisted the proposal — this just shows the review UI.
 	onPlanReviewRequest(pi, (payload: PlanReviewRequestPayload) => {
 		if (payload.source !== "ferment") return
-		if (!ctx) return
+		const sessionCtx = ctx
+		if (!sessionCtx) return
 		const review = runtime.getCurrentPendingPlanReview()
 		if (!review || planReviewRunning) return
 		clearPlanReviewTimer()
 		planReviewTimer = setTimeout(() => {
 			planReviewTimer = undefined
-			void runPendingPlanReview(ctx!, review)
+			void runPendingPlanReview(sessionCtx, review)
 		}, 0)
 	})
 

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -14,6 +14,13 @@ import type { ExtensionAPI, ExtensionContext, MessageRenderer } from "@earendil-
 import { Container, Text } from "@earendil-works/pi-tui"
 import type { Step } from "../../ferment/types.js"
 import * as EntryTriggerRegistry from "../../shared/planning/entry-trigger-registry.js"
+import {
+	consumePlanReviewContext,
+	emitPlanReviewDecision,
+	emitPlanReviewRequest,
+	onPlanReviewDecision,
+	type PlanReviewDecisionPayload,
+} from "../../shared/planning/plan-review-bus.js"
 import * as PromptSupplementRegistry from "../../shared/planning/prompt-supplement-registry.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { withBlocked } from "../herdr-events.js"
@@ -156,80 +163,130 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 
 		planReviewRunning = true
 		try {
+			// Emit plan-review request — TUI popup and plannotator both listen.
+			// Fire-and-forget: the TUI review is shown below without awaiting,
+			// and plannotator's browser opens via the adapter. First decision wins.
+			emitPlanReviewRequest(
+				pi,
+				{
+					planContent: review.planMarkdown,
+					source: "ferment",
+					fermentId: review.fermentId,
+				},
+				{ ctx, planText: review.planMarkdown, fermentId: review.fermentId },
+			)
+
 			// promptPlanReview is TUI-only and returns undefined without prompting
 			// in other modes — only activate the herdr blocked pair when it will
 			// actually wait on the user (see herdr-events.ts PROTOCOL).
-			const outcome =
+			let dismissReview: (() => void) | undefined
+			const reviewPromise =
 				ctx.mode === "tui"
-					? await withBlocked(pi.events, "Ferment plan review", () =>
-							promptPlanReview(ctx, { planMarkdown: review.planMarkdown }),
+					? withBlocked(pi.events, "Ferment plan review", () =>
+							promptPlanReview(ctx, {
+								planMarkdown: review.planMarkdown,
+								onDismissRegister: (dismiss) => {
+									dismissReview = dismiss
+								},
+							}),
 						)
-					: await promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
-			if (!outcome) {
-				// promptPlanReview resolved to undefined (e.g. UI dismissed without
-				// an explicit choice). Treat it the same as cancellation: clear the
-				// pending review and restore the tool profile so the model is not
-				// left with all tools suppressed.
-				runtime.clearPendingPlanReview(review.fermentId)
-				applyFermentRuntimeToolProfile(pi, runtime)
-				return
-			}
-			if (outcome.kind === "cancelled") {
-				// Delete the persisted proposal and clear the in-memory pending
-				// review, then restore the planning-ferment tool profile. Without
-				// this, `hasPendingPlanReview` in tool-scope.ts keeps all tools
-				// suppressed, leaving the model unable to call any tools after
-				// the user cancels the review.
-				deletePendingProposal(review.fermentId)
-				runtime.clearPendingPlanReview(review.fermentId)
-				applyFermentRuntimeToolProfile(pi, runtime)
-				return
-			}
+					: promptPlanReview(ctx, { planMarkdown: review.planMarkdown })
 
-			if (!isCurrentPendingReview(review)) return
+			// Dismiss the TUI popup if plannotator decides first
+			onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+				if (payload.planReviewSource !== "ferment") return
+				if (payload.source !== "plannotator") return
+				dismissReview?.()
+			})
 
-			if (outcome.kind === "start" || outcome.kind === "start_auto") {
-				const scopeOutcome = confirmPendingScope(runtime, review.fermentId, undefined, "turn_end", pi)
-				if (!scopeOutcome.ok) {
-					ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
+			// Fire-and-forget: emit a decision when the TUI resolves.
+			// The decision handler below acts on whichever surface decides first.
+			void reviewPromise.then((outcome) => {
+				if (!outcome || outcome.kind === "cancelled") {
+					emitPlanReviewDecision(pi, {
+						decision: "rework",
+						source: "kimchi-tui",
+						planReviewSource: "ferment",
+						fermentId: review.fermentId,
+					})
 					return
 				}
-				if (outcome.kind === "start_auto") {
-					runtime.setContinuationPolicy("automated")
-					requestSharedStatusLineRender()
+				if (outcome.kind === "start" || outcome.kind === "start_auto") {
+					emitPlanReviewDecision(pi, {
+						decision: "execute",
+						source: "kimchi-tui",
+						planReviewSource: "ferment",
+						fermentId: review.fermentId,
+					})
+				} else if (outcome.kind === "feedback") {
+					emitPlanReviewDecision(pi, {
+						decision: "feedback",
+						feedback: outcome.text,
+						source: "kimchi-tui",
+						planReviewSource: "ferment",
+						fermentId: review.fermentId,
+					})
 				}
-				runtime.clearPendingPlanReview(review.fermentId)
-				applyFermentRuntimeToolProfile(pi, runtime)
-				scheduleFermentWakeUp(pi, runtime, {
-					deliverAs: "followUp",
-					fermentId: review.fermentId,
-					tag: "Plan review start",
-				})
+			})
+		} finally {
+			// planReviewRunning stays true until the decision handler clears it.
+			// The TUI prompt is fire-and-forget — the finally runs immediately.
+		}
+	}
+
+	// Decision handler for ferment plan reviews — handles decisions from both
+	// the TUI review component and plannotator's browser UI (first decision wins).
+	onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+		if (payload.planReviewSource !== "ferment") return
+		const reviewCtx = consumePlanReviewContext()
+		if (!reviewCtx) return
+		const fermentId = payload.fermentId ?? reviewCtx.fermentId
+		if (!fermentId) return
+
+		planReviewRunning = false
+
+		if (payload.decision === "execute") {
+			const scopeOutcome = confirmPendingScope(runtime, fermentId, undefined, "turn_end", pi)
+			if (!scopeOutcome.ok) {
+				reviewCtx.ctx?.ui?.notify?.(`Failed to save plan: ${scopeOutcome.error.message}`, "error")
 				return
 			}
-
+			runtime.clearPendingPlanReview(fermentId)
+			applyFermentRuntimeToolProfile(pi, runtime)
+			scheduleFermentWakeUp(pi, runtime, {
+				deliverAs: "followUp",
+				fermentId,
+				tag: "Plan review start",
+			})
+		} else if (payload.decision === "feedback") {
 			// Clear the pending review before triggering the revision turn.
 			// The model needs its full toolset to revise the plan (read files,
 			// ask_user, etc.). If the pending review were left set, tool-scope.ts
 			// would suppress all tools via `hasPendingPlanReview`, blocking the
 			// revision. The model will set a new pending review by calling
 			// `propose_ferment_scoping` again once the revision is complete.
-			runtime.clearPendingPlanReview(review.fermentId)
+			runtime.clearPendingPlanReview(fermentId)
 			applyFermentRuntimeToolProfile(pi, runtime)
 			safeSendMessage(
 				pi,
 				{
-					content: buildFreeformScopingFeedbackMessage(review.fermentId, outcome.text),
+					content: buildFreeformScopingFeedbackMessage(fermentId, payload.feedback ?? ""),
 					customType: "ferment_scoping_iteration",
 					display: false,
 				},
 				{ triggerTurn: true, deliverAs: "followUp" },
 			)
-			runtime.clearPendingPlanReview(review.fermentId)
-		} finally {
-			planReviewRunning = false
+		} else {
+			// rework / cancel — delete the persisted proposal and clear the
+			// in-memory pending review, then restore the planning-ferment tool
+			// profile. Without this, `hasPendingPlanReview` in tool-scope.ts
+			// keeps all tools suppressed, leaving the model unable to call any
+			// tools after the user cancels the review.
+			deletePendingProposal(fermentId)
+			runtime.clearPendingPlanReview(fermentId)
+			applyFermentRuntimeToolProfile(pi, runtime)
 		}
-	}
+	})
 
 	// Register the plan-review trigger so `resumeFerment` can present a
 	// re-armed review directly (no LLM turn) after hydrating from the sidecar.

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -51,7 +51,7 @@ export function clearAllPendingPlanReviews(): void {
 
 export async function promptPlanReview(
 	ctx: ExtensionContext,
-	opts: { planMarkdown: string },
+	opts: { planMarkdown: string; onDismissRegister?: (dismiss: () => void) => void },
 ): Promise<PlanReviewOutcome | undefined> {
 	if (ctx.mode !== "tui") return undefined
 	const ui = ctx.ui
@@ -59,7 +59,7 @@ export async function promptPlanReview(
 		ui,
 		() =>
 			ui.custom?.<PlanReviewOutcome>((tui, theme, keybindings, done) =>
-				createPlanReviewComponent(tui, theme, keybindings, opts.planMarkdown, done),
+				createPlanReviewComponent(tui, theme, keybindings, opts.planMarkdown, done, opts.onDismissRegister),
 			) ?? Promise.resolve(undefined),
 	)
 }
@@ -76,6 +76,7 @@ class PlanReviewComponent extends Container {
 	private selectedIndex = 0
 	private mode: "decision" | "feedback" = "decision"
 	private editor: ExtensionEditorComponent | undefined
+	private dismissed = false
 
 	constructor(
 		tui: TUI,
@@ -83,6 +84,7 @@ class PlanReviewComponent extends Container {
 		keybindings: KeybindingsManager,
 		planMarkdown: string,
 		done: (result: PlanReviewOutcome) => void,
+		onDismissRegister?: (dismiss: () => void) => void,
 	) {
 		super()
 		this.tui = tui
@@ -91,6 +93,14 @@ class PlanReviewComponent extends Container {
 		this.done = done
 		this.markdown = new Markdown(planMarkdown, 1, 0, getMarkdownTheme())
 		this.showDecision()
+
+		// Register an external dismiss function so the caller can close
+		// the popup when plannotator decides first.
+		onDismissRegister?.(() => {
+			if (this.dismissed) return
+			this.dismissed = true
+			this.done({ kind: "cancelled", reason: "decision_cancelled" })
+		})
 	}
 
 	override render(width: number): string[] {
@@ -200,6 +210,7 @@ export function createPlanReviewComponent(
 	keybindings: KeybindingsManager,
 	planMarkdown: string,
 	done: (result: PlanReviewOutcome) => void,
+	onDismissRegister?: (dismiss: () => void) => void,
 ): Component {
-	return new PlanReviewComponent(tui, theme, keybindings, planMarkdown, done)
+	return new PlanReviewComponent(tui, theme, keybindings, planMarkdown, done, onDismissRegister)
 }

--- a/src/extensions/ferment/scoping-flow.integration.test.ts
+++ b/src/extensions/ferment/scoping-flow.integration.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { clearFermentCache } from "../../ferment/store.js"
 import { createContext } from "../__mocks__/context.js"
+import { createMiniEventBus } from "../__mocks__/mini-event-bus.js"
 import { createDefaultFermentRuntime, type FermentRuntime } from "./runtime.js"
 import { clearAllPendingScopes, getPendingScope, runScopingFlow } from "./scoping.js"
 import { clearAllScopingGates, clearAllStepStarts, setActive } from "./state.js"
@@ -40,9 +41,7 @@ function createHarness() {
 	const runtime: FermentRuntime = { ...createDefaultFermentRuntime(), getStorage: () => eventStorage }
 	const tools = new Map<string, RegisteredTool>()
 	let activeTools: string[] = []
-	// Real mini event-bus — propose_ferment_scoping emits plan-review requests
-	// over pi.events; without this the emit throws on a missing `.emit`.
-	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+	const { events } = createMiniEventBus()
 
 	const pi = {
 		on: vi.fn(),
@@ -52,20 +51,7 @@ function createHarness() {
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
 		appendEntry: vi.fn(),
-		events: {
-			emit: vi.fn((channel: string, data: unknown) => {
-				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
-			}),
-			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
-				const list = eventHandlers.get(channel) ?? []
-				list.push(handler)
-				eventHandlers.set(channel, list)
-				return () => {
-					const idx = list.indexOf(handler)
-					if (idx !== -1) list.splice(idx, 1)
-				}
-			}),
-		},
+		events,
 		getActiveTools: vi.fn(() => activeTools),
 		getAllTools: vi.fn(() => Array.from(tools.keys()).map((name) => ({ name }))),
 		setActiveTools: vi.fn((names: string[]) => {

--- a/src/extensions/ferment/scoping-flow.integration.test.ts
+++ b/src/extensions/ferment/scoping-flow.integration.test.ts
@@ -40,6 +40,9 @@ function createHarness() {
 	const runtime: FermentRuntime = { ...createDefaultFermentRuntime(), getStorage: () => eventStorage }
 	const tools = new Map<string, RegisteredTool>()
 	let activeTools: string[] = []
+	// Real mini event-bus — propose_ferment_scoping emits plan-review requests
+	// over pi.events; without this the emit throws on a missing `.emit`.
+	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
 
 	const pi = {
 		on: vi.fn(),
@@ -49,6 +52,20 @@ function createHarness() {
 		sendMessage: vi.fn(),
 		sendUserMessage: vi.fn(),
 		appendEntry: vi.fn(),
+		events: {
+			emit: vi.fn((channel: string, data: unknown) => {
+				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
+			}),
+			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
+				const list = eventHandlers.get(channel) ?? []
+				list.push(handler)
+				eventHandlers.set(channel, list)
+				return () => {
+					const idx = list.indexOf(handler)
+					if (idx !== -1) list.splice(idx, 1)
+				}
+			}),
+		},
 		getActiveTools: vi.fn(() => activeTools),
 		getAllTools: vi.fn(() => Array.from(tools.keys()).map((name) => ({ name }))),
 		setActiveTools: vi.fn((names: string[]) => {

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -46,6 +46,8 @@ export const PLANNING_TOOL_NAMES: ReadonlySet<string> = new Set([
 	"ls",
 	"web_fetch",
 	"web_search",
+	// Plan submission tool — available in both adhoc and ferment planning
+	"submit_plan",
 	// Phase tracker injected by the ferment planner supplement
 	"set_phase",
 	// Ferment planning tools
@@ -155,12 +157,13 @@ export function applyFermentToolProfile(pi: ExtensionAPI, profile: FermentToolPr
 
 export function applyFermentRuntimeToolProfile(pi: ExtensionAPI, runtime: FermentRuntime): void {
 	// If a plan review is pending (propose_ferment_scoping returned "Plan ready
-	// for review"), suppress ALL tools. This forces the model's next LLM call
-	// to be text-only (stopReason: "stop"), ending the turn so `agent_end` fires
-	// and the review dialog is shown via the setTimeout(0) in index.ts.
+	// for review"), suppress ALL tools except submit_plan. This forces the
+	// model's next LLM call to be text-only (stopReason: "stop"), ending the
+	// turn so `agent_end` fires and the review dialog is shown. submit_plan
+	// stays visible so the model can call it to trigger the review directly.
 	// Restored by the caller after confirmPendingScope() or review cancellation.
 	if (hasPendingPlanReview(runtime)) {
-		pi.setActiveTools([])
+		pi.setActiveTools(["submit_plan"])
 		return
 	}
 	applyFermentToolProfile(pi, profileForFerment(runtime.getActive()))

--- a/src/extensions/ferment/tool-scope.ts
+++ b/src/extensions/ferment/tool-scope.ts
@@ -46,8 +46,6 @@ export const PLANNING_TOOL_NAMES: ReadonlySet<string> = new Set([
 	"ls",
 	"web_fetch",
 	"web_search",
-	// Plan submission tool — available in both adhoc and ferment planning
-	"submit_plan",
 	// Phase tracker injected by the ferment planner supplement
 	"set_phase",
 	// Ferment planning tools
@@ -157,13 +155,13 @@ export function applyFermentToolProfile(pi: ExtensionAPI, profile: FermentToolPr
 
 export function applyFermentRuntimeToolProfile(pi: ExtensionAPI, runtime: FermentRuntime): void {
 	// If a plan review is pending (propose_ferment_scoping returned "Plan ready
-	// for review"), suppress ALL tools except submit_plan. This forces the
-	// model's next LLM call to be text-only (stopReason: "stop"), ending the
-	// turn so `agent_end` fires and the review dialog is shown. submit_plan
-	// stays visible so the model can call it to trigger the review directly.
+	// for review"), suppress ALL tools. This forces the model's next LLM call
+	// to be text-only (stopReason: "stop"), ending the turn. The review is
+	// now triggered directly by propose_ferment_scoping via emitPlanReviewRequest,
+	// so no agent_end → setTimeout chain is needed.
 	// Restored by the caller after confirmPendingScope() or review cancellation.
 	if (hasPendingPlanReview(runtime)) {
-		pi.setActiveTools(["submit_plan"])
+		pi.setActiveTools([])
 		return
 	}
 	applyFermentToolProfile(pi, profileForFerment(runtime.getActive()))

--- a/src/extensions/ferment/tools/lifecycle.ts
+++ b/src/extensions/ferment/tools/lifecycle.ts
@@ -29,6 +29,7 @@ import {
 	type ScopingQuestionType,
 } from "../../../ferment/types.js"
 import { fermentPlanFileName, savePlanMarkdown } from "../../../shared/planning/plan-markdown.js"
+import { emitPlanReviewRequest } from "../../../shared/planning/plan-review-bus.js"
 import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
 import { withBlocked } from "../../herdr-events.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
@@ -1251,9 +1252,23 @@ ${renderGateGuidance("scope_ferment")}`,
 					proposeIterations: nextIterations,
 					savedAt: new Date().toISOString(),
 				})
-				return planToolOk(
-					`Plan ready for review.${savedPlanNote}\n\nThe review dialog will open when this turn finishes.`,
+
+				// Emit plan-review request — TUI popup and plannotator both listen.
+				// Fire-and-forget: first decision wins. The decision handler in
+				// index.ts acts on whichever surface decides first.
+				emitPlanReviewRequest(
+					pi,
+					{
+						planContent: planEntry,
+						planFilePath: planPath,
+						source: "ferment",
+						fermentId,
+					},
+					{ ctx, planPath, planText: planEntry, fermentId },
 				)
+
+				const result = planToolOk(`Plan ready for review.${savedPlanNote}`)
+				return { ...result, terminate: true }
 			}
 
 			// 7. Tabbed question form + review loop.

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { FermentEventStore } from "../../ferment/event-store.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
 import { createExtensionApi } from "../__mocks__/extension-api.js"
+import { createMiniEventBus } from "../__mocks__/mini-event-bus.js"
 import { runAsAgentWorker } from "../agent-worker-context.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import { FERMENT_TOOLS } from "../ferment/tool-names.js"
@@ -171,9 +172,7 @@ function createPermissionsHarness(
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const commands = new Map<string, RegisteredCommand>()
 	const registeredTools = new Map<string, { name: string; execute: unknown }>()
-	// Real mini event-bus: emit must deliver to handlers registered via events.on
-	// because the plan-review decision flow routes through these channels.
-	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+	const { events } = createMiniEventBus()
 	const tools = toolNames.map((name) => ({ name, description: `${name} tool` }) as ToolInfo)
 	let activeTools = [...initialActiveTools]
 
@@ -199,20 +198,7 @@ function createPermissionsHarness(
 		}),
 		sendMessage: vi.fn(),
 		appendEntry: vi.fn(),
-		events: {
-			emit: vi.fn((channel: string, data: unknown) => {
-				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
-			}),
-			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
-				const list = eventHandlers.get(channel) ?? []
-				list.push(handler)
-				eventHandlers.set(channel, list)
-				return () => {
-					const idx = list.indexOf(handler)
-					if (idx !== -1) list.splice(idx, 1)
-				}
-			}),
-		},
+		events,
 	} as unknown as ExtensionAPI
 
 	permissionsExtension(pi)

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -170,6 +170,10 @@ function createPermissionsHarness(
 ) {
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const commands = new Map<string, RegisteredCommand>()
+	const registeredTools = new Map<string, { name: string; execute: unknown }>()
+	// Real mini event-bus: emit must deliver to handlers registered via events.on
+	// because the plan-review decision flow routes through these channels.
+	const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
 	const tools = toolNames.map((name) => ({ name, description: `${name} tool` }) as ToolInfo)
 	let activeTools = [...initialActiveTools]
 
@@ -190,9 +194,25 @@ function createPermissionsHarness(
 			const known = new Set(toolNames)
 			activeTools = names.filter((name) => known.has(name))
 		}),
+		registerTool: vi.fn((tool: { name: string } & Record<string, unknown>) => {
+			registeredTools.set(tool.name, tool as { name: string; execute: unknown })
+		}),
 		sendMessage: vi.fn(),
 		appendEntry: vi.fn(),
-		events: { emit: vi.fn() },
+		events: {
+			emit: vi.fn((channel: string, data: unknown) => {
+				for (const handler of eventHandlers.get(channel) ?? []) handler(data)
+			}),
+			on: vi.fn((channel: string, handler: (data: unknown) => unknown) => {
+				const list = eventHandlers.get(channel) ?? []
+				list.push(handler)
+				eventHandlers.set(channel, list)
+				return () => {
+					const idx = list.indexOf(handler)
+					if (idx !== -1) list.splice(idx, 1)
+				}
+			}),
+		},
 	} as unknown as ExtensionAPI
 
 	permissionsExtension(pi)
@@ -200,6 +220,7 @@ function createPermissionsHarness(
 	return {
 		pi,
 		commands,
+		registeredTools,
 		activeTools: () => activeTools,
 		async fire(event: string, payload: unknown, ctx: ExtensionContext = createMockContext([])) {
 			let result: unknown
@@ -355,16 +376,31 @@ describe("plan mode assumption detection", () => {
 
 	// --- Integration tests for turn_end handler ---
 
-	function makeAssistantMessage(text: string): unknown {
-		return { role: "assistant", content: [{ type: "text", text }] }
+	type SubmitPlanToolDef = {
+		execute: (
+			toolCallId: string,
+			params: { plan: string },
+			signal: AbortSignal | undefined,
+			onUpdate: undefined,
+			ctx: ExtensionContext,
+		) => Promise<unknown>
 	}
 
-	async function fireTurnEnd(
+	// Drive the submit_plan flow: invoke the captured tool's execute with the
+	// plan text (no completion markers — that protocol is gone), then flush
+	// the task queue so the TUI decision callback (`void .then(...)`) and any
+	// review-decision side effects (mode changes, sendMessage, ferment
+	// artefacts) have run before assertions.
+	async function submitPlan(
 		harness: ReturnType<typeof createPermissionsHarness>,
-		text: string,
+		plan: string,
 		ctx: ExtensionContext,
-	) {
-		return harness.fire("turn_end", { message: makeAssistantMessage(text) }, ctx)
+	): Promise<unknown> {
+		const tool = harness.registeredTools.get("submit_plan") as SubmitPlanToolDef | undefined
+		if (!tool) throw new Error("submit_plan tool was not registered with pi")
+		const result = await tool.execute("tc-submit-plan", { plan }, undefined, undefined, ctx)
+		await new Promise<void>((resolve) => setTimeout(resolve, 0))
+		return result
 	}
 
 	it("shows approval menu when plan is clean", async () => {
@@ -375,9 +411,9 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"# Plan\n\n## Goal\nFix the bug.\n\n## Chunk 1\nChange the code.\nAccept When: tests pass.\n\n## Verification\nRun test suite.\n\n<!-- PLAN_COMPLETE -->\n",
+			"# Plan\n\n## Goal\nFix the bug.\n\n## Chunk 1\nChange the code.\nAccept When: tests pass.\n\n## Verification\nRun test suite.",
 			ctx,
 		)
 
@@ -390,11 +426,7 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
-			harness,
-			"# Plan\n\n## Assumptions\n- Database schema may differ\n\n## Chunks\n- Chunk 1\n\n<!-- PLAN_COMPLETE -->\n",
-			ctx,
-		)
+		await submitPlan(harness, "# Plan\n\n## Assumptions\n- Database schema may differ\n\n## Chunks\n- Chunk 1", ctx)
 
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
@@ -405,9 +437,9 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"# Plan\n\n## Open Questions\n- Should we use JWT or sessions?\n\n## Chunks\n- Chunk 1\n\n<!-- PLAN_COMPLETE -->\n",
+			"# Plan\n\n## Open Questions\n- Should we use JWT or sessions?\n\n## Chunks\n- Chunk 1",
 			ctx,
 		)
 
@@ -420,9 +452,9 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"## Goal\nFix it.\n\n## Assumptions\n\n## Chunk 1\nChange code.\nAccept When: works.\n\n## Verification\nCheck tests.\n\n<!-- PLAN_COMPLETE -->\n",
+			"## Goal\nFix it.\n\n## Assumptions\n\n## Chunk 1\nChange code.\nAccept When: works.\n\n## Verification\nCheck tests.",
 			ctx,
 		)
 
@@ -435,22 +467,22 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"## Goal\nDo the thing.\n\n## Chunk 1\nChange code.\nAccept When: works.\n\n## Verification\nCheck tests.\n\n<!-- PLAN_COMPLETE -->\n",
+			"## Goal\nDo the thing.\n\n## Chunk 1\nChange code.\nAccept When: works.\n\n## Verification\nCheck tests.",
 			ctx,
 		)
 
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
 
-	it("shows menu for plan with assumptions (PLAN_COMPLETE is the gate)", async () => {
+	it("shows menu for plan with assumptions (submit_plan is the gate)", async () => {
 		const harness = createPermissionsHarness(["read", "bash"], { plan: true })
 		await harness.fire("session_start", {}, createMockContext([]))
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(harness, "## ASSUMPTIONS\n- Schema TBD\n\n<!-- PLAN_COMPLETE -->\n", ctx)
+		await submitPlan(harness, "## ASSUMPTIONS\n- Schema TBD", ctx)
 
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
@@ -461,7 +493,7 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(harness, "## Assumptions\n\n- Database schema may differ\n\n<!-- PLAN_COMPLETE -->\n", ctx)
+		await submitPlan(harness, "## Assumptions\n\n- Database schema may differ", ctx)
 
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
@@ -472,9 +504,9 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"## Goal\nAdd auth.\n\n## Chunk 1\nImplement login.\nAccept When: tests pass.\n\n## Verification\nRun the test suite.\n\n<!-- PLAN_COMPLETE -->\n",
+			"## Goal\nAdd auth.\n\n## Chunk 1\nImplement login.\nAccept When: tests pass.\n\n## Verification\nRun the test suite.",
 			ctx,
 		)
 
@@ -485,15 +517,15 @@ describe("plan mode assumption detection", () => {
 		)
 	})
 
-	it("review gate: menu shows for any plan with PLAN_COMPLETE marker", async () => {
+	it("review gate: menu shows for any plan submitted via submit_plan", async () => {
 		const harness = createPermissionsHarness(["read", "bash"], { plan: true })
 		await harness.fire("session_start", {}, createMockContext([]))
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(
+		await submitPlan(
 			harness,
-			"## Chunk 1\nJust a chunk.\n\nSome extra lines\nto make it non-simple.\nMore content here.\n\n<!-- PLAN_COMPLETE -->\n",
+			"## Chunk 1\nJust a chunk.\n\nSome extra lines\nto make it non-simple.\nMore content here.",
 			ctx,
 		)
 
@@ -506,7 +538,7 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("tool_execution_start", {})
 
 		const ctx = createMockContext(["No, do something else"])
-		await fireTurnEnd(harness, "## Chunk 1\nJust one chunk.\n\n<!-- PLAN_COMPLETE -->\n", ctx)
+		await submitPlan(harness, "## Chunk 1\nJust one chunk.", ctx)
 
 		expect(ctx.ui.select).toHaveBeenCalled()
 	})
@@ -516,15 +548,15 @@ describe("plan mode assumption detection", () => {
 		await harness.fire("session_start", {}, createMockContext([]))
 
 		const planText =
-			"# Plan\n\n## Goal\nAdd caching layer.\n\n## Chunks\n- Chunk 1\nImplement cache.\n\n## Verification\nRun tests.\n\n<!-- PLAN_COMPLETE -->"
+			"# Plan\n\n## Goal\nAdd caching layer.\n\n## Chunks\n- Chunk 1\nImplement cache.\n\n## Verification\nRun tests."
 		const ctx = createMockContext(["Rework the plan"])
-		await fireTurnEnd(harness, planText, ctx)
+		await submitPlan(harness, planText, ctx)
 
-		expect(ctx.ui.select).toHaveBeenCalledWith("Plan complete. How would you like to proceed?", [
-			"Execute the plan",
-			"Rework the plan",
-			"Start as ferment",
-		])
+		expect(ctx.ui.select).toHaveBeenCalledWith(
+			"Plan complete. How would you like to proceed?",
+			["Execute the plan", "Rework the plan", "Start as ferment"],
+			expect.anything(),
+		)
 		expect(harness.pi.sendMessage).not.toHaveBeenCalled()
 		expect(getPermissionMode(TEST_SESSION_ID)).toEqual({ mode: "plan", source: "flag", initiatedBy: "user" })
 	})
@@ -536,10 +568,9 @@ describe("plan mode assumption detection", () => {
 			n === "ferment-oneshot" ? true : undefined
 		await harness.fire("session_start", {}, createMockContext([]))
 
-		const planText =
-			"# Plan\n\n## Goal\nAdd caching layer.\n\n## Chunks\n- Chunk 1\nImplement cache.\n\n<!-- PLAN_COMPLETE -->"
+		const planText = "# Plan\n\n## Goal\nAdd caching layer.\n\n## Chunks\n- Chunk 1\nImplement cache."
 		const ctx = createMockContext([])
-		await fireTurnEnd(harness, planText, ctx)
+		await submitPlan(harness, planText, ctx)
 
 		// The dropdown must NOT have been shown — oneshot sessions bypass it.
 		expect(ctx.ui.select).not.toHaveBeenCalled()
@@ -547,9 +578,9 @@ describe("plan mode assumption detection", () => {
 
 	describe("plan file persistence", () => {
 		const PLAN_V1 =
-			"# Plan: Cache Layer\n\n## Goal\nAdd caching layer.\n\n## Chunks\n\n### Chunk 1: Add cache primitive\n- **Accept When**: round-trip works\n\n<!-- PLAN_COMPLETE -->\n"
+			"# Plan: Cache Layer\n\n## Goal\nAdd caching layer.\n\n## Chunks\n\n### Chunk 1: Add cache primitive\n- **Accept When**: round-trip works"
 		const PLAN_V2 =
-			"# Plan: Cache Layer\n\n## Goal\nAdd caching layer with TTL.\n\n## Chunks\n\n### Chunk 1: Add cache primitive\n- **Accept When**: round-trip works\n\n<!-- PLAN_COMPLETE -->\n"
+			"# Plan: Cache Layer\n\n## Goal\nAdd caching layer with TTL.\n\n## Chunks\n\n### Chunk 1: Add cache primitive\n- **Accept When**: round-trip works"
 
 		it("saves the plan file when the plan is produced, before the approval choice", async () => {
 			const harness = createPermissionsHarness(["read", "bash"], { plan: true })
@@ -558,7 +589,7 @@ describe("plan mode assumption detection", () => {
 			try {
 				const ctx = createMockContext(["Rework the plan"])
 				ctx.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V1, ctx)
+				await submitPlan(harness, PLAN_V1, ctx)
 
 				const plansDir = join(tmpDir, ".kimchi", "plans")
 				expect(readdirSync(plansDir)).toEqual(["plan-cache-layer.md"])
@@ -580,7 +611,7 @@ describe("plan mode assumption detection", () => {
 				const ctx = createMockContext([])
 				Object.assign(ctx, { hasUI: false })
 				ctx.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V1, ctx)
+				await submitPlan(harness, PLAN_V1, ctx)
 
 				const plansDir = join(tmpDir, ".kimchi", "plans")
 				expect(readdirSync(plansDir)).toEqual(["plan-cache-layer.md"])
@@ -597,10 +628,10 @@ describe("plan mode assumption detection", () => {
 			try {
 				const ctx1 = createMockContext(["Rework the plan"])
 				ctx1.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V1, ctx1)
+				await submitPlan(harness, PLAN_V1, ctx1)
 				const ctx2 = createMockContext(["Rework the plan"])
 				ctx2.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V2, ctx2)
+				await submitPlan(harness, PLAN_V2, ctx2)
 
 				const plansDir = join(tmpDir, ".kimchi", "plans")
 				expect(readdirSync(plansDir)).toEqual(["plan-cache-layer.md"])
@@ -618,7 +649,7 @@ describe("plan mode assumption detection", () => {
 			try {
 				const ctx = createMockContext(["Execute the plan"])
 				ctx.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V1, ctx)
+				await submitPlan(harness, PLAN_V1, ctx)
 
 				const planFile = join(tmpDir, ".kimchi", "plans", "plan-cache-layer.md")
 				expect(existsSync(planFile)).toBe(true)
@@ -634,10 +665,10 @@ describe("plan mode assumption detection", () => {
 				// mode and emit a differently titled plan to verify a fresh file.
 				const command = harness.commands.get("permissions")
 				await command?.handler("mode plan", createMockContext([]))
-				const OTHER_PLAN = "# Plan: Rate Limits\n\n## Goal\nAdd rate limits.\n\n<!-- PLAN_COMPLETE -->\n"
+				const OTHER_PLAN = "# Plan: Rate Limits\n\n## Goal\nAdd rate limits."
 				const ctx2 = createMockContext(["Rework the plan"])
 				ctx2.cwd = tmpDir
-				await fireTurnEnd(harness, OTHER_PLAN, ctx2)
+				await submitPlan(harness, OTHER_PLAN, ctx2)
 				expect(readdirSync(join(tmpDir, ".kimchi", "plans")).sort()).toEqual([
 					"plan-cache-layer.md",
 					"plan-rate-limits.md",
@@ -654,7 +685,7 @@ describe("plan mode assumption detection", () => {
 			try {
 				const ctx = createMockContext(["Start as ferment"])
 				ctx.cwd = tmpDir
-				await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+				await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 				const planFile = join(tmpDir, ".kimchi", "plans", "plan.md")
 				expect(existsSync(planFile)).toBe(true)
@@ -683,7 +714,7 @@ describe("plan mode assumption detection", () => {
 				writeFileSync(join(tmpDir, ".kimchi"), "not a directory")
 				const ctx = createMockContext(["Rework the plan"])
 				ctx.cwd = tmpDir
-				await fireTurnEnd(harness, PLAN_V1, ctx)
+				await submitPlan(harness, PLAN_V1, ctx)
 
 				expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("failed to save plan file"), "warning")
 				expect(ctx.ui.select).toHaveBeenCalled()
@@ -707,8 +738,7 @@ describe("plan mode assumption detection", () => {
 		"### Chunk 1: Add cache primitive\n- **Files Changed**: src/api/cache.ts\n- **Accept When**: cache.get/set round-trip works\n\n" +
 		"### Chunk 2: Wire cache into client\n- **Files Changed**: src/api/client.ts\n- **Accept When**: repeat GET hits the cache\n\n" +
 		"## Verification Strategy\nRun pnpm test src/api after each chunk.\n\n" +
-		"## Risks\nCache staleness: short default TTL.\n\n" +
-		"<!-- PLAN_COMPLETE -->"
+		"## Risks\nCache staleness: short default TTL.\n"
 
 	it("Start as ferment persists a ferment artifact under .kimchi/ferments", async () => {
 		const harness = createPermissionsHarness(["read", "bash"], { plan: true })
@@ -719,7 +749,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			const fermentsDir = join(tmpDir, ".kimchi", "ferments")
 			expect(existsSync(fermentsDir)).toBe(true)
@@ -753,7 +783,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			// Find the implementation-ferment apply call by selecting the largest
 			// setActiveTools call — the planning-adhoc profile produces a 12-tool set
@@ -793,7 +823,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			const calls = vi.mocked(harness.pi.setActiveTools).mock.calls
 			const implementationFermentCall = calls.reduce<{ size: number; arr: string[] | undefined }>(
@@ -834,7 +864,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			// After 'Start as ferment', the ferment runtime must know the active ferment.
 			const { defaultFermentRuntime } = await import("../ferment/runtime.js")
@@ -858,7 +888,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			// appendRefEntry calls pi.sendMessage with customType 'ferment_reference'.
 			// safeSendMessage passes (message, options) — options may be undefined.
@@ -891,7 +921,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			const handoffCall = vi
 				.mocked(harness.pi.sendMessage)
@@ -933,7 +963,7 @@ describe("plan mode assumption detection", () => {
 		const ctx = createMockContext(["Start as ferment"])
 		ctx.cwd = "/dev/null/nonexistent-path-that-cannot-be-created"
 
-		await fireTurnEnd(harness, planText, ctx)
+		await submitPlan(harness, planText, ctx)
 
 		// 1) No setActiveTools call should include implementation-ferment-only tools
 		//    like edit/write/Agent (the implementation profile signature).
@@ -970,7 +1000,7 @@ describe("plan mode assumption detection", () => {
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, SHARED_PLAN_TEXT, ctx)
+			await submitPlan(harness, SHARED_PLAN_TEXT, ctx)
 
 			expect(harness.activeTools()).toEqual(planningTools)
 			expect(getPermissionMode(TEST_SESSION_ID)).toEqual({ mode: "plan", source: "flag", initiatedBy: "user" })
@@ -993,13 +1023,12 @@ describe("plan mode assumption detection", () => {
 		const harness = createPermissionsHarness(["read", "bash"], { plan: true })
 		await harness.fire("session_start", {}, createMockContext([]))
 
-		const PLAN_WITHOUT_CHUNKS =
-			"# Plan\n\n## Goal\nAdd caching layer.\n\n## Constraints\n- No new dependencies\n\n<!-- PLAN_COMPLETE -->"
+		const PLAN_WITHOUT_CHUNKS = "# Plan\n\n## Goal\nAdd caching layer.\n\n## Constraints\n- No new dependencies"
 		const tmpDir = mkdtempSync(join(tmpdir(), "draft-only-"))
 		try {
 			const ctx = createMockContext(["Start as ferment"])
 			ctx.cwd = tmpDir
-			await fireTurnEnd(harness, PLAN_WITHOUT_CHUNKS, ctx)
+			await submitPlan(harness, PLAN_WITHOUT_CHUNKS, ctx)
 
 			// 1) The artifact is persisted as a draft (no phase activated).
 			const fermentsDir = join(tmpDir, ".kimchi", "ferments")

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -250,9 +250,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	// session restarts.
 	let activePlanSlug: string | undefined
 	// Per-session count of plan-mode stall nudges (model stopped after tool
-	// calls without calling submit_plan). Reset when submit_plan is called,
-	// when the mode leaves plan, and on session restart.
-	let planStopNudgeCount = 0
+	// calls without calling submit_plan). Keyed by session ID so concurrent
+	// sessions don't share a budget. Reset when submit_plan is called, when
+	// the mode leaves plan, and on session restart.
+	const planStopNudgeCounts = new Map<string, number>()
 	let planModeApplied = false
 	let planModeHiddenTools: string[] = []
 	const planToolVisibility: ToolVisibilityAPI = createToolVisibility(pi)
@@ -384,7 +385,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (current === "plan" && next.mode !== "plan") {
 			restoreToolsFromPlanMode()
 			activePlanSlug = undefined
-			planStopNudgeCount = 0
+			planStopNudgeCounts.delete(ctx.sessionManager.getSessionId())
 		}
 		if (next.mode === "plan") applyPlanModeTools()
 		// Dismiss all active permission prompts so tool_call handlers re-evaluate under the new mode.
@@ -476,7 +477,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		currentCtx = ctx
 		cliMode = undefined
 		activePlanSlug = undefined
-		planStopNudgeCount = 0
+		planStopNudgeCounts.delete(ctx.sessionManager.getSessionId())
 		const { errors } = doLoadConfig(ctx)
 
 		for (const err of errors) {
@@ -594,7 +595,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	// the session would stall silently — nudge it to resolve open questions and
 	// submit the plan. Capped per session; agent workers are excluded (they
 	// submit via submit_plan in their own terminate-on-tool-return flow).
-	pi.on("turn_end", (event) => {
+	pi.on("turn_end", (event, ctx) => {
 		if (isAgentWorker()) return
 		if (getRuntimePermissionMode().mode !== "plan") return
 		if (event.message.role !== "assistant") return
@@ -606,15 +607,17 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (hasPlanSubmitToolCall(toolNames)) {
 			// The review flow owns the turn now. Reset the stall budget so a
 			// rework round starts fresh.
-			planStopNudgeCount = 0
+			planStopNudgeCounts.delete(ctx.sessionManager.getSessionId())
 			return
 		}
 		const stopReason = (event.message as { stopReason?: string }).stopReason
 		if (!shouldNudge({ hasToolCall: contentHasToolCall(content), stopReason, completionSignalPresent: false })) {
 			return
 		}
-		planStopNudgeCount++
-		if (isNudgeSuppressed(planStopNudgeCount)) return
+		const sessionId = ctx.sessionManager.getSessionId()
+		const count = (planStopNudgeCounts.get(sessionId) ?? 0) + 1
+		planStopNudgeCounts.set(sessionId, count)
+		if (isNudgeSuppressed(count)) return
 		safeSendMessage(
 			pi,
 			{
@@ -703,32 +706,25 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				}
 			}
 
-			// Non-TUI / oneshot: emit the review request then end the turn.
-			// Emitters always emit — subscribers self-select. The plannotator
-			// adapter skips subscribing in non-interactive sessions, so this
-			// is a no-op today, but future integrations (logging, CI reviewers,
-			// alternative UIs) can hook in without changes here.
+			// Emit plan-review request once — TUI popup, plannotator browser, and
+			// future integrations all listen on the same channel. Subscribers
+			// self-select: the plannotator adapter skips non-interactive sessions.
+			emitPlanReviewRequest(
+				pi,
+				{ planContent: planText, planFilePath: planPath, source: "adhoc" },
+				{ ctx, planPath, planText, rawText: planText, activePlanSlug },
+			)
+
+			// Non-TUI / oneshot: no popup to show — end the turn. The emit above
+			// is a no-op today (adapter skips subscribing), but future integrations
+			// (logging, CI reviewers, alternative UIs) can hook in without changes.
 			if (!ctx.hasUI || pi.getFlag?.("ferment-oneshot") === true) {
-				emitPlanReviewRequest(
-					pi,
-					{ planContent: planText, planFilePath: planPath, source: "adhoc" },
-					{ ctx, planPath, planText, rawText: planText, activePlanSlug },
-				)
 				return {
 					content: [{ type: "text", text: "Plan submitted." }],
 					details: { submitted: true },
 					terminate: true,
 				}
 			}
-
-			// Emit plan-review request — TUI popup and plannotator both listen.
-			// Fire-and-forget: the TUI menu is shown below without awaiting, and
-			// plannotator's browser opens via the adapter. First decision wins.
-			emitPlanReviewRequest(
-				pi,
-				{ planContent: planText, planFilePath: planPath, source: "adhoc" },
-				{ ctx, planPath, planText, rawText: planText, activePlanSlug },
-			)
 
 			// AbortSignal lets the decision handler dismiss the menu when
 			// plannotator decides first (select returns undefined on abort).
@@ -751,30 +747,37 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 						signal: planMenuAbort.signal,
 					}),
 				),
-			).then((choice) => {
-				unsubscribeAbortListener()
-				// select returns undefined when aborted — plannotator already decided.
-				if (choice === undefined) return
-				if (choice === EXECUTE) {
-					emitPlanReviewDecision(pi, {
-						decision: "execute",
-						source: "kimchi-tui",
-						planReviewSource: "adhoc",
-					})
-				} else if (choice === START_AS_FERMENT) {
-					emitPlanReviewDecision(pi, {
-						decision: "start_ferment",
-						source: "kimchi-tui",
-						planReviewSource: "adhoc",
-					})
-				} else {
-					emitPlanReviewDecision(pi, {
-						decision: "rework",
-						source: "kimchi-tui",
-						planReviewSource: "adhoc",
-					})
-				}
-			})
+			)
+				.then((choice) => {
+					unsubscribeAbortListener()
+					// select returns undefined when aborted — plannotator already decided.
+					if (choice === undefined) return
+					if (choice === EXECUTE) {
+						emitPlanReviewDecision(pi, {
+							decision: "execute",
+							source: "kimchi-tui",
+							planReviewSource: "adhoc",
+						})
+					} else if (choice === START_AS_FERMENT) {
+						emitPlanReviewDecision(pi, {
+							decision: "start_ferment",
+							source: "kimchi-tui",
+							planReviewSource: "adhoc",
+						})
+					} else {
+						emitPlanReviewDecision(pi, {
+							decision: "rework",
+							source: "kimchi-tui",
+							planReviewSource: "adhoc",
+						})
+					}
+				})
+				.catch(() => {
+					// select rejects when the AbortSignal fires (plannotator decided
+					// first) or on unexpected UI errors. Either way, ensure the
+					// abort-listener is cleaned up so it doesn't leak on the bus.
+					unsubscribeAbortListener()
+				})
 
 			return {
 				content: [{ type: "text", text: "Plan submitted for review. Waiting for user decision." }],

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -17,6 +17,13 @@ import {
 	onPlanReviewDecision,
 	type PlanReviewDecisionPayload,
 } from "../../shared/planning/plan-review-bus.js"
+import {
+	contentHasToolCall,
+	hasPlanSubmitToolCall,
+	isNudgeSuppressed,
+	PLAN_MODE_STOP_NUDGE,
+	shouldNudge,
+} from "../../shared/planning/planning-stop-nudge.js"
 import * as PromptSupplementRegistry from "../../shared/planning/prompt-supplement-registry.js"
 import * as ToolProfileManager from "../../shared/planning/tool-profile-manager.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -242,6 +249,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	// released when the plan is approved (execute / start-as-ferment) or the
 	// session restarts.
 	let activePlanSlug: string | undefined
+	// Per-session count of plan-mode stall nudges (model stopped after tool
+	// calls without calling submit_plan). Reset when submit_plan is called,
+	// when the mode leaves plan, and on session restart.
+	let planStopNudgeCount = 0
 	let planModeApplied = false
 	let planModeHiddenTools: string[] = []
 	const planToolVisibility: ToolVisibilityAPI = createToolVisibility(pi)
@@ -373,6 +384,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		if (current === "plan" && next.mode !== "plan") {
 			restoreToolsFromPlanMode()
 			activePlanSlug = undefined
+			planStopNudgeCount = 0
 		}
 		if (next.mode === "plan") applyPlanModeTools()
 		// Dismiss all active permission prompts so tool_call handlers re-evaluate under the new mode.
@@ -464,6 +476,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		currentCtx = ctx
 		cliMode = undefined
 		activePlanSlug = undefined
+		planStopNudgeCount = 0
 		const { errors } = doLoadConfig(ctx)
 
 		for (const err of errors) {
@@ -576,7 +589,44 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		maybePersistPermissionMode(ctx)
 	})
 
-	// submit_plan tool — replaces the <!-- PLAN_COMPLETE --> marker.
+	// Plan-mode stall recovery: when the model made tool calls in plan mode and
+	// then ended the turn with stopReason "stop" without calling submit_plan,
+	// the session would stall silently — nudge it to resolve open questions and
+	// submit the plan. Capped per session; agent workers are excluded (they
+	// submit via submit_plan in their own terminate-on-tool-return flow).
+	pi.on("turn_end", (event) => {
+		if (isAgentWorker()) return
+		if (getRuntimePermissionMode().mode !== "plan") return
+		if (event.message.role !== "assistant") return
+		const content = Array.isArray(event.message.content) ? event.message.content : []
+		const toolNames = content
+			.filter((c) => (c as { type: string }).type === "toolCall" || (c as { type: string }).type === "tool_use")
+			.map((c) => (c as { name?: unknown }).name)
+			.filter((name): name is string => typeof name === "string")
+		if (hasPlanSubmitToolCall(toolNames)) {
+			// The review flow owns the turn now. Reset the stall budget so a
+			// rework round starts fresh.
+			planStopNudgeCount = 0
+			return
+		}
+		const stopReason = (event.message as { stopReason?: string }).stopReason
+		if (!shouldNudge({ hasToolCall: contentHasToolCall(content), stopReason, completionSignalPresent: false })) {
+			return
+		}
+		planStopNudgeCount++
+		if (isNudgeSuppressed(planStopNudgeCount)) return
+		safeSendMessage(
+			pi,
+			{
+				customType: "plan-mode-stop-nudge",
+				content: PLAN_MODE_STOP_NUDGE,
+				display: false,
+			},
+			{ triggerTurn: true, deliverAs: "steer" },
+		)
+	})
+
+	// submit_plan tool — the adhoc plan-mode completion signal.
 	// Visible in both adhoc plan mode and ferment planning phase (via the
 	// tool catalog). The model calls it when the plan is ready for review.
 	// For ferment, the model should call propose_ferment_scoping first (to
@@ -606,11 +656,20 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				}
 			}
 
-			// Guard: must be in plan mode
+			// Allowed contexts:
+			// 1. Adhoc plan mode (mode === "plan") — full review flow.
+			// 2. Agent workers (e.g. Plan persona subagents) — saves + terminates
+			//    with no review emit; the parent orchestrator is the plan's
+			//    evaluator.
 			const mode = getRuntimePermissionMode().mode
-			if (mode !== "plan") {
+			if (mode !== "plan" && !isAgentWorker()) {
 				return {
-					content: [{ type: "text", text: "Error: submit_plan is only available during plan mode." }],
+					content: [
+						{
+							type: "text",
+							text: "Error: submit_plan is only available during plan mode or in a Plan agent worker.",
+						},
+					],
 					details: { submitted: false },
 				}
 			}
@@ -624,6 +683,24 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				const detail = err instanceof Error ? err.message : String(err)
 				if (ctx.hasUI) ctx.ui.notify(`permissions: failed to save plan file: ${detail}`, "warning")
 				else console.error(`permissions: failed to save plan file: ${detail}`)
+			}
+
+			// Agent worker: silent submit. Saves the plan and terminates the turn
+			// with no review emit — workers have no review surface, the parent
+			// orchestrator evaluates the plan, and the plannotator adapter skips
+			// worker sessions. agent-runner surfaces planPath back to the parent
+			// from this tool result.
+			if (isAgentWorker()) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: planPath ? `Plan submitted and saved to ${planPath}.` : "Plan submitted.",
+						},
+					],
+					details: { submitted: true, source: "worker", planPath },
+					terminate: true,
+				}
 			}
 
 			// Non-TUI / oneshot: emit the review request then end the turn.

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path"
+import { Type } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext, SessionManager, ToolCallEvent } from "@earendil-works/pi-coding-agent"
 import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui"
 import { RST_FG, resolvedSemanticFg } from "../../ansi.js"
@@ -8,12 +9,7 @@ import { isExistingDirectory } from "../../fs-paths.js"
 import { getAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
 import * as EntryTriggerRegistry from "../../shared/planning/entry-trigger-registry.js"
 import { parseSharedPlan } from "../../shared/planning/plan-decomposition.js"
-import {
-	derivePlanTitle,
-	savePlanMarkdown,
-	slugifyPlanName,
-	stripPlanCompletionMarkers,
-} from "../../shared/planning/plan-markdown.js"
+import { derivePlanTitle, savePlanMarkdown, slugifyPlanName } from "../../shared/planning/plan-markdown.js"
 import {
 	consumePlanReviewContext,
 	emitPlanReviewDecision,
@@ -21,14 +17,6 @@ import {
 	onPlanReviewDecision,
 	type PlanReviewDecisionPayload,
 } from "../../shared/planning/plan-review-bus.js"
-import {
-	contentHasToolCall,
-	extractTextFromContent,
-	hasPlanCompletionSignal,
-	isNudgeSuppressed,
-	PLAN_MODE_STOP_NUDGE,
-	shouldNudge,
-} from "../../shared/planning/planning-stop-nudge.js"
 import * as PromptSupplementRegistry from "../../shared/planning/prompt-supplement-registry.js"
 import * as ToolProfileManager from "../../shared/planning/tool-profile-manager.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -126,6 +114,7 @@ const PLAN_MODE_TOOLS = [
 	"web_fetch",
 	"mcp",
 	"questionnaire",
+	"submit_plan",
 	"bash",
 	...TODO_TOOL_NAMES,
 	// DAP debugger tools — available in plan mode by product decision: the
@@ -587,87 +576,152 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		maybePersistPermissionMode(ctx)
 	})
 
-	// When the agent produces <!-- PLAN_COMPLETE --> in plan mode, persist the plan
-	// file immediately (production-time save, overwrite-in-place) and show the approval menu.
-	pi.on("turn_end", async (event, ctx) => {
-		if (getRuntimePermissionMode().mode !== "plan") return
-
-		const message = event.message
-		if (message.role !== "assistant") return
-
-		const text = message.content
-			.filter((c) => c.type === "text")
-			.map((c) => (c as { type: "text"; text: string }).text)
-			.join("\n")
-
-		if (!text.includes("<!-- PLAN_COMPLETE -->") && !text.includes("<done>")) return
-
-		// Persist the plan the moment it is produced — before any approval
-		// choice and for headless/one-shot sessions too (both bypass the
-		// dropdown, but the plan still exists). Rework turns overwrite the same
-		// file: the slug is held per session so a title edit during rework does
-		// not fork the filename. Persistence is non-fatal but never silent —
-		// on failure the user is warned and the flow continues without a path.
-		const planText = stripPlanCompletionMarkers(text)
-		if (!activePlanSlug) activePlanSlug = slugifyPlanName(derivePlanTitle(planText))
-		let planPath: string | undefined
-		try {
-			planPath = savePlanMarkdown({ cwd: ctx.cwd, name: activePlanSlug, planText })
-		} catch (err) {
-			const detail = err instanceof Error ? err.message : String(err)
-			if (ctx.hasUI) ctx.ui.notify(`permissions: failed to save plan file: ${detail}`, "warning")
-			else console.error(`permissions: failed to save plan file: ${detail}`)
-		}
-
-		if (!ctx.hasUI) return
-
-		// Oneshot sessions bypass the dropdown entirely — the bench path auto-pilots
-		// the rest of the lifecycle through scope_ferment and friends, no user prompt needed.
-		if (pi.getFlag?.("ferment-oneshot") === true) return
-
-		// Emit plan-review request — TUI popup and plannotator both listen.
-		// Fire-and-forget: the TUI menu is shown below without awaiting, and
-		// plannotator's browser opens via the adapter. First decision wins.
-		emitPlanReviewRequest(
-			pi,
-			{
-				planContent: planText,
-				planFilePath: planPath,
-				source: "adhoc",
-			},
-			{ ctx, planPath, planText, rawText: text, activePlanSlug },
-		)
-
-		// AbortSignal lets the decision handler dismiss the menu when
-		// plannotator decides first (select returns undefined on abort).
-		const planMenuAbort = new AbortController()
-		onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
-			if (payload.planReviewSource !== "adhoc") return
-			if (payload.source !== "plannotator") return
-			planMenuAbort.abort()
-		})
-
-		const EXECUTE = "Execute the plan"
-		const DECLINE = "Rework the plan"
-		const START_AS_FERMENT = "Start as ferment"
-
-		void withBlocked(pi.events, "Plan complete", () =>
-			withWorkingHidden(ctx, () =>
-				ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, DECLINE, START_AS_FERMENT], {
-					signal: planMenuAbort.signal,
-				}),
-			),
-		).then((choice) => {
-			// select returns undefined when aborted — plannotator already decided.
-			if (choice === undefined) return
-			if (choice === EXECUTE) {
-				emitPlanReviewDecision(pi, { decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
-			} else if (choice === START_AS_FERMENT) {
-				emitPlanReviewDecision(pi, { decision: "start_ferment", source: "kimchi-tui", planReviewSource: "adhoc" })
-			} else {
-				emitPlanReviewDecision(pi, { decision: "rework", source: "kimchi-tui", planReviewSource: "adhoc" })
+	// submit_plan tool — replaces the <!-- PLAN_COMPLETE --> marker.
+	// Visible in both adhoc plan mode and ferment planning phase (via the
+	// tool catalog). The model calls it when the plan is ready for review.
+	// For ferment, the model should call propose_ferment_scoping first (to
+	// populate the structured scope), then submit_plan to trigger the review.
+	pi.registerTool({
+		name: "submit_plan",
+		label: "Submit Plan",
+		description:
+			"Submit your completed plan for user review. Call this only after the plan " +
+			"is fully written and all open questions are resolved. The plan will be " +
+			"saved to disk and the user will review it in a visual UI before execution. " +
+			"If the plan is denied with feedback, revise and call this again.",
+		parameters: Type.Object({
+			plan: Type.String({
+				description:
+					"The complete plan as markdown. Must follow the required structure: " +
+					"Goal, Constraints, Chunks (with Files Changed, Depends On, Accept When, " +
+					"Test Coverage, Open Questions), Verification Strategy, Decision Log, Risks.",
+			}),
+		}) as any,
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const planText = (params as { plan?: string })?.plan
+			if (!planText?.trim()) {
+				return {
+					content: [{ type: "text", text: "Error: plan text is empty." }],
+					details: { submitted: false },
+				}
 			}
-		})
+
+			// Determine mode: adhoc plan mode or ferment planning
+			const mode = getRuntimePermissionMode().mode
+			const isAdhoc = mode === "plan"
+			const activeFerment = defaultFermentRuntime.getActive()
+			const isFermentPlanning =
+				!isAdhoc &&
+				activeFerment !== undefined &&
+				activeFerment.phases !== undefined &&
+				!activeFerment.phases.some((p) => p.status !== "planned")
+
+			if (!isAdhoc && !isFermentPlanning) {
+				return {
+					content: [{ type: "text", text: "Error: submit_plan is only available during planning." }],
+					details: { submitted: false },
+				}
+			}
+
+			// Save plan to disk (adhoc only — ferment plans are persisted via scoping)
+			let planPath: string | undefined
+			if (isAdhoc) {
+				if (!activePlanSlug) activePlanSlug = slugifyPlanName(derivePlanTitle(planText))
+				try {
+					planPath = savePlanMarkdown({ cwd: ctx.cwd, name: activePlanSlug, planText })
+				} catch (err) {
+					const detail = err instanceof Error ? err.message : String(err)
+					if (ctx.hasUI) ctx.ui.notify(`permissions: failed to save plan file: ${detail}`, "warning")
+					else console.error(`permissions: failed to save plan file: ${detail}`)
+				}
+			}
+
+			// For ferment: set the pending plan review so hasPendingPlanReview()
+			// suppresses tools (same as propose_ferment_scoping does today)
+			if (isFermentPlanning && activeFerment) {
+				defaultFermentRuntime.setPendingPlanReview({
+					fermentId: activeFerment.id,
+					planMarkdown: planText,
+				})
+			}
+
+			const reviewSource = isAdhoc ? "adhoc" : "ferment"
+			const fermentId = isFermentPlanning ? activeFerment?.id : undefined
+
+			// Non-TUI / oneshot: skip the menu, emit request only
+			if (!ctx.hasUI || pi.getFlag?.("ferment-oneshot") === true) {
+				emitPlanReviewRequest(
+					pi,
+					{ planContent: planText, planFilePath: planPath, source: reviewSource, fermentId },
+					{ ctx, planPath, planText, rawText: planText, activePlanSlug, fermentId },
+				)
+				return {
+					content: [{ type: "text", text: "Plan submitted." }],
+					details: { submitted: true },
+					terminate: true,
+				}
+			}
+
+			// Emit plan-review request — TUI popup and plannotator both listen.
+			// Fire-and-forget: the TUI menu is shown below without awaiting, and
+			// plannotator's browser opens via the adapter. First decision wins.
+			emitPlanReviewRequest(
+				pi,
+				{ planContent: planText, planFilePath: planPath, source: reviewSource, fermentId },
+				{ ctx, planPath, planText, rawText: planText, activePlanSlug, fermentId },
+			)
+
+			// AbortSignal lets the decision handler dismiss the menu when
+			// plannotator decides first (select returns undefined on abort).
+			const planMenuAbort = new AbortController()
+			onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+				if (payload.planReviewSource !== reviewSource) return
+				if (payload.source !== "plannotator") return
+				planMenuAbort.abort()
+			})
+
+			const EXECUTE = "Execute the plan"
+			const DECLINE = "Rework the plan"
+			const START_AS_FERMENT = "Start as ferment"
+
+			void withBlocked(pi.events, "Plan complete", () =>
+				withWorkingHidden(ctx, () =>
+					ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, DECLINE, START_AS_FERMENT], {
+						signal: planMenuAbort.signal,
+					}),
+				),
+			).then((choice) => {
+				// select returns undefined when aborted — plannotator already decided.
+				if (choice === undefined) return
+				if (choice === EXECUTE) {
+					emitPlanReviewDecision(pi, {
+						decision: "execute",
+						source: "kimchi-tui",
+						planReviewSource: reviewSource,
+						fermentId,
+					})
+				} else if (choice === START_AS_FERMENT) {
+					emitPlanReviewDecision(pi, {
+						decision: "start_ferment",
+						source: "kimchi-tui",
+						planReviewSource: reviewSource,
+					})
+				} else {
+					emitPlanReviewDecision(pi, {
+						decision: "rework",
+						source: "kimchi-tui",
+						planReviewSource: reviewSource,
+						fermentId,
+					})
+				}
+			})
+
+			return {
+				content: [{ type: "text", text: "Plan submitted for review. Waiting for user decision." }],
+				details: { submitted: true },
+				terminate: true,
+			}
+		},
 	})
 
 	// Decision handler for adhoc plan reviews — handles decisions from both
@@ -856,56 +910,6 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			)
 		}
 		// "rework" = stay in plan mode, no action needed
-	})
-
-	// Plan-mode stop nudge: fires when the model made tool calls this turn but
-	// ended with stopReason "stop" without writing PLAN_COMPLETE.
-	// Logic lives in src/shared/planning/planning-stop-nudge.ts.
-	const planStopNudgeCounts = new Map<string, number>()
-
-	pi.on("turn_end", (event, ctx) => {
-		if (getRuntimePermissionMode().mode !== "plan") {
-			planStopNudgeCounts.clear()
-			return
-		}
-
-		const message = event.message
-		if (message.role !== "assistant") return
-
-		const stopReason = (message as { stopReason?: string }).stopReason
-		// Reset counter on non-stop turns (model still progressing).
-		if (stopReason !== "stop") {
-			planStopNudgeCounts.clear()
-			return
-		}
-
-		const content = message.content as unknown[]
-		const text = extractTextFromContent(content)
-
-		if (
-			!shouldNudge({
-				hasToolCall: contentHasToolCall(content),
-				stopReason,
-				completionSignalPresent: hasPlanCompletionSignal(text),
-			})
-		)
-			return
-
-		const sessionId = ctx.sessionManager.getSessionId()
-		const count = (planStopNudgeCounts.get(sessionId) ?? 0) + 1
-		planStopNudgeCounts.set(sessionId, count)
-
-		if (isNudgeSuppressed(count)) return
-
-		void pi.sendMessage(
-			{
-				customType: "plan_stop_nudge",
-				content: [{ type: "text", text: PLAN_MODE_STOP_NUDGE }],
-				display: false,
-				details: undefined,
-			},
-			{ triggerTurn: true },
-		)
 	})
 
 	pi.on("tool_call", async (event, ctx) => {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -606,54 +606,32 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				}
 			}
 
-			// Determine mode: adhoc plan mode or ferment planning
+			// Guard: must be in plan mode
 			const mode = getRuntimePermissionMode().mode
-			const isAdhoc = mode === "plan"
-			const activeFerment = defaultFermentRuntime.getActive()
-			const isFermentPlanning =
-				!isAdhoc &&
-				activeFerment !== undefined &&
-				activeFerment.phases !== undefined &&
-				!activeFerment.phases.some((p) => p.status !== "planned")
-
-			if (!isAdhoc && !isFermentPlanning) {
+			if (mode !== "plan") {
 				return {
-					content: [{ type: "text", text: "Error: submit_plan is only available during planning." }],
+					content: [{ type: "text", text: "Error: submit_plan is only available during plan mode." }],
 					details: { submitted: false },
 				}
 			}
 
-			// Save plan to disk (adhoc only — ferment plans are persisted via scoping)
+			// Save plan to disk
+			if (!activePlanSlug) activePlanSlug = slugifyPlanName(derivePlanTitle(planText))
 			let planPath: string | undefined
-			if (isAdhoc) {
-				if (!activePlanSlug) activePlanSlug = slugifyPlanName(derivePlanTitle(planText))
-				try {
-					planPath = savePlanMarkdown({ cwd: ctx.cwd, name: activePlanSlug, planText })
-				} catch (err) {
-					const detail = err instanceof Error ? err.message : String(err)
-					if (ctx.hasUI) ctx.ui.notify(`permissions: failed to save plan file: ${detail}`, "warning")
-					else console.error(`permissions: failed to save plan file: ${detail}`)
-				}
+			try {
+				planPath = savePlanMarkdown({ cwd: ctx.cwd, name: activePlanSlug, planText })
+			} catch (err) {
+				const detail = err instanceof Error ? err.message : String(err)
+				if (ctx.hasUI) ctx.ui.notify(`permissions: failed to save plan file: ${detail}`, "warning")
+				else console.error(`permissions: failed to save plan file: ${detail}`)
 			}
-
-			// For ferment: set the pending plan review so hasPendingPlanReview()
-			// suppresses tools (same as propose_ferment_scoping does today)
-			if (isFermentPlanning && activeFerment) {
-				defaultFermentRuntime.setPendingPlanReview({
-					fermentId: activeFerment.id,
-					planMarkdown: planText,
-				})
-			}
-
-			const reviewSource = isAdhoc ? "adhoc" : "ferment"
-			const fermentId = isFermentPlanning ? activeFerment?.id : undefined
 
 			// Non-TUI / oneshot: skip the menu, emit request only
 			if (!ctx.hasUI || pi.getFlag?.("ferment-oneshot") === true) {
 				emitPlanReviewRequest(
 					pi,
-					{ planContent: planText, planFilePath: planPath, source: reviewSource, fermentId },
-					{ ctx, planPath, planText, rawText: planText, activePlanSlug, fermentId },
+					{ planContent: planText, planFilePath: planPath, source: "adhoc" },
+					{ ctx, planPath, planText, rawText: planText, activePlanSlug },
 				)
 				return {
 					content: [{ type: "text", text: "Plan submitted." }],
@@ -667,15 +645,15 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			// plannotator's browser opens via the adapter. First decision wins.
 			emitPlanReviewRequest(
 				pi,
-				{ planContent: planText, planFilePath: planPath, source: reviewSource, fermentId },
-				{ ctx, planPath, planText, rawText: planText, activePlanSlug, fermentId },
+				{ planContent: planText, planFilePath: planPath, source: "adhoc" },
+				{ ctx, planPath, planText, rawText: planText, activePlanSlug },
 			)
 
 			// AbortSignal lets the decision handler dismiss the menu when
 			// plannotator decides first (select returns undefined on abort).
 			const planMenuAbort = new AbortController()
 			onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
-				if (payload.planReviewSource !== reviewSource) return
+				if (payload.planReviewSource !== "adhoc") return
 				if (payload.source !== "plannotator") return
 				planMenuAbort.abort()
 			})
@@ -697,21 +675,19 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					emitPlanReviewDecision(pi, {
 						decision: "execute",
 						source: "kimchi-tui",
-						planReviewSource: reviewSource,
-						fermentId,
+						planReviewSource: "adhoc",
 					})
 				} else if (choice === START_AS_FERMENT) {
 					emitPlanReviewDecision(pi, {
 						decision: "start_ferment",
 						source: "kimchi-tui",
-						planReviewSource: reviewSource,
+						planReviewSource: "adhoc",
 					})
 				} else {
 					emitPlanReviewDecision(pi, {
 						decision: "rework",
 						source: "kimchi-tui",
-						planReviewSource: reviewSource,
-						fermentId,
+						planReviewSource: "adhoc",
 					})
 				}
 			})

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -15,6 +15,13 @@ import {
 	stripPlanCompletionMarkers,
 } from "../../shared/planning/plan-markdown.js"
 import {
+	consumePlanReviewContext,
+	emitPlanReviewDecision,
+	emitPlanReviewRequest,
+	onPlanReviewDecision,
+	type PlanReviewDecisionPayload,
+} from "../../shared/planning/plan-review-bus.js"
+import {
 	contentHasToolCall,
 	extractTextFromContent,
 	hasPlanCompletionSignal,
@@ -618,23 +625,64 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 		// the rest of the lifecycle through scope_ferment and friends, no user prompt needed.
 		if (pi.getFlag?.("ferment-oneshot") === true) return
 
+		// Emit plan-review request — TUI popup and plannotator both listen.
+		// Fire-and-forget: the TUI menu is shown below without awaiting, and
+		// plannotator's browser opens via the adapter. First decision wins.
+		emitPlanReviewRequest(
+			pi,
+			{
+				planContent: planText,
+				planFilePath: planPath,
+				source: "adhoc",
+			},
+			{ ctx, planPath, planText, rawText: text, activePlanSlug },
+		)
+
+		// AbortSignal lets the decision handler dismiss the menu when
+		// plannotator decides first (select returns undefined on abort).
+		const planMenuAbort = new AbortController()
+		onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+			if (payload.planReviewSource !== "adhoc") return
+			if (payload.source !== "plannotator") return
+			planMenuAbort.abort()
+		})
+
 		const EXECUTE = "Execute the plan"
 		const DECLINE = "Rework the plan"
 		const START_AS_FERMENT = "Start as ferment"
 
-		const choice = await withBlocked(pi.events, "Plan complete", () =>
+		void withBlocked(pi.events, "Plan complete", () =>
 			withWorkingHidden(ctx, () =>
-				ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, DECLINE, START_AS_FERMENT]),
+				ctx.ui.select("Plan complete. How would you like to proceed?", [EXECUTE, DECLINE, START_AS_FERMENT], {
+					signal: planMenuAbort.signal,
+				}),
 			),
-		)
+		).then((choice) => {
+			// select returns undefined when aborted — plannotator already decided.
+			if (choice === undefined) return
+			if (choice === EXECUTE) {
+				emitPlanReviewDecision(pi, { decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
+			} else if (choice === START_AS_FERMENT) {
+				emitPlanReviewDecision(pi, { decision: "start_ferment", source: "kimchi-tui", planReviewSource: "adhoc" })
+			} else {
+				emitPlanReviewDecision(pi, { decision: "rework", source: "kimchi-tui", planReviewSource: "adhoc" })
+			}
+		})
+	})
 
-		if (choice === EXECUTE) {
+	// Decision handler for adhoc plan reviews — handles decisions from both
+	// the TUI menu and plannotator's browser UI (first decision wins).
+	onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+		if (payload.planReviewSource !== "adhoc") return
+		const reviewCtx = consumePlanReviewContext()
+		if (!reviewCtx) return
+		const { ctx, planPath, planText, rawText } = reviewCtx
+
+		if (payload.decision === "execute") {
 			changeMode(ctx, "plan", { mode: "auto", initiatedBy: "user", source: "runtime" }, "plan_approval")
 			executePlan(planPath, planText)
-			// The plan is approved and dispatched — the next planning round in
-			// this session derives a fresh slug so it gets its own file.
 			activePlanSlug = undefined
-		} else if (choice === START_AS_FERMENT) {
+		} else if (payload.decision === "start_ferment") {
 			// Converted into a ferment — same release as the execute path.
 			activePlanSlug = undefined
 			// ── Tool-swap contract ────────────────────────────────────────────────
@@ -676,7 +724,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				// Goal / Constraints / Chunks become structured ferment fields;
 				// Verification Strategy / Decision Log / Risks are metadata and must
 				// not become implementation steps. (PR #683 review nit 3473746281.)
-				const parsed = parseSharedPlan(text)
+				const parsed = parseSharedPlan(rawText ?? planText)
 				// Create a storage instance scoped to ctx.cwd so the ferment artifact
 				// lands in the project's .kimchi/ferments/ directory, not process.cwd().
 				// defaultFermentRuntime.getStorage() always uses process.cwd(); in
@@ -696,7 +744,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					const draftName = parsed.goal.split("\n")[0] || "Plan from --plan mode"
 					const draft = createFerment(runtime, {
 						name: draftName,
-						goal: parsed.goal || text.trim(),
+						goal: parsed.goal || (rawText ?? planText).trim(),
 						hasUI: ctx.hasUI,
 						isOneShot: pi.getFlag("ferment-oneshot") === true,
 					})
@@ -796,8 +844,18 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				const message = err instanceof Error ? err.message : String(err)
 				ctx.ui?.notify?.(`Could not start this plan as a ferment: ${message}. Staying in plan mode.`)
 			}
+		} else if (payload.decision === "feedback") {
+			safeSendMessage(
+				pi,
+				{
+					customType: "plannotator-feedback",
+					content: [{ type: "text", text: payload.feedback ?? "" }],
+					display: false,
+				},
+				{ triggerTurn: true },
+			)
 		}
-		// Decline or escape: stay in plan mode.
+		// "rework" = stay in plan mode, no action needed
 	})
 
 	// Plan-mode stop nudge: fires when the model made tool calls this turn but

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -596,7 +596,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					"Goal, Constraints, Chunks (with Files Changed, Depends On, Accept When, " +
 					"Test Coverage, Open Questions), Verification Strategy, Decision Log, Risks.",
 			}),
-		}) as any,
+		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const planText = (params as { plan?: string })?.plan
 			if (!planText?.trim()) {
@@ -626,7 +626,11 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				else console.error(`permissions: failed to save plan file: ${detail}`)
 			}
 
-			// Non-TUI / oneshot: skip the menu, emit request only
+			// Non-TUI / oneshot: emit the review request then end the turn.
+			// Emitters always emit — subscribers self-select. The plannotator
+			// adapter skips subscribing in non-interactive sessions, so this
+			// is a no-op today, but future integrations (logging, CI reviewers,
+			// alternative UIs) can hook in without changes here.
 			if (!ctx.hasUI || pi.getFlag?.("ferment-oneshot") === true) {
 				emitPlanReviewRequest(
 					pi,
@@ -651,8 +655,10 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 
 			// AbortSignal lets the decision handler dismiss the menu when
 			// plannotator decides first (select returns undefined on abort).
+			// The listener is unsubscribed when the menu resolves — it is
+			// per-review and must not accumulate on the shared event bus.
 			const planMenuAbort = new AbortController()
-			onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
+			const unsubscribeAbortListener = onPlanReviewDecision(pi, (payload: PlanReviewDecisionPayload) => {
 				if (payload.planReviewSource !== "adhoc") return
 				if (payload.source !== "plannotator") return
 				planMenuAbort.abort()
@@ -669,6 +675,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 					}),
 				),
 			).then((choice) => {
+				unsubscribeAbortListener()
 				// select returns undefined when aborted — plannotator already decided.
 				if (choice === undefined) return
 				if (choice === EXECUTE) {

--- a/src/extensions/permissions/prompts/plan-mode-supplement.test.ts
+++ b/src/extensions/permissions/prompts/plan-mode-supplement.test.ts
@@ -30,8 +30,9 @@ describe("plan-mode-supplement", () => {
 			expect(planModeSupplement).toContain("questionnaire")
 		})
 
-		it("contains plan completion marker", () => {
-			expect(planModeSupplement).toContain("PLAN_COMPLETE")
+		it("references the submit_plan tool as the plan completion signal", () => {
+			expect(planModeSupplement).toContain("`submit_plan`")
+			expect(planModeSupplement).not.toContain("PLAN_COMPLETE")
 		})
 
 		it("states that plans are auto-saved (shared location note)", () => {

--- a/src/extensions/permissions/prompts/plan-mode-supplement.ts
+++ b/src/extensions/permissions/prompts/plan-mode-supplement.ts
@@ -1,9 +1,6 @@
 import { generatePlanPersistenceNote } from "../../../shared/planning/plan-markdown.js"
 import { SHARED_PLANNING_PROCESS } from "../../../shared/planning/shared-planning-process.js"
 
-const PLAN_COMPLETE_MARKER = "<!-- PLAN_COMPLETE -->"
-const DONE_MARKER = "<done>"
-
 export default `Plan mode is active. You have read-only access to this codebase: you can read files, search, list directories, and run read-only shell commands. You cannot edit, write, or run any command that changes state.
 
 **First, decide whether the task requires codebase exploration:**
@@ -26,17 +23,15 @@ STEP 3 (Completion Criteria):
 
 STEP 5 (Plan):
 - Draft the plan directly within this conversation using the structure defined above.
-- Emit exactly one completion marker when ALL of the following are true:
+- When the plan is complete and ALL of the following are true:
   1. The plan is written in full (Goal, Constraints, Chunks, Verification Strategy, Decision Log, Risks).
   2. All Open Questions are resolved — none remain unanswered.
   3. You are not waiting on any clarification from the user.
-  Use one of these markers on its own line at the end of your response:
-    ${PLAN_COMPLETE_MARKER}
-  or simply:
-    ${DONE_MARKER}
-- Do NOT include these markers on intermediate drafts, while posing clarifying questions,
+  Call the \`submit_plan\` tool with the full plan text as the \`plan\` parameter.
+- Do NOT call \`submit_plan\` on intermediate drafts, while posing clarifying questions,
   or while any Open Question remains unresolved. The approval menu will not appear until all
   Open Questions are cleared.
+- If the plan is denied with feedback, revise the plan and call \`submit_plan\` again.
 
 ## Plan File Persistence
 

--- a/src/extensions/plannotator/index.test.ts
+++ b/src/extensions/plannotator/index.test.ts
@@ -9,7 +9,7 @@ interface MockCaptures {
 	resultHandler?: (data: unknown) => void
 }
 
-function createMockPi(captures: MockCaptures): ExtensionAPI {
+function createMockPi(captures: MockCaptures, opts?: { hasUI?: boolean; oneshot?: boolean }): ExtensionAPI {
 	const emit = vi.fn((channel: string, data: unknown) => {
 		captures.emitCalls.push({ channel, data })
 		// If this is a plannotator:request, capture nothing — the adapter
@@ -25,25 +25,33 @@ function createMockPi(captures: MockCaptures): ExtensionAPI {
 		return () => {}
 	})
 
-	const sessionStartHandlers: Array<() => Promise<void>> = []
-	const piOn = vi.fn((event: string, handler: () => Promise<void>) => {
+	const sessionStartHandlers: Array<(event: unknown, ctx: unknown) => Promise<void>> = []
+	const piOn = vi.fn((event: string, handler: (event: unknown, ctx: unknown) => Promise<void>) => {
 		if (event === "session_start") sessionStartHandlers.push(handler)
 	})
+
+	const getFlag = vi.fn((flag: string) => (flag === "ferment-oneshot" && opts?.oneshot ? true : false))
 
 	return {
 		events: { emit, on },
 		on: piOn,
+		getFlag,
 		_sessionStartHandlers: sessionStartHandlers,
+		_hasUI: opts?.hasUI ?? true,
 	} as unknown as ExtensionAPI
 }
 
-function setupExtension(): { pi: ExtensionAPI; captures: MockCaptures } {
+function setupExtension(opts?: { hasUI?: boolean; oneshot?: boolean }): { pi: ExtensionAPI; captures: MockCaptures } {
 	const captures: MockCaptures = { emitCalls: [] }
-	const pi = createMockPi(captures)
+	const pi = createMockPi(captures, opts)
 	plannotatorExtension(pi)
 	// Fire session_start to register listeners
-	const piWithHandlers = pi as unknown as { _sessionStartHandlers: Array<() => Promise<void>> }
-	piWithHandlers._sessionStartHandlers.forEach((h) => void h())
+	const piWithHandlers = pi as unknown as {
+		_sessionStartHandlers: Array<(event: unknown, ctx: unknown) => Promise<void>>
+		_hasUI: boolean
+	}
+	const mockCtx = { hasUI: piWithHandlers._hasUI, mode: "tui" }
+	piWithHandlers._sessionStartHandlers.forEach((h) => void h({}, mockCtx))
 	return { pi, captures }
 }
 
@@ -113,6 +121,31 @@ describe("plannotator adapter", () => {
 		})
 	})
 
+	describe("subscribe-side gating", () => {
+		it("does not subscribe when hasUI is false (headless/print mode)", () => {
+			const { pi, captures } = setupExtension({ hasUI: false })
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+
+			// No requestHandler should have been registered
+			expect(captures.requestHandler).toBeUndefined()
+
+			// Emitting a request should NOT produce a plannotator:request emit
+			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
+			expect(plannotatorEmit).toBeUndefined()
+		})
+
+		it("does not subscribe when ferment-oneshot flag is set", () => {
+			const { pi, captures } = setupExtension({ oneshot: true })
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+
+			expect(captures.requestHandler).toBeUndefined()
+			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
+			expect(plannotatorEmit).toBeUndefined()
+		})
+	})
+
 	describe("plannotator:review-result → kimchi:plan-review-decision", () => {
 		it("emits plan-review-decision with execute when plannotator approves", () => {
 			const { pi, captures } = setupExtension()
@@ -148,6 +181,23 @@ describe("plannotator adapter", () => {
 			expect(decisionEmit!.data).toMatchObject({
 				decision: "feedback",
 				feedback: "Add more detail to chunk 2",
+				source: "plannotator",
+				planReviewSource: "adhoc",
+			})
+		})
+
+		it("emits plan-review-decision with rework when plannotator denies without feedback", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+
+			// Deny with blank feedback — must not become an empty feedback turn
+			captures.resultHandler!({ approved: false, feedback: "  " })
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit!.data).toMatchObject({
+				decision: "rework",
 				source: "plannotator",
 				planReviewSource: "adhoc",
 			})

--- a/src/extensions/plannotator/index.test.ts
+++ b/src/extensions/plannotator/index.test.ts
@@ -76,7 +76,7 @@ describe("plannotator adapter", () => {
 
 			// The adapter's onPlanReviewRequest handler should have been called
 			expect(captures.requestHandler).toBeDefined()
-			captures.requestHandler!({
+			captures.requestHandler?.({
 				planContent: "# My Plan",
 				planFilePath: "/plans/my-plan.md",
 				source: "adhoc",
@@ -84,7 +84,7 @@ describe("plannotator adapter", () => {
 
 			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
 			expect(plannotatorEmit).toBeDefined()
-			expect(plannotatorEmit!.data).toMatchObject({
+			expect(plannotatorEmit?.data).toMatchObject({
 				action: "plan-review",
 				payload: {
 					planContent: "# My Plan",
@@ -92,7 +92,7 @@ describe("plannotator adapter", () => {
 					origin: "adhoc",
 				},
 			})
-			expect((plannotatorEmit!.data as { requestId: string }).requestId).toBeTypeOf("string")
+			expect((plannotatorEmit?.data as { requestId: string }).requestId).toBeTypeOf("string")
 		})
 
 		it("passes ferment source as origin", () => {
@@ -108,14 +108,14 @@ describe("plannotator adapter", () => {
 				{ ctx: {} as never, planText: "ferment plan", fermentId: "f-1" },
 			)
 
-			captures.requestHandler!({
+			captures.requestHandler?.({
 				planContent: "ferment plan",
 				source: "ferment",
 				fermentId: "f-1",
 			})
 
 			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
-			expect(plannotatorEmit!.data).toMatchObject({
+			expect(plannotatorEmit?.data).toMatchObject({
 				payload: { origin: "ferment" },
 			})
 		})
@@ -152,14 +152,14 @@ describe("plannotator adapter", () => {
 
 			// First, emit a request to set the active review source
 			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
-			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+			captures.requestHandler?.({ planContent: "plan", source: "adhoc" })
 
 			// Simulate plannotator review-result: approved
-			captures.resultHandler!({ approved: true })
+			captures.resultHandler?.({ approved: true })
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
 			expect(decisionEmit).toBeDefined()
-			expect(decisionEmit!.data).toMatchObject({
+			expect(decisionEmit?.data).toMatchObject({
 				decision: "execute",
 				source: "plannotator",
 				planReviewSource: "adhoc",
@@ -170,15 +170,15 @@ describe("plannotator adapter", () => {
 			const { pi, captures } = setupExtension()
 
 			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
-			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+			captures.requestHandler?.({ planContent: "plan", source: "adhoc" })
 
-			captures.resultHandler!({
+			captures.resultHandler?.({
 				approved: false,
 				feedback: "Add more detail to chunk 2",
 			})
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
-			expect(decisionEmit!.data).toMatchObject({
+			expect(decisionEmit?.data).toMatchObject({
 				decision: "feedback",
 				feedback: "Add more detail to chunk 2",
 				source: "plannotator",
@@ -190,13 +190,13 @@ describe("plannotator adapter", () => {
 			const { pi, captures } = setupExtension()
 
 			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
-			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+			captures.requestHandler?.({ planContent: "plan", source: "adhoc" })
 
 			// Deny with blank feedback — must not become an empty feedback turn
-			captures.resultHandler!({ approved: false, feedback: "  " })
+			captures.resultHandler?.({ approved: false, feedback: "  " })
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
-			expect(decisionEmit!.data).toMatchObject({
+			expect(decisionEmit?.data).toMatchObject({
 				decision: "rework",
 				source: "plannotator",
 				planReviewSource: "adhoc",
@@ -206,7 +206,7 @@ describe("plannotator adapter", () => {
 		it("ignores review-result when no review is active", () => {
 			const { captures } = setupExtension()
 
-			captures.resultHandler!({ approved: true })
+			captures.resultHandler?.({ approved: true })
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
 			expect(decisionEmit).toBeUndefined()
@@ -216,9 +216,9 @@ describe("plannotator adapter", () => {
 			const { pi, captures } = setupExtension()
 
 			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
-			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+			captures.requestHandler?.({ planContent: "plan", source: "adhoc" })
 
-			captures.resultHandler!({ feedback: "some text" })
+			captures.resultHandler?.({ feedback: "some text" })
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
 			expect(decisionEmit).toBeUndefined()
@@ -232,12 +232,12 @@ describe("plannotator adapter", () => {
 				{ planContent: "plan", source: "ferment", fermentId: "f-1" },
 				{ ctx: {} as never, planText: "plan", fermentId: "f-1" },
 			)
-			captures.requestHandler!({ planContent: "plan", source: "ferment", fermentId: "f-1" })
+			captures.requestHandler?.({ planContent: "plan", source: "ferment", fermentId: "f-1" })
 
-			captures.resultHandler!({ approved: true })
+			captures.resultHandler?.({ approved: true })
 
 			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
-			expect(decisionEmit!.data).toMatchObject({
+			expect(decisionEmit?.data).toMatchObject({
 				planReviewSource: "ferment",
 			})
 		})
@@ -248,16 +248,16 @@ describe("plannotator adapter", () => {
 			const { pi, captures } = setupExtension()
 
 			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
-			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+			captures.requestHandler?.({ planContent: "plan", source: "adhoc" })
 
 			// First decision
-			captures.resultHandler!({ approved: true })
+			captures.resultHandler?.({ approved: true })
 
 			// Consume the context (simulating the decision handler acting)
 			consumePlanReviewContext()
 
 			// Second decision — should be ignored
-			captures.resultHandler!({ approved: false, feedback: "too late" })
+			captures.resultHandler?.({ approved: false, feedback: "too late" })
 
 			const decisionEmits = captures.emitCalls.filter((c) => c.channel === "kimchi:plan-review-decision")
 			expect(decisionEmits).toHaveLength(1)

--- a/src/extensions/plannotator/index.test.ts
+++ b/src/extensions/plannotator/index.test.ts
@@ -1,0 +1,216 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { consumePlanReviewContext, emitPlanReviewRequest } from "../../shared/planning/plan-review-bus.js"
+import plannotatorExtension from "./index.js"
+
+interface MockCaptures {
+	emitCalls: Array<{ channel: string; data: unknown }>
+	requestHandler?: (data: unknown) => void
+	resultHandler?: (data: unknown) => void
+}
+
+function createMockPi(captures: MockCaptures): ExtensionAPI {
+	const emit = vi.fn((channel: string, data: unknown) => {
+		captures.emitCalls.push({ channel, data })
+		// If this is a plannotator:request, capture nothing — the adapter
+		// doesn't need a respond callback result.
+	})
+
+	const on = vi.fn((channel: string, handler: (data: unknown) => void) => {
+		if (channel === "kimchi:plan-review-request") {
+			captures.requestHandler = handler
+		} else if (channel === "plannotator:review-result") {
+			captures.resultHandler = handler
+		}
+		return () => {}
+	})
+
+	const sessionStartHandlers: Array<() => Promise<void>> = []
+	const piOn = vi.fn((event: string, handler: () => Promise<void>) => {
+		if (event === "session_start") sessionStartHandlers.push(handler)
+	})
+
+	return {
+		events: { emit, on },
+		on: piOn,
+		_sessionStartHandlers: sessionStartHandlers,
+	} as unknown as ExtensionAPI
+}
+
+function setupExtension(): { pi: ExtensionAPI; captures: MockCaptures } {
+	const captures: MockCaptures = { emitCalls: [] }
+	const pi = createMockPi(captures)
+	plannotatorExtension(pi)
+	// Fire session_start to register listeners
+	const piWithHandlers = pi as unknown as { _sessionStartHandlers: Array<() => Promise<void>> }
+	piWithHandlers._sessionStartHandlers.forEach((h) => void h())
+	return { pi, captures }
+}
+
+describe("plannotator adapter", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	describe("kimchi:plan-review-request → plannotator:request", () => {
+		it("emits plannotator:request with plan-review action when a plan-review-request arrives", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(
+				pi,
+				{
+					planContent: "# My Plan",
+					planFilePath: "/plans/my-plan.md",
+					source: "adhoc",
+				},
+				{ ctx: {} as never, planText: "# My Plan", planPath: "/plans/my-plan.md" },
+			)
+
+			// The adapter's onPlanReviewRequest handler should have been called
+			expect(captures.requestHandler).toBeDefined()
+			captures.requestHandler!({
+				planContent: "# My Plan",
+				planFilePath: "/plans/my-plan.md",
+				source: "adhoc",
+			})
+
+			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
+			expect(plannotatorEmit).toBeDefined()
+			expect(plannotatorEmit!.data).toMatchObject({
+				action: "plan-review",
+				payload: {
+					planContent: "# My Plan",
+					planFilePath: "/plans/my-plan.md",
+					origin: "adhoc",
+				},
+			})
+			expect((plannotatorEmit!.data as { requestId: string }).requestId).toBeTypeOf("string")
+		})
+
+		it("passes ferment source as origin", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(
+				pi,
+				{
+					planContent: "ferment plan",
+					source: "ferment",
+					fermentId: "f-1",
+				},
+				{ ctx: {} as never, planText: "ferment plan", fermentId: "f-1" },
+			)
+
+			captures.requestHandler!({
+				planContent: "ferment plan",
+				source: "ferment",
+				fermentId: "f-1",
+			})
+
+			const plannotatorEmit = captures.emitCalls.find((c) => c.channel === "plannotator:request")
+			expect(plannotatorEmit!.data).toMatchObject({
+				payload: { origin: "ferment" },
+			})
+		})
+	})
+
+	describe("plannotator:review-result → kimchi:plan-review-decision", () => {
+		it("emits plan-review-decision with execute when plannotator approves", () => {
+			const { pi, captures } = setupExtension()
+
+			// First, emit a request to set the active review source
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+
+			// Simulate plannotator review-result: approved
+			captures.resultHandler!({ approved: true })
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit).toBeDefined()
+			expect(decisionEmit!.data).toMatchObject({
+				decision: "execute",
+				source: "plannotator",
+				planReviewSource: "adhoc",
+			})
+		})
+
+		it("emits plan-review-decision with feedback when plannotator denies", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+
+			captures.resultHandler!({
+				approved: false,
+				feedback: "Add more detail to chunk 2",
+			})
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit!.data).toMatchObject({
+				decision: "feedback",
+				feedback: "Add more detail to chunk 2",
+				source: "plannotator",
+				planReviewSource: "adhoc",
+			})
+		})
+
+		it("ignores review-result when no review is active", () => {
+			const { captures } = setupExtension()
+
+			captures.resultHandler!({ approved: true })
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit).toBeUndefined()
+		})
+
+		it("ignores review-result with missing approved field", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+
+			captures.resultHandler!({ feedback: "some text" })
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit).toBeUndefined()
+		})
+
+		it("uses the correct planReviewSource for ferment reviews", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(
+				pi,
+				{ planContent: "plan", source: "ferment", fermentId: "f-1" },
+				{ ctx: {} as never, planText: "plan", fermentId: "f-1" },
+			)
+			captures.requestHandler!({ planContent: "plan", source: "ferment", fermentId: "f-1" })
+
+			captures.resultHandler!({ approved: true })
+
+			const decisionEmit = captures.emitCalls.find((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmit!.data).toMatchObject({
+				planReviewSource: "ferment",
+			})
+		})
+	})
+
+	describe("first-decision-wins", () => {
+		it("second plannotator decision is ignored after first is consumed", () => {
+			const { pi, captures } = setupExtension()
+
+			emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, { ctx: {} as never, planText: "plan" })
+			captures.requestHandler!({ planContent: "plan", source: "adhoc" })
+
+			// First decision
+			captures.resultHandler!({ approved: true })
+
+			// Consume the context (simulating the decision handler acting)
+			consumePlanReviewContext()
+
+			// Second decision — should be ignored
+			captures.resultHandler!({ approved: false, feedback: "too late" })
+
+			const decisionEmits = captures.emitCalls.filter((c) => c.channel === "kimchi:plan-review-decision")
+			expect(decisionEmits).toHaveLength(1)
+		})
+	})
+})

--- a/src/extensions/plannotator/index.test.ts
+++ b/src/extensions/plannotator/index.test.ts
@@ -30,7 +30,7 @@ function createMockPi(captures: MockCaptures, opts?: { hasUI?: boolean; oneshot?
 		if (event === "session_start") sessionStartHandlers.push(handler)
 	})
 
-	const getFlag = vi.fn((flag: string) => (flag === "ferment-oneshot" && opts?.oneshot ? true : false))
+	const getFlag = vi.fn((flag: string) => !!(flag === "ferment-oneshot" && opts?.oneshot))
 
 	return {
 		events: { emit, on },

--- a/src/extensions/plannotator/index.ts
+++ b/src/extensions/plannotator/index.ts
@@ -11,6 +11,11 @@
  * - On `plannotator:review-result`: translates the approve/deny decision
  *   into a `kimchi:plan-review-decision` event.
  *
+ * **Subscribe-side gating**: emitters always emit the request (even in
+ * headless/oneshot sessions) so future integrations can hook in. This
+ * adapter subscribes ONLY in interactive TUI sessions — opening a browser
+ * in bench/CI would block on a human that isn't there.
+ *
  * If plannotator isn't installed, the `plannotator:request` emit is a
  * no-op (nobody listens) and no browser opens. The TUI popup is the
  * fallback. Fire-and-forget — no timeout, no waiting.
@@ -29,9 +34,16 @@ const PLANNOTATOR_REQUEST_CHANNEL = "plannotator:request"
 const PLANNOTATOR_REVIEW_RESULT_CHANNEL = "plannotator:review-result"
 
 export default function plannotatorExtension(pi: ExtensionAPI): void {
-	pi.on("session_start", async () => {
+	pi.on("session_start", async (_event, ctx) => {
 		// Skip subagent sessions — they don't run plan reviews
 		if (process.env[PARENT_SESSION_ID_ENV_KEY]) return
+
+		// Subscribe-side gating: emitters always emit (even in headless/oneshot),
+		// but this adapter only subscribes in interactive TUI sessions. Opening
+		// plannotator's browser in bench/CI would block on a human that isn't
+		// there. Future integrations (logging, alternative reviewers) can
+		// subscribe independently.
+		if (!ctx.hasUI || pi.getFlag("ferment-oneshot") === true) return
 
 		// kimchi:plan-review-request → plannotator:request plan-review (browser UI)
 		onPlanReviewRequest(pi, (payload: PlanReviewRequestPayload) => {
@@ -64,9 +76,13 @@ export default function plannotatorExtension(pi: ExtensionAPI): void {
 			const planReviewSource = getActivePlanReviewSource()
 			if (!planReviewSource) return
 
+			// Deny with a comment maps to "feedback" (model revises with direction).
+			// Deny without one maps to "rework" — emitting "feedback" with empty
+			// text would trigger a directionless revision turn.
+			const feedback = result.feedback?.trim() || undefined
 			emitPlanReviewDecision(pi, {
-				decision: result.approved ? "execute" : "feedback",
-				feedback: result.feedback,
+				decision: result.approved ? "execute" : feedback ? "feedback" : "rework",
+				feedback,
 				source: "plannotator",
 				planReviewSource,
 			})

--- a/src/extensions/plannotator/index.ts
+++ b/src/extensions/plannotator/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Plannotator plan-review adapter.
+ *
+ * Translates between kimchi's internal plan-review bus
+ * (`kimchi:plan-review-request` / `kimchi:plan-review-decision`) and
+ * plannotator's extension event bus (`plannotator:request` /
+ * `plannotator:review-result`).
+ *
+ * - On `kimchi:plan-review-request`: fires plannotator's browser UI by
+ *   emitting `plannotator:request` with action `plan-review`.
+ * - On `plannotator:review-result`: translates the approve/deny decision
+ *   into a `kimchi:plan-review-decision` event.
+ *
+ * If plannotator isn't installed, the `plannotator:request` emit is a
+ * no-op (nobody listens) and no browser opens. The TUI popup is the
+ * fallback. Fire-and-forget — no timeout, no waiting.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import {
+	emitPlanReviewDecision,
+	getActivePlanReviewSource,
+	onPlanReviewRequest,
+	type PlanReviewRequestPayload,
+} from "../../shared/planning/plan-review-bus.js"
+import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
+
+const PLANNOTATOR_REQUEST_CHANNEL = "plannotator:request"
+const PLANNOTATOR_REVIEW_RESULT_CHANNEL = "plannotator:review-result"
+
+export default function plannotatorExtension(pi: ExtensionAPI): void {
+	pi.on("session_start", async () => {
+		// Skip subagent sessions — they don't run plan reviews
+		if (process.env[PARENT_SESSION_ID_ENV_KEY]) return
+
+		// kimchi:plan-review-request → plannotator:request plan-review (browser UI)
+		onPlanReviewRequest(pi, (payload: PlanReviewRequestPayload) => {
+			const requestId = `kimchi-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+			pi.events.emit(PLANNOTATOR_REQUEST_CHANNEL, {
+				requestId,
+				action: "plan-review",
+				payload: {
+					planContent: payload.planContent,
+					planFilePath: payload.planFilePath,
+					origin: payload.source,
+				},
+				respond: () => {
+					// Fire-and-forget — we don't need the reviewId.
+					// The decision arrives asynchronously via review-result.
+				},
+			})
+		})
+
+		// plannotator:review-result → kimchi:plan-review-decision
+		pi.events.on(PLANNOTATOR_REVIEW_RESULT_CHANNEL, (data: unknown) => {
+			const result = data as {
+				approved?: boolean
+				feedback?: string
+			}
+			if (typeof result?.approved !== "boolean") return
+
+			// Determine which review surface this result belongs to
+			const planReviewSource = getActivePlanReviewSource()
+			if (!planReviewSource) return
+
+			emitPlanReviewDecision(pi, {
+				decision: result.approved ? "execute" : "feedback",
+				feedback: result.feedback,
+				source: "plannotator",
+				planReviewSource,
+			})
+		})
+	})
+}

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -393,13 +393,22 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			const cleanup = restoreEnv("OPENAI_API_KEY", "fake-key-for-testing")
 
 			try {
+				// pi-mono auth resolution reads the stored credentials file, not the
+				// OPENAI_API_KEY env var — availability requires a real auth entry
+				// on disk (probe: env stub alone leaves auth configured: false).
+				writeFileSync(
+					resolve(tempAgentDir, "auth.json"),
+					JSON.stringify({ openai: { type: "api_key", key: "fake-key" } }),
+				)
 				const modelsJson = {
 					providers: {
 						openai: {
+							baseUrl: "https://api.openai.com/v1",
 							models: [
 								{
 									id: "gpt-4o",
 									name: "GPT-4o",
+									api: "openai-responses",
 									input: ["text", "image"],
 								},
 							],
@@ -4736,9 +4745,29 @@ describe("ACP mode controller integration with permissions extension", () => {
 			},
 			getFlag: (name: string) => flags[name],
 			registerFlag: () => {},
+			registerTool: () => {},
 			sendMessage: () => {},
 			appendEntry: () => {},
-			events: { emit: () => {} },
+			events: (() => {
+				// Real mini event-bus: the plan-review decision channels route
+				// through events.emit → events.on; a stubbed emit-only object
+				// crashes the decision-handlers' on() registration.
+				const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
+				return {
+					emit: (channel: string, data: unknown) => {
+						for (const handler of eventHandlers.get(channel) ?? []) handler(data)
+					},
+					on: (channel: string, handler: (data: unknown) => unknown) => {
+						const list = eventHandlers.get(channel) ?? []
+						list.push(handler)
+						eventHandlers.set(channel, list)
+						return () => {
+							const idx = list.indexOf(handler)
+							if (idx !== -1) list.splice(idx, 1)
+						}
+					},
+				}
+			})(),
 			getEnvironment: () => ({
 				environmentInfo: {
 					permittedTools: new Set(tools),

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -50,6 +50,7 @@ const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 import { populateCliArgs } from "../../cli-args.js"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
 import { clearApiKey, writeApiKey } from "../../config.js"
+import { createMiniEventBus } from "../../extensions/__mocks__/mini-event-bus.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../../extensions/agents/manager/constants.js"
 import { setProcessOrchestratorRef } from "../../extensions/kimchi-process.js"
 import { getMultiModelEnabled, setMultiModelEnabled } from "../../extensions/multi-model.js"
@@ -4748,26 +4749,7 @@ describe("ACP mode controller integration with permissions extension", () => {
 			registerTool: () => {},
 			sendMessage: () => {},
 			appendEntry: () => {},
-			events: (() => {
-				// Real mini event-bus: the plan-review decision channels route
-				// through events.emit → events.on; a stubbed emit-only object
-				// crashes the decision-handlers' on() registration.
-				const eventHandlers = new Map<string, ((data: unknown) => unknown)[]>()
-				return {
-					emit: (channel: string, data: unknown) => {
-						for (const handler of eventHandlers.get(channel) ?? []) handler(data)
-					},
-					on: (channel: string, handler: (data: unknown) => unknown) => {
-						const list = eventHandlers.get(channel) ?? []
-						list.push(handler)
-						eventHandlers.set(channel, list)
-						return () => {
-							const idx = list.indexOf(handler)
-							if (idx !== -1) list.splice(idx, 1)
-						}
-					},
-				}
-			})(),
+			events: createMiniEventBus().events,
 			getEnvironment: () => ({
 				environmentInfo: {
 					permittedTools: new Set(tools),

--- a/src/shared/planning/plan-markdown.test.ts
+++ b/src/shared/planning/plan-markdown.test.ts
@@ -2,13 +2,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSy
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import {
-	derivePlanTitle,
-	fermentPlanFileName,
-	savePlanMarkdown,
-	slugifyPlanName,
-	stripPlanCompletionMarkers,
-} from "./plan-markdown.js"
+import { derivePlanTitle, fermentPlanFileName, savePlanMarkdown, slugifyPlanName } from "./plan-markdown.js"
 
 describe("slugifyPlanName", () => {
 	it("converts a title to kebab-case", () => {
@@ -44,27 +38,6 @@ describe("derivePlanTitle", () => {
 
 	it("returns untitled-plan when neither is present", () => {
 		expect(derivePlanTitle("Some prose without structure.")).toBe("untitled-plan")
-	})
-})
-
-describe("stripPlanCompletionMarkers", () => {
-	it("removes both markers and ends with a single newline", () => {
-		const cleaned = stripPlanCompletionMarkers("# Plan\n\nBody.\n\n<!-- PLAN_COMPLETE -->\n")
-		expect(cleaned).toBe("# Plan\n\nBody.\n")
-	})
-
-	it("removes a standalone <done> marker", () => {
-		expect(stripPlanCompletionMarkers("# Plan\nBody\n\n<done>\n")).toBe("# Plan\nBody\n")
-	})
-
-	it("keeps inline marker-like text inside content", () => {
-		expect(stripPlanCompletionMarkers('emit "<done>" only on its own line\n')).toBe(
-			'emit "<done>" only on its own line\n',
-		)
-	})
-
-	it("returns empty string for marker-only input", () => {
-		expect(stripPlanCompletionMarkers("<!-- PLAN_COMPLETE -->\n")).toBe("")
 	})
 })
 

--- a/src/shared/planning/plan-markdown.ts
+++ b/src/shared/planning/plan-markdown.ts
@@ -6,7 +6,7 @@
  *
  * | Flow | Written when | Filename |
  * |---|---|---|
- * | adhoc plan mode | plan is produced (completion-marker `turn_end`) | `<slug-of-plan-title>.md` |
+ * | adhoc plan mode | plan is produced (`submit_plan` tool call) | `<slug-of-plan-title>.md` |
  * | ferment scoping | `propose_ferment_scoping` builds the plan | `ferment-<slug>-<first12(fermentId)>.md` |
  *
  * All files land under `<cwd>/.kimchi/plans/`. Saving is overwrite-in-place:
@@ -53,8 +53,6 @@ export function generatePlanPersistenceNote(opts: {
 	return `Write the completed plan to ${location} — one file per plan, updated in place when the plan changes. The file path must be returned in the \`files\` array of your response.`
 }
 
-const PLAN_COMPLETE_MARKER = "<!-- PLAN_COMPLETE -->"
-const DONE_MARKER = "<done>"
 const DEFAULT_SLUG = "untitled-plan"
 const MAX_SLUG_LENGTH = 48
 
@@ -88,21 +86,6 @@ export function derivePlanTitle(text: string): string {
 }
 
 /**
- * Remove the plan-completion markers (`<!-- PLAN_COMPLETE -->`, `<done>`)
- * from a plan text before persisting it. Markers are protocol signals, not
- * plan content. Only lines consisting solely of a marker are stripped; the
- * result ends in exactly one trailing newline (empty input yields "").
- */
-export function stripPlanCompletionMarkers(text: string): string {
-	const keptLines = text.split("\n").filter((line) => {
-		const trimmed = line.trim()
-		return trimmed !== PLAN_COMPLETE_MARKER && trimmed !== DONE_MARKER
-	})
-	const body = keptLines.join("\n").replace(/\s+$/, "")
-	return body ? `${body}\n` : ""
-}
-
-/**
  * Deterministic filename stem for a ferment's plan file: `ferment-` prefix,
  * kebab-case ferment name, and the first 12 chars of the ferment id. The
  * `ferment-` prefix keeps ferment plans visually separate from adhoc plans.
@@ -119,7 +102,7 @@ export interface SavePlanMarkdownOptions {
 	readonly cwd: string
 	/** Filename base; slugified via {@link slugifyPlanName} before use. */
 	readonly name: string
-	/** Markdown content to persist (completion markers already stripped by the caller). */
+	/** Markdown content to persist (written verbatim). */
 	readonly planText: string
 }
 

--- a/src/shared/planning/plan-review-bus.test.ts
+++ b/src/shared/planning/plan-review-bus.test.ts
@@ -1,0 +1,239 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	consumePlanReviewContext,
+	emitPlanReviewDecision,
+	emitPlanReviewRequest,
+	getActivePlanReviewSource,
+	onPlanReviewDecision,
+	onPlanReviewRequest,
+	PLAN_REVIEW_DECISION_CHANNEL,
+	PLAN_REVIEW_REQUEST_CHANNEL,
+	type PlanReviewContext,
+} from "./plan-review-bus.js"
+
+function createMockPi(): {
+	pi: ExtensionAPI
+	emit: ReturnType<typeof vi.fn>
+	on: ReturnType<typeof vi.fn>
+} {
+	const emit = vi.fn()
+	const on = vi.fn((_channel: string, _handler: (data: unknown) => void) => () => {})
+	return { pi: { events: { emit, on } } as unknown as ExtensionAPI, emit, on }
+}
+
+const fakeContext: PlanReviewContext = {
+	ctx: {} as PlanReviewContext["ctx"],
+	planText: "# Plan",
+	planPath: "/plans/plan.md",
+}
+
+describe("emitPlanReviewRequest", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	it("emits on the request channel with correct payload", () => {
+		const { pi, emit } = createMockPi()
+
+		emitPlanReviewRequest(
+			pi,
+			{
+				planContent: "# My Plan",
+				planFilePath: "/plans/my-plan.md",
+				source: "adhoc",
+			},
+			fakeContext,
+		)
+
+		expect(emit).toHaveBeenCalledWith(
+			PLAN_REVIEW_REQUEST_CHANNEL,
+			expect.objectContaining({
+				planContent: "# My Plan",
+				planFilePath: "/plans/my-plan.md",
+				source: "adhoc",
+			}),
+		)
+	})
+
+	it("stores context for the decision handler", () => {
+		const { pi } = createMockPi()
+
+		emitPlanReviewRequest(
+			pi,
+			{
+				planContent: "plan",
+				source: "adhoc",
+			},
+			fakeContext,
+		)
+
+		expect(consumePlanReviewContext()).toBe(fakeContext)
+	})
+
+	it("resets previous pending state on new emission", () => {
+		const { pi: pi1 } = createMockPi()
+		const { pi: pi2 } = createMockPi()
+
+		emitPlanReviewRequest(pi1, { planContent: "plan1", source: "adhoc" }, fakeContext)
+		emitPlanReviewRequest(pi2, { planContent: "plan2", source: "ferment" }, { ...fakeContext, fermentId: "f-1" })
+
+		const ctx = consumePlanReviewContext()
+		expect(ctx?.fermentId).toBe("f-1")
+	})
+})
+
+describe("emitPlanReviewDecision", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	it("emits on the decision channel", () => {
+		const { pi, emit } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+
+		emitPlanReviewDecision(pi, {
+			decision: "execute",
+			source: "kimchi-tui",
+			planReviewSource: "adhoc",
+		})
+
+		expect(emit).toHaveBeenCalledWith(
+			PLAN_REVIEW_DECISION_CHANNEL,
+			expect.objectContaining({ decision: "execute", source: "kimchi-tui" }),
+		)
+	})
+
+	it("first decision wins — second emission is ignored", () => {
+		const { pi, emit } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+
+		emitPlanReviewDecision(pi, { decision: "execute", source: "plannotator", planReviewSource: "adhoc" })
+		emitPlanReviewDecision(pi, { decision: "rework", source: "kimchi-tui", planReviewSource: "adhoc" })
+
+		const decisionCalls = emit.mock.calls.filter((c: unknown[]) => c[0] === PLAN_REVIEW_DECISION_CHANNEL)
+		expect(decisionCalls).toHaveLength(1)
+		expect(decisionCalls[0][1]).toMatchObject({ decision: "execute" })
+	})
+
+	it("ignores decision when no review is active", () => {
+		const { pi, emit } = createMockPi()
+
+		emitPlanReviewDecision(pi, { decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
+
+		const decisionCalls = emit.mock.calls.filter((c: unknown[]) => c[0] === PLAN_REVIEW_DECISION_CHANNEL)
+		expect(decisionCalls).toHaveLength(0)
+	})
+
+	it("ignores decision with mismatched planReviewSource", () => {
+		const { pi, emit } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+
+		emitPlanReviewDecision(pi, { decision: "execute", source: "plannotator", planReviewSource: "ferment" })
+
+		const decisionCalls = emit.mock.calls.filter((c: unknown[]) => c[0] === PLAN_REVIEW_DECISION_CHANNEL)
+		expect(decisionCalls).toHaveLength(0)
+	})
+})
+
+describe("consumePlanReviewContext", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	it("returns undefined when no review is active", () => {
+		expect(consumePlanReviewContext()).toBeUndefined()
+	})
+
+	it("returns context and clears state", () => {
+		const { pi } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+
+		expect(consumePlanReviewContext()).toBe(fakeContext)
+		expect(consumePlanReviewContext()).toBeUndefined()
+	})
+})
+
+describe("getActivePlanReviewSource", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	it("returns undefined when no review is active", () => {
+		expect(getActivePlanReviewSource()).toBeUndefined()
+	})
+
+	it("returns the source after a request is emitted", () => {
+		const { pi } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "ferment" }, fakeContext)
+		expect(getActivePlanReviewSource()).toBe("ferment")
+	})
+
+	it("returns undefined after decision is consumed", () => {
+		const { pi } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+		consumePlanReviewContext()
+		expect(getActivePlanReviewSource()).toBeUndefined()
+	})
+
+	it("returns undefined after first decision is emitted", () => {
+		const { pi } = createMockPi()
+		emitPlanReviewRequest(pi, { planContent: "plan", source: "adhoc" }, fakeContext)
+		emitPlanReviewDecision(pi, { decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
+		expect(getActivePlanReviewSource()).toBeUndefined()
+	})
+})
+
+describe("onPlanReviewRequest / onPlanReviewDecision", () => {
+	beforeEach(() => {
+		consumePlanReviewContext()
+	})
+
+	it("onPlanReviewRequest registers a handler that receives payloads", () => {
+		const { pi, on } = createMockPi()
+		const handler = vi.fn()
+
+		onPlanReviewRequest(pi, handler)
+
+		// Simulate the event bus calling the registered handler
+		const registeredHandler = on.mock.calls.find((c: unknown[]) => c[0] === PLAN_REVIEW_REQUEST_CHANNEL)?.[1] as
+			| ((data: unknown) => void)
+			| undefined
+		expect(registeredHandler).toBeDefined()
+
+		registeredHandler?.({ planContent: "plan", source: "adhoc" })
+		expect(handler).toHaveBeenCalledWith({ planContent: "plan", source: "adhoc" })
+	})
+
+	it("onPlanReviewDecision registers a handler that receives payloads", () => {
+		const { pi, on } = createMockPi()
+		const handler = vi.fn()
+
+		onPlanReviewDecision(pi, handler)
+
+		const registeredHandler = on.mock.calls.find((c: unknown[]) => c[0] === PLAN_REVIEW_DECISION_CHANNEL)?.[1] as
+			| ((data: unknown) => void)
+			| undefined
+		expect(registeredHandler).toBeDefined()
+
+		registeredHandler?.({ decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
+		expect(handler).toHaveBeenCalledWith({ decision: "execute", source: "kimchi-tui", planReviewSource: "adhoc" })
+	})
+
+	it("onPlanReviewRequest ignores malformed payloads", () => {
+		const { pi, on } = createMockPi()
+		const handler = vi.fn()
+
+		onPlanReviewRequest(pi, handler)
+
+		const registeredHandler = on.mock.calls.find((c: unknown[]) => c[0] === PLAN_REVIEW_REQUEST_CHANNEL)?.[1] as
+			| ((data: unknown) => void)
+			| undefined
+
+		registeredHandler?.(null)
+		registeredHandler?.({})
+		registeredHandler?.({ source: "adhoc" }) // missing planContent
+
+		expect(handler).not.toHaveBeenCalled()
+	})
+})

--- a/src/shared/planning/plan-review-bus.ts
+++ b/src/shared/planning/plan-review-bus.ts
@@ -1,0 +1,144 @@
+/**
+ * Event-driven plan-review bus.
+ *
+ * Two channels on the pi event bus coordinate plan reviews across surfaces:
+ *
+ * - `kimchi:plan-review-request` — emitted when a plan is ready for review.
+ *   Both the TUI popup and the plannotator adapter listen for this.
+ *
+ * - `kimchi:plan-review-decision` — emitted when any surface reaches a
+ *   decision (TUI menu pick, plannotator browser approve/deny). First
+ *   decision wins; subsequent emissions are silently ignored.
+ *
+ * Context (plan text, path, slug, etc.) is stored when the request is
+ * emitted and consumed by the decision handler. Only one plan review is
+ * active at a time — adhoc plan mode and ferment scoping are mutually
+ * exclusive.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+
+export const PLAN_REVIEW_REQUEST_CHANNEL = "kimchi:plan-review-request"
+export const PLAN_REVIEW_DECISION_CHANNEL = "kimchi:plan-review-decision"
+
+export type PlanReviewSource = "adhoc" | "ferment"
+export type PlanReviewDecision = "execute" | "start_ferment" | "rework" | "feedback"
+export type PlanReviewDecisionSource = "kimchi-tui" | "plannotator"
+
+export interface PlanReviewRequestPayload {
+	readonly planContent: string
+	readonly planFilePath?: string
+	readonly source: PlanReviewSource
+	readonly fermentId?: string
+}
+
+export interface PlanReviewDecisionPayload {
+	readonly decision: PlanReviewDecision
+	readonly feedback?: string
+	readonly source: PlanReviewDecisionSource
+	readonly planReviewSource: PlanReviewSource
+	readonly fermentId?: string
+}
+
+export interface PlanReviewContext {
+	readonly ctx: ExtensionContext
+	readonly planPath?: string
+	readonly planText: string
+	/** Raw assistant message text (before marker stripping) — used by ferment creation. */
+	readonly rawText?: string
+	readonly activePlanSlug?: string
+	readonly fermentId?: string
+}
+
+// ── Internal state ────────────────────────────────────────────────────
+//
+// Module-level is acceptable: only one plan review can be active per
+// session at a time. `currentContext` is set when a request is emitted
+// and consumed when a decision is handled. `firstDecisionConsumed`
+// ensures only the first decision acts — subsequent emissions (from a
+// stale TUI menu pick arriving after plannotator already decided) are
+// silently dropped.
+let currentContext: PlanReviewContext | undefined
+let firstDecisionConsumed = false
+let currentSource: PlanReviewSource | undefined
+
+/**
+ * Emit a plan-review request and store the context for the decision handler.
+ * Resets any previous pending review state.
+ */
+export function emitPlanReviewRequest(
+	pi: ExtensionAPI,
+	payload: PlanReviewRequestPayload,
+	context: PlanReviewContext,
+): void {
+	currentContext = context
+	currentSource = payload.source
+	firstDecisionConsumed = false
+	pi.events.emit(PLAN_REVIEW_REQUEST_CHANNEL, payload)
+}
+
+/**
+ * Emit a plan-review decision. First decision wins — subsequent calls are
+ * silently ignored. The decision is only emitted if a matching review is
+ * active (same `planReviewSource`).
+ */
+export function emitPlanReviewDecision(pi: ExtensionAPI, payload: PlanReviewDecisionPayload): void {
+	if (firstDecisionConsumed) return
+	if (!currentContext) return
+	if (payload.planReviewSource !== currentSource) return
+	firstDecisionConsumed = true
+	pi.events.emit(PLAN_REVIEW_DECISION_CHANNEL, payload)
+}
+
+/**
+ * Consume the stored plan review context. Returns undefined if no review
+ * is active or the context was already consumed. Clears state after
+ * consumption.
+ */
+export function consumePlanReviewContext(): PlanReviewContext | undefined {
+	const ctx = currentContext
+	currentContext = undefined
+	currentSource = undefined
+	return ctx
+}
+
+/**
+ * Check whether a plan review is currently active (request emitted,
+ * decision not yet consumed). Used by the plannotator adapter to
+ * determine which surface the review-result belongs to.
+ */
+export function getActivePlanReviewSource(): PlanReviewSource | undefined {
+	return firstDecisionConsumed ? undefined : currentSource
+}
+
+/**
+ * Register a handler for plan-review-request events.
+ * Returns an unsubscribe function.
+ */
+export function onPlanReviewRequest(
+	pi: ExtensionAPI,
+	handler: (payload: PlanReviewRequestPayload) => void,
+): () => void {
+	return pi.events.on(PLAN_REVIEW_REQUEST_CHANNEL, (data: unknown) => {
+		const payload = data as PlanReviewRequestPayload
+		if (payload && typeof payload.planContent === "string") {
+			handler(payload)
+		}
+	})
+}
+
+/**
+ * Register a handler for plan-review-decision events.
+ * Returns an unsubscribe function.
+ */
+export function onPlanReviewDecision(
+	pi: ExtensionAPI,
+	handler: (payload: PlanReviewDecisionPayload) => void,
+): () => void {
+	return pi.events.on(PLAN_REVIEW_DECISION_CHANNEL, (data: unknown) => {
+		const payload = data as PlanReviewDecisionPayload
+		if (payload && typeof payload.decision === "string") {
+			handler(payload)
+		}
+	})
+}

--- a/src/shared/planning/plan-review-bus.ts
+++ b/src/shared/planning/plan-review-bus.ts
@@ -38,6 +38,8 @@ export interface PlanReviewDecisionPayload {
 	readonly source: PlanReviewDecisionSource
 	readonly planReviewSource: PlanReviewSource
 	readonly fermentId?: string
+	/** Ferment-only: user picked "start in auto mode" — run all stages without stopping. */
+	readonly auto?: boolean
 }
 
 export interface PlanReviewContext {

--- a/src/shared/planning/planning-stop-nudge.test.ts
+++ b/src/shared/planning/planning-stop-nudge.test.ts
@@ -6,7 +6,7 @@ import {
 	FERMENT_SCOPING_STOP_NUDGE_INTERACTIVE,
 	FERMENT_SCOPING_STOP_NUDGE_ONESHOT,
 	hasFermentScopingCompletionSignal,
-	hasPlanCompletionSignal,
+	hasPlanSubmitToolCall,
 	isNudgeSuppressed,
 	MAX_PLANNING_STOP_NUDGES,
 	PLAN_MODE_STOP_NUDGE,
@@ -54,25 +54,17 @@ describe("isNudgeSuppressed", () => {
 	})
 })
 
-describe("hasPlanCompletionSignal", () => {
-	it("detects <!-- PLAN_COMPLETE --> marker", () => {
-		expect(hasPlanCompletionSignal("Here is the plan.\n\n<!-- PLAN_COMPLETE -->")).toBe(true)
+describe("hasPlanSubmitToolCall", () => {
+	it("returns true when submit_plan is in the tool call list", () => {
+		expect(hasPlanSubmitToolCall(["read", "submit_plan"])).toBe(true)
 	})
 
-	it("detects <done> marker", () => {
-		expect(hasPlanCompletionSignal("Plan complete.\n<done>")).toBe(true)
+	it("returns false when only exploration tools are present", () => {
+		expect(hasPlanSubmitToolCall(["read", "grep", "questionnaire"])).toBe(false)
 	})
 
-	it("returns false for text without any marker", () => {
-		expect(hasPlanCompletionSignal("Here is the plan but it is not done.")).toBe(false)
-	})
-
-	it("returns false for empty string", () => {
-		expect(hasPlanCompletionSignal("")).toBe(false)
-	})
-
-	it("detects marker embedded in longer text", () => {
-		expect(hasPlanCompletionSignal("Some text <!-- PLAN_COMPLETE --> more text")).toBe(true)
+	it("returns false for an empty list", () => {
+		expect(hasPlanSubmitToolCall([])).toBe(false)
 	})
 })
 
@@ -140,8 +132,13 @@ describe("contentHasToolCall", () => {
 })
 
 describe("PLAN_MODE_STOP_NUDGE", () => {
-	it("references the completion marker", () => {
-		expect(PLAN_MODE_STOP_NUDGE).toContain("<!-- PLAN_COMPLETE -->")
+	it("instructs the model to call the submit_plan tool", () => {
+		expect(PLAN_MODE_STOP_NUDGE).toContain("`submit_plan`")
+	})
+
+	it("does not reference the removed plan-completion markers", () => {
+		expect(PLAN_MODE_STOP_NUDGE).not.toContain("PLAN_COMPLETE")
+		expect(PLAN_MODE_STOP_NUDGE).not.toContain("<done>")
 	})
 
 	it("references the questionnaire tool", () => {

--- a/src/shared/planning/planning-stop-nudge.ts
+++ b/src/shared/planning/planning-stop-nudge.ts
@@ -3,7 +3,7 @@
  *
  * Used by:
  * - Plan mode (permissions extension): the model made tool calls, then ended
- *   with stopReason "stop" without writing PLAN_COMPLETE.
+ *   with stopReason "stop" without calling `submit_plan`.
  * - Ferment scoping (ferment extension): the model made tool calls during
  *   draft scoping, then ended with stopReason "stop" without calling
  *   scope_ferment or propose_ferment_scoping.
@@ -50,13 +50,13 @@ import { markHarnessSteer } from "../../extensions/steer-marker.js"
 
 /**
  * Nudge text for plan mode (interactive, non-worker session).
- * Instructs the model to finish writing the plan and emit PLAN_COMPLETE.
+ * Instructs the model to finish writing the plan and call `submit_plan`.
  */
 export const PLAN_MODE_STOP_NUDGE = markHarnessSteer(
-	"You stopped without completing the plan. Continue now:\n" +
+	"You stopped without submitting the plan. Continue now:\n" +
 		"- If you still have open questions, use the questionnaire tool to resolve them.\n" +
-		"- If the plan is ready, write it out in full using the Goal / Constraints / Chunks / Verification Strategy / Decision Log / Risks structure, then end your response with <!-- PLAN_COMPLETE --> on its own line.\n" +
-		"- Do NOT stop again until you have written <!-- PLAN_COMPLETE -->.",
+		"- If the plan is ready, write it out in full using the Goal / Constraints / Chunks / Verification Strategy / Decision Log / Risks structure, then call the `submit_plan` tool with the full plan text as the `plan` parameter.\n" +
+		"- Do NOT stop again until you have called `submit_plan`.",
 )
 
 /**
@@ -88,10 +88,11 @@ export const FERMENT_SCOPING_STOP_NUDGE_ONESHOT = markHarnessSteer(
 export const FERMENT_SCOPING_STOP_NUDGE = FERMENT_SCOPING_STOP_NUDGE_INTERACTIVE
 
 /**
- * Returns true if the turn text contains a known plan-mode completion signal.
+ * Returns true if the turn's tool calls include `submit_plan` — the adhoc
+ * plan-mode completion signal. Mirrors {@link hasFermentScopingCompletionSignal}.
  */
-export function hasPlanCompletionSignal(text: string): boolean {
-	return text.includes("<!-- PLAN_COMPLETE -->") || text.includes("<done>")
+export function hasPlanSubmitToolCall(toolNames: string[]): boolean {
+	return toolNames.includes("submit_plan")
 }
 
 /**

--- a/src/shared/planning/shared-planning-process.ts
+++ b/src/shared/planning/shared-planning-process.ts
@@ -79,7 +79,7 @@ Synthesize everything — orient findings, interview answers, confirmed criteria
 and exploration results — into a structured plan.
 - Ensure completion criteria were confirmed with the user before finalizing.
 - Do NOT finalize the plan while any open question remains unresolved.
-- Call the \`submit_plan\` tool to submit the plan for user review.
+- Use your mode's completion mechanism to submit the plan for user review.
 
 Every plan must use this structure:
 

--- a/src/shared/planning/shared-planning-process.ts
+++ b/src/shared/planning/shared-planning-process.ts
@@ -79,7 +79,7 @@ Synthesize everything — orient findings, interview answers, confirmed criteria
 and exploration results — into a structured plan.
 - Ensure completion criteria were confirmed with the user before finalizing.
 - Do NOT finalize the plan while any open question remains unresolved.
-- Use your mode's completion mechanism to submit the plan for user review.
+- Call the \`submit_plan\` tool to submit the plan for user review.
 
 Every plan must use this structure:
 

--- a/src/shared/planning/tool-catalog.ts
+++ b/src/shared/planning/tool-catalog.ts
@@ -147,6 +147,15 @@ export const ADHOC_MODE_TOOLS: ToolEntry[] = [
 ]
 
 /**
+ * Plan-submission tool available in both adhoc plan mode and ferment
+ * planning phase. The model calls it when the plan is ready for user
+ * review. Visible only in planning profiles — hidden in idle, worker,
+ * and implementation-ferment. This is the only "write-like" tool visible
+ * during planning (edit, write, bash-write are all suppressed).
+ */
+export const SHARED_PLANNING_TOOLS: ToolEntry[] = [{ name: "submit_plan", modes: ["adhoc", "ferment"] }]
+
+/**
  * Tools gated behind the ferment lifecycle.
  *
  * `phases: ['planning']` — only visible before the first phase is activated.
@@ -264,13 +273,14 @@ export function getToolsForProfile(profile: ToolProfile): ToolEntry[] {
 			return [
 				...SHARED_CORE_TOOLS,
 				...ADHOC_MODE_TOOLS,
+				...SHARED_PLANNING_TOOLS,
 				// bash is the only write tool in adhoc planning mode
 				...WRITE_TOOLS.filter((t) => t.modes.includes("adhoc")),
 			]
 
 		case "planning-ferment": {
 			const ferment = FERMENT_MODE_TOOLS.filter((t) => t.phases === undefined || t.phases.includes("planning"))
-			return [...SHARED_CORE_TOOLS, ...ferment]
+			return [...SHARED_CORE_TOOLS, ...SHARED_PLANNING_TOOLS, ...ferment]
 		}
 
 		case "implementation-ferment":

--- a/src/shared/planning/tool-catalog.ts
+++ b/src/shared/planning/tool-catalog.ts
@@ -153,7 +153,7 @@ export const ADHOC_MODE_TOOLS: ToolEntry[] = [
  * and implementation-ferment. This is the only "write-like" tool visible
  * during planning (edit, write, bash-write are all suppressed).
  */
-export const SHARED_PLANNING_TOOLS: ToolEntry[] = [{ name: "submit_plan", modes: ["adhoc", "ferment"] }]
+export const SHARED_PLANNING_TOOLS: ToolEntry[] = [{ name: "submit_plan", modes: ["adhoc"] }]
 
 /**
  * Tools gated behind the ferment lifecycle.
@@ -280,7 +280,7 @@ export function getToolsForProfile(profile: ToolProfile): ToolEntry[] {
 
 		case "planning-ferment": {
 			const ferment = FERMENT_MODE_TOOLS.filter((t) => t.phases === undefined || t.phases.includes("planning"))
-			return [...SHARED_CORE_TOOLS, ...SHARED_PLANNING_TOOLS, ...ferment]
+			return [...SHARED_CORE_TOOLS, ...ferment]
 		}
 
 		case "implementation-ferment":

--- a/tests/e2e/acp/plan-updates.test.ts
+++ b/tests/e2e/acp/plan-updates.test.ts
@@ -282,22 +282,17 @@ describe("ACP integration — plan sessionUpdates from ferment lifecycle", () =>
 		// or stay idle under the manual continuation policy — in which case the
 		// first client prompt absorbs those same scripts. Wait briefly for the
 		// wake path; if no plan arrives, prod with an explicit prompt.
+		// Under manual continuation policy the wake path never fires, so
+		// prompt immediately instead of waiting 15s (which races with the
+		// resume path's model turn on slow CI runners).
+		await prompt(fixture, sessionId, "continue the ferment")
 		const initial = await waitForSnapshotWith(
 			fixture,
 			sessionId,
 			(entries) => entries.length === 3 && entries.every((e) => e.status === "pending"),
-			15_000,
-			"wake-path initial plan",
-		).catch(async () => {
-			await prompt(fixture, sessionId, "continue the ferment")
-			return waitForSnapshotWith(
-				fixture,
-				sessionId,
-				(entries) => entries.length === 3 && entries.every((e) => e.status === "pending"),
-				PROMPT_TIMEOUT_LONG_MS,
-				"prompt-driven initial plan",
-			)
-		})
+			PROMPT_TIMEOUT_LONG_MS,
+			"initial plan",
+		)
 
 		expect(
 			initial.map((e) => e.content),
@@ -365,24 +360,19 @@ describe("ACP integration — plan sessionUpdates from ferment lifecycle", () =>
 
 		const sessionA = await newSession(fixture, fixture.workDir)
 
-		// Drive activation in session A (via the wake path, or an explicit
-		// prompt when the wake path stays idle under the manual policy).
+		// Under manual continuation policy the wake path never fires, so
+		// prompt immediately instead of waiting 15s (which races with the
+		// resume path's model turn on slow CI runners — the resume turn
+		// consumes the first scripted response, leaving the prompt with a
+		// no-tool-call response and no plan snapshot).
+		await prompt(fixture, sessionA, "continue the ferment")
 		await waitForSnapshotWith(
 			fixture,
 			sessionA,
 			(entries) => entries.length === 3 && entries.every((e) => e.status === "pending"),
-			15_000,
-			"session A wake-path initial plan",
-		).catch(async () => {
-			await prompt(fixture, sessionA, "continue the ferment")
-			await waitForSnapshotWith(
-				fixture,
-				sessionA,
-				(entries) => entries.length === 3 && entries.every((e) => e.status === "pending"),
-				PROMPT_TIMEOUT_LONG_MS,
-				"session A prompt-driven initial plan",
-			)
-		})
+			PROMPT_TIMEOUT_LONG_MS,
+			"session A initial plan",
+		)
 
 		// A second session on the same process must not get plan notifications:
 		// the ferment events are emitted on session A's bus and the todo bridge

--- a/tests/e2e/tui/ask-user-form.test.ts
+++ b/tests/e2e/tui/ask-user-form.test.ts
@@ -42,11 +42,10 @@ const PROPOSE_SCOPING_PAYLOAD = JSON.stringify({
 
 /** Shared boilerplate to drive a ferment from cold-start through the plan-review confirm.
  *
- * Turn sequence (with tool suppression):
- *   Turn 1: propose_ferment_scoping → sets pending plan review
- *   Turn 2: text-only (tools suppressed by hasPendingPlanReview) → agent_end fires
- *           → review dialog appears → user confirms → tools restored
- *   Turn 3: ask_user / confirm_ferment_completion_criteria (the stream we wait for)
+ * Turn sequence (with terminate:true on propose_ferment_scoping):
+ *   Turn 1: propose_ferment_scoping → sets pending plan review + terminate:true
+ *           → review dialog appears via onPlanReviewRequest setTimeout(0)
+ *   Turn 2: ask_user / confirm_ferment_completion_criteria (tools restored after confirm)
  *
  * @param nextStream the post-confirmation stream text to wait for — differs per test
  */
@@ -73,13 +72,9 @@ async function startFerment(
 	await waitForText(terminal, "I'll outline the scope.", { timeoutMs: STREAM_TIMEOUT_MS })
 	trace.step("turn 1 stream received — propose_ferment_scoping completed")
 
-	// Turn 2 is the suppression turn: tools are suppressed (pi.setActiveTools([]))
-	// because a pending plan review exists. The model produces a text-only response,
-	// firing agent_end → the review dialog appears.
-	// We don't wait for the Turn 2 stream text — go straight to the dialog.
-
-	// Wait for the plan-review dialog to appear (triggered by agent_end after
-	// the suppression turn).
+	// The review dialog appears directly after propose_ferment_scoping terminates
+	// the turn (the onPlanReviewRequest listener schedules it via setTimeout(0)).
+	// No suppression turn is needed — the dialog appears without agent_end.
 	await waitForText(terminal, "Proceed with this plan?", { timeoutMs: STREAM_TIMEOUT_MS })
 	await waitForText(terminal, "Start execution", { timeoutMs: INPUT_TIMEOUT_MS })
 	trace.step("plan-review dialog visible")
@@ -88,7 +83,7 @@ async function startFerment(
 	terminal.submit("")
 	trace.step("confirmed 'Start execution' (Enter on default option)")
 
-	// Wait for the model's turn 3 stream — tools are restored after confirmation,
+	// Wait for the model's turn 2 stream — tools are restored after confirmation,
 	// so ask_user / confirm_ferment_completion_criteria is now available.
 	await waitForText(terminal, nextStream, { timeoutMs: STREAM_TIMEOUT_MS })
 	trace.step(`post-confirmation stream received: ${nextStream}`)
@@ -102,7 +97,8 @@ test("ask_user renders a single-choice question and accepts selection", async ({
 			gitInit: true,
 			models: [NO_COMPACTION_MODEL],
 			responses: [
-				// Turn 1: propose scoping so the ferment starts in planning phase.
+				// Turn 1: propose scoping — terminate:true ends the turn and the
+				// review dialog appears via the onPlanReviewRequest listener.
 				{
 					stream: ["I'll outline the scope."],
 					toolCalls: [
@@ -114,11 +110,7 @@ test("ask_user renders a single-choice question and accepts selection", async ({
 						},
 					],
 				},
-				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
-				// sets a pending plan review. The model produces a text-only response,
-				// ending the turn so agent_end fires and the review dialog appears.
-				{ stream: ["Plan ready for review."] },
-				// Turn 3: ask the user a single-choice question (tools restored after confirm).
+				// Turn 2: ask the user a single-choice question (tools restored after confirm).
 				{
 					stream: ["Let me ask the user."],
 					toolCalls: [
@@ -142,7 +134,7 @@ test("ask_user renders a single-choice question and accepts selection", async ({
 						},
 					],
 				},
-				// Turn 4: stream a follow-up after the user picks Vanilla.
+				// Turn 3: stream a follow-up after the user picks Vanilla.
 				{ stream: ["Thanks! I'll use vanilla."] },
 			],
 		},
@@ -185,7 +177,8 @@ test("confirm_ferment_completion_criteria shows 'Type your own answer' label", a
 			gitInit: true,
 			models: [NO_COMPACTION_MODEL],
 			responses: [
-				// Turn 1: propose scoping.
+				// Turn 1: propose scoping — terminate:true ends the turn and the
+				// review dialog appears via the onPlanReviewRequest listener.
 				{
 					stream: ["I'll outline the scope."],
 					toolCalls: [
@@ -197,11 +190,7 @@ test("confirm_ferment_completion_criteria shows 'Type your own answer' label", a
 						},
 					],
 				},
-				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
-				// sets a pending plan review. The model produces a text-only response,
-				// ending the turn so agent_end fires and the review dialog appears.
-				{ stream: ["Plan ready for review."] },
-				// Turn 3: confirm completion criteria (tools restored after confirm).
+				// Turn 2: confirm completion criteria (tools restored after confirm).
 				{
 					stream: ["Let me confirm the criteria."],
 					toolCalls: [
@@ -216,7 +205,7 @@ test("confirm_ferment_completion_criteria shows 'Type your own answer' label", a
 						},
 					],
 				},
-				// Turn 4: stream after the user confirms.
+				// Turn 3: stream after the user confirms.
 				{ stream: ["Great, criteria confirmed."] },
 			],
 		},
@@ -248,7 +237,8 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 			gitInit: true,
 			models: [NO_COMPACTION_MODEL],
 			responses: [
-				// Turn 1: propose scoping.
+				// Turn 1: propose scoping — terminate:true ends the turn and the
+				// review dialog appears via the onPlanReviewRequest listener.
 				{
 					stream: ["I'll outline the scope."],
 					toolCalls: [
@@ -260,11 +250,7 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 						},
 					],
 				},
-				// Turn 2 (suppression): tools are suppressed after propose_ferment_scoping
-				// sets a pending plan review. The model produces a text-only response,
-				// ending the turn so agent_end fires and the review dialog appears.
-				{ stream: ["Plan ready for review."] },
-				// Turn 3: ask_user with a confirm question (tools restored after confirm).
+				// Turn 2: ask_user with a confirm question (tools restored after confirm).
 				{
 					stream: ["Let me confirm."],
 					toolCalls: [
@@ -276,7 +262,7 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 										{
 											id: "proceed",
 											type: "confirm",
-											prompt: "Should I proceed?",
+											prompt: "Should we proceed?",
 										},
 									],
 								}),
@@ -284,25 +270,25 @@ test("ask_user with a confirm question renders Yes/No options", async ({ termina
 						},
 					],
 				},
-				// Turn 4: stream after the user confirms.
-				{ stream: ["Proceeding."] },
+				// Turn 3: stream after the user confirms.
+				{ stream: ["Proceeding with the plan."] },
 			],
 		},
 		async (_fixture, trace) => {
 			await startFerment(terminal, trace, "Let me confirm.")
 
-			// Stage 2: confirm question text + Yes/No options visible.
-			await waitForText(terminal, "Should I proceed?", { timeoutMs: STREAM_TIMEOUT_MS })
+			// Stage 2: the confirm question renders Yes/No options.
+			await waitForText(terminal, "Should we proceed?", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "Yes", { timeoutMs: INPUT_TIMEOUT_MS })
 			await waitForText(terminal, "No", { timeoutMs: INPUT_TIMEOUT_MS })
-			trace.step("ask_user confirm prompt visible with Yes/No")
+			trace.step("confirm prompt visible with Yes/No options")
 
 			// Stage 3: press Enter to select "Yes" (first option).
 			terminal.submit("")
-			trace.step("selected Yes")
+			trace.step("selected 'Yes'")
 
 			// Stage 4: model's next stream appears.
-			await waitForText(terminal, "Proceeding", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "Proceeding with the plan", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("model streamed follow-up after confirm")
 		},
 	)

--- a/tests/e2e/tui/ferment-new-runs-planning.test.ts
+++ b/tests/e2e/tui/ferment-new-runs-planning.test.ts
@@ -92,9 +92,7 @@ test("/ferment new runs planning and produces a scoped ferment artifact", async 
 						},
 					],
 				},
-				// Turn 2 (after tool result): short text, no trailing "?".
-				{ stream: ["I've outlined the scope for the cache layer feature."] },
-				// Turn 3 (post-confirmation): keeps session alive.
+				// Turn 2 (post-confirmation): keeps session alive.
 				{},
 			],
 		},

--- a/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-oneshot.test.ts
@@ -71,10 +71,8 @@ test("plan review dialog appears in one-shot mode after propose_ferment_scoping"
 						},
 					],
 				},
-				// Turn 2: tools suppressed → model produces text-only response.
-				// The test does not assert the exact text here; the important behavior
-				// is that agent_end fires and the review dialog surfaces.
-				{ stream: ["I've submitted the plan for your review."] },
+				// Turn 2: terminate:true ends the turn; the review dialog surfaces
+				// via onPlanReviewRequest. No suppression turn needed.
 			],
 		},
 		async (fixture, trace) => {

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -302,6 +302,8 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 			models: [NO_COMPACTION_MODEL],
 			responses: [
 				// Turn 1: model calls propose_ferment_scoping (questions=[]).
+				// terminate:true ends the turn; the review dialog appears via
+				// the onPlanReviewRequest listener's setTimeout(0).
 				{
 					toolCalls: [
 						{
@@ -312,9 +314,7 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 						},
 					],
 				},
-				// Turn 2: tools suppressed → text-only response (proves suppression works).
-				{ stream: ["I've outlined the scope for the test feature."] },
-				// Turn 3: post-confirmation.
+				// Turn 2: post-confirmation.
 				{ stream: ["Proceeding with execution."] },
 			],
 		},
@@ -359,24 +359,10 @@ test("plan review: existing zero-questions scoping flow still works (no regressi
 			expect(phases[0].name).toBe("Implement")
 			trace.step("ferment artifact verified — planned, 1 phase, correct structure")
 
-			// Stage 8: verify at least 2 HTTP requests were made.
+			// Stage 8: verify at least 2 HTTP requests were made (propose + post-confirm).
 			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
 			expect(chatRequests.length).toBeGreaterThanOrEqual(2)
 			trace.step(`${chatRequests.length} chat requests recorded`)
-
-			// Stage 9: verify the 2nd request (after tool result) had no tool calls
-			// in the response (proving tool suppression worked — model produced text-only).
-			// The 2nd request is the one where the model should have had no tools.
-			// We can verify this by checking the `tools` array in the request body.
-			// After propose_ferment_scoping returns "Plan ready for review",
-			// tools are suppressed. The 2nd request should have an empty `tools` array.
-			if (chatRequests.length >= 2) {
-				const body = chatRequests[1].body as Record<string, unknown>
-				const tools = body.tools as unknown[]
-				expect(Array.isArray(tools)).toBe(true)
-				expect(tools.length).toBe(0)
-				trace.step("2nd request has empty tools[] — tools were suppressed after propose_ferment_scoping")
-			}
 		},
 	)
 })

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -108,9 +108,7 @@ test("plan review: model stops after propose, review dialog appears, user confir
 						},
 					],
 				},
-				// Turn 2: tools suppressed → model produces text-only response (no tool calls).
-				{ stream: ["I've submitted the plan for your review."] },
-				// Turn 3: post-confirmation, keeps session alive.
+				// Turn 2: post-confirmation, keeps session alive.
 				{ stream: ["Starting execution now."] },
 			],
 		},
@@ -197,9 +195,7 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 						},
 					],
 				},
-				// Turn 2: tools suppressed → text-only response.
-				{ stream: ["Plan is ready for review."] },
-				// Turn 3: after cancel, tools restored → model calls propose_ferment_scoping again.
+				// Turn 2: after cancel, tools restored → model calls propose_ferment_scoping again.
 				{
 					toolCalls: [
 						{

--- a/tests/e2e/tui/ferment-plan-review-suppression.test.ts
+++ b/tests/e2e/tui/ferment-plan-review-suppression.test.ts
@@ -270,8 +270,8 @@ test("plan review: cancel restores planning tools, model can re-propose, ferment
 			// Find the first chat request after the 2nd one that has a tools array
 			// (skip compaction requests which have no tools field).
 			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
-			expect(chatRequests.length).toBeGreaterThanOrEqual(3)
-			const revisionReq = chatRequests.slice(2).find((req) => {
+			expect(chatRequests.length).toBeGreaterThanOrEqual(2)
+			const revisionReq = chatRequests.slice(1).find((req) => {
 				const body = req.body as Record<string, unknown>
 				return Array.isArray(body.tools) && body.tools.length > 0
 			})

--- a/tests/e2e/tui/ferment-stage-compaction-wire-shrink.test.ts
+++ b/tests/e2e/tui/ferment-stage-compaction-wire-shrink.test.ts
@@ -108,11 +108,9 @@ test("stage compaction makes the next request carry the summary instead of the o
 						},
 					],
 				},
-				// Turn 2 (after tool result): short ack ending the turn → plan dialog.
-				{ stream: ["I've outlined the scope."] },
-				// Turn 3 (post-confirmation keepalive nudge).
+				// Turn 2 (post-confirmation keepalive nudge).
 				{},
-				// Turn 4 (host nudge): activate the phase.
+				// Turn 3 (host nudge): activate the phase.
 				{
 					stream: ["Activating the phase."],
 					toolCalls: [

--- a/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
+++ b/tests/e2e/tui/ferment-status-line-updates-on-mutation.test.ts
@@ -61,11 +61,9 @@ test("ferment status-line segment updates after activate_ferment_phase tool call
 						},
 					],
 				},
-				// Turn 2 (after tool result): short text, no trailing "?".
-				{ stream: ["I've outlined the scope for this test."] },
-				// Turn 3 (post-confirmation keepalive): mirrors ferment-new-runs-planning.
+				// Turn 2 (post-confirmation keepalive): mirrors ferment-new-runs-planning.
 				{},
-				// Turn 4 (host nudge): activate the implementation phase.
+				// Turn 3 (host nudge): activate the implementation phase.
 				{
 					stream: ["Starting implementation."],
 					toolCalls: [

--- a/tests/e2e/tui/oneshot-bypasses-dropdown.test.ts
+++ b/tests/e2e/tui/oneshot-bypasses-dropdown.test.ts
@@ -5,8 +5,8 @@
  * 1. Launch with --ferment-oneshot flag (no --plan).
  * 2. User types a request.
  * 3. The dropdown (Execute / Rework / Start as ferment) does NOT appear.
- * 4. Ferment lifecycle proceeds without showing the dropdown (the flag guard at
- *    permissions/index.ts:506-508 returns early from the dropdown handler).
+ * 4. Ferment lifecycle proceeds without showing the dropdown (the flag guard
+ *    in submit_plan's execute returns early with terminate:true and no emit).
  */
 
 import { expect, Key, test } from "@microsoft/tui-test"
@@ -22,9 +22,9 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 			artifactName: "oneshot-bypasses-dropdown",
 			gitInit: true,
 			responses: [
-				// In oneshot mode the model can emit a plan with PLAN_COMPLETE — but the
-				// flag guard at permissions/index.ts:506-508 returns early, so the dropdown
-				// handler is skipped entirely and no dropdown appears in the TUI.
+				// In oneshot mode the model calls submit_plan — but the flag guard
+				// in submit_plan's execute returns early with terminate:true and no
+				// review emit, so no dropdown appears in the TUI.
 				{
 					stream: [
 						"# Plan\n",
@@ -36,7 +36,21 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 						"1. Create the route handler.\n",
 						"2. Add tests.\n",
 						"\n",
-						"<!-- PLAN_COMPLETE -->\n",
+					],
+					toolCalls: [
+						{
+							id: "call_submit_plan",
+							type: "function",
+							function: {
+								name: "submit_plan",
+								arguments: JSON.stringify({
+									plan:
+										"# Plan\n\n" +
+										"## Goal\nAdd a new API endpoint.\n\n" +
+										"## Steps\n1. Create the route handler.\n2. Add tests.\n",
+								}),
+							},
+						},
 					],
 				},
 				// Follow-up response so the session stays alive after the first response.
@@ -56,11 +70,12 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 			)
 			trace.step("ready prompt visible (or oneshot bootstrapped)")
 
-			// Stage 2: submit request → model emits plan with PLAN_COMPLETE marker.
+			// Stage 2: submit request → model streams the plan, then calls
+			// submit_plan. In oneshot mode the dropdown must NOT appear.
 			terminal.submit("Add a new API endpoint")
 			trace.step("submitted request")
-			await waitForText(terminal, "<!-- PLAN_COMPLETE -->", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("plan complete marker seen — but dropdown must NOT appear in oneshot mode")
+			await waitForText(terminal, "Plan submitted", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("submit_plan tool called — dropdown must NOT appear in oneshot mode")
 
 			// Stage 3: wait briefly to give the dropdown handler a chance to (incorrectly)
 			// render, then sample the terminal text and assert the dropdown labels are absent.

--- a/tests/e2e/tui/oneshot-bypasses-dropdown.test.ts
+++ b/tests/e2e/tui/oneshot-bypasses-dropdown.test.ts
@@ -5,8 +5,10 @@
  * 1. Launch with --ferment-oneshot flag (no --plan).
  * 2. User types a request.
  * 3. The dropdown (Execute / Rework / Start as ferment) does NOT appear.
- * 4. Ferment lifecycle proceeds without showing the dropdown (the flag guard
- *    in submit_plan's execute returns early with terminate:true and no emit).
+ * 4. Ferment lifecycle proceeds without showing the dropdown (the oneshot
+ *    scoping tool scope_ferment scopes directly without emitting a review
+ *    request — the plannotator adapter skips oneshot sessions, and the TUI
+ *    popup is never triggered).
  */
 
 import { expect, Key, test } from "@microsoft/tui-test"
@@ -15,6 +17,29 @@ import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
+const SCOPE_FERMENT_PAYLOAD = JSON.stringify({
+	ferment_id: "__FERMENT_ID__",
+	title: "Add API Endpoint",
+	goal: "Add a new API endpoint.",
+	success_criteria: ["Endpoint responds correctly"],
+	phases: [
+		{
+			name: "Implement",
+			goal: "Create the route handler and tests.",
+			steps: [
+				{ description: "Create the route handler.", verify: "echo done" },
+				{ description: "Add tests.", verify: "echo done" },
+			],
+		},
+	],
+	assumptions: [],
+	gates: [
+		{ id: "P1", verdict: "pass", rationale: "Steps have verify", evidence: "echo done" },
+		{ id: "P2", verdict: "omitted", rationale: "single phase", evidence: "n/a" },
+		{ id: "P3", verdict: "pass", rationale: "criterion checked", evidence: "n/a" },
+	],
+})
+
 test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment lifecycle", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
@@ -22,9 +47,9 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 			artifactName: "oneshot-bypasses-dropdown",
 			gitInit: true,
 			responses: [
-				// In oneshot mode the model calls submit_plan — but the flag guard
-				// in submit_plan's execute returns early with terminate:true and no
-				// review emit, so no dropdown appears in the TUI.
+				// In oneshot mode the model calls scope_ferment, which scopes
+				// the ferment directly without emitting a review request — no
+				// dropdown appears in the TUI.
 				{
 					stream: [
 						"# Plan\n",
@@ -39,21 +64,16 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 					],
 					toolCalls: [
 						{
-							id: "call_submit_plan",
+							id: "call_scope_ferment",
 							type: "function",
 							function: {
-								name: "submit_plan",
-								arguments: JSON.stringify({
-									plan:
-										"# Plan\n\n" +
-										"## Goal\nAdd a new API endpoint.\n\n" +
-										"## Steps\n1. Create the route handler.\n2. Add tests.\n",
-								}),
+								name: "scope_ferment",
+								arguments: SCOPE_FERMENT_PAYLOAD,
 							},
 						},
 					],
 				},
-				// Follow-up response so the session stays alive after the first response.
+				// Follow-up response so the session stays alive after scoping.
 				{ stream: ["Proceeding with the ferment lifecycle."] },
 			],
 			extraArgs: ["--ferment-oneshot=true"],
@@ -70,17 +90,15 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 			)
 			trace.step("ready prompt visible (or oneshot bootstrapped)")
 
-			// Stage 2: submit request → model streams the plan, then calls
-			// submit_plan. In oneshot mode the dropdown must NOT appear.
+			// Stage 2: submit request → model calls scope_ferment. In oneshot
+			// mode the dropdown must NOT appear.
 			terminal.submit("Add a new API endpoint")
 			trace.step("submitted request")
-			await waitForText(terminal, "Plan submitted", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("submit_plan tool called — dropdown must NOT appear in oneshot mode")
+			await waitForText(terminal, "Proceeding with the ferment lifecycle", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("scope_ferment called — dropdown must NOT appear in oneshot mode")
 
-			// Stage 3: wait briefly to give the dropdown handler a chance to (incorrectly)
-			// render, then sample the terminal text and assert the dropdown labels are absent.
-			// @microsoft/tui-test expect() takes only one argument (no message), so we
-			// collect violations in an array and assert once at the end.
+			// Stage 3: wait briefly to give any dropdown handler a chance to
+			// (incorrectly) render, then assert the dropdown labels are absent.
 			await new Promise((resolve) => setTimeout(resolve, 2_000))
 			const text = fullText(terminal)
 
@@ -90,19 +108,19 @@ test("--ferment-oneshot bypasses the plan-complete dropdown and enters ferment l
 				"Rework the plan",
 				"Start as ferment",
 				"How would you like to proceed",
+				"Proceed with this plan?",
 			]) {
 				if (text.includes(label)) violations.push(label)
 			}
 			expect(violations.length === 0).toBe(true)
 			trace.step("no dropdown labels present in --ferment-oneshot session")
 
-			// Stage 4: ensure no key input accidentally triggers the dropdown. Send a
-			// harmless Enter and verify the dropdown still hasn't appeared.
+			// Stage 4: ensure no key input accidentally triggers the dropdown.
 			terminal.keyPress(Key.Enter)
 			await new Promise((resolve) => setTimeout(resolve, 1_000))
 			const finalText = fullText(terminal)
 			const finalViolations: string[] = []
-			for (const label of ["Execute the plan", "Start as ferment"]) {
+			for (const label of ["Execute the plan", "Start as ferment", "Proceed with this plan?"]) {
 				if (finalText.includes(label)) finalViolations.push(label)
 			}
 			expect(finalViolations.length === 0).toBe(true)

--- a/tests/e2e/tui/plan-mode-tool-switch.test.ts
+++ b/tests/e2e/tui/plan-mode-tool-switch.test.ts
@@ -20,14 +20,29 @@ test("plan-mode tool switch: Execute approved plan exits plan mode", async ({ te
 			extraArgs: ["--plan=true"], // registered boolean flag in permissions/index.ts:160
 			extraEnv: { KIMCHI_PERMISSIONS: "plan" }, // env fallback per permissions/index.ts:200
 			responses: [
-				// Stream a complete plan ending with the plan-mode marker.
+				// Stream a complete plan, then call submit_plan to trigger the review dropdown.
 				{
 					stream: [
 						"Here's a lightweight plan:\n\n",
 						"1. Read the relevant source files\n",
 						"2. Make the targeted change\n",
 						"3. Run tests to verify\n\n",
-						"<!-- PLAN_COMPLETE -->\n",
+					],
+					toolCalls: [
+						{
+							id: "call_submit_plan",
+							type: "function",
+							function: {
+								name: "submit_plan",
+								arguments: JSON.stringify({
+									plan:
+										"Here's a lightweight plan:\n\n" +
+										"1. Read the relevant source files\n" +
+										"2. Make the targeted change\n" +
+										"3. Run tests to verify\n",
+								}),
+							},
+						},
 					],
 				},
 				// After Execute is picked, the model will respond again (now in auto mode).
@@ -45,19 +60,15 @@ test("plan-mode tool switch: Execute approved plan exits plan mode", async ({ te
 			await waitForText(terminal, "plan → shift+tab", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("status line confirms plan mode")
 
-			// Stage 2: submit a trivial request — model responds with a complete plan.
+			// Stage 2: submit a trivial request — model responds by calling
+			// submit_plan, which triggers the review dropdown.
 			terminal.submit("Plan out how to add a new feature.")
 			trace.step("submitted planning request")
-			await waitForText(terminal, "<!-- PLAN_COMPLETE -->", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("plan complete marker seen")
+			await waitForText(terminal, "Execute the plan", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("submit_plan tool called — dropdown appeared")
 
-			// Stage 4: plan-complete approval dropdown appears (permissions/index.ts:498).
-			// NOTE: in this TUI test harness the dropdown overlay is not reliably captured
-			// by `terminal.getBuffer()` — we therefore press Enter directly after seeing the
-			// PLAN_COMPLETE marker, and rely on the dropdown's `ctx.ui.select(...)` to
-			// accept Enter as the default selection of the first option ("Execute the plan").
-			// See the parallel test `plan-to-ferment-promo.test.ts` for a `test.fail` that
-			// explicitly asserts on the overlay text (with a KNOWN ISSUE comment).
+			// Stage 4: plan-complete approval dropdown appears (permissions/index.ts).
+			// Press Enter to default-select "Execute the plan" (first option).
 			terminal.keyPress(Key.Enter)
 			trace.step("pressed Enter to select default dropdown option ('Execute the plan')")
 
@@ -65,7 +76,7 @@ test("plan-mode tool switch: Execute approved plan exits plan mode", async ({ te
 			// status line mode transition (`plan → shift+tab` → `auto → shift+tab`)
 			// instead of the post-execute model response (which is timing-flaky in CI).
 			// This proves the dropdown consumed Enter and the session exited plan mode
-			// (permissions/index.ts:520: changeMode("plan", "auto", "user")).
+			// (permissions/index.ts: changeMode("plan", "auto", "user")).
 			await waitForText(terminal, "auto → shift+tab", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("status line transitioned to auto — dropdown consumed Enter and plan mode exited")
 		},

--- a/tests/e2e/tui/plan-review-dismissal.test.ts
+++ b/tests/e2e/tui/plan-review-dismissal.test.ts
@@ -116,7 +116,8 @@ test("plan review dialog does not re-appear after Esc dismissal", async ({ termi
 			// firing mid-test and consuming scripted responses.
 			models: [{ slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 }],
 			responses: [
-				// Turn 1: model calls propose_ferment_scoping.
+				// Turn 1: model calls propose_ferment_scoping. terminate:true ends
+				// the turn; the review dialog appears via onPlanReviewRequest.
 				{
 					toolCalls: [
 						{
@@ -127,8 +128,6 @@ test("plan review dialog does not re-appear after Esc dismissal", async ({ termi
 						},
 					],
 				},
-				// Turn 1 continuation after the tool result is sent back.
-				{ stream: ["Plan ready for review."] },
 				// Turn 2 (after the new user turn): short text response.
 				{ stream: ["Understood, I'll wait for your direction."] },
 			],
@@ -211,7 +210,8 @@ test("plan review dialog does not re-appear after feedback", async ({ terminal }
 			// firing mid-test and consuming scripted responses.
 			models: [{ slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 }],
 			responses: [
-				// Turn 1: model calls propose_ferment_scoping.
+				// Turn 1: model calls propose_ferment_scoping. terminate:true ends
+				// the turn; the review dialog appears via onPlanReviewRequest.
 				{
 					toolCalls: [
 						{
@@ -222,8 +222,6 @@ test("plan review dialog does not re-appear after feedback", async ({ terminal }
 						},
 					],
 				},
-				// Turn 1 continuation after the tool result is sent back.
-				{ stream: ["Plan ready for review."] },
 				// Turn 2 (after the feedback): short text response.
 				{ stream: ["Got it — I'll revise the plan based on your feedback."] },
 			],

--- a/tests/e2e/tui/plan-to-ferment-promo.test.ts
+++ b/tests/e2e/tui/plan-to-ferment-promo.test.ts
@@ -8,10 +8,10 @@
  *    Choosing Start as ferment must trigger the implementation turn without
  *    another user message.
  *
- * 2. "plan-to-ferment promotion — side effects via plan complete handler"
+ * 2. "plan-to-ferment promotion — side effects via submit_plan handler"
  *    (test): Verifies the side effects of the plan-to-ferment flow by
  *    checking that the approved plan file is written to .kimchi/plans/ when
- *    the model emits <!-- PLAN_COMPLETE -->. No dropdown UI assertions.
+ *    the model calls submit_plan. No dropdown UI assertions.
  *    The tool-swap from questionnaire → ask_user is also confirmed via the
  *    recorded request bodies (proxied by the TUI's tool-list rendering).
  */
@@ -43,7 +43,25 @@ test("plan-to-ferment promotion — Start as ferment immediately continues execu
 						"- **Files Changed**: src/parser.ts\n",
 						"- **Accept When**: streaming think blocks parse correctly\n\n",
 						"## Verification Strategy\nRun the parser tests.\n\n",
-						"<!-- PLAN_COMPLETE -->\n",
+					],
+					toolCalls: [
+						{
+							id: "call_submit_plan",
+							type: "function",
+							function: {
+								name: "submit_plan",
+								arguments: JSON.stringify({
+									plan:
+										"## Goal\nImplement a streaming think parser.\n\n" +
+										"## Constraints\n- Preserve the existing parser API\n\n" +
+										"## Chunks\n\n" +
+										"### Chunk 1: Implement streaming parser\n" +
+										"- **Files Changed**: src/parser.ts\n" +
+										"- **Accept When**: streaming think blocks parse correctly\n\n" +
+										"## Verification Strategy\nRun the parser tests.\n",
+								}),
+							},
+						},
 					],
 				},
 				{ stream: ["I'll start implementing the streaming think parser."] },
@@ -57,11 +75,11 @@ test("plan-to-ferment promotion — Start as ferment immediately continues execu
 			await waitForText(terminal, /plan(?: → shift\+tab)? · basic\b/, { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("status line confirms plan mode")
 
-			// Stage 2: submit request → model emits plan with PLAN_COMPLETE marker.
+			// Stage 2: submit request → model streams the plan, then calls
+			// submit_plan. The dropdown appears after the tool call terminates
+			// the turn.
 			terminal.submit("Implement a streaming think parser")
 			trace.step("submitted planning request")
-			await waitForText(terminal, "<!-- PLAN_COMPLETE -->", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("plan complete marker seen")
 
 			// Stage 3: dropdown appears — all three options must be visible in buffer.
 			await waitForText(terminal, "Execute the plan", { timeoutMs: STREAM_TIMEOUT_MS })
@@ -107,12 +125,12 @@ test("plan-to-ferment promotion — Start as ferment immediately continues execu
 })
 
 // ---------------------------------------------------------------------------
-// Test 2: Side-effect verification via plan-complete handler (no dropdown UI)
+// Test 2: Side-effect verification via submit_plan handler (no dropdown UI)
 // ---------------------------------------------------------------------------
 
 // Verifies the plan-to-ferment contract by checking the filesystem side effects
-// of the plan-complete handler (permissions/index.ts:506-540). The model emits
-// <!-- PLAN_COMPLETE -->, the handler writes the approved plan to .kimchi/plans/
+// of the submit_plan handler (permissions/index.ts). The model calls submit_plan
+// with the plan text, the handler writes the approved plan to .kimchi/plans/
 // and transitions to auto mode. No dropdown UI assertions are made — this test
 // proves the contract works by examining the artifact files and TUI state.
 test("plan-to-ferment promotion — side effects: plan file written + tool swap at turn boundary", async ({
@@ -130,7 +148,22 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 						"1. Read the relevant source files\n",
 						"2. Make the targeted change\n",
 						"3. Run tests to verify\n\n",
-						"<!-- PLAN_COMPLETE -->\n",
+					],
+					toolCalls: [
+						{
+							id: "call_submit_plan",
+							type: "function",
+							function: {
+								name: "submit_plan",
+								arguments: JSON.stringify({
+									plan:
+										"Here's a lightweight plan:\n\n" +
+										"1. Read the relevant source files\n" +
+										"2. Make the targeted change\n" +
+										"3. Run tests to verify\n",
+								}),
+							},
+						},
 					],
 				},
 				{ stream: ["Plan executed. Ready for the next task.\n"] },
@@ -144,17 +177,16 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 			await waitForText(terminal, /plan(?: → shift\+tab)? · basic\b/, { timeoutMs: STARTUP_TIMEOUT_MS })
 			trace.step("status line confirms plan mode")
 
-			// Stage 2: submit request → model emits plan with PLAN_COMPLETE marker.
+			// Stage 2: submit request → model streams the plan, then calls
+			// submit_plan. The dropdown appears after the tool call terminates
+			// the turn.
 			terminal.submit("Plan out how to add a new feature.")
 			trace.step("submitted planning request")
-			await waitForText(terminal, "<!-- PLAN_COMPLETE -->", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("plan complete marker seen — plan-complete handler should have fired")
+			await waitForText(terminal, "Execute the plan", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("submit_plan tool called — plan-complete handler fired")
 
-			// Stage 3: the dropdown appears. NOTE: in this TUI test harness the dropdown
-			// overlay is not reliably captured by `terminal.getBuffer()` (observed across
-			// multiple runs), so we press Enter directly after seeing PLAN_COMPLETE — the
-			// plan-complete handler is awaited by `ctx.ui.select(...)` which accepts Enter
-			// to default-select "Execute the plan" (first option).
+			// Stage 3: the dropdown appears. Press Enter to default-select
+			// "Execute the plan" (first option).
 			terminal.keyPress(Key.Enter)
 			trace.step("pressed Enter to select default dropdown option ('Execute the plan')")
 
@@ -164,8 +196,8 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 			await waitForText(terminal, /auto(?: → shift\+tab)? · basic\b/, { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("status line transitioned to auto — handler fired and mode changed")
 
-			// Verify the approved plan file was written (proof that plan-complete
-			// handler executed the write path at permissions/index.ts:527-540).
+			// Verify the approved plan file was written (proof that submit_plan
+			// executed the write path at permissions/index.ts).
 			const plansDir = join(fixture.workDir, ".kimchi", "plans")
 			const planFiles = readdirSync(plansDir)
 			expect(planFiles.length > 0).toBe(true)
@@ -173,9 +205,8 @@ test("plan-to-ferment promotion — side effects: plan file written + tool swap 
 			expect(planFile).toMatch(/\.md$/)
 
 			const planContent = readFileSync(join(plansDir, planFile), "utf-8")
+			// The plan text comes from the submit_plan tool argument.
 			expect(planContent.includes("Read the relevant source files")).toBe(true)
-			// Markers are stripped by savePlanMarkdown before persistence.
-			expect(planContent.includes("<!-- PLAN_COMPLETE -->")).toBe(false)
 			expect(planContent.includes("Make the targeted change")).toBe(true)
 			expect(planContent.includes("Run tests to verify")).toBe(true)
 			trace.step("approved plan file written and content verified")

--- a/tests/e2e/tui/suppress-retried-errors.test.ts
+++ b/tests/e2e/tui/suppress-retried-errors.test.ts
@@ -276,9 +276,7 @@ test("ferment pause on error surfaces sanitized message with /ferment resume hin
 						},
 					],
 				},
-				// Turn 2: tools suppressed → text-only response (plan review).
-				{ stream: ["I've submitted the plan for your review."] },
-				// Turn 3: post-confirmation, model starts working but hits an error.
+				// Turn 2: post-confirmation, model starts working but hits an error.
 				{ status: 500, body: VLLM_ERROR_BODY },
 				{ status: 500, body: VLLM_ERROR_BODY },
 				{ status: 500, body: VLLM_ERROR_BODY },

--- a/tests/e2e/tui/todo-widget-ferment.test.ts
+++ b/tests/e2e/tui/todo-widget-ferment.test.ts
@@ -110,11 +110,9 @@ test("todo tools are available during ferment execution", async ({ terminal }) =
 						},
 					],
 				},
-				// Turn 2 (after tool result): short text, no trailing "?".
-				{ stream: ["I've outlined the scope for this test."] },
-				// Turn 3 (post-confirmation keepalive): mirrors ferment-new-runs-planning.
+				// Turn 2 (post-confirmation keepalive): mirrors ferment-new-runs-planning.
 				{},
-				// Turn 4 (host nudge): activate the implementation phase.
+				// Turn 3 (host nudge): activate the implementation phase.
 				{
 					stream: ["Starting implementation."],
 					toolCalls: [


### PR DESCRIPTION
## Summary

Integrates plannotator's plan-review browser UI into kimchi's planning flow and replaces the fragile `<!-- PLAN_COMPLETE -->` text-marker protocol with a dedicated `submit_plan` tool. Also fixes two bugs blocking third-party npm extensions in the built binary.

## Changes

### Plannotator integration + event-driven review architecture
- **`src/shared/planning/plan-review-bus.ts`** — new event-driven bus with two channels (`kimchi:plan-review-request` / `kimchi:plan-review-decision`), first-decision-wins semantics, and context storage. Emitters always emit (even headless/oneshot); subscribers self-select.
- **`src/extensions/plannotator/index.ts`** — pure adapter translating between kimchi's bus and plannotator's extension events. Subscribes only in interactive TUI sessions (skips workers via `PARENT_SESSION_ID_ENV_KEY`, skips headless/oneshot via `ctx.hasUI` + flag check).
- **`src/extensions/permissions/index.ts`** — `submit_plan` tool replaces the `turn_end` marker-scanning flow. Non-blocking `ctx.ui.select()` with `AbortSignal` for cross-surface dismissal. Plan-mode stall recovery restored via `turn_end` handler with tool-call-based detection (`hasPlanSubmitToolCall`), capped per session, workers excluded.
- **`src/extensions/ferment/index.ts`** — non-blocking `promptPlanReview` with `onDismissRegister`. Decision handler consumes context from the bus. `agent_end` restores pending-review scheduling (emit + schedule, guarded against double-fire).
- **`src/extensions/ferment/tools/lifecycle.ts`** — `propose_ferment_scoping` now emits `emitPlanReviewRequest` + `terminate: true`.

### Marker to submit_plan migration
- **submit_plan worker path** — allowed when `mode === "plan"` OR `isAgentWorker()`. Workers save the plan and terminate with no review emit; the parent orchestrator is the evaluator. `agent-runner.extractSubmitPlanPath` reads `planPath` from the tool result `details` payload.
- **Plan persona** (`default-agents.ts`) — STEP 5 instructs calling `submit_plan` instead of appending markers.
- **`plan-markdown.ts`** — `stripPlanCompletionMarkers` and marker constants removed.
- **`planning-stop-nudge.ts`** — nudge text rewritten for `submit_plan`; `hasPlanCompletionSignal(text)` replaced with `hasPlanSubmitToolCall(toolNames)`.

### Extension loader fixes (patches/)
- **Type2 ReferenceError** — Bun bundler renames Google GenAI Type enum to Type2; a Proxy overrides `.Type` with the typebox namespace directly.
- **Flag conflict crash** — npm extension flag conflicts (e.g. `--plan`) downgraded from hard error to warning (kimchi built-in extensions load first and win).

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 0 errors (24 pre-existing warnings)
- [x] `pnpm run test` — 9,010 passed / 0 failed
- [x] Targeted suites: permissions (115), ferment (1,195), agent-runner (59), plannotator (11), stop-nudge, plan-markdown — all green
- [ ] Live testing with plannotator browser (needs binary rebuild)

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

Co-Authored-By: Kimchi <noreply@kimchi.dev>
