### PR TITLE
fix(build): disable dotenv/bunfig autoloading in compiled binaries

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,6 +33,8 @@ runs:
     - name: Setup Bun
       if: inputs.bun == 'true'
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: "1.4.0"
 
     - name: Cache Playwright browsers
       if: inputs.playwright == 'true'

--- a/.github/workflows/acp-e2e.yml
+++ b/.github/workflows/acp-e2e.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/arc-terminal-bench-poc.yml
+++ b/.github/workflows/arc-terminal-bench-poc.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/tui-e2e.yml
+++ b/.github/workflows/tui-e2e.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
 
       - uses: actions/setup-go@v5
         with:

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
 		"ws": "^8.20.1"
 	},
 	"engines": {
+		"bun": ">=1.4.0",
 		"node": ">=22.19.0"
 	},
 	"packageManager": "pnpm@10.8.1",

--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -97,9 +97,10 @@ const externalFlags = externals.map((name) => `--external ${name}`).join(" ")
 // Trust the OS certificate store in addition to Bun's bundled roots so users behind
 // TLS-intercepting corporate proxies (Netskope, Zscaler, etc.) can reach the API without
 // extra env vars. Bun ignores the system store by default; --use-system-ca is additive.
+// `--no-compile-autoload-dotenv` and `--no-compile-autoload-bunfig` disable loading `.env` and `bunfig.toml` files.
 run(
 	"compile",
-	`bun build src/entry.ts --compile${targetFlag} --compile-exec-argv="--use-system-ca" --outfile dist/bin/${target.binaryName} ${externalFlags}`.trim(),
+	`bun build src/entry.ts --compile${targetFlag} --no-compile-autoload-dotenv --no-compile-autoload-bunfig --compile-exec-argv="--use-system-ca" --outfile dist/bin/${target.binaryName} ${externalFlags}`.trim(),
 )
 
 // Bun --compile produces binaries with an invalid code signature on macOS.

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -8,6 +8,7 @@ import {
 	readFileSync,
 	rmSync,
 	statSync,
+	writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -123,6 +124,35 @@ describe("binary smoke tests", () => {
 			.flatMap(readSessionEntries)
 
 		expect(newEntries).toContainEqual(expect.objectContaining({ type: "session_info", name: prompt }))
+	})
+
+	describe("runtime config autoloading", () => {
+		let workDir: string
+
+		beforeEach(() => {
+			workDir = mkdtempSync(join(tmpdir(), "kimchi-smoke-runtime-config-"))
+		})
+
+		afterEach(() => {
+			rmSync(workDir, { recursive: true, force: true })
+		})
+
+		it("does not load .env from the working directory", () => {
+			writeFileSync(join(workDir, ".env"), "KIMCHI_TELEMETRY_ENABLED=0\n", "utf-8")
+
+			const result = runBinary({ args: ["config", "telemetry"], cwd: workDir })
+
+			expect(result.stdout.trim()).toBe("Telemetry: enabled (from config)")
+		})
+
+		it("does not load bunfig.toml from the working directory", () => {
+			writeFileSync(join(workDir, "bunfig.toml"), 'preload = ["./disable-telemetry.js"]\n', "utf-8")
+			writeFileSync(join(workDir, "disable-telemetry.js"), 'process.env.KIMCHI_TELEMETRY_ENABLED = "0"\n', "utf-8")
+
+			const result = runBinary({ args: ["config", "telemetry"], cwd: workDir })
+
+			expect(result.stdout.trim()).toBe("Telemetry: enabled (from config)")
+		})
 	})
 
 	describe("--export", () => {

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -101,6 +101,7 @@ const DEFAULT_TIMEOUT_MS = 30_000
 
 interface RunBinaryOptions {
 	args?: string[]
+	cwd?: string
 	extraEnv?: Record<string, string>
 	timeoutMs?: number
 	/** When false, non-zero exit codes and signals don't throw. Useful for testing error paths. Defaults to true. */
@@ -108,9 +109,10 @@ interface RunBinaryOptions {
 }
 
 export function runBinary(opts: RunBinaryOptions = {}): SpawnSyncReturns<string> {
-	const { args = [], extraEnv = {}, timeoutMs = DEFAULT_TIMEOUT_MS, throwOnError = true } = opts
+	const { args = [], cwd, extraEnv = {}, timeoutMs = DEFAULT_TIMEOUT_MS, throwOnError = true } = opts
 	const home = getTempHome()
 	const result = spawnSync(BINARY_PATH, args, {
+		cwd,
 		encoding: "utf-8",
 		timeout: timeoutMs,
 		env: {


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Compiled binaries should not pick up .env or bunfig.toml files from the user's working directory at startup.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
