### PR TITLE
test(mcp): add repository-owned e2e suite for MCP transports, auth, and failures

### DIFF
--- a/.github/workflows/mcp-e2e.yml
+++ b/.github/workflows/mcp-e2e.yml
@@ -33,7 +33,9 @@ jobs:
         run: make -C tools/proxy-helper build
 
       - name: Run MCP end-to-end suite
-        run: KIMCHI_PROXY_HELPER=$(pwd)/bin/proxy-helper pnpm run test:e2e:mcp
+        run: |
+          test -x tools/proxy-helper/bin/proxy-helper
+          KIMCHI_PROXY_HELPER=$(pwd)/tools/proxy-helper/bin/proxy-helper pnpm run test:e2e:mcp
 
       - name: Upload MCP E2E artifacts
         if: failure()

--- a/.github/workflows/mcp-e2e.yml
+++ b/.github/workflows/mcp-e2e.yml
@@ -1,0 +1,50 @@
+name: MCP E2E
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-e2e-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mcp-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup
+        with:
+          bun: "true"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/proxy-helper/go.mod
+          cache-dependency-path: tools/proxy-helper/go.sum
+
+      - name: Build proxy-helper
+        run: make -C tools/proxy-helper build
+
+      - name: Run MCP end-to-end suite
+        run: KIMCHI_PROXY_HELPER=$(pwd)/bin/proxy-helper pnpm run test:e2e:mcp
+
+      - name: Upload MCP E2E artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-e2e-artifacts-${{ github.run_attempt }}
+          path: |
+            mcp-*.tui-e2e.log
+            *mcp*.acp-e2e.log
+            .kimchi/mcp-conformance-results/**
+            **/tui-traces/**
+            **/acp-traces/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/mcp-e2e-testing.md
+++ b/docs/mcp-e2e-testing.md
@@ -1,0 +1,110 @@
+# MCP end-to-end testing
+
+Kimchi's MCP end-to-end suite runs the real compiled Kimchi client against a deterministic, repository-owned MCP server. It covers both product entry points: PTY-driven TUI sessions and ACP sessions over NDJSON stdio.
+## Architecture
+
+The suite has four cooperating parts:
+
+1. `tests/e2e/mcp/fixture-server.mjs` is a scenario-driven MCP server built on the pinned official TypeScript SDK. It supports stdio, Streamable HTTP, legacy SSE fallback, static bearer authentication, and a local OAuth authorization server.
+2. `tests/e2e/tui/support/mcp-fixture.ts` creates isolated MCP configuration, event logs, loopback listeners, and an OAuth browser driver for each test.
+3. The existing TUI and ACP fixtures launch `dist/bin/kimchi` with an isolated `HOME`, work directory, model configuration, MCP cache, and OAuth credential store.
+4. `tests/e2e/tui/support/mcp-model-script.ts` builds deterministic gateway or direct MCP tool calls and exposes semantic accessors for the results sent back to the model. This tests Kimchi's transport and tool behavior without depending on model tool-selection quality.
+
+Important workflows assert more than the final response:
+
+- the terminal text or ACP events seen by the client;
+- the tool definition and result sent to the next fake-model request;
+- protocol events recorded by the MCP fixture;
+- persisted cache or OAuth behavior across a real Kimchi process restart.
+
+The fixture's stdout is reserved for MCP protocol messages. Diagnostics go to a per-test JSONL event file. OAuth access tokens, refresh tokens, authorization codes, and client secrets are not written to that event log.
+
+## Running the tests
+
+Build and run every MCP end-to-end tier:
+
+```sh
+pnpm run test:e2e:mcp
+```
+
+Run one tier while iterating after `pnpm run build:binary`:
+
+```sh
+pnpm run test:e2e:mcp:tui
+pnpm run test:e2e:mcp:acp
+pnpm run test:e2e:mcp:conformance
+```
+
+Run one TUI file by its name fragment:
+
+```sh
+node scripts/run-tui-e2e.js mcp-oauth
+```
+
+The dedicated `MCP E2E` GitHub Actions workflow runs the aggregate suite for pull requests, or on manual dispatch.
+
+## Coverage
+
+| Area | End-to-end behavior |
+| --- | --- |
+| stdio | initialization, discovery, gateway calls, search-to-direct-tool injection, resources, error results, mixed content, and empty gateway status |
+| direct tools and cache | first-session exposure specification and successful direct invocation after a real process restart |
+| failures | invalid arguments, startup failure, disconnect during a call, bounded slow calls, transport loss, malformed HTTP, and cancellation specification |
+| Streamable HTTP | initialization, session IDs, custom headers, static bearer authentication, unavailable server behavior, and legacy SSE fallback |
+| OAuth | protected-resource and authorization-server metadata, dynamic client registration, authorization code with PKCE, browser callback, denial, token failure, persistence, and refresh after restart |
+| ACP | server probing, cache population, MCP-backed agent turns, image forwarding, authentication-required probing, OAuth login, and protected tool calls |
+| official conformance | the pinned runner's `initialize` and `tools_call` client scenarios against Kimchi's real ACP-hosted client stack |
+
+The suite contains two `test.fail` behavioral specifications for known product regressions:
+
+- a configured direct MCP tool is not available to the first model request because asynchronous bootstrap completes too late;
+- cancelling an agent turn does not currently propagate the abort signal as MCP `notifications/cancelled`.
+
+Keep these tests enabled. When either starts passing, Vitest reports an unexpected pass; remove `test.fail` as part of the corresponding production fix.
+
+## Adding a fixture behavior
+
+Prefer extending the existing fixture over creating another server:
+
+1. Add one deterministic tool or named scenario to `fixture-server.mjs`.
+2. Record a small event at the protocol boundary that the test needs to observe. Do not include credentials or whole request headers.
+3. Add an option to `McpFixtureOptions` only if the test must alter server setup. Tool inputs should normally select per-call behavior instead.
+4. Add one user-recognizable workflow to the relevant `mcp-*.test.ts` file. Drive it through the real TUI or ACP boundary and assert the model and protocol boundaries where applicable.
+5. Give every wait a fixed timeout and ensure fixture-owned children and listeners are stopped in teardown.
+
+Use `test.fail` only for a stable, known product bug with a comment naming the regression. Use the TUI skip list only for genuine test instability.
+
+## Writing a workflow with little boilerplate
+
+Use `runMcpKimchiSession` so the callback receives a fixture whose `mcp` property is required, and use the model-script builders instead of hand-writing OpenAI tool-call envelopes:
+
+```ts
+const echo = gatewayMcpCall("echo", { message: "hello" })
+
+await runMcpKimchiSession(
+	terminal,
+	{
+		artifactName: "mcp-echo",
+		mcp: {},
+		responses: [echo.response, modelReply("The MCP server answered.")],
+	},
+	async (fixture) => {
+		terminal.submit("Ask the MCP server to echo hello")
+		await waitForText(terminal, "The MCP server answered.")
+		await fixture.mcp.waitForEvent("tool_called", {
+			where: { name: "echo", arguments: { message: "hello" } },
+		})
+		expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: hello")
+	},
+)
+```
+
+This verifies three production boundaries: the user-visible response, the actual MCP protocol call, and the tool result returned to the model. Prefer typed `where` filters and checkpoints over custom polling or sleeps. For process-lifecycle scenarios, use `runRestartableMcpKimchiSession`; its `restart()` waits for a verified shell exit before launching the next Kimchi process.
+
+An empty `mcp: {}` deliberately exercises production defaults. Set `lifecycle`, `idleTimeout`, `toolPrefix`, or authentication only when that setting is the behavior under test. Add `additionalStdioServers` when a workflow needs to prove routing or isolation between multiple configured servers.
+
+## Choosing the right test tier
+
+Use a focused co-located unit or integration test for parsing, configuration normalization, or a protocol branch that does not need a user workflow. Use the fixture-backed TUI or ACP suite when the risk crosses process, transport, model, cache, OAuth, or content-forwarding boundaries.
+
+A real external MCP smoke test can be useful for optional manual or scheduled compatibility checking, but it should not gate pull requests. External availability, credentials, and server changes make it unsuitable as the primary regression suite; the local fixture remains the source of deterministic CI evidence.

--- a/docs/mcp-e2e-testing.md
+++ b/docs/mcp-e2e-testing.md
@@ -55,20 +55,21 @@ The dedicated `MCP E2E` GitHub Actions workflow runs the aggregate suite for pul
 | ACP | server probing, cache population, MCP-backed agent turns, image forwarding, authentication-required probing, OAuth login, and protected tool calls |
 | official conformance | the pinned runner's `initialize` and `tools_call` client scenarios against Kimchi's real ACP-hosted client stack |
 
-The suite contains two `test.fail` behavioral specifications for known product regressions:
+The suite contains three `test.fail` behavioral specifications for known product regressions:
 
-- a configured direct MCP tool is not available to the first model request because asynchronous bootstrap completes too late;
-- cancelling an agent turn does not currently propagate the abort signal as MCP `notifications/cancelled`.
+- `test.fail`: a configured direct MCP tool is not available to the first model request because asynchronous bootstrap completes too late (fixed upstream in pi-mcp-adapter v2.26.1, PR #374);
+- `test.fail`: cancelling an agent turn does not currently propagate the abort signal as MCP `notifications/cancelled` (fixed upstream in pi-mcp-adapter v2.11.0, PR #159);
+- `test.fail`: a crashed keep-alive stdio server cannot reconnect because the closed client remains marked connected (fixed upstream in pi-mcp-adapter v2.12.0, PR #194).
 
-Keep these tests enabled. When either starts passing, Vitest reports an unexpected pass; remove `test.fail` as part of the corresponding production fix.
+These specifications still execute, and an unexpected pass tells us to remove `test.fail` after upgrading the bundled adapter.
 
 ## Adding a fixture behavior
 
-Prefer extending the existing fixture over creating another server:
+Keep transport mechanics in the existing fixture, but declare the MCP outcome in the test that exercises it:
 
-1. Add one deterministic tool or named scenario to `fixture-server.mjs`.
+1. Add the tool or resource protocol definition to `fixture-server.mjs` only when the fixture does not advertise it yet.
 2. Record a small event at the protocol boundary that the test needs to observe. Do not include credentials or whole request headers.
-3. Add an option to `McpFixtureOptions` only if the test must alter server setup. Tool inputs should normally select per-call behavior instead.
+3. Declare tool results, delayed results, process exits, startup exits, and resource responses under the test's `mcp.behavior` setup. Do not hardcode test outcomes in `fixture-server.mjs`.
 4. Add one user-recognizable workflow to the relevant `mcp-*.test.ts` file. Drive it through the real TUI or ACP boundary and assert the model and protocol boundaries where applicable.
 5. Give every wait a fixed timeout and ensure fixture-owned children and listeners are stopped in teardown.
 
@@ -85,7 +86,17 @@ await runMcpKimchiSession(
 	terminal,
 	{
 		artifactName: "mcp-echo",
-		mcp: {},
+		mcp: {
+			behavior: {
+				tools: [
+					mcpToolResult(
+						"echo",
+						{ content: [{ type: "text", text: "fixture echo: hello" }] },
+						{ message: "hello" },
+					),
+				],
+			},
+		},
 		responses: [echo.response, modelReply("The MCP server answered.")],
 	},
 	async (fixture) => {
@@ -99,9 +110,9 @@ await runMcpKimchiSession(
 )
 ```
 
-This verifies three production boundaries: the user-visible response, the actual MCP protocol call, and the tool result returned to the model. Prefer typed `where` filters and checkpoints over custom polling or sleeps. For process-lifecycle scenarios, use `runRestartableMcpKimchiSession`; its `restart()` waits for a verified shell exit before launching the next Kimchi process.
+Here `mcp.behavior` is the real MCP server response, while top-level `responses` scripts the fake model. This verifies three production boundaries: the user-visible response, the actual MCP protocol call, and the tool result returned to the model. Prefer typed `where` filters and checkpoints over custom polling or sleeps. For process-lifecycle scenarios, use `runRestartableMcpKimchiSession`; its `restart()` waits for a verified shell exit before launching the next Kimchi process.
 
-An empty `mcp: {}` deliberately exercises production defaults. Set `lifecycle`, `idleTimeout`, `toolPrefix`, or authentication only when that setting is the behavior under test. Add `additionalStdioServers` when a workflow needs to prove routing or isolation between multiple configured servers.
+An empty `mcp: {}` deliberately exercises production defaults only when the workflow does not call or read from the fixture. Called tools and resources require an explicit behavior; an omitted tool response becomes a model-facing fixture configuration error. Set `lifecycle`, `idleTimeout`, `toolPrefix`, or authentication only when that setting is the behavior under test. Add `additionalStdioServers` when a workflow needs to prove routing or isolation between multiple configured servers.
 
 ## Choosing the right test tier
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
 		"test:e2e:tui:trace": "pnpm run build:binary && node scripts/run-tui-e2e.js --trace",
 		"test:e2e:tui:trace:replay": "node scripts/run-tui-e2e.js replay",
 		"test:e2e:acp": "pnpm run build:binary && vitest run --config tests/e2e/acp/vitest.config.ts",
+		"test:e2e:mcp": "pnpm run build:binary && pnpm run test:e2e:mcp:tui && pnpm run test:e2e:mcp:acp && pnpm run test:e2e:mcp:conformance",
+		"test:e2e:mcp:tui": "node scripts/run-tui-e2e.js mcp-stdio && node scripts/run-tui-e2e.js mcp-failures && node scripts/run-tui-e2e.js mcp-http && node scripts/run-tui-e2e.js mcp-oauth && node scripts/run-tui-e2e.js mcp-restart && node scripts/run-tui-e2e.js mcp-panel && node scripts/run-tui-e2e.js mcp-lifecycle && node scripts/run-tui-e2e.js mcp-ui",
+		"test:e2e:mcp:acp": "vitest run --config tests/e2e/acp/vitest.config.ts tests/e2e/acp/mcp-workflow.test.ts tests/e2e/acp/mcp-probe-command.test.ts",
+		"test:e2e:mcp:conformance": "conformance client --command \"pnpm exec tsx tests/e2e/mcp/conformance-client.ts\" --scenario initialize --spec-version 2025-11-25 --timeout 30000 --output-dir .kimchi/mcp-conformance-results && conformance client --command \"pnpm exec tsx tests/e2e/mcp/conformance-client.ts\" --scenario tools_call --spec-version 2025-11-25 --timeout 30000 --output-dir .kimchi/mcp-conformance-results && conformance client --command \"pnpm exec tsx tests/e2e/mcp/conformance-client.ts\" --scenario sse-retry --spec-version 2025-11-25 --timeout 30000 --output-dir .kimchi/mcp-conformance-results && conformance client --command \"pnpm exec tsx tests/e2e/mcp/conformance-client.ts\" --scenario auth/metadata-default --spec-version 2025-11-25 --timeout 60000 --output-dir .kimchi/mcp-conformance-results && conformance client --command \"pnpm exec tsx tests/e2e/mcp/conformance-client.ts\" --scenario auth/pre-registration --spec-version 2025-11-25 --timeout 60000 --output-dir .kimchi/mcp-conformance-results",
 		"postinstall": "node scripts/patch-pi-ai-oauth.js && node scripts/copy-resources.js --dev",
 		"prepare": "husky",
 		"verify": "pnpm run check && pnpm run build:binary && pnpm run test && pnpm run test:smoke"
@@ -83,6 +87,7 @@
 		"@earendil-works/pi-ai": "0.84.1",
 		"@microsoft/tui-test": "0.0.4",
 		"@mixmark-io/domino": "^2.2.0",
+		"@modelcontextprotocol/conformance": "0.1.16",
 		"@types/micromatch": "^4.0.10",
 		"@types/node": "^22.19.18",
 		"@types/shell-quote": "^1.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@mixmark-io/domino':
         specifier: ^2.2.0
         version: 2.2.0
+      '@modelcontextprotocol/conformance':
+        specifier: 0.1.16
+        version: 0.1.16(supports-color@10.2.2)
       '@types/micromatch':
         specifier: ^4.0.10
         version: 4.0.10
@@ -751,6 +754,10 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
+  '@modelcontextprotocol/conformance@0.1.16':
+    resolution: {integrity: sha512-GI7qiN0r39/MH2srVUR3AXaEN0YLCro20lIBbnvc1frBhszenxvUifBuTzxeVQVagILfBzCIcnungUOma8OrgA==}
+    hasBin: true
+
   '@modelcontextprotocol/ext-apps@1.7.1':
     resolution: {integrity: sha512-J3WdG1A4JSSKnSWKyU+895dBVYBV2Utgtf7fUsUK45mlkETm53a/1DR6Pm3hUGKqLLQthZLmpxOg8VPzJi/lyg==}
     engines: {node: '>=20'}
@@ -777,6 +784,64 @@ packages:
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.15':
+    resolution: {integrity: sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1440,6 +1505,9 @@ packages:
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -1543,6 +1611,10 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -1550,6 +1622,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
+    engines: {node: '>=22'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1985,6 +2061,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -2511,6 +2590,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.2.0:
     resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
     engines: {node: '>=22.19.0'}
@@ -2533,6 +2616,9 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -3380,6 +3466,21 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
+  '@modelcontextprotocol/conformance@0.1.16(supports-color@10.2.2)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@10.2.2)(zod@4.4.3)
+      '@octokit/rest': 22.0.1
+      commander: 14.0.3
+      eventsource-parser: 3.0.8
+      express: 5.2.1(supports-color@10.2.2)
+      jose: 6.2.3
+      undici: 7.29.0
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@modelcontextprotocol/ext-apps@1.7.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(supports-color@10.2.2)(zod@4.4.3)
@@ -3409,6 +3510,75 @@ snapshots:
       - supports-color
 
   '@nodable/entities@2.1.0': {}
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.15
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.15
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.15':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -3951,6 +4121,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
+  before-after-hook@4.0.0: {}
+
   bignumber.js@9.3.1: {}
 
   body-parser@2.2.2(supports-color@10.2.2):
@@ -4044,9 +4216,13 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@14.0.3: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  content-type@3.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4529,6 +4705,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-with-bigint@3.5.12: {}
 
   jwa@2.0.1:
     dependencies:
@@ -5082,6 +5260,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.29.0: {}
+
   undici@8.2.0: {}
 
   undici@8.9.0: {}
@@ -5108,6 +5288,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@7.0.3: {}
 
   unpipe@1.0.0: {}
 

--- a/tests/e2e/acp/mcp-probe-command.test.ts
+++ b/tests/e2e/acp/mcp-probe-command.test.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it } from "vitest"
+import { type McpFixture, seedMcpStdioFixture } from "../tui/support/mcp-fixture.js"
+
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url))
+const BINARY_PATH = resolve(REPO_ROOT, "dist/bin/kimchi")
+const PACKAGE_DIR = resolve(REPO_ROOT, "dist/share/kimchi")
+
+describe("compiled kimchi mcp probe command", () => {
+	const tempDirs: string[] = []
+	const fixtures: McpFixture[] = []
+
+	afterEach(async () => {
+		await Promise.all(fixtures.splice(0).map((fixture) => fixture.stop().catch(() => {})))
+		for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("discovers tools through a real stdio MCP process and emits JSON", async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), "kimchi-mcp-probe-home-"))
+		const workDir = mkdtempSync(join(tmpdir(), "kimchi-mcp-probe-work-"))
+		tempDirs.push(homeDir, workDir)
+		const agentDir = join(homeDir, ".config", "kimchi", "harness")
+		mkdirSync(agentDir, { recursive: true })
+		const fixture = seedMcpStdioFixture(agentDir)
+		fixtures.push(fixture)
+		const isolatedEnv = Object.fromEntries(
+			Object.entries(process.env).filter(([name]) => name !== "NODE_CHANNEL_FD" && name !== "NODE_UNIQUE_ID"),
+		)
+
+		const result = spawnSync(BINARY_PATH, ["mcp", "probe", "--json"], {
+			cwd: workDir,
+			input: JSON.stringify({ name: "probe-fixture", server: fixture.serverDefinition }),
+			encoding: "utf-8",
+			env: {
+				...isolatedEnv,
+				HOME: homeDir,
+				PI_PACKAGE_DIR: PACKAGE_DIR,
+				KIMCHI_NO_UPDATE_CHECK: "1",
+			},
+			timeout: 30_000,
+		})
+
+		expect(result.error).toBeUndefined()
+		expect(result.status, result.stderr).toBe(0)
+		const output = JSON.parse(result.stdout) as {
+			tools: Array<{ name: string; description?: string }>
+			needsAuth: boolean
+			error: string | null
+		}
+		expect(output.needsAuth).toBe(false)
+		expect(output.error).toBeNull()
+		expect(output.tools).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "echo" }),
+				expect.objectContaining({ name: "mixed_content" }),
+			]),
+		)
+		expect(fixture.hasEvent("initialized")).toBe(true)
+		expect(fixture.hasEvent("tools_listed")).toBe(true)
+		expect(fixture.hasEvent("process_exited", { code: 0 })).toBe(true)
+	})
+})

--- a/tests/e2e/acp/mcp-workflow.test.ts
+++ b/tests/e2e/acp/mcp-workflow.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { mcpToolResult } from "../tui/support/mcp-fixture.js"
 import { gatewayMcpCall, modelReply, toolResultText } from "../tui/support/mcp-model-script.js"
 import { type AcpMcpFixture, STARTUP_TIMEOUT_MS, startAcpMcpFixture } from "./support/acp-fixture.js"
 import { newSession, prompt } from "./support/scenarios.js"
@@ -11,7 +12,28 @@ describe("ACP integration — MCP", () => {
 	beforeEach(async () => {
 		fixture = await startAcpMcpFixture({
 			artifactName: "acp-mcp-workflow",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: acp-mcp" }] },
+							{ message: "acp-mcp" },
+						),
+						mcpToolResult("mixed_content", {
+							content: [
+								{ type: "text", text: "fixture mixed content: kimchi-mcp-mixed" },
+								{
+									type: "image",
+									mimeType: "image/png",
+									data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+								},
+							],
+							structuredContent: { fixture: "kimchi-mcp-structured", count: 1 },
+						}),
+					],
+				},
+			},
 			modelInput: ["text", "image"],
 			responses: [
 				echo.response,
@@ -83,7 +105,18 @@ describe("ACP integration — OAuth MCP", () => {
 	beforeEach(async () => {
 		fixture = await startAcpMcpFixture({
 			artifactName: "acp-mcp-oauth-workflow",
-			mcp: { transport: "oauth" },
+			mcp: {
+				transport: "oauth",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: acp-oauth-mcp" }] },
+							{ message: "acp-oauth-mcp" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("ACP called the OAuth-protected MCP tool.")],
 		})
 	}, STARTUP_TIMEOUT_MS)

--- a/tests/e2e/acp/mcp-workflow.test.ts
+++ b/tests/e2e/acp/mcp-workflow.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { gatewayMcpCall, modelReply, toolResultText } from "../tui/support/mcp-model-script.js"
+import { type AcpMcpFixture, STARTUP_TIMEOUT_MS, startAcpMcpFixture } from "./support/acp-fixture.js"
+import { newSession, prompt } from "./support/scenarios.js"
+
+describe("ACP integration — MCP", () => {
+	let fixture: AcpMcpFixture
+	const echo = gatewayMcpCall("echo", { message: "acp-mcp" })
+	const mixedContent = gatewayMcpCall("mixed_content")
+
+	beforeEach(async () => {
+		fixture = await startAcpMcpFixture({
+			artifactName: "acp-mcp-workflow",
+			mcp: {},
+			modelInput: ["text", "image"],
+			responses: [
+				echo.response,
+				modelReply("ACP received the MCP fixture result."),
+				mixedContent.response,
+				modelReply("ACP preserved the MCP image result."),
+			],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("probes a configured MCP server through the real ACP process", async () => {
+		const probe = await fixture.conn.extMethod("_kimchi.dev/probe_mcp_server", {
+			server: fixture.mcp.serverDefinition,
+			serverName: "acp-fixture-probe",
+		})
+		expect(probe.needsAuth).toBe(false)
+		expect(probe.error).toBeNull()
+		expect(probe.tools).toEqual(
+			expect.arrayContaining([expect.objectContaining({ name: "echo" }), expect.objectContaining({ name: "fail" })]),
+		)
+	})
+
+	it("forwards MCP text and image results across the ACP and model boundaries", async () => {
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Call the configured MCP fixture echo tool")
+		expect(result.stopReason).toBe("end_turn")
+		expect(result.chunks).toContain("ACP received the MCP fixture result.")
+
+		const completedToolUpdate = fixture.client.sessionUpdates.find(
+			(update) =>
+				update.sessionId === sessionId &&
+				update.update.sessionUpdate === "tool_call_update" &&
+				update.update.status === "completed",
+		)
+		expect(completedToolUpdate).toBeDefined()
+		await fixture.mcp.waitForEvent("tool_called", {
+			where: { name: "echo", arguments: { message: "acp-mcp" } },
+		})
+		expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: acp-mcp")
+
+		const imageResult = await prompt(fixture, sessionId, "Request mixed image content from the configured MCP fixture")
+		expect(imageResult.stopReason).toBe("end_turn")
+		expect(imageResult.chunks).toContain("ACP preserved the MCP image result.")
+		const imageToolUpdate = fixture.client.sessionUpdates.find(
+			(update) =>
+				update.sessionId === sessionId &&
+				update.update.sessionUpdate === "tool_call_update" &&
+				update.update.content?.some(
+					(item) =>
+						item.type === "content" &&
+						item.content.type === "image" &&
+						item.content.data.startsWith("iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"),
+				),
+		)
+		expect(imageToolUpdate).toBeDefined()
+		await fixture.mcp.waitForEvent("tool_called", { where: { name: "mixed_content", arguments: {} } })
+		expect(toolResultText(fixture.fake.requests, mixedContent)).toContain("fixture mixed content: kimchi-mcp-mixed")
+	})
+})
+
+describe("ACP integration — OAuth MCP", () => {
+	let fixture: AcpMcpFixture
+	const echo = gatewayMcpCall("echo", { message: "acp-oauth-mcp" })
+
+	beforeEach(async () => {
+		fixture = await startAcpMcpFixture({
+			artifactName: "acp-mcp-oauth-workflow",
+			mcp: { transport: "oauth" },
+			responses: [echo.response, modelReply("ACP called the OAuth-protected MCP tool.")],
+		})
+	}, STARTUP_TIMEOUT_MS)
+
+	afterEach(async () => {
+		await fixture.stop()
+	})
+
+	it("distinguishes auth-required probing, authenticates, and then uses the protected tool", async () => {
+		const server = fixture.mcp.serverDefinition
+		const unauthenticatedProbe = await fixture.conn.extMethod("_kimchi.dev/probe_mcp_server", {
+			server,
+			serverName: "fixture",
+			skipAuth: true,
+		})
+		expect(unauthenticatedProbe.needsAuth).toBe(true)
+
+		const authenticatedProbe = await fixture.conn.extMethod("_kimchi.dev/probe_mcp_server", {
+			server,
+			serverName: "fixture",
+		})
+		expect(authenticatedProbe.needsAuth).toBe(false)
+		expect(authenticatedProbe.error).toBeNull()
+		expect(authenticatedProbe.tools).toEqual(expect.arrayContaining([expect.objectContaining({ name: "echo" })]))
+		await fixture.mcp.waitForEvent("oauth_token_issued", { where: { grantType: "authorization_code" } })
+
+		const sessionId = await newSession(fixture, fixture.workDir)
+		const result = await prompt(fixture, sessionId, "Call the OAuth-protected configured MCP tool")
+		expect(result.stopReason).toBe("end_turn")
+		expect(result.chunks).toContain("ACP called the OAuth-protected MCP tool.")
+		await fixture.mcp.waitForEvent("tool_called", {
+			where: { name: "echo", arguments: { message: "acp-oauth-mcp" } },
+		})
+		expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: acp-oauth-mcp")
+	})
+})

--- a/tests/e2e/acp/support/acp-fixture.ts
+++ b/tests/e2e/acp/support/acp-fixture.ts
@@ -12,7 +12,6 @@ import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
 import type { ClientSideConnection } from "@agentclientprotocol/sdk"
 import * as acp from "@agentclientprotocol/sdk"
-import { onTestFailed } from "vitest"
 import {
 	DEFAULT_MODEL,
 	type FakeModel,
@@ -21,6 +20,7 @@ import {
 	resolveModels,
 	startFakeOpenAiServer,
 } from "../../tui/support/fake-openai-server.js"
+import { createMcpFixture, type McpFixture, type McpFixtureOptions } from "../../tui/support/mcp-fixture.js"
 
 const REPO_ROOT = process.env.KIMCHI_REPO_ROOT
 	? resolve(process.env.KIMCHI_REPO_ROOT)
@@ -46,12 +46,17 @@ export interface AcpFixture {
 	proc: ChildProcess
 	conn: ClientSideConnection
 	client: RecordingClient
+	mcp?: McpFixture
 	/**
 	 * Resolve on process exit. Pass `{ signal }` to abort the wait — used by
 	 * `stop()` so a SIGKILL doesn't hang the teardown on the exit promise.
 	 */
 	waitForExit(): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>
 	stop(): Promise<void>
+}
+
+export interface AcpMcpFixture extends AcpFixture {
+	mcp: McpFixture
 }
 
 export interface AcpFixtureOptions {
@@ -62,6 +67,8 @@ export interface AcpFixtureOptions {
 	defaultProvider?: string
 	defaultModel?: string
 	extraArgs?: string[]
+	/** Input modalities advertised by the default deterministic fake model. Ignored when `models` is provided. */
+	modelInput?: ("text" | "image")[]
 	/**
 	 * Extra capabilities merged on top of the always-present fs baseline.
 	 * Defaults to `{}` (just the fs baseline — matches `verify-acp.mjs`).
@@ -80,6 +87,8 @@ export interface AcpFixtureOptions {
 	 * a custom extension that exercises those calls.
 	 */
 	extensionPath?: string
+	/** Seed the isolated Kimchi config with the shared repository-owned MCP fixture. */
+	mcp?: McpFixtureOptions
 }
 
 export interface StartAcpFixtureOptions extends AcpFixtureOptions {
@@ -214,6 +223,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 		artifactName,
 		responses,
 		models,
+		modelInput,
 		routerResponses,
 		providerId = "fake",
 		defaultProvider,
@@ -223,14 +233,15 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 		clientMeta,
 		extensionPath,
 	} = options
-	const fake = await startFakeOpenAiServer({ responses, models, routerResponses })
 	const configuredModels = models
 		? resolveModels(models)
-		: [{ ...DEFAULT_MODEL, contextWindow: 64_000, maxTokens: 1024 }]
+		: [{ ...DEFAULT_MODEL, input: modelInput ?? DEFAULT_MODEL.input, contextWindow: 64_000, maxTokens: 1024 }]
+	const fake = await startFakeOpenAiServer({ responses, models: configuredModels, routerResponses })
 	const homeDir = mkdtempSync(join(tmpdir(), "kimchi-acp-home-"))
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-acp-work-"))
 
 	let proc: ChildProcess | null = null
+	let mcp: McpFixture | undefined
 	const abort = new AbortController()
 
 	const recordArtifact = (outcome: "pass" | "fail", error?: unknown) => {
@@ -271,13 +282,16 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 	// Registered as soon as the fixture exists so the artifact exists even if
 	// the failure happens mid-test; harmless when no test context is active
 	// (e.g. direct use outside vitest subscriptions).
-	try {
-		onTestFailed((ctx) => {
-			recordArtifact("fail", ctx.task.result?.errors?.[0])
-		})
-	} catch (hookError) {
-		// Not inside a test context — artifacts still written on start failure.
-		process.stderr.write(`[acp-e2e] onTestFailed registration skipped: ${String(hookError).slice(0, 200)}\n`)
+	if (process.env.VITEST) {
+		try {
+			const { onTestFailed } = await import("vitest")
+			onTestFailed((ctx) => {
+				recordArtifact("fail", ctx.task.result?.errors?.[0])
+			})
+		} catch (hookError) {
+			// Not inside a test context — artifacts still written on start failure.
+			process.stderr.write(`[acp-e2e] onTestFailed registration skipped: ${String(hookError).slice(0, 200)}\n`)
+		}
 	}
 
 	try {
@@ -337,6 +351,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 				"utf-8",
 			)
 		}
+		mcp = options.mcp ? await createMcpFixture(agentDir, options.mcp) : undefined
 
 		// pi-coding-agent auto-loads `${agentDir}/extensions/*.js` on every session.
 		const extPath = extensionPath ?? TEST_EXTENSION_PATH
@@ -356,6 +371,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 				// work. Keeps the ACP e2e hermetic and deterministic.
 				KIMCHI_NO_UPDATE_CHECK: "1",
 				KIMCHI_ROUTER_ENDPOINT: fake.baseUrl,
+				...(mcp?.env ?? {}),
 			},
 			cwd: workDir,
 		})
@@ -405,6 +421,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 			proc,
 			conn,
 			client,
+			mcp,
 			waitForExit,
 			async stop() {
 				abort.abort()
@@ -418,6 +435,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 					])
 				}
 				await fake.stop()
+				await mcp?.stop().catch(() => {})
 				rmSync(homeDir, { recursive: true, force: true })
 				rmSync(workDir, { recursive: true, force: true })
 			},
@@ -426,10 +444,28 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 		recordArtifact("fail", error)
 		if (proc && proc.exitCode === null) proc.kill("SIGKILL")
 		await fake.stop().catch(() => {})
+		await mcp?.stop().catch(() => {})
 		rmSync(homeDir, { recursive: true, force: true })
 		rmSync(workDir, { recursive: true, force: true })
 		throw error
 	}
+}
+
+export async function startAcpMcpFixture(
+	options: StartAcpFixtureOptions & { mcp: McpFixtureOptions },
+): Promise<AcpMcpFixture> {
+	const fixture = await startAcpFixture(options)
+	try {
+		assertAcpMcpFixture(fixture)
+		return fixture
+	} catch (error) {
+		await fixture.stop().catch(() => {})
+		throw error
+	}
+}
+
+function assertAcpMcpFixture(fixture: AcpFixture): asserts fixture is AcpMcpFixture {
+	if (!fixture.mcp) throw new Error("MCP test fixture was requested but not created")
 }
 
 function mergeCapabilities(

--- a/tests/e2e/mcp/conformance-client.ts
+++ b/tests/e2e/mcp/conformance-client.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+
+import { startAcpMcpFixture } from "../acp/support/acp-fixture.js"
+import { newSession, prompt } from "../acp/support/scenarios.js"
+import { connectMcpServer, gatewayMcpCall, modelReply } from "../tui/support/mcp-model-script.js"
+
+const scenario = process.env.MCP_CONFORMANCE_SCENARIO
+const serverUrl = process.argv.at(-1)
+const toolScenarios = new Set(["initialize", "tools_call", "tools-call", "sse-retry"])
+const authScenarios = new Set(["auth/metadata-default", "auth/pre-registration"])
+const supportedScenarios = new Set([...toolScenarios, ...authScenarios])
+function log(message: string): void {
+	process.stderr.write(`[mcp-conformance] ${message}\n`)
+}
+
+if (!scenario || !supportedScenarios.has(scenario)) {
+	throw new Error(`Unsupported Kimchi MCP conformance scenario: ${scenario ?? "(missing)"}`)
+}
+if (!serverUrl?.startsWith("http://") && !serverUrl?.startsWith("https://")) {
+	throw new Error(`MCP conformance runner did not provide a server URL: ${serverUrl ?? "(missing)"}`)
+}
+
+if (authScenarios.has(scenario)) {
+	await runAuthScenario(scenario, serverUrl)
+	process.exit(0)
+}
+
+const connect = connectMcpServer("conformance")
+const toolCall = gatewayMcpCall(
+	"__MCP_FIRST_TOOL__",
+	{ a: 2, b: 3 },
+	{
+		serverName: "conformance",
+		toolPrefix: "none",
+	},
+)
+const fixture = await startAcpMcpFixture({
+	artifactName: `mcp-conformance-${scenario.replaceAll("/", "-")}`,
+	mcp: { transport: "http", externalUrl: serverUrl, serverName: "conformance" },
+	responses: [connect.response, toolCall.response, modelReply("Kimchi MCP conformance scenario completed.")],
+})
+log(`Kimchi ACP fixture started for ${scenario}`)
+
+try {
+	const sessionId = await newSession(fixture, fixture.workDir)
+	log(`ACP session ready: ${sessionId}`)
+	const result = await prompt(fixture, sessionId, `Run MCP conformance scenario ${scenario}`)
+	log(`ACP prompt stopped with ${result.stopReason}`)
+	if (result.stopReason !== "end_turn") {
+		throw new Error(`Kimchi ACP conformance turn stopped with ${result.stopReason}`)
+	}
+	if (!result.chunks.includes("Kimchi MCP conformance scenario completed.")) {
+		throw new Error(`Kimchi ACP conformance turn did not complete: ${result.chunks}`)
+	}
+} finally {
+	await fixture.stop()
+	log("fixture stopped")
+}
+
+// The ACP SDK connection retains reader state after the child process closes.
+// All owned resources are stopped above, so terminate the short-lived conformance driver explicitly.
+process.exit(0)
+
+async function runAuthScenario(name: string, url: string): Promise<void> {
+	const rawContext = process.env.MCP_CONFORMANCE_CONTEXT
+	const context = rawContext ? (JSON.parse(rawContext) as Record<string, unknown>) : {}
+	const clientId = typeof context.client_id === "string" ? context.client_id : undefined
+	const clientSecret = typeof context.client_secret === "string" ? context.client_secret : undefined
+	const fixture = await startAcpMcpFixture({
+		artifactName: `mcp-conformance-${name.replaceAll("/", "-")}`,
+		mcp: {
+			transport: "oauth",
+			externalUrl: url,
+			serverName: "conformance",
+			oauth: {
+				...(clientId ? { clientId } : {}),
+				...(clientSecret ? { clientSecret } : {}),
+			},
+		},
+		responses: [],
+	})
+	log(`Kimchi ACP fixture started for ${name}`)
+
+	try {
+		const result = await fixture.conn.extMethod("_kimchi.dev/probe_mcp_server", {
+			server: fixture.mcp.serverDefinition,
+			serverName: "conformance",
+		})
+		if (result.needsAuth !== false || result.error !== null) {
+			throw new Error(`Kimchi MCP conformance authentication did not settle: ${JSON.stringify(result)}`)
+		}
+		log(`Kimchi completed ${name}`)
+	} finally {
+		await fixture.stop()
+		log("fixture stopped")
+	}
+}

--- a/tests/e2e/mcp/conformance-client.ts
+++ b/tests/e2e/mcp/conformance-client.ts
@@ -5,7 +5,7 @@ import { newSession, prompt } from "../acp/support/scenarios.js"
 import { connectMcpServer, gatewayMcpCall, modelReply } from "../tui/support/mcp-model-script.js"
 
 const scenario = process.env.MCP_CONFORMANCE_SCENARIO
-const serverUrl = process.argv.at(-1)
+const serverUrl = process.argv[2]
 const toolScenarios = new Set(["initialize", "tools_call", "tools-call", "sse-retry"])
 const authScenarios = new Set(["auth/metadata-default", "auth/pre-registration"])
 const supportedScenarios = new Set([...toolScenarios, ...authScenarios])

--- a/tests/e2e/mcp/fixture-server.mjs
+++ b/tests/e2e/mcp/fixture-server.mjs
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto"
 import { appendFileSync } from "node:fs"
 import { createServer } from "node:http"
 import { setTimeout as delay } from "node:timers/promises"
+import { isDeepStrictEqual } from "node:util"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
@@ -24,6 +25,16 @@ const oauthClientId = process.env.KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_ID ?? "kimchi-
 const oauthClientSecret = process.env.KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_SECRET ?? "kimchi-e2e-client-secret"
 const oauthAccessToken = "kimchi-e2e-oauth-access-token"
 const oauthRefreshToken = "kimchi-e2e-oauth-refresh-token"
+const fixtureBehavior = process.env.KIMCHI_MCP_FIXTURE_BEHAVIOR
+	? JSON.parse(process.env.KIMCHI_MCP_FIXTURE_BEHAVIOR)
+	: {}
+
+function findToolBehavior(name, args) {
+	return fixtureBehavior.tools?.find(
+		(behavior) =>
+			behavior.name === name && (behavior.arguments === undefined || isDeepStrictEqual(behavior.arguments, args ?? {})),
+	)
+}
 
 function record(type, details = {}) {
 	if (!eventPath) return
@@ -125,55 +136,25 @@ function createFixtureServer() {
 	server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 		const { uri } = request.params
 		record("resource_read", { uri })
-		if (uri === "ui://fixture/app" && scenario === "ui-app") {
-			return {
-				contents: [
-					{
-						uri,
-						mimeType: "text/html;profile=mcp-app",
-						text: '<!doctype html><html><body><main id="kimchi-mcp-app">Kimchi MCP App fixture</main></body></html>',
-					},
-				],
-			}
-		}
-		if (uri !== "fixture://note") throw new Error(`Unknown fixture resource: ${uri}`)
-		return {
-			contents: [{ uri, mimeType: "text/plain", text: "fixture resource: kimchi-mcp-resource" }],
-		}
+		const configured = fixtureBehavior.resources?.find((behavior) => behavior.uri === uri)
+		if (configured) return configured.response
+		throw new Error(`No MCP fixture resource response configured for ${uri}`)
 	})
 
 	server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
 		const { name, arguments: args } = request.params
 		record("tool_called", { name, arguments: args ?? {} })
+		const behavior = findToolBehavior(name, args)
 
-		if (name === "fail") {
-			return {
-				isError: true,
-				content: [{ type: "text", text: "fixture failure: requested by test" }],
-			}
-		}
+		if (behavior?.response.type === "result") return behavior.response.value
 
-		if (name === "mixed_content") {
-			return {
-				content: [
-					{ type: "text", text: "fixture mixed content: kimchi-mcp-mixed" },
-					{
-						type: "image",
-						mimeType: "image/png",
-						data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
-					},
-				],
-				structuredContent: { fixture: "kimchi-mcp-structured", count: 1 },
-			}
-		}
-
-		if (name === "disconnect") {
+		if (behavior?.response.type === "exit") {
 			record("disconnect_started")
-			setTimeout(() => process.exit(17), 0)
+			setTimeout(() => process.exit(behavior.response.code), 0)
 			return new Promise(() => {})
 		}
 
-		if (name === "slow") {
+		if (behavior?.response.type === "delayed-result") {
 			record("slow_call_started")
 			let onAbort
 			const aborted = new Promise((_, reject) => {
@@ -184,34 +165,22 @@ function createFixtureServer() {
 				extra.signal.addEventListener("abort", onAbort, { once: true })
 			})
 			try {
-				await Promise.race([delay(2_000), aborted])
+				await Promise.race([delay(behavior.response.delayMs), aborted])
 				record("slow_call_completed")
-				return { content: [{ type: "text", text: "fixture slow call completed" }] }
+				return behavior.response.value
 			} finally {
 				if (onAbort) extra.signal.removeEventListener("abort", onAbort)
 			}
 		}
 
-		if (name === "open_ui" && scenario === "ui-app") {
-			return { content: [{ type: "text", text: "fixture MCP App opened" }] }
-		}
-
-		if (name !== "echo") {
-			return {
-				isError: true,
-				content: [{ type: "text", text: `Unknown fixture tool: ${name}` }],
-			}
-		}
-
-		if (typeof args?.message !== "string") {
-			return {
-				isError: true,
-				content: [{ type: "text", text: "fixture validation: message must be a string" }],
-			}
-		}
-		const message = args.message
 		return {
-			content: [{ type: "text", text: `fixture echo: ${message}` }],
+			isError: true,
+			content: [
+				{
+					type: "text",
+					text: `No MCP fixture response configured for ${name} with arguments ${JSON.stringify(args ?? {})}`,
+				},
+			],
 		}
 	})
 
@@ -518,6 +487,6 @@ async function runHttpFixture() {
 process.on("exit", (code) => record("process_exited", { code }))
 record("process_started", { transport: transportKind })
 
-if (scenario === "startup-failure") process.exit(23)
+if (fixtureBehavior.startup?.type === "exit") process.exit(fixtureBehavior.startup.code)
 else if (transportKind === "http" || transportKind === "sse") await runHttpFixture()
 else await createFixtureServer().connect(new StdioServerTransport())

--- a/tests/e2e/mcp/fixture-server.mjs
+++ b/tests/e2e/mcp/fixture-server.mjs
@@ -1,0 +1,523 @@
+import { createHash, randomUUID } from "node:crypto"
+import { appendFileSync } from "node:fs"
+import { createServer } from "node:http"
+import { setTimeout as delay } from "node:timers/promises"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import {
+	CallToolRequestSchema,
+	isInitializeRequest,
+	ListResourcesRequestSchema,
+	ListToolsRequestSchema,
+	ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+
+const eventPath = process.env.KIMCHI_MCP_FIXTURE_EVENTS
+const scenario = process.env.KIMCHI_MCP_FIXTURE_SCENARIO ?? "basic"
+const transportKind = process.env.KIMCHI_MCP_FIXTURE_TRANSPORT ?? "stdio"
+const expectedBearerToken = process.env.KIMCHI_MCP_FIXTURE_BEARER_TOKEN
+const oauthEnabled = process.env.KIMCHI_MCP_FIXTURE_OAUTH === "1"
+const oauthGrantType = process.env.KIMCHI_MCP_FIXTURE_OAUTH_GRANT_TYPE ?? "authorization_code"
+const oauthClientId = process.env.KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_ID ?? "kimchi-e2e-client"
+const oauthClientSecret = process.env.KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_SECRET ?? "kimchi-e2e-client-secret"
+const oauthAccessToken = "kimchi-e2e-oauth-access-token"
+const oauthRefreshToken = "kimchi-e2e-oauth-refresh-token"
+
+function record(type, details = {}) {
+	if (!eventPath) return
+	appendFileSync(
+		eventPath,
+		`${JSON.stringify({ type, at: new Date().toISOString(), pid: process.pid, scenario, ...details })}\n`,
+		"utf-8",
+	)
+}
+
+function createFixtureServer() {
+	const server = new Server(
+		{ name: "kimchi-mcp-e2e-fixture", version: "1.0.0" },
+		{ capabilities: { tools: {}, resources: {} } },
+	)
+
+	server.oninitialized = () => record("initialized")
+
+	server.setRequestHandler(ListToolsRequestSchema, async () => {
+		record("tools_listed")
+		const uiTools =
+			scenario === "ui-app"
+				? [
+						{
+							name: "open_ui",
+							description: "Open the deterministic Kimchi MCP App fixture",
+							inputSchema: { type: "object", properties: {}, additionalProperties: false },
+							_meta: { ui: { resourceUri: "ui://fixture/app" } },
+						},
+					]
+				: []
+		return {
+			tools: [
+				{
+					name: "echo",
+					description: "Echo deterministic text for Kimchi MCP end-to-end tests",
+					inputSchema: {
+						type: "object",
+						properties: {
+							message: { type: "string", description: "Text returned by the fixture" },
+						},
+						required: ["message"],
+						additionalProperties: false,
+					},
+					annotations: { readOnlyHint: true },
+				},
+				{
+					name: "fail",
+					description: "Return a deterministic MCP tool error for Kimchi end-to-end tests",
+					inputSchema: { type: "object", properties: {}, additionalProperties: false },
+				},
+				{
+					name: "mixed_content",
+					description: "Return deterministic text, image, and structured MCP content",
+					inputSchema: { type: "object", properties: {}, additionalProperties: false },
+					annotations: { readOnlyHint: true },
+				},
+				{
+					name: "disconnect",
+					description: "Exit the stdio fixture during a tool call",
+					inputSchema: { type: "object", properties: {}, additionalProperties: false },
+				},
+				{
+					name: "slow",
+					description: "Wait for cancellation or a bounded delay",
+					inputSchema: { type: "object", properties: {}, additionalProperties: false },
+				},
+				...uiTools,
+			],
+		}
+	})
+
+	server.setRequestHandler(ListResourcesRequestSchema, async () => {
+		record("resources_listed")
+		const uiResources =
+			scenario === "ui-app"
+				? [
+						{
+							name: "fixture app",
+							uri: "ui://fixture/app",
+							description: "Deterministic MCP App for Kimchi end-to-end tests",
+							mimeType: "text/html;profile=mcp-app",
+						},
+					]
+				: []
+		return {
+			resources: [
+				{
+					name: "fixture note",
+					uri: "fixture://note",
+					description: "Deterministic MCP resource for Kimchi end-to-end tests",
+					mimeType: "text/plain",
+				},
+				...uiResources,
+			],
+		}
+	})
+
+	server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+		const { uri } = request.params
+		record("resource_read", { uri })
+		if (uri === "ui://fixture/app" && scenario === "ui-app") {
+			return {
+				contents: [
+					{
+						uri,
+						mimeType: "text/html;profile=mcp-app",
+						text: '<!doctype html><html><body><main id="kimchi-mcp-app">Kimchi MCP App fixture</main></body></html>',
+					},
+				],
+			}
+		}
+		if (uri !== "fixture://note") throw new Error(`Unknown fixture resource: ${uri}`)
+		return {
+			contents: [{ uri, mimeType: "text/plain", text: "fixture resource: kimchi-mcp-resource" }],
+		}
+	})
+
+	server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+		const { name, arguments: args } = request.params
+		record("tool_called", { name, arguments: args ?? {} })
+
+		if (name === "fail") {
+			return {
+				isError: true,
+				content: [{ type: "text", text: "fixture failure: requested by test" }],
+			}
+		}
+
+		if (name === "mixed_content") {
+			return {
+				content: [
+					{ type: "text", text: "fixture mixed content: kimchi-mcp-mixed" },
+					{
+						type: "image",
+						mimeType: "image/png",
+						data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+					},
+				],
+				structuredContent: { fixture: "kimchi-mcp-structured", count: 1 },
+			}
+		}
+
+		if (name === "disconnect") {
+			record("disconnect_started")
+			setTimeout(() => process.exit(17), 0)
+			return new Promise(() => {})
+		}
+
+		if (name === "slow") {
+			record("slow_call_started")
+			let onAbort
+			const aborted = new Promise((_, reject) => {
+				onAbort = () => {
+					record("slow_call_cancelled")
+					reject(new Error("fixture slow call cancelled"))
+				}
+				extra.signal.addEventListener("abort", onAbort, { once: true })
+			})
+			try {
+				await Promise.race([delay(2_000), aborted])
+				record("slow_call_completed")
+				return { content: [{ type: "text", text: "fixture slow call completed" }] }
+			} finally {
+				if (onAbort) extra.signal.removeEventListener("abort", onAbort)
+			}
+		}
+
+		if (name === "open_ui" && scenario === "ui-app") {
+			return { content: [{ type: "text", text: "fixture MCP App opened" }] }
+		}
+
+		if (name !== "echo") {
+			return {
+				isError: true,
+				content: [{ type: "text", text: `Unknown fixture tool: ${name}` }],
+			}
+		}
+
+		if (typeof args?.message !== "string") {
+			return {
+				isError: true,
+				content: [{ type: "text", text: "fixture validation: message must be a string" }],
+			}
+		}
+		const message = args.message
+		return {
+			content: [{ type: "text", text: `fixture echo: ${message}` }],
+		}
+	})
+
+	return server
+}
+
+async function readBody(request) {
+	const chunks = []
+	for await (const chunk of request) chunks.push(chunk)
+	return Buffer.concat(chunks).toString("utf-8")
+}
+
+async function readJsonBody(request) {
+	const body = await readBody(request)
+	if (!body) return undefined
+	return JSON.parse(body)
+}
+
+function sendJson(response, statusCode, body) {
+	response.writeHead(statusCode, { "content-type": "application/json" })
+	response.end(JSON.stringify(body))
+}
+
+async function runHttpFixture() {
+	const sessions = new Map()
+	const authorizationCodes = new Map()
+	let oauthAccessTokenExpiresAt = 0
+	let origin = ""
+	const httpServer = createServer(async (request, response) => {
+		try {
+			const url = new URL(request.url ?? "/", "http://fixture.invalid")
+			if (scenario === "http-malformed" && url.pathname === "/mcp") {
+				record("http_malformed_response", { method: request.method })
+				response.writeHead(200, { "content-type": "application/json" })
+				response.end("{not-valid-json")
+				return
+			}
+
+			if (transportKind === "sse" && url.pathname === "/sse") {
+				if (request.method !== "GET") {
+					record("sse_streamable_rejected", { method: request.method })
+					response.writeHead(405)
+					response.end("SSE endpoint requires GET")
+					return
+				}
+				const server = createFixtureServer()
+				const transport = new SSEServerTransport("/messages", response)
+				sessions.set(transport.sessionId, { server, transport })
+				transport.onclose = () => {
+					sessions.delete(transport.sessionId)
+					record("sse_session_closed", { sessionId: transport.sessionId })
+				}
+				record("sse_session_initialized", { sessionId: transport.sessionId })
+				await server.connect(transport)
+				return
+			}
+
+			if (transportKind === "sse" && request.method === "POST" && url.pathname === "/messages") {
+				const activeSession = sessions.get(url.searchParams.get("sessionId"))
+				if (!activeSession) {
+					sendJson(response, 404, { error: "SSE session not found" })
+					return
+				}
+				record("sse_message", { sessionId: url.searchParams.get("sessionId") })
+				await activeSession.transport.handlePostMessage(request, response, await readJsonBody(request))
+				return
+			}
+
+			if (oauthEnabled && url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
+				record("oauth_resource_metadata_requested", { path: url.pathname })
+				sendJson(response, 200, {
+					resource: `${origin}/mcp`,
+					authorization_servers: [origin],
+					scopes_supported: ["mcp:tools"],
+				})
+				return
+			}
+
+			if (oauthEnabled && url.pathname === "/.well-known/oauth-authorization-server") {
+				record("oauth_server_metadata_requested")
+				sendJson(response, 200, {
+					issuer: origin,
+					authorization_endpoint: `${origin}/authorize`,
+					token_endpoint: `${origin}/token`,
+					registration_endpoint: `${origin}/register`,
+					response_types_supported: ["code"],
+					grant_types_supported:
+						oauthGrantType === "client_credentials" ? ["client_credentials"] : ["authorization_code", "refresh_token"],
+					code_challenge_methods_supported: ["S256"],
+					token_endpoint_auth_methods_supported:
+						oauthGrantType === "client_credentials" ? ["client_secret_post"] : ["none"],
+					scopes_supported: ["mcp:tools"],
+				})
+				return
+			}
+
+			if (oauthEnabled && request.method === "POST" && url.pathname === "/register") {
+				const metadata = await readJsonBody(request)
+				record("oauth_client_registered", { redirectUris: metadata?.redirect_uris })
+				sendJson(response, 201, {
+					...metadata,
+					client_id: "kimchi-e2e-oauth-client",
+					client_id_issued_at: Math.floor(Date.now() / 1000),
+				})
+				return
+			}
+
+			if (oauthEnabled && request.method === "GET" && url.pathname === "/authorize") {
+				const redirectUri = url.searchParams.get("redirect_uri")
+				const state = url.searchParams.get("state")
+				const codeChallenge = url.searchParams.get("code_challenge")
+				const codeChallengeMethod = url.searchParams.get("code_challenge_method")
+				if (!redirectUri || !state || !codeChallenge || codeChallengeMethod !== "S256") {
+					sendJson(response, 400, { error: "invalid_request" })
+					return
+				}
+				if (scenario === "oauth-deny") {
+					record("oauth_authorization_denied", { redirectUri })
+					const callback = new URL(redirectUri)
+					callback.searchParams.set("error", "access_denied")
+					callback.searchParams.set("error_description", "fixture authorization denied")
+					callback.searchParams.set("state", state)
+					response.writeHead(302, { location: callback.toString() })
+					response.end()
+					return
+				}
+				const code = `kimchi-e2e-code-${randomUUID()}`
+				authorizationCodes.set(code, {
+					clientId: url.searchParams.get("client_id"),
+					codeChallenge,
+					redirectUri,
+				})
+				record("oauth_authorized", { redirectUri, state, codeChallengeMethod })
+				const callback = new URL(redirectUri)
+				callback.searchParams.set("code", code)
+				callback.searchParams.set("state", state)
+				response.writeHead(302, { location: callback.toString() })
+				response.end()
+				return
+			}
+
+			if (oauthEnabled && request.method === "POST" && url.pathname === "/token") {
+				const params = new URLSearchParams(await readBody(request))
+				const grantType = params.get("grant_type")
+				if (scenario === "oauth-token-failure") {
+					record("oauth_token_rejected", { grantType })
+					sendJson(response, 400, { error: "invalid_grant", error_description: "fixture token rejection" })
+					return
+				}
+				if (grantType === "client_credentials") {
+					const credentialsValid =
+						params.get("client_id") === oauthClientId && params.get("client_secret") === oauthClientSecret
+					if (!credentialsValid) {
+						record("oauth_token_rejected", { grantType })
+						sendJson(response, 401, { error: "invalid_client" })
+						return
+					}
+					record("oauth_token_issued", { grantType, expiresIn: 3600 })
+					oauthAccessTokenExpiresAt = Date.now() + 3_600_000
+					sendJson(response, 200, {
+						access_token: oauthAccessToken,
+						token_type: "Bearer",
+						expires_in: 3600,
+						scope: params.get("scope") ?? "mcp:tools",
+					})
+					return
+				}
+				if (grantType === "authorization_code") {
+					const code = params.get("code")
+					const authorization = code ? authorizationCodes.get(code) : undefined
+					const verifier = params.get("code_verifier")
+					const challenge = verifier ? createHash("sha256").update(verifier).digest("base64url") : undefined
+					if (
+						!authorization ||
+						challenge !== authorization.codeChallenge ||
+						params.get("redirect_uri") !== authorization.redirectUri
+					) {
+						sendJson(response, 400, { error: "invalid_grant" })
+						return
+					}
+					const expiresIn = scenario === "oauth-expiring" ? 1 : 3600
+					authorizationCodes.delete(code)
+					record("oauth_token_issued", { grantType, pkceVerified: true, expiresIn })
+					oauthAccessTokenExpiresAt = Date.now() + expiresIn * 1000
+					sendJson(response, 200, {
+						access_token: oauthAccessToken,
+						token_type: "Bearer",
+						expires_in: expiresIn,
+						refresh_token: oauthRefreshToken,
+						scope: "mcp:tools",
+					})
+					return
+				}
+				if (grantType === "refresh_token" && params.get("refresh_token") === oauthRefreshToken) {
+					record("oauth_token_issued", { grantType, expiresIn: 3600 })
+					oauthAccessTokenExpiresAt = Date.now() + 3_600_000
+					sendJson(response, 200, {
+						access_token: oauthAccessToken,
+						token_type: "Bearer",
+						expires_in: 3600,
+						refresh_token: oauthRefreshToken,
+						scope: "mcp:tools",
+					})
+					return
+				}
+				sendJson(response, 400, { error: "unsupported_grant_type" })
+				return
+			}
+
+			if (url.pathname !== "/mcp") {
+				sendJson(response, 404, { error: "not found" })
+				return
+			}
+
+			const authorization = request.headers.authorization
+			const authorized = oauthEnabled
+				? authorization === `Bearer ${oauthAccessToken}` && Date.now() < oauthAccessTokenExpiresAt
+				: expectedBearerToken === undefined || authorization === `Bearer ${expectedBearerToken}`
+			const sessionIdHeader = request.headers["mcp-session-id"]
+			const sessionId = typeof sessionIdHeader === "string" ? sessionIdHeader : undefined
+			record("http_request", {
+				method: request.method,
+				path: url.pathname,
+				sessionId,
+				authorized,
+				testHeader: request.headers["x-kimchi-e2e"],
+			})
+
+			if (!authorized) {
+				record("http_unauthorized", { method: request.method, path: url.pathname })
+				response.writeHead(401, {
+					"www-authenticate": oauthEnabled
+						? `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`
+						: "Bearer",
+				})
+				response.end("Unauthorized")
+				return
+			}
+
+			if (request.method === "POST") {
+				const body = await readJsonBody(request)
+				const activeSession = sessionId ? sessions.get(sessionId) : undefined
+				if (activeSession) {
+					await activeSession.transport.handleRequest(request, response, body)
+					return
+				}
+				if (!sessionId && isInitializeRequest(body)) {
+					const server = createFixtureServer()
+					const transport = new StreamableHTTPServerTransport({
+						sessionIdGenerator: () => randomUUID(),
+						onsessioninitialized: (initializedSessionId) => {
+							sessions.set(initializedSessionId, { server, transport })
+							record("http_session_initialized", { sessionId: initializedSessionId })
+						},
+					})
+					transport.onclose = () => {
+						if (transport.sessionId) sessions.delete(transport.sessionId)
+						record("http_session_closed", { sessionId: transport.sessionId })
+					}
+					await server.connect(transport)
+					await transport.handleRequest(request, response, body)
+					return
+				}
+				sendJson(response, 400, {
+					jsonrpc: "2.0",
+					error: { code: -32_000, message: "Bad Request: no valid session ID provided" },
+					id: null,
+				})
+				return
+			}
+
+			const activeSession = sessionId ? sessions.get(sessionId) : undefined
+			if (activeSession && (request.method === "GET" || request.method === "DELETE")) {
+				await activeSession.transport.handleRequest(request, response)
+				return
+			}
+			sendJson(response, 400, { error: "invalid or missing MCP session" })
+		} catch (error) {
+			record("http_error", { message: error instanceof Error ? error.message : String(error) })
+			if (!response.headersSent) sendJson(response, 500, { error: "fixture server error" })
+			else response.end()
+		}
+	})
+
+	await new Promise((resolve, reject) => {
+		httpServer.once("error", reject)
+		httpServer.listen(0, "127.0.0.1", resolve)
+	})
+	const address = httpServer.address()
+	if (!address || typeof address === "string") throw new Error("Fixture HTTP server did not get a TCP address")
+	origin = `http://127.0.0.1:${address.port}`
+	record("http_listening", { url: transportKind === "sse" ? `${origin}/sse` : `${origin}/mcp` })
+
+	const shutdown = async (signal) => {
+		record("process_stopping", { signal })
+		for (const { transport } of sessions.values()) await transport.close().catch(() => {})
+		await new Promise((resolve) => httpServer.close(resolve))
+		process.exit(0)
+	}
+	process.once("SIGTERM", () => void shutdown("SIGTERM"))
+	process.once("SIGINT", () => void shutdown("SIGINT"))
+}
+
+process.on("exit", (code) => record("process_exited", { code }))
+record("process_started", { transport: transportKind })
+
+if (scenario === "startup-failure") process.exit(23)
+else if (transportKind === "http" || transportKind === "sse") await runHttpFixture()
+else await createFixtureServer().connect(new StdioServerTransport())

--- a/tests/e2e/tui/mcp-failures.test.ts
+++ b/tests/e2e/tui/mcp-failures.test.ts
@@ -7,11 +7,25 @@ test.use(TUI_TEST_CONFIG)
 
 test("returns MCP argument validation failures to the model without ending the session", async ({ terminal }) => {
 	const invalidEcho = gatewayMcpCall("echo", {})
+	const validationMessage = "fixture validation: message must be a string"
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-invalid-arguments",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						{
+							name: "echo",
+							arguments: {},
+							response: {
+								type: "result",
+								value: { isError: true, content: [{ type: "text", text: validationMessage }] },
+							},
+						},
+					],
+				},
+			},
 			responses: [invalidEcho.response, modelReply("Kimchi surfaced the MCP validation error and continued.")],
 		},
 		async (fixture, trace) => {
@@ -20,9 +34,7 @@ test("returns MCP argument validation failures to the model without ending the s
 				timeoutMs: STREAM_TIMEOUT_MS,
 			})
 			await fixture.mcp.waitForEvent("tool_called", { where: { name: "echo", arguments: {} } })
-			expect(toolResultText(fixture.fake.requests, invalidEcho)).toContain(
-				"fixture validation: message must be a string",
-			)
+			expect(toolResultText(fixture.fake.requests, invalidEcho)).toContain(validationMessage)
 			trace.step("invalid MCP arguments reached the server and returned as a bounded tool error")
 		},
 	)
@@ -30,11 +42,21 @@ test("returns MCP argument validation failures to the model without ending the s
 
 test("settles the agent turn when a stdio MCP server exits during a call", async ({ terminal }) => {
 	const disconnect = gatewayMcpCall("disconnect")
+	const disconnectExitCode = 17
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-disconnect-during-call",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						{
+							name: "disconnect",
+							response: { type: "exit", code: disconnectExitCode },
+						},
+					],
+				},
+			},
 			responses: [disconnect.response, modelReply("Kimchi recovered after the MCP server disconnected.")],
 		},
 		async (fixture, trace) => {
@@ -42,8 +64,10 @@ test("settles the agent turn when a stdio MCP server exits during a call", async
 			await waitForText(terminal, "Kimchi recovered after the MCP server disconnected.", {
 				timeoutMs: STREAM_TIMEOUT_MS,
 			})
-			const exited = await fixture.mcp.waitForEvent("process_exited", { where: { code: 17 } })
-			expect(exited.code).toBe(17)
+			const exited = await fixture.mcp.waitForEvent("process_exited", {
+				where: { code: disconnectExitCode },
+			})
+			expect(exited.code).toBe(disconnectExitCode)
 			expect(toolResultText(fixture.fake.requests, disconnect)).toContain("Failed to call tool")
 			trace.step("transport disconnect became a model-facing error and the turn settled")
 		},
@@ -52,15 +76,19 @@ test("settles the agent turn when a stdio MCP server exits during a call", async
 
 test("starts Kimchi in a usable degraded state when an eager MCP server fails startup", async ({ terminal }) => {
 	const echo = gatewayMcpCall("echo", {})
+	const startupExitCode = 23
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-startup-failure",
-			mcp: { scenario: "startup-failure", lifecycle: "eager" },
+			mcp: {
+				lifecycle: "eager",
+				behavior: { startup: { type: "exit", code: startupExitCode } },
+			},
 			responses: [echo.response, modelReply("The main Kimchi session remained usable after MCP startup failed.")],
 		},
 		async (fixture, trace) => {
-			await fixture.mcp.waitForEvent("process_exited", { where: { code: 23 } })
+			await fixture.mcp.waitForEvent("process_exited", { where: { code: startupExitCode } })
 			terminal.submit("Continue despite the broken MCP fixture")
 			await waitForText(terminal, "The main Kimchi session remained usable after MCP startup failed.", {
 				timeoutMs: STREAM_TIMEOUT_MS,
@@ -73,11 +101,25 @@ test("starts Kimchi in a usable degraded state when an eager MCP server fails st
 
 test("completes a bounded slow MCP call without hanging the session", async ({ terminal }) => {
 	const slow = gatewayMcpCall("slow")
+	const slowResult = "fixture slow call completed"
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-bounded-slow-call",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						{
+							name: "slow",
+							response: {
+								type: "delayed-result",
+								delayMs: 2_000,
+								value: { content: [{ type: "text", text: slowResult }] },
+							},
+						},
+					],
+				},
+			},
 			responses: [slow.response, modelReply("The bounded slow MCP call completed.")],
 		},
 		async (fixture, trace) => {
@@ -85,7 +127,7 @@ test("completes a bounded slow MCP call without hanging the session", async ({ t
 			await fixture.mcp.waitForEvent("slow_call_started")
 			await waitForText(terminal, "The bounded slow MCP call completed.", { timeoutMs: STREAM_TIMEOUT_MS })
 			expect(fixture.mcp.hasEvent("slow_call_completed")).toBe(true)
-			expect(toolResultText(fixture.fake.requests, slow)).toContain("fixture slow call completed")
+			expect(toolResultText(fixture.fake.requests, slow)).toContain(slowResult)
 			trace.step("bounded delayed MCP request completed and the turn settled")
 		},
 	)
@@ -93,13 +135,28 @@ test("completes a bounded slow MCP call without hanging the session", async ({ t
 
 // Known product bug: the MCP gateway tool receives Pi's AbortSignal but currently ignores
 // it, so cancelling an agent turn does not send MCP notifications/cancelled to the server.
+// Fixed upstream in pi-mcp-adapter v2.11.0 by PR #159; remove test.fail once the bundled
+// adapter includes that fix.
 test.fail("propagates agent-turn cancellation to an in-flight MCP request", async ({ terminal }) => {
 	const slow = gatewayMcpCall("slow")
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-call-cancellation",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						{
+							name: "slow",
+							response: {
+								type: "delayed-result",
+								delayMs: 2_000,
+								value: { content: [{ type: "text", text: "fixture slow call completed" }] },
+							},
+						},
+					],
+				},
+			},
 			responses: [slow.response],
 		},
 		async (fixture, trace) => {

--- a/tests/e2e/tui/mcp-failures.test.ts
+++ b/tests/e2e/tui/mcp-failures.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { gatewayMcpCall, modelReply, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("returns MCP argument validation failures to the model without ending the session", async ({ terminal }) => {
+	const invalidEcho = gatewayMcpCall("echo", {})
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-invalid-arguments",
+			mcp: {},
+			responses: [invalidEcho.response, modelReply("Kimchi surfaced the MCP validation error and continued.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call MCP echo with invalid arguments")
+			await waitForText(terminal, "Kimchi surfaced the MCP validation error and continued.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("tool_called", { where: { name: "echo", arguments: {} } })
+			expect(toolResultText(fixture.fake.requests, invalidEcho)).toContain(
+				"fixture validation: message must be a string",
+			)
+			trace.step("invalid MCP arguments reached the server and returned as a bounded tool error")
+		},
+	)
+})
+
+test("settles the agent turn when a stdio MCP server exits during a call", async ({ terminal }) => {
+	const disconnect = gatewayMcpCall("disconnect")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-disconnect-during-call",
+			mcp: {},
+			responses: [disconnect.response, modelReply("Kimchi recovered after the MCP server disconnected.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Exercise an MCP server disconnect")
+			await waitForText(terminal, "Kimchi recovered after the MCP server disconnected.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			const exited = await fixture.mcp.waitForEvent("process_exited", { where: { code: 17 } })
+			expect(exited.code).toBe(17)
+			expect(toolResultText(fixture.fake.requests, disconnect)).toContain("Failed to call tool")
+			trace.step("transport disconnect became a model-facing error and the turn settled")
+		},
+	)
+})
+
+test("starts Kimchi in a usable degraded state when an eager MCP server fails startup", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", {})
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-startup-failure",
+			mcp: { scenario: "startup-failure", lifecycle: "eager" },
+			responses: [echo.response, modelReply("The main Kimchi session remained usable after MCP startup failed.")],
+		},
+		async (fixture, trace) => {
+			await fixture.mcp.waitForEvent("process_exited", { where: { code: 23 } })
+			terminal.submit("Continue despite the broken MCP fixture")
+			await waitForText(terminal, "The main Kimchi session remained usable after MCP startup failed.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toMatch(/failed|not (?:available|connected)|not found/i)
+			trace.step("startup failure stayed isolated from the main agent session")
+		},
+	)
+})
+
+test("completes a bounded slow MCP call without hanging the session", async ({ terminal }) => {
+	const slow = gatewayMcpCall("slow")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-bounded-slow-call",
+			mcp: {},
+			responses: [slow.response, modelReply("The bounded slow MCP call completed.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Wait for the bounded MCP operation")
+			await fixture.mcp.waitForEvent("slow_call_started")
+			await waitForText(terminal, "The bounded slow MCP call completed.", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(fixture.mcp.hasEvent("slow_call_completed")).toBe(true)
+			expect(toolResultText(fixture.fake.requests, slow)).toContain("fixture slow call completed")
+			trace.step("bounded delayed MCP request completed and the turn settled")
+		},
+	)
+})
+
+// Known product bug: the MCP gateway tool receives Pi's AbortSignal but currently ignores
+// it, so cancelling an agent turn does not send MCP notifications/cancelled to the server.
+test.fail("propagates agent-turn cancellation to an in-flight MCP request", async ({ terminal }) => {
+	const slow = gatewayMcpCall("slow")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-call-cancellation",
+			mcp: {},
+			responses: [slow.response],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Start an MCP call that I will cancel")
+			await fixture.mcp.waitForEvent("slow_call_started")
+			terminal.keyCtrlC()
+			await fixture.mcp.waitForEvent("slow_call_cancelled", {
+				timeoutMs: 1_000,
+				description: "MCP cancellation notification",
+			})
+			expect(fixture.mcp.hasEvent("slow_call_completed")).toBe(false)
+			trace.step("agent cancellation reached the MCP server")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-http.test.ts
+++ b/tests/e2e/tui/mcp-http.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { gatewayMcpCall, modelReply, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("calls a Streamable HTTP MCP tool and preserves configured headers", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "streamable-http" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-http",
+			mcp: { transport: "http", headers: { "X-Kimchi-E2E": "fixture-header" } },
+			responses: [echo.response, modelReply("The Streamable HTTP MCP tool returned successfully.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call the MCP fixture over Streamable HTTP")
+			await waitForText(terminal, "The Streamable HTTP MCP tool returned successfully.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+
+			const call = await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "streamable-http" } },
+			})
+			expect(call.name).toBe("echo")
+			const requests = fixture.mcp.eventsOfType("http_request")
+			expect(requests.some((event) => event.testHeader === "fixture-header")).toBe(true)
+			expect(requests.some((event) => Boolean(event.sessionId))).toBe(true)
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: streamable-http")
+			trace.step("Streamable HTTP session, custom header, and model-facing result verified")
+		},
+	)
+})
+
+test("authenticates to a Streamable HTTP MCP server with a static bearer token", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "bearer-authenticated" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-http-bearer",
+			mcp: { transport: "http", bearerToken: "kimchi-e2e-bearer-token" },
+			responses: [echo.response, modelReply("The authenticated MCP request succeeded.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call the bearer-protected MCP fixture")
+			await waitForText(terminal, "The authenticated MCP request succeeded.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "bearer-authenticated" } },
+			})
+			expect(fixture.mcp.hasEvent("http_request", { authorized: true })).toBe(true)
+			expect(fixture.mcp.hasEvent("http_unauthorized")).toBe(false)
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: bearer-authenticated")
+			trace.step("static bearer authentication verified at the fixture boundary")
+		},
+	)
+})
+
+test("falls back from Streamable HTTP to the legacy MCP SSE transport", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "legacy-sse" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-sse-fallback",
+			mcp: { transport: "sse" },
+			responses: [echo.response, modelReply("Kimchi completed the MCP call through SSE fallback.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call MCP through the legacy SSE fallback")
+			await waitForText(terminal, "Kimchi completed the MCP call through SSE fallback.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "legacy-sse" } },
+			})
+			expect(fixture.mcp.hasEvent("sse_streamable_rejected")).toBe(true)
+			expect(fixture.mcp.hasEvent("sse_session_initialized")).toBe(true)
+			expect(fixture.mcp.hasEvent("sse_message")).toBe(true)
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: legacy-sse")
+			trace.step("Streamable HTTP failure and successful SSE fallback both observed")
+		},
+	)
+})
+
+test("keeps Kimchi usable when an HTTP MCP server returns malformed protocol data", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", {})
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-http-malformed",
+			mcp: { transport: "http", scenario: "http-malformed" },
+			responses: [echo.response, modelReply("Kimchi remained usable after malformed MCP HTTP data.")],
+		},
+		async (fixture, trace) => {
+			await fixture.mcp.waitForEvent("http_malformed_response")
+			terminal.submit("Continue after malformed MCP HTTP data")
+			await waitForText(terminal, "Kimchi remained usable after malformed MCP HTTP data.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toMatch(/failed|not (?:available|connected)|not found/i)
+			trace.step("malformed HTTP protocol data remained isolated from the main session")
+		},
+	)
+})
+
+test("settles a tool call when a connected HTTP MCP server becomes unavailable", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "server-is-down" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-http-unavailable",
+			mcp: { transport: "http" },
+			responses: [echo.response, modelReply("Kimchi recovered from the unavailable HTTP MCP server.")],
+		},
+		async (fixture, trace) => {
+			await fixture.mcp.waitForEvent("tools_listed")
+			await fixture.mcp.stop()
+			terminal.submit("Call the MCP server after it becomes unavailable")
+			await waitForText(terminal, "Kimchi recovered from the unavailable HTTP MCP server.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("Failed to call tool")
+			trace.step("HTTP transport loss became a model-facing error and the turn settled")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-http.test.ts
+++ b/tests/e2e/tui/mcp-http.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpToolResult } from "./support/mcp-fixture.js"
 import { gatewayMcpCall, modelReply, toolResultText } from "./support/mcp-model-script.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -11,7 +12,19 @@ test("calls a Streamable HTTP MCP tool and preserves configured headers", async 
 		terminal,
 		{
 			artifactName: "mcp-http",
-			mcp: { transport: "http", headers: { "X-Kimchi-E2E": "fixture-header" } },
+			mcp: {
+				transport: "http",
+				headers: { "X-Kimchi-E2E": "fixture-header" },
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: streamable-http" }] },
+							{ message: "streamable-http" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The Streamable HTTP MCP tool returned successfully.")],
 		},
 		async (fixture, trace) => {
@@ -39,7 +52,19 @@ test("authenticates to a Streamable HTTP MCP server with a static bearer token",
 		terminal,
 		{
 			artifactName: "mcp-http-bearer",
-			mcp: { transport: "http", bearerToken: "kimchi-e2e-bearer-token" },
+			mcp: {
+				transport: "http",
+				bearerToken: "kimchi-e2e-bearer-token",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: bearer-authenticated" }] },
+							{ message: "bearer-authenticated" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The authenticated MCP request succeeded.")],
 		},
 		async (fixture, trace) => {
@@ -65,7 +90,18 @@ test("falls back from Streamable HTTP to the legacy MCP SSE transport", async ({
 		terminal,
 		{
 			artifactName: "mcp-sse-fallback",
-			mcp: { transport: "sse" },
+			mcp: {
+				transport: "sse",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: legacy-sse" }] },
+							{ message: "legacy-sse" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("Kimchi completed the MCP call through SSE fallback.")],
 		},
 		async (fixture, trace) => {

--- a/tests/e2e/tui/mcp-lifecycle.test.ts
+++ b/tests/e2e/tui/mcp-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpToolResult } from "./support/mcp-fixture.js"
 import { gatewayMcpCall, modelReply, parallelModelToolCalls, toolResultText } from "./support/mcp-model-script.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -12,7 +13,23 @@ test("starts a cached lazy MCP server only when a tool is called", async ({ term
 		terminal,
 		{
 			artifactName: "mcp-lifecycle-lazy",
-			mcp: { lifecycle: "lazy" },
+			mcp: {
+				lifecycle: "lazy",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: warm-lazy-cache" }] },
+							{ message: "warm-lazy-cache" },
+						),
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: lazy-start" }] },
+							{ message: "lazy-start" },
+						),
+					],
+				},
+			},
 			responses: [
 				warmCache.response,
 				modelReply("The lazy MCP cache is warm."),
@@ -56,11 +73,27 @@ test("starts a cached lazy MCP server only when a tool is called", async ({ term
 test("recovers a crashed MCP server through the reconnect command", async ({ terminal }) => {
 	const disconnect = gatewayMcpCall("disconnect")
 	const afterRecovery = gatewayMcpCall("echo", { message: "manual-reconnect-recovered" })
+	const disconnectExitCode = 17
 	await runRestartableMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-lifecycle-manual-reconnect",
-			mcp: { lifecycle: "keep-alive" },
+			mcp: {
+				lifecycle: "keep-alive",
+				behavior: {
+					tools: [
+						{
+							name: "disconnect",
+							response: { type: "exit", code: disconnectExitCode },
+						},
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: manual-reconnect-recovered" }] },
+							{ message: "manual-reconnect-recovered" },
+						),
+					],
+				},
+			},
 			responses: [
 				disconnect.response,
 				modelReply("The MCP crash was contained."),
@@ -71,7 +104,10 @@ test("recovers a crashed MCP server through the reconnect command", async ({ ter
 		async (fixture, session, trace) => {
 			const beforeCrash = fixture.mcp.checkpoint()
 			await session.turn("Crash the MCP server", "The MCP crash was contained.")
-			await fixture.mcp.waitForEvent("process_exited", { after: beforeCrash, where: { code: 17 } })
+			await fixture.mcp.waitForEvent("process_exited", {
+				after: beforeCrash,
+				where: { code: disconnectExitCode },
+			})
 			const afterCrash = fixture.mcp.checkpoint()
 
 			terminal.write("/mcp reconnect fixture")
@@ -101,7 +137,26 @@ test("single-flights concurrent calls that start a cached lazy MCP server", asyn
 		terminal,
 		{
 			artifactName: "mcp-lifecycle-lazy-concurrent",
-			mcp: { lifecycle: "lazy" },
+			mcp: {
+				lifecycle: "lazy",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: warm-concurrent-cache" }] },
+							{ message: "warm-concurrent-cache" },
+						),
+						{
+							name: "slow",
+							response: {
+								type: "delayed-result",
+								delayMs: 2_000,
+								value: { content: [{ type: "text", text: "fixture slow call completed" }] },
+							},
+						},
+					],
+				},
+			},
 			responses: [
 				warmCache.response,
 				modelReply("The concurrent lazy MCP cache is warm."),
@@ -139,16 +194,33 @@ test("single-flights concurrent calls that start a cached lazy MCP server", asyn
 	)
 })
 
-// Re-enable when the bundled pi-mcp-adapter is upgraded to >=2.12.0, which contains the
-// upstream close-state fix. The current adapter cannot reconnect after a stdio process exit.
-test.skip("reconnects a keep-alive MCP server after its process crashes", async ({ terminal }) => {
+// Fixed upstream in pi-mcp-adapter v2.12.0 by PR #194's client-close state handling.
+// Remove test.fail once the bundled adapter includes that fix; the current adapter cannot
+// reconnect after a stdio process exit.
+test.fail("reconnects a keep-alive MCP server after its process crashes", async ({ terminal }) => {
 	const disconnect = gatewayMcpCall("disconnect")
 	const afterRecovery = gatewayMcpCall("echo", { message: "keep-alive-recovered" })
+	const disconnectExitCode = 17
 	await runRestartableMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-lifecycle-keep-alive",
-			mcp: { lifecycle: "keep-alive" },
+			mcp: {
+				lifecycle: "keep-alive",
+				behavior: {
+					tools: [
+						{
+							name: "disconnect",
+							response: { type: "exit", code: disconnectExitCode },
+						},
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: keep-alive-recovered" }] },
+							{ message: "keep-alive-recovered" },
+						),
+					],
+				},
+			},
 			responses: [
 				disconnect.response,
 				modelReply("The keep-alive crash was contained."),
@@ -159,7 +231,10 @@ test.skip("reconnects a keep-alive MCP server after its process crashes", async 
 		async (fixture, session, trace) => {
 			const beforeCrash = fixture.mcp.checkpoint()
 			await session.turn("Crash the keep-alive MCP server", "The keep-alive crash was contained.")
-			await fixture.mcp.waitForEvent("process_exited", { after: beforeCrash, where: { code: 17 } })
+			await fixture.mcp.waitForEvent("process_exited", {
+				after: beforeCrash,
+				where: { code: disconnectExitCode },
+			})
 			const afterCrash = fixture.mcp.checkpoint()
 
 			await fixture.mcp.waitForEvent("process_started", {

--- a/tests/e2e/tui/mcp-lifecycle.test.ts
+++ b/tests/e2e/tui/mcp-lifecycle.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { gatewayMcpCall, modelReply, parallelModelToolCalls, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("starts a cached lazy MCP server only when a tool is called", async ({ terminal }) => {
+	const warmCache = gatewayMcpCall("echo", { message: "warm-lazy-cache" })
+	const lazyCall = gatewayMcpCall("echo", { message: "lazy-start" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-lifecycle-lazy",
+			mcp: { lifecycle: "lazy" },
+			responses: [
+				warmCache.response,
+				modelReply("The lazy MCP cache is warm."),
+				lazyCall.response,
+				modelReply("The lazy MCP server started on demand."),
+			],
+		},
+		async (fixture, session, trace) => {
+			await session.turn("Warm the lazy MCP metadata cache", "The lazy MCP cache is warm.")
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "warm-lazy-cache" } },
+			})
+
+			const beforeRestart = fixture.mcp.checkpoint()
+			await session.restart()
+			terminal.write("/mcp tools")
+			await waitForText(terminal, "/mcp tools", { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "MCP Tools:", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(
+				fixture.mcp
+					.readEvents()
+					.slice(beforeRestart)
+					.some((event) => event.type === "process_started"),
+			).toBe(false)
+			trace.step("cached lazy server stayed stopped after process restart")
+
+			const onDemandCheckpoint = fixture.mcp.checkpoint()
+			await session.turn("Call the lazy MCP server", "The lazy MCP server started on demand.")
+			await fixture.mcp.waitForEvent("process_started", { after: onDemandCheckpoint })
+			await fixture.mcp.waitForEvent("tool_called", {
+				after: onDemandCheckpoint,
+				where: { name: "echo", arguments: { message: "lazy-start" } },
+			})
+			expect(toolResultText(fixture.fake.requests, lazyCall)).toContain("fixture echo: lazy-start")
+			trace.step("first post-restart call launched the lazy server")
+		},
+	)
+})
+
+test("recovers a crashed MCP server through the reconnect command", async ({ terminal }) => {
+	const disconnect = gatewayMcpCall("disconnect")
+	const afterRecovery = gatewayMcpCall("echo", { message: "manual-reconnect-recovered" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-lifecycle-manual-reconnect",
+			mcp: { lifecycle: "keep-alive" },
+			responses: [
+				disconnect.response,
+				modelReply("The MCP crash was contained."),
+				afterRecovery.response,
+				modelReply("The manually reconnected MCP server worked."),
+			],
+		},
+		async (fixture, session, trace) => {
+			const beforeCrash = fixture.mcp.checkpoint()
+			await session.turn("Crash the MCP server", "The MCP crash was contained.")
+			await fixture.mcp.waitForEvent("process_exited", { after: beforeCrash, where: { code: 17 } })
+			const afterCrash = fixture.mcp.checkpoint()
+
+			terminal.write("/mcp reconnect fixture")
+			await waitForText(terminal, "/mcp reconnect fixture", { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "MCP: Reconnected to fixture", { timeoutMs: STREAM_TIMEOUT_MS })
+			const recoveryEvents = fixture.mcp.readEvents().slice(afterCrash)
+			expect(recoveryEvents.filter((event) => event.type === "process_started")).toHaveLength(1)
+			trace.step("manual reconnect launched one replacement MCP process")
+
+			await session.turn("Call MCP after the manual reconnect", "The manually reconnected MCP server worked.")
+			await fixture.mcp.waitForEvent("tool_called", {
+				after: afterCrash,
+				where: { name: "echo", arguments: { message: "manual-reconnect-recovered" } },
+			})
+			expect(toolResultText(fixture.fake.requests, afterRecovery)).toContain("fixture echo: manual-reconnect-recovered")
+			trace.step("a tool call succeeded through the replacement MCP process")
+		},
+	)
+})
+
+test("single-flights concurrent calls that start a cached lazy MCP server", async ({ terminal }) => {
+	const warmCache = gatewayMcpCall("echo", { message: "warm-concurrent-cache" })
+	const firstSlowCall = gatewayMcpCall("slow", undefined, { id: "call_mcp_slow_first" })
+	const secondSlowCall = gatewayMcpCall("slow", undefined, { id: "call_mcp_slow_second" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-lifecycle-lazy-concurrent",
+			mcp: { lifecycle: "lazy" },
+			responses: [
+				warmCache.response,
+				modelReply("The concurrent lazy MCP cache is warm."),
+				parallelModelToolCalls(firstSlowCall, secondSlowCall),
+				modelReply("Both concurrent lazy MCP calls completed."),
+			],
+		},
+		async (fixture, session, trace) => {
+			await session.turn("Warm the MCP cache", "The concurrent lazy MCP cache is warm.")
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "warm-concurrent-cache" } },
+			})
+			await session.restart()
+			const beforeConcurrentCalls = fixture.mcp.checkpoint()
+
+			await session.turn("Run two slow MCP calls together", "Both concurrent lazy MCP calls completed.", {
+				timeoutMs: STREAM_TIMEOUT_MS + 5_000,
+			})
+			const events = fixture.mcp.readEvents().slice(beforeConcurrentCalls)
+			expect(events.filter((event) => event.type === "process_started")).toHaveLength(1)
+			expect(events.filter((event) => event.type === "slow_call_started")).toHaveLength(2)
+			expect(events.filter((event) => event.type === "slow_call_completed")).toHaveLength(2)
+			const secondStart = events.findIndex(
+				(event, index) =>
+					event.type === "slow_call_started" &&
+					events.slice(0, index).some((previous) => previous.type === "slow_call_started"),
+			)
+			const firstCompletion = events.findIndex((event) => event.type === "slow_call_completed")
+			expect(secondStart).toBeGreaterThan(-1)
+			expect(firstCompletion).toBeGreaterThan(secondStart)
+			expect(toolResultText(fixture.fake.requests, firstSlowCall)).toContain("fixture slow call completed")
+			expect(toolResultText(fixture.fake.requests, secondSlowCall)).toContain("fixture slow call completed")
+			trace.step("concurrent lazy calls shared one server startup and overlapped")
+		},
+	)
+})
+
+// Re-enable when the bundled pi-mcp-adapter is upgraded to >=2.12.0, which contains the
+// upstream close-state fix. The current adapter cannot reconnect after a stdio process exit.
+test.skip("reconnects a keep-alive MCP server after its process crashes", async ({ terminal }) => {
+	const disconnect = gatewayMcpCall("disconnect")
+	const afterRecovery = gatewayMcpCall("echo", { message: "keep-alive-recovered" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-lifecycle-keep-alive",
+			mcp: { lifecycle: "keep-alive" },
+			responses: [
+				disconnect.response,
+				modelReply("The keep-alive crash was contained."),
+				afterRecovery.response,
+				modelReply("The keep-alive MCP server recovered."),
+			],
+		},
+		async (fixture, session, trace) => {
+			const beforeCrash = fixture.mcp.checkpoint()
+			await session.turn("Crash the keep-alive MCP server", "The keep-alive crash was contained.")
+			await fixture.mcp.waitForEvent("process_exited", { after: beforeCrash, where: { code: 17 } })
+			const afterCrash = fixture.mcp.checkpoint()
+
+			await fixture.mcp.waitForEvent("process_started", {
+				after: afterCrash,
+				timeoutMs: 32_000,
+				description: "keep-alive MCP process restart",
+			})
+			await session.turn("Call MCP after keep-alive recovery", "The keep-alive MCP server recovered.")
+			expect(toolResultText(fixture.fake.requests, afterRecovery)).toContain("fixture echo: keep-alive-recovered")
+			trace.step("keep-alive health check relaunched the crashed server")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-oauth.test.ts
+++ b/tests/e2e/tui/mcp-oauth.test.ts
@@ -1,0 +1,209 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runMcpKimchiSession, runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { gatewayMcpCall, modelReply, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("logs into an HTTP MCP server with OAuth authorization code and PKCE", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "oauth-login" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-login",
+			mcp: { transport: "oauth" },
+			responses: [echo.response, modelReply("The OAuth-authenticated MCP tool returned successfully.")],
+		},
+		async (fixture, trace) => {
+			await fixture.mcp.waitForEvent("http_unauthorized", {
+				description: "initial OAuth challenge",
+			})
+			trace.step("protected MCP endpoint challenged the unauthenticated client")
+
+			terminal.submit("/mcp-auth fixture")
+			await waitForText(terminal, 'OAuth authentication successful for "fixture"!', {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("oauth_token_issued", {
+				where: { grantType: "authorization_code", pkceVerified: true },
+				description: "OAuth token exchange with verified PKCE",
+			})
+			trace.step("browser redirect, callback, and authorization-code exchange completed")
+
+			terminal.submit("/mcp reconnect fixture")
+			await waitForText(terminal, "MCP: Reconnected to fixture", { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.submit("Call the OAuth-protected MCP echo tool")
+			await waitForText(terminal, "The OAuth-authenticated MCP tool returned successfully.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "oauth-login" } },
+			})
+
+			expect(fixture.mcp.hasEvent("oauth_resource_metadata_requested")).toBe(true)
+			expect(fixture.mcp.hasEvent("oauth_server_metadata_requested")).toBe(true)
+			expect(fixture.mcp.hasEvent("oauth_client_registered")).toBe(true)
+			expect(fixture.mcp.hasEvent("oauth_browser_opened")).toBe(true)
+			expect(fixture.mcp.hasEvent("oauth_browser_completed")).toBe(true)
+			expect(fixture.mcp.hasEvent("http_request", { authorized: true })).toBe(true)
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: oauth-login")
+			trace.step("authenticated MCP call and every OAuth protocol boundary verified")
+		},
+	)
+})
+
+test("automatically authenticates and retries an OAuth-protected MCP call", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "oauth-auto-auth" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-auto-auth",
+			mcp: { transport: "oauth", autoAuth: true },
+			responses: [echo.response, modelReply("Automatic MCP OAuth completed without a slash command.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call the protected MCP tool and authenticate automatically")
+			await waitForText(terminal, "Automatic MCP OAuth completed without a slash command.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("oauth_token_issued", {
+				where: { grantType: "authorization_code", pkceVerified: true },
+			})
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "oauth-auto-auth" } },
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: oauth-auto-auth")
+			trace.step("gateway call initiated OAuth, retried, and returned the protected tool result")
+		},
+	)
+})
+
+test("authenticates a non-interactive MCP server with client credentials", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: "oauth-client-credentials" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-client-credentials",
+			mcp: {
+				transport: "oauth",
+				autoAuth: true,
+				oauth: {
+					grantType: "client_credentials",
+					clientId: "kimchi-e2e-client",
+					clientSecret: "kimchi-e2e-client-secret",
+					scope: "mcp:tools",
+				},
+			},
+			responses: [echo.response, modelReply("MCP client credentials authenticated without a browser.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call the machine-authenticated MCP tool")
+			await waitForText(terminal, "MCP client credentials authenticated without a browser.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("oauth_token_issued", {
+				where: { grantType: "client_credentials" },
+			})
+			expect(fixture.mcp.hasEvent("oauth_browser_opened")).toBe(false)
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "oauth-client-credentials" } },
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: oauth-client-credentials")
+			trace.step("client-credentials token exchange and protected call completed without browser interaction")
+		},
+	)
+})
+
+test("returns an OAuth denial to the TUI and keeps the Kimchi session usable", async ({ terminal }) => {
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-denial",
+			mcp: { transport: "oauth", scenario: "oauth-deny" },
+			responses: [modelReply("The session stayed usable after OAuth was denied.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("/mcp-auth fixture")
+			await waitForText(terminal, 'Failed to authenticate "fixture": fixture authorization denied', {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("oauth_authorization_denied")
+			expect(fixture.mcp.hasEvent("oauth_token_issued")).toBe(false)
+			expect(fixture.mcp.hasEvent("oauth_browser_completed")).toBe(true)
+			trace.step("authorization denial returned through the callback without storing a token")
+
+			terminal.submit("Continue with a normal response after the denied login")
+			await waitForText(terminal, "The session stayed usable after OAuth was denied.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			trace.step("main session remained usable after OAuth denial")
+		},
+	)
+})
+
+test("reports a failed OAuth token exchange without persisting partial authentication", async ({ terminal }) => {
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-token-failure",
+			mcp: { transport: "oauth", scenario: "oauth-token-failure" },
+			responses: [],
+		},
+		async (fixture, trace) => {
+			terminal.submit("/mcp-auth fixture")
+			await waitForText(terminal, 'Failed to authenticate "fixture"', { timeoutMs: STREAM_TIMEOUT_MS })
+			await fixture.mcp.waitForEvent("oauth_token_rejected")
+			expect(fixture.mcp.hasEvent("oauth_token_issued")).toBe(false)
+			trace.step("token endpoint failure settled and no access token was issued")
+		},
+	)
+})
+
+test("refreshes an expired MCP OAuth token after a real Kimchi process restart", async ({ terminal }) => {
+	const beforeRestart = gatewayMcpCall("echo", { message: "before-oauth-restart" })
+	const afterRestart = gatewayMcpCall("echo", { message: "after-oauth-refresh" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-oauth-refresh-restart",
+			mcp: { transport: "oauth", scenario: "oauth-expiring" },
+			responses: [
+				beforeRestart.response,
+				modelReply("The first OAuth MCP call succeeded."),
+				afterRestart.response,
+				modelReply("The refreshed OAuth MCP call succeeded after restart."),
+			],
+		},
+		async (fixture, session, trace) => {
+			terminal.submit("/mcp-auth fixture")
+			await waitForText(terminal, 'OAuth authentication successful for "fixture"!', {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			const initialToken = await fixture.mcp.waitForEvent("oauth_token_issued", {
+				where: { grantType: "authorization_code", pkceVerified: true },
+			})
+			terminal.submit("/mcp reconnect fixture")
+			await waitForText(terminal, "MCP: Reconnected to fixture", { timeoutMs: STREAM_TIMEOUT_MS })
+			await session.turn("Call MCP before restarting", "The first OAuth MCP call succeeded.")
+			expect(toolResultText(fixture.fake.requests, beforeRestart)).toContain("fixture echo: before-oauth-restart")
+			await fixture.mcp.waitForOAuthTokenExpiry(initialToken)
+
+			await session.restart()
+			trace.step("expired OAuth credentials persisted across a verified process restart")
+			await session.turn(
+				"Call MCP using the persisted token after restarting",
+				"The refreshed OAuth MCP call succeeded after restart.",
+			)
+
+			const refresh = await fixture.mcp.waitForEvent("oauth_token_issued", {
+				where: { grantType: "refresh_token" },
+				description: "OAuth refresh-token exchange after restart",
+			})
+			expect(refresh.grantType).toBe("refresh_token")
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "after-oauth-refresh" } },
+			})
+			expect(toolResultText(fixture.fake.requests, afterRestart)).toContain("fixture echo: after-oauth-refresh")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-oauth.test.ts
+++ b/tests/e2e/tui/mcp-oauth.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runMcpKimchiSession, runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpToolResult } from "./support/mcp-fixture.js"
 import { gatewayMcpCall, modelReply, toolResultText } from "./support/mcp-model-script.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -11,7 +12,18 @@ test("logs into an HTTP MCP server with OAuth authorization code and PKCE", asyn
 		terminal,
 		{
 			artifactName: "mcp-oauth-login",
-			mcp: { transport: "oauth" },
+			mcp: {
+				transport: "oauth",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: oauth-login" }] },
+							{ message: "oauth-login" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The OAuth-authenticated MCP tool returned successfully.")],
 		},
 		async (fixture, trace) => {
@@ -58,7 +70,19 @@ test("automatically authenticates and retries an OAuth-protected MCP call", asyn
 		terminal,
 		{
 			artifactName: "mcp-oauth-auto-auth",
-			mcp: { transport: "oauth", autoAuth: true },
+			mcp: {
+				transport: "oauth",
+				autoAuth: true,
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: oauth-auto-auth" }] },
+							{ message: "oauth-auto-auth" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("Automatic MCP OAuth completed without a slash command.")],
 		},
 		async (fixture, trace) => {
@@ -92,6 +116,15 @@ test("authenticates a non-interactive MCP server with client credentials", async
 					clientId: "kimchi-e2e-client",
 					clientSecret: "kimchi-e2e-client-secret",
 					scope: "mcp:tools",
+				},
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: oauth-client-credentials" }] },
+							{ message: "oauth-client-credentials" },
+						),
+					],
 				},
 			},
 			responses: [echo.response, modelReply("MCP client credentials authenticated without a browser.")],
@@ -166,7 +199,24 @@ test("refreshes an expired MCP OAuth token after a real Kimchi process restart",
 		terminal,
 		{
 			artifactName: "mcp-oauth-refresh-restart",
-			mcp: { transport: "oauth", scenario: "oauth-expiring" },
+			mcp: {
+				transport: "oauth",
+				scenario: "oauth-expiring",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: before-oauth-restart" }] },
+							{ message: "before-oauth-restart" },
+						),
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: after-oauth-refresh" }] },
+							{ message: "after-oauth-refresh" },
+						),
+					],
+				},
+			},
 			responses: [
 				beforeRestart.response,
 				modelReply("The first OAuth MCP call succeeded."),

--- a/tests/e2e/tui/mcp-panel.test.ts
+++ b/tests/e2e/tui/mcp-panel.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs"
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { PROMPT_READY, runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpToolResult } from "./support/mcp-fixture.js"
 import { directMcpCall, modelReply, requireRequestAdvertisingTool, toolResultText } from "./support/mcp-model-script.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -12,7 +13,17 @@ test("persists a direct-tool choice from the MCP panel and applies it after rest
 		terminal,
 		{
 			artifactName: "mcp-panel-persistence",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: panel-persisted" }] },
+							{ message: "panel-persisted" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The MCP panel direct-tool choice survived restart.")],
 		},
 		async (fixture, session, trace) => {

--- a/tests/e2e/tui/mcp-panel.test.ts
+++ b/tests/e2e/tui/mcp-panel.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs"
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { PROMPT_READY, runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { directMcpCall, modelReply, requireRequestAdvertisingTool, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("persists a direct-tool choice from the MCP panel and applies it after restart", async ({ terminal }) => {
+	const echo = directMcpCall("echo", { message: "panel-persisted" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-panel-persistence",
+			mcp: {},
+			responses: [echo.response, modelReply("The MCP panel direct-tool choice survived restart.")],
+		},
+		async (fixture, session, trace) => {
+			terminal.write("/mcp")
+			await waitForText(terminal, "/mcp")
+			terminal.submit("")
+			await waitForText(terminal, "MCP Servers", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("MCP panel opened with the fixture server selected")
+
+			terminal.submit("")
+			await waitForText(terminal, "echo", { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.keyDown()
+			terminal.keyPress(" ")
+			terminal.keyPress("s", { ctrl: true })
+			await waitForText(terminal, "Saved", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("echo toggled to direct and saved")
+
+			const saved = JSON.parse(readFileSync(fixture.mcp.configPath, "utf-8")) as {
+				mcpServers?: Record<string, { directTools?: unknown }>
+			}
+			expect(saved.mcpServers?.fixture?.directTools).toEqual(["echo"])
+
+			terminal.keyEscape()
+			await waitForText(terminal, PROMPT_READY, { timeoutMs: STREAM_TIMEOUT_MS })
+			await session.restart()
+			await session.turn(
+				"Call the direct tool enabled in the MCP panel",
+				"The MCP panel direct-tool choice survived restart.",
+			)
+
+			requireRequestAdvertisingTool(fixture.fake.requests, echo.modelToolName)
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "panel-persisted" } },
+			})
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: panel-persisted")
+			trace.step("persisted direct tool was advertised and called after restart")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-restart.test.ts
+++ b/tests/e2e/tui/mcp-restart.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import type { MetadataCache } from "../../../src/extensions/mcp-adapter/metadata-cache.js"
+import type { McpConfig } from "../../../src/extensions/mcp-adapter/types.js"
+import { runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import {
+	directMcpCall,
+	gatewayMcpCall,
+	modelReply,
+	searchMcpTools,
+	toolResultText,
+} from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("uses cached MCP metadata to call a direct tool after restart", async ({ terminal }) => {
+	const warmCache = gatewayMcpCall("echo", { message: "warm-cache" })
+	const afterRestart = directMcpCall("echo", { message: "after-restart" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-restart-cache",
+			mcp: { directTools: ["echo"] },
+			responses: [
+				warmCache.response,
+				modelReply("The first MCP session populated the cache."),
+				afterRestart.response,
+				modelReply("The cached direct MCP tool worked after restart."),
+			],
+		},
+		async (fixture, session, trace) => {
+			await session.turn(
+				"Warm the MCP metadata cache through the gateway",
+				"The first MCP session populated the cache.",
+			)
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "warm-cache" } },
+				description: "first-session gateway tool call",
+			})
+			expect(toolResultText(fixture.fake.requests, warmCache)).toContain("fixture echo: warm-cache")
+			trace.step("first real session populated MCP metadata")
+
+			await session.restart()
+			trace.step("first Kimchi process exited and a second reached the ready prompt")
+			await session.turn(
+				"Call the cached direct MCP tool after restart",
+				"The cached direct MCP tool worked after restart.",
+			)
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "after-restart" } },
+				description: "second-session direct tool call",
+			})
+			expect(toolResultText(fixture.fake.requests, afterRestart)).toContain("fixture echo: after-restart")
+			trace.step("cached direct tool crossed MCP and model boundaries after restart")
+		},
+	)
+})
+
+test("invalidates cached MCP metadata when the server config changes", async ({ terminal }) => {
+	const warmCache = gatewayMcpCall("echo", { message: "warm-config-cache" })
+	const searchAfterChange = searchMcpTools("fixture_echo", { serverName: "fixture" })
+	await runRestartableMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-restart-config-cache-invalidation",
+			mcp: { lifecycle: "lazy" },
+			responses: [
+				warmCache.response,
+				modelReply("The config-sensitive MCP cache is warm."),
+				searchAfterChange.response,
+				modelReply("The stale MCP cache entry was removed."),
+			],
+		},
+		async (fixture, session, trace) => {
+			await session.turn("Warm the MCP metadata cache", "The config-sensitive MCP cache is warm.")
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "warm-config-cache" } },
+			})
+
+			const config = JSON.parse(readFileSync(fixture.mcp.configPath, "utf-8")) as McpConfig
+			const definition = config.mcpServers.fixture
+			if (!definition) throw new Error("Fixture MCP server is missing from its config")
+			config.mcpServers.fixture = { ...definition, excludeTools: ["echo"] }
+			writeFileSync(fixture.mcp.configPath, JSON.stringify(config, null, "\t"), "utf-8")
+			await session.restart()
+			const afterRestart = fixture.mcp.checkpoint()
+			trace.step("Kimchi restarted after the MCP server definition changed")
+
+			await session.turn("Search for the excluded cached MCP tool", "The stale MCP cache entry was removed.")
+			expect(toolResultText(fixture.fake.requests, searchAfterChange)).toContain(
+				'No tools matching "fixture_echo" in "fixture"',
+			)
+			expect(
+				fixture.mcp
+					.readEvents()
+					.slice(afterRestart)
+					.some((event) => event.type === "process_started"),
+			).toBe(false)
+			const cache = JSON.parse(readFileSync(join(fixture.agentDir, "mcp-cache.json"), "utf-8")) as MetadataCache
+			expect(cache.servers.fixture).toBeUndefined()
+			trace.step("stale metadata disappeared without starting the lazy server")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-restart.test.ts
+++ b/tests/e2e/tui/mcp-restart.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from "@microsoft/tui-test"
 import type { MetadataCache } from "../../../src/extensions/mcp-adapter/metadata-cache.js"
 import type { McpConfig } from "../../../src/extensions/mcp-adapter/types.js"
 import { runRestartableMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpToolResult } from "./support/mcp-fixture.js"
 import {
 	directMcpCall,
 	gatewayMcpCall,
@@ -21,7 +22,23 @@ test("uses cached MCP metadata to call a direct tool after restart", async ({ te
 		terminal,
 		{
 			artifactName: "mcp-restart-cache",
-			mcp: { directTools: ["echo"] },
+			mcp: {
+				directTools: ["echo"],
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: warm-cache" }] },
+							{ message: "warm-cache" },
+						),
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: after-restart" }] },
+							{ message: "after-restart" },
+						),
+					],
+				},
+			},
 			responses: [
 				warmCache.response,
 				modelReply("The first MCP session populated the cache."),
@@ -64,7 +81,18 @@ test("invalidates cached MCP metadata when the server config changes", async ({ 
 		terminal,
 		{
 			artifactName: "mcp-restart-config-cache-invalidation",
-			mcp: { lifecycle: "lazy" },
+			mcp: {
+				lifecycle: "lazy",
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: warm-config-cache" }] },
+							{ message: "warm-config-cache" },
+						),
+					],
+				},
+			},
 			responses: [
 				warmCache.response,
 				modelReply("The config-sensitive MCP cache is warm."),

--- a/tests/e2e/tui/mcp-stdio.test.ts
+++ b/tests/e2e/tui/mcp-stdio.test.ts
@@ -1,0 +1,229 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import {
+	directMcpCall,
+	emptyMcpCall,
+	gatewayMcpCall,
+	modelReply,
+	requireRequestAdvertisingTool,
+	searchMcpTools,
+	toolResultText,
+} from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const SENTINEL = "kimchi-mcp-e2e"
+
+test("calls a stdio MCP tool through the real Kimchi session", async ({ terminal }) => {
+	const echo = gatewayMcpCall("echo", { message: SENTINEL })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio",
+			mcp: {},
+			responses: [echo.response, modelReply("The MCP fixture returned the expected echo.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Use the MCP fixture to echo the test sentinel")
+
+			await waitForText(terminal, "The MCP fixture returned the expected echo.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			trace.step("final response visible after MCP tool result")
+
+			const called = await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: SENTINEL } },
+				description: "echo tool invocation",
+			})
+			expect(called.arguments).toEqual({ message: SENTINEL })
+
+			expect(fixture.mcp.hasEvent("initialized")).toBe(true)
+			expect(fixture.mcp.hasEvent("tools_listed")).toBe(true)
+
+			expect(toolResultText(fixture.fake.requests, echo)).toContain(`fixture echo: ${SENTINEL}`)
+			trace.step("fixture invocation and model-facing tool result verified")
+		},
+	)
+})
+
+// Known product bug: asynchronous MCP bootstrap exposes a configured direct tool only after
+// the first model request has already been built, so that request rejects the tool as unavailable.
+test.fail("registers and calls a direct MCP tool on the first session", async ({ terminal }) => {
+	const echo = directMcpCall("echo", { message: "direct-first-session" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio-direct-tool",
+			mcp: { directTools: ["echo"] },
+			responses: [echo.response, modelReply("The direct MCP tool worked without restarting Kimchi.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call the direct MCP echo tool")
+			await waitForText(terminal, "The direct MCP tool worked without restarting Kimchi.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+
+			requireRequestAdvertisingTool(fixture.fake.requests, echo.modelToolName)
+			const event = await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "direct-first-session" } },
+			})
+			expect(event.arguments).toEqual({ message: "direct-first-session" })
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: direct-first-session")
+			trace.step("first-session direct tool registration and invocation verified")
+		},
+	)
+})
+
+test("delivers an MCP isError result to the next model turn", async ({ terminal }) => {
+	const failure = gatewayMcpCall("fail")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio-tool-error",
+			mcp: {},
+			responses: [failure.response, modelReply("Kimchi handled the MCP tool error and the session continued.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Exercise the MCP fixture failure")
+			await waitForText(terminal, "Kimchi handled the MCP tool error and the session continued.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+
+			expect(toolResultText(fixture.fake.requests, failure)).toContain("Error: fixture failure: requested by test")
+			expect(fixture.mcp.hasEvent("tool_called", { name: "fail", arguments: {} })).toBe(true)
+			trace.step("MCP isError result reached the model and the turn settled")
+		},
+	)
+})
+
+test("reads an MCP resource through the gateway", async ({ terminal }) => {
+	const resource = gatewayMcpCall("get_fixture_note")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio-resource",
+			mcp: {},
+			responses: [resource.response, modelReply("The MCP resource content reached the model.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Read the MCP fixture resource")
+			await waitForText(terminal, "The MCP resource content reached the model.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			const resourceEvent = await fixture.mcp.waitForEvent("resource_read", {
+				where: { uri: "fixture://note" },
+			})
+			expect(resourceEvent.uri).toBe("fixture://note")
+			expect(toolResultText(fixture.fake.requests, resource)).toContain("fixture resource: kimchi-mcp-resource")
+			trace.step("resource read crossed MCP and model boundaries")
+		},
+	)
+})
+
+test("preserves MCP text and safely represents image content for a text-only model", async ({ terminal }) => {
+	const mixedContent = gatewayMcpCall("mixed_content")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio-mixed-content",
+			mcp: {},
+			responses: [mixedContent.response, modelReply("The MCP text and image content both reached the model.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Request mixed text and image content from MCP")
+			await waitForText(terminal, "The MCP text and image content both reached the model.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+
+			const content = toolResultText(fixture.fake.requests, mixedContent)
+			expect(content).toContain("fixture mixed content: kimchi-mcp-mixed")
+			expect(content).toContain("[image removed: image/png — stripped for non-vision model compatibility]")
+			expect(fixture.mcp.hasEvent("tool_called", { name: "mixed_content", arguments: {} })).toBe(true)
+			trace.step("mixed MCP content followed the text-only model compatibility contract")
+		},
+	)
+})
+
+test("injects the correctly named direct tool after MCP gateway search", async ({ terminal }) => {
+	const search = searchMcpTools("fixture echo")
+	const echo = directMcpCall("echo", { message: "search-injected-direct-tool" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-search-direct-injection",
+			mcp: {},
+			responses: [
+				search.response,
+				echo.response,
+				modelReply("The MCP search-injected tool used the correct original name."),
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Search MCP and then call the discovered echo tool")
+			await waitForText(terminal, "The MCP search-injected tool used the correct original name.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "search-injected-direct-tool" } },
+			})
+			requireRequestAdvertisingTool(fixture.fake.requests, echo.modelToolName)
+			expect(toolResultText(fixture.fake.requests, echo)).toContain("fixture echo: search-injected-direct-tool")
+			trace.step("search injection, direct name mapping, and invocation verified")
+		},
+	)
+})
+
+test("returns MCP server status for an empty gateway call", async ({ terminal }) => {
+	const status = emptyMcpCall()
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-empty-call-status",
+			mcp: {},
+			responses: [status.response, modelReply("The empty MCP gateway call returned server status.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Show MCP status through an empty gateway call")
+			await waitForText(terminal, "The empty MCP gateway call returned server status.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			expect(toolResultText(fixture.fake.requests, status)).toMatch(/MCP: 1\/1 servers/)
+			trace.step("empty gateway call preserved the MCP status contract")
+		},
+	)
+})
+
+test("routes same-named tools across multiple servers using production defaults", async ({ terminal }) => {
+	const primaryEcho = gatewayMcpCall("echo", { message: "from-primary" })
+	const secondaryEcho = gatewayMcpCall("echo", { message: "from-secondary" }, { serverName: "secondary" })
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-stdio-multiple-servers",
+			mcp: { additionalStdioServers: { secondary: {} } },
+			responses: [
+				primaryEcho.response,
+				modelReply("The primary MCP server answered."),
+				secondaryEcho.response,
+				modelReply("The secondary MCP server answered."),
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Call echo on the primary MCP server")
+			await waitForText(terminal, "The primary MCP server answered.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "from-primary" } },
+			})
+			expect(fixture.mcp.server("secondary").hasEvent("tool_called", { name: "echo" })).toBe(false)
+			expect(toolResultText(fixture.fake.requests, primaryEcho)).toContain("fixture echo: from-primary")
+
+			terminal.submit("Call echo on the secondary MCP server")
+			await waitForText(terminal, "The secondary MCP server answered.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await fixture.mcp.server("secondary").waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "from-secondary" } },
+			})
+			expect(toolResultText(fixture.fake.requests, secondaryEcho)).toContain("fixture echo: from-secondary")
+			trace.step("default prefixing routed identical tool names to distinct real MCP servers")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-stdio.test.ts
+++ b/tests/e2e/tui/mcp-stdio.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpResourceResult, mcpToolResult } from "./support/mcp-fixture.js"
 import {
 	directMcpCall,
 	emptyMcpCall,
@@ -21,7 +22,17 @@ test("calls a stdio MCP tool through the real Kimchi session", async ({ terminal
 		terminal,
 		{
 			artifactName: "mcp-stdio",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: `fixture echo: ${SENTINEL}` }] },
+							{ message: SENTINEL },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The MCP fixture returned the expected echo.")],
 		},
 		async (fixture, trace) => {
@@ -49,13 +60,26 @@ test("calls a stdio MCP tool through the real Kimchi session", async ({ terminal
 
 // Known product bug: asynchronous MCP bootstrap exposes a configured direct tool only after
 // the first model request has already been built, so that request rejects the tool as unavailable.
+// Fixed upstream in pi-mcp-adapter v2.26.1 by PR #374's pre-input initialization barrier;
+// remove test.fail once the bundled adapter includes that fix.
 test.fail("registers and calls a direct MCP tool on the first session", async ({ terminal }) => {
 	const echo = directMcpCall("echo", { message: "direct-first-session" })
 	await runMcpKimchiSession(
 		terminal,
 		{
 			artifactName: "mcp-stdio-direct-tool",
-			mcp: { directTools: ["echo"] },
+			mcp: {
+				directTools: ["echo"],
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: direct-first-session" }] },
+							{ message: "direct-first-session" },
+						),
+					],
+				},
+			},
 			responses: [echo.response, modelReply("The direct MCP tool worked without restarting Kimchi.")],
 		},
 		async (fixture, trace) => {
@@ -81,7 +105,16 @@ test("delivers an MCP isError result to the next model turn", async ({ terminal 
 		terminal,
 		{
 			artifactName: "mcp-stdio-tool-error",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult("fail", {
+							isError: true,
+							content: [{ type: "text", text: "fixture failure: requested by test" }],
+						}),
+					],
+				},
+			},
 			responses: [failure.response, modelReply("Kimchi handled the MCP tool error and the session continued.")],
 		},
 		async (fixture, trace) => {
@@ -103,7 +136,21 @@ test("reads an MCP resource through the gateway", async ({ terminal }) => {
 		terminal,
 		{
 			artifactName: "mcp-stdio-resource",
-			mcp: {},
+			mcp: {
+				behavior: {
+					resources: [
+						mcpResourceResult("fixture://note", {
+							contents: [
+								{
+									uri: "fixture://note",
+									mimeType: "text/plain",
+									text: "fixture resource: kimchi-mcp-resource",
+								},
+							],
+						}),
+					],
+				},
+			},
 			responses: [resource.response, modelReply("The MCP resource content reached the model.")],
 		},
 		async (fixture, trace) => {
@@ -126,7 +173,23 @@ test("preserves MCP text and safely represents image content for a text-only mod
 		terminal,
 		{
 			artifactName: "mcp-stdio-mixed-content",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult("mixed_content", {
+							content: [
+								{ type: "text", text: "fixture mixed content: kimchi-mcp-mixed" },
+								{
+									type: "image",
+									mimeType: "image/png",
+									data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+								},
+							],
+							structuredContent: { fixture: "kimchi-mcp-structured", count: 1 },
+						}),
+					],
+				},
+			},
 			responses: [mixedContent.response, modelReply("The MCP text and image content both reached the model.")],
 		},
 		async (fixture, trace) => {
@@ -151,7 +214,17 @@ test("injects the correctly named direct tool after MCP gateway search", async (
 		terminal,
 		{
 			artifactName: "mcp-search-direct-injection",
-			mcp: {},
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: search-injected-direct-tool" }] },
+							{ message: "search-injected-direct-tool" },
+						),
+					],
+				},
+			},
 			responses: [
 				search.response,
 				echo.response,
@@ -200,7 +273,30 @@ test("routes same-named tools across multiple servers using production defaults"
 		terminal,
 		{
 			artifactName: "mcp-stdio-multiple-servers",
-			mcp: { additionalStdioServers: { secondary: {} } },
+			mcp: {
+				behavior: {
+					tools: [
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: from-primary" }] },
+							{ message: "from-primary" },
+						),
+					],
+				},
+				additionalStdioServers: {
+					secondary: {
+						behavior: {
+							tools: [
+								mcpToolResult(
+									"echo",
+									{ content: [{ type: "text", text: "fixture echo: from-secondary" }] },
+									{ message: "from-secondary" },
+								),
+							],
+						},
+					},
+				},
+			},
 			responses: [
 				primaryEcho.response,
 				modelReply("The primary MCP server answered."),

--- a/tests/e2e/tui/mcp-ui.test.ts
+++ b/tests/e2e/tui/mcp-ui.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
+import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { gatewayMcpCall, mcpUiMessages, modelReply, toolResultText } from "./support/mcp-model-script.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("bridges an MCP App tool call and prompt back into the agent", async ({ terminal }) => {
+	const openUi = gatewayMcpCall("open_ui")
+	const uiMessages = mcpUiMessages()
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-ui-app-bridge",
+			mcp: { scenario: "ui-app" },
+			responses: [
+				openUi.response,
+				modelReply("The MCP App opened."),
+				modelReply("The MCP App prompt triggered an agent turn."),
+				uiMessages.response,
+				modelReply("The completed MCP App messages reached the model."),
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Open the fixture MCP App")
+			await waitForText(terminal, "The MCP App opened.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await fixture.mcp.waitForEvent("resource_read", { where: { uri: "ui://fixture/app" } })
+			await fixture.mcp.waitForEvent("ui_host_loaded", { where: { status: 200 } })
+			const ui = fixture.mcp.ui
+			expect(ui).toBeDefined()
+			if (!ui) throw new Error("MCP UI fixture was not configured")
+			trace.step("MCP App resource loaded in the local browser host")
+
+			await ui.post("/proxy/ui/consent", { approved: true })
+			const proxied = await ui.post("/proxy/tools/call", {
+				name: "echo",
+				arguments: { message: "from-ui" },
+			})
+			expect(proxied?.ok).toBe(true)
+			await fixture.mcp.waitForEvent("tool_called", {
+				where: { name: "echo", arguments: { message: "from-ui" } },
+			})
+			trace.step("MCP App called a server tool through the consent-gated bridge")
+
+			await ui.post("/proxy/ui/message", {
+				type: "prompt",
+				prompt: "continue from the fixture app",
+			})
+			await waitForText(terminal, "The MCP App prompt triggered an agent turn.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			await ui.post("/proxy/ui/complete", { reason: "done" })
+			trace.step("UI prompt triggered a deterministic follow-up turn and the app completed")
+
+			terminal.submit("Retrieve the completed MCP App messages")
+			await waitForText(terminal, "The completed MCP App messages reached the model.", {
+				timeoutMs: STREAM_TIMEOUT_MS,
+			})
+			expect(toolResultText(fixture.fake.requests, uiMessages)).toContain("continue from the fixture app")
+			trace.step("completed UI messages crossed the MCP gateway and model boundary")
+		},
+	)
+})
+
+test("denies MCP App tool access without consent and tears down on completion", async ({ terminal }) => {
+	const openUi = gatewayMcpCall("open_ui")
+	await runMcpKimchiSession(
+		terminal,
+		{
+			artifactName: "mcp-ui-consent-denial",
+			mcp: { scenario: "ui-app" },
+			responses: [openUi.response, modelReply("The consent-gated MCP App opened.")],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Open the consent-gated fixture MCP App")
+			await waitForText(terminal, "The consent-gated MCP App opened.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await fixture.mcp.waitForEvent("ui_host_loaded", { where: { status: 200 } })
+			const ui = fixture.mcp.ui
+			expect(ui).toBeDefined()
+			if (!ui) throw new Error("MCP UI fixture was not configured")
+			const beforeDeniedCall = fixture.mcp.checkpoint()
+
+			await ui.post("/proxy/ui/consent", { approved: false })
+			const denied = await ui.request("/proxy/tools/call", {
+				name: "echo",
+				arguments: { message: "must-not-run" },
+			})
+			expect(denied.status).toBe(403)
+			expect(denied.body).toEqual(expect.objectContaining({ error: expect.stringMatching(/denied/i) }))
+			expect(
+				fixture.mcp
+					.readEvents()
+					.slice(beforeDeniedCall)
+					.some(
+						(event) =>
+							event.type === "tool_called" && event.name === "echo" && event.arguments.message === "must-not-run",
+					),
+			).toBe(false)
+			trace.step("denied consent blocked the UI tool call before MCP dispatch")
+
+			await ui.post("/proxy/ui/complete", { reason: "denied" })
+			await ui.waitForClosed()
+			trace.step("completing the denied app closed its local UI host")
+		},
+	)
+})

--- a/tests/e2e/tui/mcp-ui.test.ts
+++ b/tests/e2e/tui/mcp-ui.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@microsoft/tui-test"
 import { STREAM_TIMEOUT_MS, waitForText } from "./support/assertions.js"
 import { runMcpKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+import { mcpResourceResult, mcpToolResult } from "./support/mcp-fixture.js"
 import { gatewayMcpCall, mcpUiMessages, modelReply, toolResultText } from "./support/mcp-model-script.js"
 
 test.use(TUI_TEST_CONFIG)
@@ -12,7 +13,32 @@ test("bridges an MCP App tool call and prompt back into the agent", async ({ ter
 		terminal,
 		{
 			artifactName: "mcp-ui-app-bridge",
-			mcp: { scenario: "ui-app" },
+			mcp: {
+				scenario: "ui-app",
+				behavior: {
+					tools: [
+						mcpToolResult("open_ui", {
+							content: [{ type: "text", text: "fixture MCP App opened" }],
+						}),
+						mcpToolResult(
+							"echo",
+							{ content: [{ type: "text", text: "fixture echo: from-ui" }] },
+							{ message: "from-ui" },
+						),
+					],
+					resources: [
+						mcpResourceResult("ui://fixture/app", {
+							contents: [
+								{
+									uri: "ui://fixture/app",
+									mimeType: "text/html;profile=mcp-app",
+									text: '<!doctype html><html><body><main id="kimchi-mcp-app">Kimchi MCP App fixture</main></body></html>',
+								},
+							],
+						}),
+					],
+				},
+			},
 			responses: [
 				openUi.response,
 				modelReply("The MCP App opened."),
@@ -68,7 +94,27 @@ test("denies MCP App tool access without consent and tears down on completion", 
 		terminal,
 		{
 			artifactName: "mcp-ui-consent-denial",
-			mcp: { scenario: "ui-app" },
+			mcp: {
+				scenario: "ui-app",
+				behavior: {
+					tools: [
+						mcpToolResult("open_ui", {
+							content: [{ type: "text", text: "fixture MCP App opened" }],
+						}),
+					],
+					resources: [
+						mcpResourceResult("ui://fixture/app", {
+							contents: [
+								{
+									uri: "ui://fixture/app",
+									mimeType: "text/html;profile=mcp-app",
+									text: '<!doctype html><html><body><main id="kimchi-mcp-app">Kimchi MCP App fixture</main></body></html>',
+								},
+							],
+						}),
+					],
+				},
+			},
 			responses: [openUi.response, modelReply("The consent-gated MCP App opened.")],
 		},
 		async (fixture, trace) => {

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -354,10 +354,12 @@ async function writeChatCompletion(res: ServerResponse, script: FakeResponseScri
 	// Substitute dynamic ids from previous tool results into scripted tool args.
 	const fermentId = extractFermentId(body)
 	const agentId = extractAgentId(body)
+	const firstMcpTool = extractFirstMcpTool(body)
 	for (const toolCall of script.toolCalls ?? []) {
 		const fn = { ...toolCall.function }
 		if (fermentId) fn.arguments = fn.arguments.replaceAll("__FERMENT_ID__", fermentId)
 		if (agentId) fn.arguments = fn.arguments.replaceAll("__AGENT_ID__", agentId)
+		if (firstMcpTool) fn.arguments = fn.arguments.replaceAll("__MCP_FIRST_TOOL__", firstMcpTool)
 		chunk([
 			{
 				index: 0,
@@ -431,6 +433,11 @@ function extractAgentId(body: unknown): string | undefined {
 		}
 	}
 	return extractAgentIdFromText(JSON.stringify(body ?? ""))
+}
+
+/** Pull the first namespaced MCP tool from a prior gateway connect/list result. */
+function extractFirstMcpTool(body: unknown): string | undefined {
+	return JSON.stringify(body ?? "").match(/-\s*(conformance_[A-Za-z0-9_.-]+)/)?.[1]
 }
 
 function extractAgentIdFromValue(value: unknown): string | undefined {

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Shell } from "@microsoft/tui-test"
 import type { Terminal } from "@microsoft/tui-test/lib/terminal/term.js"
-import { fullText, STARTUP_TIMEOUT_MS, viewText, waitForText } from "./assertions.js"
+import { fullText, STARTUP_TIMEOUT_MS, STREAM_TIMEOUT_MS, viewText, waitForText } from "./assertions.js"
 import { type StartFakeOllamaServerOptions, startFakeOllamaServer } from "./fake-ollama-server.js"
 import {
 	DEFAULT_MODEL,
@@ -16,6 +16,7 @@ import {
 	resolveModels,
 	startFakeOpenAiServer,
 } from "./fake-openai-server.js"
+import { createMcpFixture, type McpFixture, type McpFixtureOptions } from "./mcp-fixture.js"
 
 /** Shared terminal geometry/shell for every TUI e2e test. */
 export const TUI_TEST_CONFIG = { shell: Shell.Bash, rows: 40, columns: 120 } as const
@@ -44,6 +45,8 @@ export interface KimchiFixture {
 	agentDir: string
 	fake: FakeOpenAiServer
 	ollama?: { baseUrl: string; requests: RecordedRequest[] }
+	/** Repository-owned MCP server configured for this session, when requested. */
+	mcp?: McpFixture
 	/** Value returned by the `seedHome` option, if used; else undefined. */
 	seedResult?: unknown
 	/** Env vars returned by `seedHome`, merged into the launched process env. */
@@ -51,6 +54,10 @@ export interface KimchiFixture {
 	providerId: string
 	initialModel: string | false
 	stop(): Promise<void>
+}
+
+export interface McpKimchiFixture extends KimchiFixture {
+	mcp: McpFixture
 }
 
 export interface LaunchKimchiOptions {
@@ -76,7 +83,7 @@ export interface SeedHomeResult {
 	data?: unknown
 }
 
-interface CreateKimchiFixtureOptions {
+export interface CreateKimchiFixtureOptions {
 	models?: FakeModel[]
 	responses: FakeResponseScript[]
 	routerResponses?: unknown[]
@@ -118,6 +125,19 @@ interface CreateKimchiFixtureOptions {
 	 *  completions (/v1/chat/completions) so the TUI E2E can run without a real
 	 *  `ollama serve` running. */
 	ollama?: StartFakeOllamaServerOptions
+	/** Seed the isolated Kimchi home with a repository-owned MCP server. */
+	mcp?: McpFixtureOptions
+}
+
+export type RunKimchiSessionOptions = CreateKimchiFixtureOptions & {
+	artifactName: string
+	/**
+	 * Optional hook that runs AFTER launch but BEFORE the PROMPT_READY wait.
+	 * Use to dismiss startup dialogs (e.g. a ferment resume dialog triggered
+	 * by KIMCHI_ACTIVE_FERMENT) that would otherwise block PROMPT_READY.
+	 * The hook receives the terminal so it can interact with the UI.
+	 */
+	beforeReady?: (terminal: Terminal) => Promise<void>
 }
 
 export async function createKimchiFixture(options: CreateKimchiFixtureOptions): Promise<KimchiFixture> {
@@ -127,6 +147,7 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-tui-work-"))
 	const providerId = options.providerId ?? FAKE_PROVIDER
 	const initialModel = options.initialModel ?? DEFAULT_MODEL.slug
+	let mcp: McpFixture | undefined
 	// Tear down server + temp dirs if any setup step throws.
 	try {
 		if (options.gitInit) execFileSync("git", ["init", "-q"], { cwd: workDir })
@@ -162,6 +183,7 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 		)
 
 		writeModelsConfig(join(agentDir, "models.json"), fake.baseUrl, options.models, providerId)
+		mcp = options.mcp ? await createMcpFixture(agentDir, options.mcp) : undefined
 
 		const rawSeed = options.seedHome?.(homeDir, workDir)
 		const seedIsResult =
@@ -170,6 +192,7 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 			("env" in (rawSeed as SeedHomeResult) || "data" in (rawSeed as SeedHomeResult))
 		const seedEnv = {
 			KIMCHI_ROUTER_ENDPOINT: fake.baseUrl,
+			...(mcp?.env ?? {}),
 			...(seedIsResult ? ((rawSeed as SeedHomeResult).env ?? {}) : {}),
 		}
 		const seedResult = seedIsResult ? (rawSeed as SeedHomeResult).data : rawSeed
@@ -180,17 +203,18 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 			agentDir,
 			fake,
 			ollama: ollama ? { baseUrl: ollama.baseUrl, requests: ollama.requests } : undefined,
+			mcp,
 			seedResult,
 			seedEnv,
 			providerId,
 			initialModel,
 			async stop() {
-				// Run both server stops even if one throws, so a failing OpenAI
-				// fake doesn't leak an Ollama fake listening on a port.
+				// Run all server stops even if one throws so no fixture process leaks.
 				await fake.stop().catch(() => {})
 				if (ollama) {
 					await ollama.stop().catch(() => {})
 				}
+				await mcp?.stop().catch(() => {})
 				rmSync(homeDir, { recursive: true, force: true })
 				rmSync(workDir, { recursive: true, force: true })
 			},
@@ -200,10 +224,19 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 		if (ollama) {
 			await ollama.stop().catch(() => {})
 		}
+		await mcp?.stop().catch(() => {})
 		rmSync(homeDir, { recursive: true, force: true })
 		rmSync(workDir, { recursive: true, force: true })
 		throw error
 	}
+}
+
+export async function createMcpKimchiFixture(
+	options: Omit<CreateKimchiFixtureOptions, "mcp"> & { mcp: McpFixtureOptions },
+): Promise<McpKimchiFixture> {
+	const fixture = await createKimchiFixture(options)
+	assertMcpFixture(fixture)
+	return fixture
 }
 
 export function launchKimchi(
@@ -243,6 +276,57 @@ export function launchKimchi(
 	terminal.submit(`${command}${exitMarker}`)
 }
 
+export interface KimchiSessionController {
+	start(): Promise<void>
+	turn(prompt: string, expectedText: string, options?: { timeoutMs?: number }): Promise<void>
+	restart(): Promise<void>
+	quit(): Promise<void>
+}
+
+export function createKimchiSessionController(
+	terminal: Terminal,
+	fixture: KimchiFixture,
+	options: { extraArgs?: string[]; extraEnv?: Record<string, string> } = {},
+): KimchiSessionController {
+	let running = false
+	let exitMarker = ""
+	let launchNumber = 0
+	const extraArgs = options.extraArgs ?? []
+	const extraEnv = options.extraEnv ?? fixture.seedEnv
+
+	const start = async () => {
+		if (running) throw new Error("Kimchi session is already running")
+		launchNumber += 1
+		exitMarker = `KIMCHI_E2E_EXIT_${process.pid}_${launchNumber}`
+		launchKimchi(terminal, fixture, extraArgs, extraEnv, { exitMarker })
+		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		running = true
+	}
+
+	const quit = async () => {
+		if (!running) return
+		terminal.submit("/quit")
+		await waitForText(terminal, exitMarker, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		running = false
+	}
+
+	return {
+		start,
+		async turn(prompt, expectedText, turnOptions = {}) {
+			if (!running) throw new Error("Kimchi session is not running")
+			terminal.submit(prompt)
+			await waitForText(terminal, expectedText, {
+				timeoutMs: turnOptions.timeoutMs ?? STREAM_TIMEOUT_MS,
+			})
+		},
+		async restart() {
+			await quit()
+			await start()
+		},
+		quit,
+	}
+}
+
 export async function stopKimchi(terminal: Terminal): Promise<void> {
 	const exit = new Promise<{ exitCode: number; signal?: number }>((resolveExit) => terminal.onExit(resolveExit))
 	terminal.keyCtrlC(2)
@@ -254,16 +338,7 @@ export async function stopKimchi(terminal: Terminal): Promise<void> {
 /** Create fixture, launch kimchi, wait for ready, run `body`, always tear down (artifact on throw). */
 export async function runKimchiSession(
 	terminal: Terminal,
-	options: CreateKimchiFixtureOptions & {
-		artifactName: string
-		/**
-		 * Optional hook that runs AFTER launch but BEFORE the PROMPT_READY wait.
-		 * Use to dismiss startup dialogs (e.g. a ferment resume dialog triggered
-		 * by KIMCHI_ACTIVE_FERMENT) that would otherwise block PROMPT_READY.
-		 * The hook receives the terminal so it can interact with the UI.
-		 */
-		beforeReady?: (terminal: Terminal) => Promise<void>
-	},
+	options: RunKimchiSessionOptions,
 	body: (fixture: KimchiFixture, trace: TuiScenarioTrace) => Promise<void>,
 ): Promise<void> {
 	const { artifactName, beforeReady, ...fixtureOptions } = options
@@ -311,6 +386,65 @@ export async function runKimchiSession(
 		} catch (stopError) {
 			process.stderr.write(`[tui-e2e] fixture.stop failed: ${String(stopError)}\n`)
 		}
+	}
+}
+
+function assertMcpFixture(fixture: KimchiFixture): asserts fixture is McpKimchiFixture {
+	if (!fixture.mcp) throw new Error("MCP test fixture was requested but not created")
+}
+
+export async function runMcpKimchiSession(
+	terminal: Terminal,
+	options: Omit<RunKimchiSessionOptions, "mcp"> & { mcp: McpFixtureOptions },
+	body: (fixture: McpKimchiFixture, trace: TuiScenarioTrace) => Promise<void>,
+): Promise<void> {
+	await runKimchiSession(terminal, options, async (fixture, trace) => {
+		assertMcpFixture(fixture)
+		await body(fixture, trace)
+	})
+}
+
+export async function runRestartableMcpKimchiSession(
+	terminal: Terminal,
+	options: Omit<RunKimchiSessionOptions, "beforeReady" | "mcp"> & { mcp: McpFixtureOptions },
+	body: (fixture: McpKimchiFixture, session: KimchiSessionController, trace: TuiScenarioTrace) => Promise<void>,
+): Promise<void> {
+	const { artifactName, ...fixtureOptions } = options
+	const fixture = await createMcpKimchiFixture(fixtureOptions)
+	const session = createKimchiSessionController(terminal, fixture, {
+		extraArgs: fixtureOptions.extraArgs,
+		extraEnv: { ...fixtureOptions.env, ...fixture.seedEnv },
+	})
+	let artifactWritten = false
+	const steps: TuiStepSnapshot[] = []
+	const trace: TuiScenarioTrace = {
+		step(label) {
+			steps.push({ label, at: new Date().toISOString(), view: viewText(terminal) })
+		},
+	}
+
+	try {
+		await session.start()
+		trace.step("ready prompt visible")
+		await body(fixture, session, trace)
+		trace.step("scenario body completed")
+	} catch (error) {
+		artifactWritten = true
+		try {
+			await writeTuiArtifact({ name: artifactName, outcome: "fail", terminal, fixture, steps, error })
+		} catch (writeError) {
+			process.stderr.write(`[tui-e2e] failed to write fail artifact: ${String(writeError)}\n`)
+		}
+		throw error
+	} finally {
+		if (DEBUG_ARTIFACTS && !artifactWritten) {
+			await writeTuiArtifact({ name: artifactName, outcome: "pass", terminal, fixture, steps }).catch((writeError) => {
+				process.stderr.write(`[tui-e2e] failed to write pass artifact: ${String(writeError)}\n`)
+			})
+		}
+		await session.quit().catch(() => {})
+		await stopKimchi(terminal).catch(() => {})
+		await fixture.stop().catch(() => {})
 	}
 }
 

--- a/tests/e2e/tui/support/mcp-fixture.ts
+++ b/tests/e2e/tui/support/mcp-fixture.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
 import { isDeepStrictEqual } from "node:util"
+import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js"
 import type { McpConfig, McpSettings, OAuthConfig, ServerEntry } from "../../../../src/extensions/mcp-adapter/types.js"
 
 const REPO_ROOT = process.env.KIMCHI_REPO_ROOT
@@ -82,12 +83,53 @@ interface WaitForMcpFixtureEventOptions<T extends McpFixtureEventType> {
 
 export type McpFixtureScenario =
 	| "basic"
-	| "startup-failure"
 	| "http-malformed"
 	| "oauth-deny"
 	| "oauth-token-failure"
 	| "oauth-expiring"
 	| "ui-app"
+
+export type McpFixtureToolResponse =
+	| { type: "result"; value: CallToolResult }
+	| { type: "exit"; code: number }
+	| { type: "delayed-result"; delayMs: number; value: CallToolResult }
+
+export interface McpFixtureToolBehavior {
+	name: string
+	/** When present, only calls with exactly these arguments use this response. */
+	arguments?: Record<string, unknown>
+	response: McpFixtureToolResponse
+}
+
+export interface McpFixtureResourceBehavior {
+	uri: string
+	response: ReadResourceResult
+}
+
+export interface McpFixtureBehavior {
+	/** Exit before connecting a transport, simulating a server that cannot start. */
+	startup?: { type: "exit"; code: number }
+	/** MCP call outcomes declared by the test that exercises them. */
+	tools?: McpFixtureToolBehavior[]
+	/** MCP resource-read outcomes declared by the test that exercises them. */
+	resources?: McpFixtureResourceBehavior[]
+}
+
+export function mcpToolResult(
+	name: string,
+	value: CallToolResult,
+	args?: Record<string, unknown>,
+): McpFixtureToolBehavior {
+	return {
+		name,
+		...(args === undefined ? {} : { arguments: args }),
+		response: { type: "result", value },
+	}
+}
+
+export function mcpResourceResult(uri: string, response: ReadResourceResult): McpFixtureResourceBehavior {
+	return { uri, response }
+}
 
 export interface McpServerFixtureOptions {
 	serverName?: string
@@ -97,6 +139,7 @@ export interface McpServerFixtureOptions {
 	idleTimeout?: number
 	toolPrefix?: McpSettings["toolPrefix"]
 	autoAuth?: boolean
+	behavior?: McpFixtureBehavior
 }
 
 export interface McpUiFixture {
@@ -213,6 +256,10 @@ function configuredServerFields(options: McpServerFixtureOptions): ServerEntry {
 	}
 }
 
+function fixtureBehaviorEnv(behavior: McpFixtureBehavior | undefined): Record<string, string> {
+	return behavior ? { KIMCHI_MCP_FIXTURE_BEHAVIOR: JSON.stringify(behavior) } : {}
+}
+
 function writeMcpConfig(
 	agentDir: string,
 	serverDefinitions: Record<string, ServerEntry>,
@@ -286,6 +333,7 @@ function seedStdioServer(
 			env: {
 				KIMCHI_MCP_FIXTURE_EVENTS: eventPath,
 				KIMCHI_MCP_FIXTURE_SCENARIO: scenario,
+				...fixtureBehaviorEnv(options.behavior),
 			},
 			...configuredServerFields(options),
 		},
@@ -324,6 +372,7 @@ export async function createMcpFixture(agentDir: string, options: McpFixtureOpti
 			KIMCHI_MCP_FIXTURE_EVENTS: eventPath,
 			KIMCHI_MCP_FIXTURE_SCENARIO: scenario,
 			KIMCHI_MCP_FIXTURE_TRANSPORT: transport,
+			...fixtureBehaviorEnv(options.behavior),
 			...(oauth ? { KIMCHI_MCP_FIXTURE_OAUTH: "1" } : {}),
 			...(oauth && options.oauth?.grantType ? { KIMCHI_MCP_FIXTURE_OAUTH_GRANT_TYPE: options.oauth.grantType } : {}),
 			...(oauth && options.oauth?.clientId ? { KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_ID: options.oauth.clientId } : {}),

--- a/tests/e2e/tui/support/mcp-fixture.ts
+++ b/tests/e2e/tui/support/mcp-fixture.ts
@@ -1,0 +1,519 @@
+import { type ChildProcess, spawn } from "node:child_process"
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { setTimeout as delay } from "node:timers/promises"
+import { fileURLToPath } from "node:url"
+import { isDeepStrictEqual } from "node:util"
+import type { McpConfig, McpSettings, OAuthConfig, ServerEntry } from "../../../../src/extensions/mcp-adapter/types.js"
+
+const REPO_ROOT = process.env.KIMCHI_REPO_ROOT
+	? resolve(process.env.KIMCHI_REPO_ROOT)
+	: fileURLToPath(new URL("../../../../", import.meta.url))
+const FIXTURE_SERVER_PATH = resolve(REPO_ROOT, "tests/e2e/mcp/fixture-server.mjs")
+
+interface McpFixtureEventBase {
+	at: string
+	pid: number
+	scenario: string
+}
+
+interface McpFixtureEventDetails {
+	initialized: Record<string, never>
+	tools_listed: Record<string, never>
+	resources_listed: Record<string, never>
+	resource_read: { uri: string }
+	tool_called: { name: string; arguments: Record<string, unknown> }
+	disconnect_started: Record<string, never>
+	slow_call_started: Record<string, never>
+	slow_call_cancelled: Record<string, never>
+	slow_call_completed: Record<string, never>
+	http_malformed_response: { method?: string }
+	sse_streamable_rejected: { method?: string }
+	sse_session_initialized: { sessionId: string }
+	sse_session_closed: { sessionId: string }
+	sse_message: { sessionId: string }
+	oauth_resource_metadata_requested: { path: string }
+	oauth_server_metadata_requested: Record<string, never>
+	oauth_client_registered: { redirectUris?: string[] }
+	oauth_authorization_denied: { redirectUri: string }
+	oauth_authorized: { redirectUri: string; state: string; codeChallengeMethod: string }
+	oauth_token_issued: { grantType: string; expiresIn: number; pkceVerified?: boolean }
+	oauth_token_rejected: { grantType?: string }
+	oauth_browser_opened: Record<string, never>
+	oauth_browser_completed: { status: number }
+	http_request: {
+		method?: string
+		path: string
+		sessionId?: string
+		authorized: boolean
+		testHeader?: string
+	}
+	http_unauthorized: { method?: string; path: string }
+	http_session_initialized: { sessionId: string }
+	http_session_closed: { sessionId?: string }
+	http_error: { message: string }
+	http_listening: { url: string }
+	process_started: { transport: "stdio" | "http" | "sse" }
+	process_stopping: { signal: string }
+	process_exited: { code: number }
+	ui_browser_opened: Record<string, never>
+	ui_host_loaded: { status: number }
+}
+
+export type McpFixtureEventType = keyof McpFixtureEventDetails
+export type McpFixtureEventOf<T extends McpFixtureEventType> = McpFixtureEventBase & {
+	type: T
+} & McpFixtureEventDetails[T]
+export type McpFixtureEvent = {
+	[T in McpFixtureEventType]: McpFixtureEventOf<T>
+}[McpFixtureEventType]
+
+type McpFixtureEventWhere<T extends McpFixtureEventType> = Partial<
+	Omit<McpFixtureEventOf<T>, keyof McpFixtureEventBase | "type">
+>
+
+interface WaitForMcpFixtureEventOptions<T extends McpFixtureEventType> {
+	where?: McpFixtureEventWhere<T>
+	predicate?: (event: McpFixtureEventOf<T>) => boolean
+	after?: number
+	timeoutMs?: number
+	description?: string
+}
+
+export type McpFixtureScenario =
+	| "basic"
+	| "startup-failure"
+	| "http-malformed"
+	| "oauth-deny"
+	| "oauth-token-failure"
+	| "oauth-expiring"
+	| "ui-app"
+
+export interface McpServerFixtureOptions {
+	serverName?: string
+	scenario?: McpFixtureScenario
+	directTools?: boolean | string[]
+	lifecycle?: "keep-alive" | "lazy" | "eager"
+	idleTimeout?: number
+	toolPrefix?: McpSettings["toolPrefix"]
+	autoAuth?: boolean
+}
+
+export interface McpUiFixture {
+	waitForTarget(): Promise<string>
+	request(path: string, params: Record<string, unknown>): Promise<{ status: number; body: Record<string, unknown> }>
+	post(path: string, params: Record<string, unknown>): Promise<Record<string, unknown>>
+	waitForClosed(): Promise<void>
+}
+
+export interface McpServerFixture {
+	serverName: string
+	serverDefinition: ServerEntry
+	configPath: string
+	eventPath: string
+	readEvents(): McpFixtureEvent[]
+	eventsOfType<T extends McpFixtureEventType>(type: T): McpFixtureEventOf<T>[]
+	hasEvent<T extends McpFixtureEventType>(type: T, where?: McpFixtureEventWhere<T>): boolean
+	checkpoint(): number
+	waitForOAuthTokenExpiry(event: McpFixtureEventOf<"oauth_token_issued">): Promise<void>
+	waitForEvent<T extends McpFixtureEventType>(
+		type: T,
+		options?: WaitForMcpFixtureEventOptions<T>,
+	): Promise<McpFixtureEventOf<T>>
+}
+
+export interface McpFixtureOptions extends McpServerFixtureOptions {
+	transport?: "stdio" | "http" | "oauth" | "sse"
+	/** Additional stdio servers written into the same production MCP config. */
+	additionalStdioServers?: Record<string, Omit<McpServerFixtureOptions, "serverName">>
+	/** Configure an already-running HTTP server instead of spawning the repository fixture. */
+	externalUrl?: string
+	headers?: Record<string, string>
+	/** Require this static token at the HTTP fixture and configure Kimchi to send it. */
+	bearerToken?: string
+	/** OAuth settings used by automatic-auth and conformance scenarios. */
+	oauth?: OAuthConfig
+}
+
+export interface McpFixture extends McpServerFixture {
+	transport: "stdio" | "http" | "oauth" | "sse"
+	url?: string
+	env: Record<string, string>
+	ui?: McpUiFixture
+	servers: Record<string, McpServerFixture>
+	server(name: string): McpServerFixture
+	stop(): Promise<void>
+}
+
+function eventMatches<T extends McpFixtureEventType>(
+	event: McpFixtureEventOf<T>,
+	where: McpFixtureEventWhere<T> | undefined,
+): boolean {
+	if (!where) return true
+	return Object.entries(where).every(([key, value]) =>
+		isDeepStrictEqual(event[key as keyof McpFixtureEventOf<T>], value),
+	)
+}
+
+function createEventReader(
+	eventPath: string,
+): Pick<
+	McpServerFixture,
+	"readEvents" | "eventsOfType" | "hasEvent" | "checkpoint" | "waitForOAuthTokenExpiry" | "waitForEvent"
+> {
+	const readEvents = (): McpFixtureEvent[] => {
+		if (!existsSync(eventPath)) return []
+		const contents = readFileSync(eventPath, "utf-8")
+		const lines = contents.split("\n")
+		if (!contents.endsWith("\n")) lines.pop()
+		return lines.filter(Boolean).map((line) => JSON.parse(line) as McpFixtureEvent)
+	}
+	const eventsOfType = <T extends McpFixtureEventType>(type: T): McpFixtureEventOf<T>[] =>
+		readEvents().filter((event): event is McpFixtureEventOf<T> => event.type === type)
+	const hasEvent = <T extends McpFixtureEventType>(type: T, where?: McpFixtureEventWhere<T>): boolean =>
+		eventsOfType(type).some((event) => eventMatches(event, where))
+
+	return {
+		readEvents,
+		eventsOfType,
+		hasEvent,
+		checkpoint: () => readEvents().length,
+		async waitForOAuthTokenExpiry(event) {
+			const remainingMs = Date.parse(event.at) + event.expiresIn * 1_000 - Date.now()
+			if (remainingMs > 0) await delay(remainingMs + 100)
+		},
+		async waitForEvent(type, waitOptions = {}) {
+			const timeoutMs = waitOptions.timeoutMs ?? 10_000
+			const startedAt = Date.now()
+			while (Date.now() - startedAt < timeoutMs) {
+				const events = readEvents().slice(waitOptions.after ?? 0)
+				const event = eventsOfTypeFrom(events, type).find(
+					(candidate) => eventMatches(candidate, waitOptions.where) && (waitOptions.predicate?.(candidate) ?? true),
+				)
+				if (event) return event
+				await delay(25)
+			}
+			const description = waitOptions.description ?? `${type} MCP fixture event`
+			throw new Error(
+				`Timed out after ${timeoutMs}ms waiting for ${description}. Events: ${JSON.stringify(readEvents())}`,
+			)
+		},
+	}
+}
+
+function eventsOfTypeFrom<T extends McpFixtureEventType>(events: McpFixtureEvent[], type: T): McpFixtureEventOf<T>[] {
+	return events.filter((event): event is McpFixtureEventOf<T> => event.type === type)
+}
+
+function configuredServerFields(options: McpServerFixtureOptions): ServerEntry {
+	return {
+		...(options.lifecycle === undefined ? {} : { lifecycle: options.lifecycle }),
+		...(options.idleTimeout === undefined ? {} : { idleTimeout: options.idleTimeout }),
+		...(options.directTools === undefined ? {} : { directTools: options.directTools }),
+	}
+}
+
+function writeMcpConfig(
+	agentDir: string,
+	serverDefinitions: Record<string, ServerEntry>,
+	options: McpServerFixtureOptions,
+): string {
+	const configPath = resolve(agentDir, "mcp.json")
+	const config: McpConfig = {
+		mcpServers: serverDefinitions,
+		...(options.toolPrefix === undefined && options.autoAuth === undefined
+			? {}
+			: {
+					settings: {
+						...(options.toolPrefix === undefined ? {} : { toolPrefix: options.toolPrefix }),
+						...(options.autoAuth === undefined ? {} : { autoAuth: options.autoAuth }),
+					},
+				}),
+	}
+	writeFileSync(configPath, JSON.stringify(config, null, "\t"), "utf-8")
+	return configPath
+}
+
+export function seedMcpStdioFixture(agentDir: string, options: McpFixtureOptions = {}): McpFixture {
+	const serverName = options.serverName ?? "fixture"
+	const allOptions: Array<[string, McpServerFixtureOptions]> = [
+		[serverName, options],
+		...Object.entries(options.additionalStdioServers ?? {}).map(
+			([name, serverOptions]): [string, McpServerFixtureOptions] => [name, { ...serverOptions, serverName: name }],
+		),
+	]
+	const seeded = allOptions.map(([name, serverOptions]) => seedStdioServer(agentDir, name, serverOptions))
+	const configPath = writeMcpConfig(
+		agentDir,
+		Object.fromEntries(seeded.map((server) => [server.serverName, server.serverDefinition])),
+		options,
+	)
+	const servers = Object.fromEntries(
+		seeded.map((server) => [server.serverName, { ...server, configPath } satisfies McpServerFixture]),
+	)
+	const primary = servers[serverName]
+	if (!primary) throw new Error(`Primary MCP fixture ${serverName} was not seeded`)
+	const uiDriver = options.scenario === "ui-app" ? createUiBrowserDriver(agentDir, primary.eventPath) : undefined
+
+	return {
+		...primary,
+		transport: "stdio",
+		env: uiDriver?.env ?? {},
+		ui: uiDriver?.ui,
+		servers,
+		server(name) {
+			const fixture = servers[name]
+			if (!fixture) throw new Error(`MCP fixture server ${name} is not configured`)
+			return fixture
+		},
+		async stop() {},
+	}
+}
+
+function seedStdioServer(
+	agentDir: string,
+	serverName: string,
+	options: McpServerFixtureOptions,
+): Omit<McpServerFixture, "configPath"> {
+	const scenario = options.scenario ?? "basic"
+	const eventPath = resolve(agentDir, `mcp-fixture-${serverName}.jsonl`)
+	writeFileSync(eventPath, "", "utf-8")
+	return {
+		serverName,
+		serverDefinition: {
+			command: process.execPath,
+			args: [FIXTURE_SERVER_PATH],
+			env: {
+				KIMCHI_MCP_FIXTURE_EVENTS: eventPath,
+				KIMCHI_MCP_FIXTURE_SCENARIO: scenario,
+			},
+			...configuredServerFields(options),
+		},
+		eventPath,
+		...createEventReader(eventPath),
+	}
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return
+	const exited = new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()))
+	child.kill("SIGTERM")
+	const graceful = await Promise.race([exited.then(() => true), delay(3_000).then(() => false)])
+	if (graceful) return
+	child.kill("SIGKILL")
+	await exited
+}
+
+export async function createMcpFixture(agentDir: string, options: McpFixtureOptions = {}): Promise<McpFixture> {
+	if (options.additionalStdioServers && (options.externalUrl || (options.transport ?? "stdio") !== "stdio")) {
+		throw new Error("additionalStdioServers is currently supported only by the stdio MCP fixture")
+	}
+	if (options.externalUrl) return seedExternalHttpFixture(agentDir, options)
+	if ((options.transport ?? "stdio") === "stdio") return seedMcpStdioFixture(agentDir, options)
+
+	const serverName = options.serverName ?? "fixture"
+	const scenario = options.scenario ?? "basic"
+	const oauth = options.transport === "oauth"
+	const transport = options.transport === "sse" ? "sse" : "http"
+	const eventPath = resolve(agentDir, `mcp-fixture-${serverName}.jsonl`)
+	writeFileSync(eventPath, "", "utf-8")
+
+	const child = spawn(process.execPath, [FIXTURE_SERVER_PATH], {
+		env: {
+			...process.env,
+			KIMCHI_MCP_FIXTURE_EVENTS: eventPath,
+			KIMCHI_MCP_FIXTURE_SCENARIO: scenario,
+			KIMCHI_MCP_FIXTURE_TRANSPORT: transport,
+			...(oauth ? { KIMCHI_MCP_FIXTURE_OAUTH: "1" } : {}),
+			...(oauth && options.oauth?.grantType ? { KIMCHI_MCP_FIXTURE_OAUTH_GRANT_TYPE: options.oauth.grantType } : {}),
+			...(oauth && options.oauth?.clientId ? { KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_ID: options.oauth.clientId } : {}),
+			...(oauth && options.oauth?.clientSecret
+				? { KIMCHI_MCP_FIXTURE_OAUTH_CLIENT_SECRET: options.oauth.clientSecret }
+				: {}),
+			...(oauth
+				? { KIMCHI_MCP_FIXTURE_BEARER_TOKEN: "kimchi-e2e-oauth-access-token" }
+				: options.bearerToken
+					? { KIMCHI_MCP_FIXTURE_BEARER_TOKEN: options.bearerToken }
+					: {}),
+		},
+		stdio: ["ignore", "ignore", "inherit"],
+	})
+	const eventReader = createEventReader(eventPath)
+	try {
+		const listening = await eventReader.waitForEvent("http_listening", {
+			description: "HTTP MCP fixture to listen",
+		})
+		const serverDefinition: ServerEntry = {
+			url: listening.url,
+			...(options.headers === undefined ? {} : { headers: options.headers }),
+			...(oauth ? { auth: "oauth" as const, oauth: options.oauth ?? { scope: "mcp:tools" } } : {}),
+			...(!oauth && options.bearerToken ? { auth: "bearer" as const, bearerToken: options.bearerToken } : {}),
+			...configuredServerFields(options),
+		}
+		const configPath = writeMcpConfig(agentDir, { [serverName]: serverDefinition }, options)
+		const browserEnv = oauth ? createOAuthBrowserDriver(agentDir, eventPath) : {}
+		const serverFixture: McpServerFixture = { serverName, serverDefinition, configPath, eventPath, ...eventReader }
+
+		return {
+			...serverFixture,
+			transport: oauth ? "oauth" : transport,
+			url: listening.url,
+			env: browserEnv,
+			servers: { [serverName]: serverFixture },
+			server(name) {
+				if (name !== serverName) throw new Error(`MCP fixture server ${name} is not configured`)
+				return serverFixture
+			},
+			async stop() {
+				await stopChild(child)
+			},
+		}
+	} catch (error) {
+		await stopChild(child)
+		throw error
+	}
+}
+
+function seedExternalHttpFixture(agentDir: string, options: McpFixtureOptions): McpFixture {
+	const serverName = options.serverName ?? "fixture"
+	const eventPath = resolve(agentDir, `mcp-fixture-${serverName}.jsonl`)
+	writeFileSync(eventPath, "", "utf-8")
+	const serverDefinition: ServerEntry = {
+		url: options.externalUrl,
+		...(options.headers === undefined ? {} : { headers: options.headers }),
+		...(options.transport === "oauth"
+			? { auth: "oauth" as const, oauth: options.oauth ?? { scope: "mcp:tools" } }
+			: {}),
+		...configuredServerFields(options),
+	}
+	const configPath = writeMcpConfig(agentDir, { [serverName]: serverDefinition }, options)
+	const browserEnv = options.transport === "oauth" ? createOAuthBrowserDriver(agentDir, eventPath) : {}
+	const serverFixture: McpServerFixture = {
+		serverName,
+		serverDefinition,
+		configPath,
+		eventPath,
+		...createEventReader(eventPath),
+	}
+	return {
+		...serverFixture,
+		transport: options.transport === "oauth" ? "oauth" : "http",
+		url: options.externalUrl,
+		env: browserEnv,
+		servers: { [serverName]: serverFixture },
+		server(name) {
+			if (name !== serverName) throw new Error(`MCP fixture server ${name} is not configured`)
+			return serverFixture
+		},
+		async stop() {},
+	}
+}
+
+function createUiBrowserDriver(agentDir: string, eventPath: string): { env: Record<string, string>; ui: McpUiFixture } {
+	const browserBinDir = resolve(agentDir, "mcp-ui-browser")
+	const browserPath = resolve(browserBinDir, "open")
+	const targetPath = resolve(agentDir, "mcp-ui-target.json")
+	mkdirSync(browserBinDir, { recursive: true })
+	writeFileSync(
+		browserPath,
+		`#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs"
+const eventPath = ${JSON.stringify(eventPath)}
+const targetPath = ${JSON.stringify(targetPath)}
+const target = process.argv.find((argument) => argument.startsWith("http://") || argument.startsWith("https://"))
+if (!target) throw new Error("MCP UI browser driver did not receive an HTTP URL")
+writeFileSync(targetPath, JSON.stringify({ target }), "utf-8")
+appendFileSync(eventPath, JSON.stringify({ type: "ui_browser_opened", at: new Date().toISOString(), pid: process.pid, scenario: "ui-app" }) + "\\n")
+const response = await fetch(target)
+appendFileSync(eventPath, JSON.stringify({ type: "ui_host_loaded", at: new Date().toISOString(), pid: process.pid, scenario: "ui-app", status: response.status }) + "\\n")
+if (!response.ok) throw new Error(\`MCP UI browser driver received HTTP \${response.status}\`)
+`,
+		"utf-8",
+	)
+	chmodSync(browserPath, 0o755)
+
+	const waitForTarget = async (): Promise<string> => {
+		const startedAt = Date.now()
+		while (Date.now() - startedAt < 10_000) {
+			if (existsSync(targetPath)) {
+				const parsed = JSON.parse(readFileSync(targetPath, "utf-8")) as { target?: unknown }
+				if (typeof parsed.target === "string") return parsed.target
+			}
+			await delay(25)
+		}
+		throw new Error("Timed out waiting for the MCP UI browser target")
+	}
+	const request = async (
+		path: string,
+		params: Record<string, unknown>,
+	): Promise<{ status: number; body: Record<string, unknown> }> => {
+		const target = new URL(await waitForTarget())
+		const token = target.searchParams.get("session")
+		if (!token) throw new Error("MCP UI target did not contain a session token")
+		const response = await fetch(new URL(path, target.origin), {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ token, params }),
+		})
+		return { status: response.status, body: (await response.json()) as Record<string, unknown> }
+	}
+	const post = async (path: string, params: Record<string, unknown>): Promise<Record<string, unknown>> => {
+		const response = await request(path, params)
+		if (response.status < 200 || response.status >= 300) {
+			throw new Error(`MCP UI request failed (${response.status}): ${JSON.stringify(response.body)}`)
+		}
+		return response.body
+	}
+	const waitForClosed = async (): Promise<void> => {
+		const target = new URL(await waitForTarget())
+		const startedAt = Date.now()
+		while (Date.now() - startedAt < 5_000) {
+			try {
+				await fetch(target)
+			} catch {
+				return
+			}
+			await delay(25)
+		}
+		throw new Error("Timed out waiting for the MCP UI host to close")
+	}
+
+	return {
+		env: {
+			BROWSER: browserPath,
+			PATH: `${browserBinDir}:${process.env.PATH ?? ""}`,
+			MCP_UI_VIEWER: "browser",
+		},
+		ui: {
+			waitForTarget,
+			request,
+			post,
+			waitForClosed,
+		},
+	}
+}
+
+function createOAuthBrowserDriver(agentDir: string, eventPath: string): Record<string, string> {
+	const browserBinDir = resolve(agentDir, "mcp-oauth-browser")
+	const browserPath = resolve(browserBinDir, "open")
+	mkdirSync(browserBinDir, { recursive: true })
+	writeFileSync(
+		browserPath,
+		`#!/usr/bin/env node
+import { appendFileSync } from "node:fs"
+const eventPath = ${JSON.stringify(eventPath)}
+const target = process.argv.find((argument) => argument.startsWith("http://") || argument.startsWith("https://"))
+if (!target) throw new Error("OAuth browser driver did not receive an HTTP URL")
+appendFileSync(eventPath, JSON.stringify({ type: "oauth_browser_opened", at: new Date().toISOString(), pid: process.pid, scenario: "oauth" }) + "\\n")
+const response = await fetch(target, { redirect: "follow" })
+appendFileSync(eventPath, JSON.stringify({ type: "oauth_browser_completed", at: new Date().toISOString(), pid: process.pid, scenario: "oauth", status: response.status }) + "\\n")
+if (!response.ok) throw new Error(\`OAuth browser driver received HTTP \${response.status}\`)
+`,
+		"utf-8",
+	)
+	chmodSync(browserPath, 0o755)
+	return {
+		BROWSER: browserPath,
+		PATH: `${browserBinDir}:${process.env.PATH ?? ""}`,
+	}
+}

--- a/tests/e2e/tui/support/mcp-model-script.ts
+++ b/tests/e2e/tui/support/mcp-model-script.ts
@@ -1,0 +1,178 @@
+import type { McpSettings } from "../../../../src/extensions/mcp-adapter/types.js"
+import type { FakeResponseScript, RecordedRequest } from "./fake-openai-server.js"
+
+type JsonObject = Record<string, unknown>
+
+export interface ScriptedModelToolCall {
+	id: string
+	modelToolName: string
+	response: FakeResponseScript
+}
+
+export interface ScriptedMcpToolCall extends ScriptedModelToolCall {
+	serverName: string
+	originalToolName: string
+}
+
+interface McpCallOptions {
+	id?: string
+	serverName?: string
+	toolPrefix?: McpSettings["toolPrefix"]
+}
+
+let generatedCallId = 0
+
+function nextCallId(label: string): string {
+	generatedCallId += 1
+	return `call_mcp_${label.replaceAll(/[^a-zA-Z0-9]+/g, "_")}_${generatedCallId}`
+}
+
+function prefixedToolName(serverName: string, toolName: string, prefix: McpCallOptions["toolPrefix"]): string {
+	if (prefix === "none") return toolName
+	let normalizedServerName = serverName.replaceAll("-", "_")
+	if (prefix === "short") {
+		normalizedServerName = serverName.replace(/-?mcp$/i, "").replaceAll("-", "_") || "mcp"
+	}
+	return `${normalizedServerName}_${toolName}`
+}
+
+function modelToolCall(name: string, args: JsonObject, id: string): FakeResponseScript {
+	return {
+		toolCalls: [
+			{
+				id,
+				function: { name, arguments: JSON.stringify(args) },
+			},
+		],
+	}
+}
+
+export function gatewayMcpCall(toolName: string, args?: JsonObject, options: McpCallOptions = {}): ScriptedMcpToolCall {
+	const serverName = options.serverName ?? "fixture"
+	const id = options.id ?? nextCallId(`gateway_${serverName}_${toolName}`)
+	const gatewayArgs: JsonObject = {
+		tool: prefixedToolName(serverName, toolName, options.toolPrefix),
+		server: serverName,
+		...(args === undefined ? {} : { args: JSON.stringify(args) }),
+	}
+	return {
+		id,
+		modelToolName: "mcp",
+		serverName,
+		originalToolName: toolName,
+		response: modelToolCall("mcp", gatewayArgs, id),
+	}
+}
+
+export function directMcpCall(toolName: string, args: JsonObject, options: McpCallOptions = {}): ScriptedMcpToolCall {
+	const serverName = options.serverName ?? "fixture"
+	const id = options.id ?? nextCallId(`direct_${serverName}_${toolName}`)
+	const modelName = prefixedToolName(serverName, toolName, options.toolPrefix)
+	return {
+		id,
+		modelToolName: modelName,
+		serverName,
+		originalToolName: toolName,
+		response: modelToolCall(modelName, args, id),
+	}
+}
+
+export function searchMcpTools(
+	query: string,
+	options: Pick<McpCallOptions, "id" | "serverName"> = {},
+): ScriptedModelToolCall {
+	const id = options.id ?? nextCallId("search")
+	return {
+		id,
+		modelToolName: "mcp",
+		response: modelToolCall(
+			"mcp",
+			{ search: query, ...(options.serverName === undefined ? {} : { server: options.serverName }) },
+			id,
+		),
+	}
+}
+
+export function connectMcpServer(serverName: string, options: Pick<McpCallOptions, "id"> = {}): ScriptedModelToolCall {
+	const id = options.id ?? nextCallId(`connect_${serverName}`)
+	return { id, modelToolName: "mcp", response: modelToolCall("mcp", { connect: serverName }, id) }
+}
+
+export function emptyMcpCall(options: Pick<McpCallOptions, "id"> = {}): ScriptedModelToolCall {
+	const id = options.id ?? nextCallId("status")
+	return { id, modelToolName: "mcp", response: modelToolCall("mcp", {}, id) }
+}
+
+export function mcpUiMessages(options: Pick<McpCallOptions, "id"> = {}): ScriptedModelToolCall {
+	const id = options.id ?? nextCallId("ui_messages")
+	return { id, modelToolName: "mcp", response: modelToolCall("mcp", { action: "ui-messages" }, id) }
+}
+
+export function modelReply(text: string): FakeResponseScript {
+	return { stream: [text] }
+}
+
+export function parallelModelToolCalls(...calls: ScriptedModelToolCall[]): FakeResponseScript {
+	return {
+		toolCalls: calls.map((call, index) => {
+			const toolCall = call.response.toolCalls?.[0]
+			if (!toolCall) throw new Error(`Scripted model call ${call.id} does not contain a tool call`)
+			return { ...toolCall, index }
+		}),
+	}
+}
+
+function requestMessages(request: RecordedRequest): JsonObject[] {
+	if (!request.body || typeof request.body !== "object") return []
+	const messages = (request.body as JsonObject).messages
+	if (!Array.isArray(messages)) return []
+	return messages.filter((message): message is JsonObject => Boolean(message) && typeof message === "object")
+}
+
+export function requireToolResult(
+	requests: readonly RecordedRequest[],
+	call: Pick<ScriptedModelToolCall, "id"> | string,
+): JsonObject {
+	const toolCallId = typeof call === "string" ? call : call.id
+	for (const request of requests) {
+		const result = requestMessages(request).find(
+			(message) => message.role === "tool" && message.tool_call_id === toolCallId,
+		)
+		if (result) return result
+	}
+	throw new Error(
+		`No model request contained a tool result for ${toolCallId}. Recorded requests: ${JSON.stringify(requests)}`,
+	)
+}
+
+export function toolResultText(
+	requests: readonly RecordedRequest[],
+	call: Pick<ScriptedModelToolCall, "id"> | string,
+): string {
+	const content = requireToolResult(requests, call).content
+	if (typeof content === "string") return content
+	if (!Array.isArray(content)) return JSON.stringify(content)
+	return content
+		.map((block) => {
+			if (block && typeof block === "object" && typeof (block as JsonObject).text === "string") {
+				return (block as JsonObject).text
+			}
+			return JSON.stringify(block)
+		})
+		.join("\n")
+}
+
+export function requireRequestAdvertisingTool(requests: readonly RecordedRequest[], toolName: string): RecordedRequest {
+	for (const request of requests) {
+		if (!request.body || typeof request.body !== "object") continue
+		const tools = (request.body as JsonObject).tools
+		if (!Array.isArray(tools)) continue
+		const advertised = tools.some((tool) => {
+			if (!tool || typeof tool !== "object") return false
+			const fn = (tool as JsonObject).function
+			return Boolean(fn && typeof fn === "object" && (fn as JsonObject).name === toolName)
+		})
+		if (advertised) return request
+	}
+	throw new Error(`No model request advertised tool ${toolName}. Recorded requests: ${JSON.stringify(requests)}`)
+}


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Introduce a deterministic, fully repository-owned MCP end-to-end harness that exercises the real compiled Kimchi client against stdio, Streamable HTTP, legacy SSE, and OAuth transports — with no mocked transport layers.

Fixture server (tests/e2e/mcp/fixture-server.mjs):
  Scenario-driven server on the pinned MCP SDK supporting all four
  transports, static bearer auth, a local OAuth authorization server
  (protected-resource + authorization-server metadata, dynamic client
  registration, auth code + PKCE, refresh, denial, token failure), and
  tools covering echo, isError results, mixed text/image content,
  mid-call disconnect, and cancellation-aware slow calls.

TUI e2e (tests/e2e/tui/mcp-*.test.ts):
  - stdio: init, discovery, gateway calls, search-to-direct injection, resources, error results, mixed content, empty gateway status
  - http: session IDs, custom headers, static bearer, SSE fallback, malformed protocol, server-unavailable recovery
  - oauth: full authorization-code + PKCE flow, denial, token failure, persistence and refresh after a real process restart
  - restart: cache population via gateway, direct tool after restart
  - failures: invalid args, startup failure, disconnect, bounded slow calls, transport loss Two test.fail specs pin known product bugs (async direct-tool bootstrap timing; cancellation not propagated as notifications/cancelled).

ACP e2e (tests/e2e/acp/mcp-workflow.test.ts):
  Server probing via _kimchi.dev/probe_mcp_server, cache population,
  MCP-backed agent turns, image forwarding, auth-required probing, and
  OAuth-protected tool calls.

Conformance (tests/e2e/mcp/conformance-client.ts):
  Official @modelcontextprotocol/conformance runner executing the
  initialize and tools_call client scenarios against Kimchi's real
  ACP-hosted client stack.

Infrastructure:
  - Shared mcp-fixture.ts wiring config, event readers, loopback listeners, and a fake OAuth browser driver per test
  - kimchi-fixture.ts and acp-fixture.ts gain an `mcp` option and teardown; acp-fixture supports image input modality
  - fake-openai-server.ts: __MCP_FIRST_TOOL__ substitution for conformance scenarios
  - package.json: test:e2e:mcp aggregate + per-tier scripts
  - .github/workflows/mcp-e2e.yml: PR, manual, and weekly schedule with artifact retention
  - docs/mcp-e2e-testing.md: architecture, coverage matrix, and guidance for extending the fixture

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
