### PR TITLE
fix(pi): patch pi-coding-agent tools to use ctx.cwd

### DIFF
--- a/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -1,12 +1,20 @@
 # Patch: Kimchi runtime and UI integrations for pi-coding-agent 0.84.1
 #
-# Tracking: LLM-2564. No matching upstream issue exists yet; report remaining
+# 1. LLM-2564
+# No matching upstream issue exists yet; report remaining
 # generic changes to https://github.com/earendil-works/pi before the next upgrade.
 # Retains Kimchi CLI/provider defaults, extension-triggered prompt handling,
 # forced compaction, model selection, extension UI helpers, and compact visuals.
 # Removal: delete each hunk once the pinned Pi release exposes equivalent APIs
 # or Kimchi no longer needs the branded behavior.
 #
+# 2. LLM-3185
+# Upstream issue for cwd-aware tool execution: https://github.com/earendil-works/pi/issues/8679
+# Remove the cwd-resolution hunks once the upstream release makes the built-in
+# tools respect ExtensionContext.cwd. Changes: make cwd-sensitive built-in tools
+# (read, write, edit, grep, find, ls, bash) use ctx.cwd from the execute ExtensionContext
+# when available, falling back to the cwd captured at tool creation time.
+
 diff --git a/dist/cli/args.js b/dist/cli/args.js
 index e66b528fe676bd24ee5ad95abaa6201418850678..a15fe8267bfe863a8becaadc0f894ace5db70767 100644
 --- a/dist/cli/args.js
@@ -170,7 +178,7 @@ index 7d93ba62bdb5d47e129751e8075cbb34620322ad..89c8147bdfcd8ce91ea6a51ea4822c81
              ? provider
              : withRemoteCatalog(provider, options.catalogBaseUrl, builtinModelDataGeneratedAt));
 diff --git a/dist/core/tools/bash.js b/dist/core/tools/bash.js
-index f274908793624a5870008ab738fa19ac6758165c..320acfb56155b8d9711b423824350b7630b8e8cb 100644
+index f274908793624a5870008ab738fa19ac6758165c..c697aeeb7a651ef86cccef4fec944f41ccede0ee 100644
 --- a/dist/core/tools/bash.js
 +++ b/dist/core/tools/bash.js
 @@ -81,6 +81,12 @@ export function createLocalBashOperations(options) {
@@ -186,8 +194,17 @@ index f274908793624a5870008ab738fa19ac6758165c..320acfb56155b8d9711b423824350b76
                      }, timeoutMs);
                  }
                  // Stream stdout and stderr.
+@@ -236,7 +242,7 @@ export function createBashToolDefinition(cwd, options) {
+         parameters: bashSchema,
+         async execute(_toolCallId, { command, timeout }, signal, onUpdate, ctx) {
+             const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
+-            const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook, exposeSessionEnvironment, ctx);
++            const spawnContext = resolveSpawnContext(resolvedCommand, ctx?.cwd || cwd, spawnHook, exposeSessionEnvironment, ctx);
+             const output = new OutputAccumulator({ tempFilePrefix: "pi-bash" });
+             let acceptingOutput = true;
+             let updateTimer;
 diff --git a/dist/core/tools/edit.js b/dist/core/tools/edit.js
-index 9e83601e93c81b87d52448b429f4817e6cf25bd5..a124622278d37c6372466b990a2240dae094e9c5 100644
+index 9e83601e93c81b87d52448b429f4817e6cf25bd5..77842d28d32ddd4b172ff0993d58b82ccf4913f0 100644
 --- a/dist/core/tools/edit.js
 +++ b/dist/core/tools/edit.js
 @@ -64,7 +64,7 @@ function validateEditInput(input) {
@@ -218,6 +235,112 @@ index 9e83601e93c81b87d52448b429f4817e6cf25bd5..a124622278d37c6372466b990a2240da
  }
  function buildEditCallComponent(component, args, theme, cwd) {
      component.setBgFn(getEditHeaderBg(component.preview, component.settledError, theme));
+@@ -175,9 +175,9 @@ export function createEditToolDefinition(cwd, options) {
+         parameters: editSchema,
+         renderShell: "self",
+         prepareArguments: prepareEditArguments,
+-        async execute(_toolCallId, input, signal, _onUpdate, _ctx) {
++        async execute(_toolCallId, input, signal, _onUpdate, ctx) {
+             const { path, edits } = validateEditInput(input);
+-            const absolutePath = resolveToCwd(path, cwd);
++            const absolutePath = resolveToCwd(path, ctx?.cwd || cwd);
+             return withFileMutationQueue(absolutePath, async () => {
+                 // Do not reject from an abort event listener here: that would release the
+                 // mutation queue while an in-flight filesystem operation may still finish.
+diff --git a/dist/core/tools/find.js b/dist/core/tools/find.js
+index 2e91d7dacb94bf5f018d4464ca46d2b1be689629..9a4e6d7a80af4465d0c8119b0f83bf3fef5a67e1 100644
+--- a/dist/core/tools/find.js
++++ b/dist/core/tools/find.js
+@@ -81,7 +81,7 @@ export function createFindToolDefinition(cwd, options) {
+         description: `Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} results or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
+         promptSnippet: findToolSystemPromptContribution.snippet,
+         parameters: findSchema,
+-        async execute(_toolCallId, { pattern, path: searchDir, limit }, signal, _onUpdate, _ctx) {
++        async execute(_toolCallId, { pattern, path: searchDir, limit }, signal, _onUpdate, ctx) {
+             return new Promise((resolve, reject) => {
+                 if (signal?.aborted) {
+                     reject(new Error("Operation aborted"));
+@@ -104,7 +104,7 @@ export function createFindToolDefinition(cwd, options) {
+                 signal?.addEventListener("abort", onAbort, { once: true });
+                 (async () => {
+                     try {
+-                        const searchPath = resolveToCwd(searchDir || ".", cwd);
++                        const searchPath = resolveToCwd(searchDir || ".", ctx?.cwd || cwd);
+                         const effectiveLimit = limit ?? DEFAULT_LIMIT;
+                         const ops = customOps ?? defaultFindOperations;
+                         // If custom operations provide glob(), use that instead of fd.
+diff --git a/dist/core/tools/grep.js b/dist/core/tools/grep.js
+index 6bf8d30f6da2b78d8df60ddc59980e3ce47669d4..505a0f9e5a352e1d4dfa6093cf299b0fd456d7fd 100644
+--- a/dist/core/tools/grep.js
++++ b/dist/core/tools/grep.js
+@@ -81,7 +81,7 @@ export function createGrepToolDefinition(cwd, options) {
+         description: `Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to ${DEFAULT_LIMIT} matches or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Long lines are truncated to ${GREP_MAX_LINE_LENGTH} chars.`,
+         promptSnippet: grepToolSystemPromptContribution.snippet,
+         parameters: grepSchema,
+-        async execute(_toolCallId, { pattern, path: searchDir, glob, ignoreCase, literal, context, limit, }, signal, _onUpdate, _ctx) {
++        async execute(_toolCallId, { pattern, path: searchDir, glob, ignoreCase, literal, context, limit, }, signal, _onUpdate, ctx) {
+             return new Promise((resolve, reject) => {
+                 if (signal?.aborted) {
+                     reject(new Error("Operation aborted"));
+@@ -101,7 +101,7 @@ export function createGrepToolDefinition(cwd, options) {
+                             settle(() => reject(new Error("ripgrep (rg) is not available and could not be downloaded")));
+                             return;
+                         }
+-                        const searchPath = resolveToCwd(searchDir || ".", cwd);
++                        const searchPath = resolveToCwd(searchDir || ".", ctx?.cwd || cwd);
+                         const ops = customOps ?? defaultGrepOperations;
+                         let isDirectory;
+                         try {
+diff --git a/dist/core/tools/ls.js b/dist/core/tools/ls.js
+index ad34121da4a020ad76e840d9fba35380b8d9e60e..8720da282a217da260a405fb476dcd1f23a2f938 100644
+--- a/dist/core/tools/ls.js
++++ b/dist/core/tools/ls.js
+@@ -63,7 +63,7 @@ export function createLsToolDefinition(cwd, options) {
+         description: `List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to ${DEFAULT_LIMIT} entries or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first).`,
+         promptSnippet: lsToolSystemPromptContribution.snippet,
+         parameters: lsSchema,
+-        async execute(_toolCallId, { path, limit }, signal, _onUpdate, _ctx) {
++        async execute(_toolCallId, { path, limit }, signal, _onUpdate, ctx) {
+             return new Promise((resolve, reject) => {
+                 if (signal?.aborted) {
+                     reject(new Error("Operation aborted"));
+@@ -73,7 +73,7 @@ export function createLsToolDefinition(cwd, options) {
+                 signal?.addEventListener("abort", onAbort, { once: true });
+                 (async () => {
+                     try {
+-                        const dirPath = resolveToCwd(path || ".", cwd);
++                        const dirPath = resolveToCwd(path || ".", ctx?.cwd || cwd);
+                         const effectiveLimit = limit ?? DEFAULT_LIMIT;
+                         // Check if path exists.
+                         if (!(await ops.exists(dirPath))) {
+diff --git a/dist/core/tools/read.js b/dist/core/tools/read.js
+index 9664aab002dd44b8e76097bed35b38cace9e1c22..56e876f0a669dd630452801b4b91a950ac10ad52 100644
+--- a/dist/core/tools/read.js
++++ b/dist/core/tools/read.js
+@@ -155,7 +155,7 @@ export function createReadToolDefinition(cwd, options) {
+                 signal?.addEventListener("abort", onAbort, { once: true });
+                 (async () => {
+                     try {
+-                        const absolutePath = await resolveReadPathAsync(path, cwd);
++                        const absolutePath = await resolveReadPathAsync(path, ctx?.cwd || cwd);
+                         if (aborted)
+                             return;
+                         // Check if file exists and is readable.
+diff --git a/dist/core/tools/write.js b/dist/core/tools/write.js
+index 36c3d7fd9c8e30555387498d4520be00391a3d0b..a6b116089913fc9eea6e7b2688c47ecfc2c0ff93 100644
+--- a/dist/core/tools/write.js
++++ b/dist/core/tools/write.js
+@@ -141,8 +141,8 @@ export function createWriteToolDefinition(cwd, options) {
+         promptSnippet: writeToolSystemPromptContribution.snippet,
+         promptGuidelines: [...writeToolSystemPromptContribution.guidelines],
+         parameters: writeSchema,
+-        async execute(_toolCallId, { path, content }, signal, _onUpdate, _ctx) {
+-            const absolutePath = resolveToCwd(path, cwd);
++        async execute(_toolCallId, { path, content }, signal, _onUpdate, ctx) {
++            const absolutePath = resolveToCwd(path, ctx?.cwd || cwd);
+             const dir = dirname(absolutePath);
+             return withFileMutationQueue(absolutePath, async () => {
+                 // Do not reject from an abort event listener here: that would release the
 diff --git a/dist/modes/interactive/components/branch-summary-message.js b/dist/modes/interactive/components/branch-summary-message.js
 index e23ca6db02a29814112dd4945bd868604eb6676f..d0f6fd7aeb79c6a20655805152a30970f1b4cc2a 100644
 --- a/dist/modes/interactive/components/branch-summary-message.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: 833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: 1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930
+    hash: d7ba09544987562e64e9e2c7f2cd4b850f6677927e29ab4539178a4a81879024
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
   '@earendil-works/pi-tui@0.84.1':
     hash: 311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5
@@ -33,7 +33,7 @@ importers:
         version: 1.3.0
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
+        version: 0.84.1(patch_hash=d7ba09544987562e64e9e2c7f2cd4b850f6677927e29ab4539178a4a81879024)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=311ed17d2e9bd3f47057a281306fb7466c18b26940fcc5b534e0a4d252171ce5)
@@ -2853,7 +2853,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.1
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=1c6c6adae54bedc6366078abbf7f56d3f410ef82a020347f0b889c7c15db4930)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=d7ba09544987562e64e9e2c7f2cd4b850f6677927e29ab4539178a4a81879024)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/extensions/behaviours/tool-cwd-patch.test.ts
+++ b/src/extensions/behaviours/tool-cwd-patch.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+	createBashToolDefinition,
+	createEditToolDefinition,
+	createFindToolDefinition,
+	createGrepToolDefinition,
+	createLsToolDefinition,
+	createReadToolDefinition,
+	createWriteToolDefinition,
+	type ExtensionContext,
+} from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+/**
+ * Minimal ExtensionContext for testing cwd-sensitive tool execution.
+ * The patched tool factories only access ctx.cwd from the context passed to
+ * execute, so the remaining fields are stubbed.
+ */
+function fakeCtx(cwd: string): ExtensionContext {
+	return { cwd } as ExtensionContext
+}
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text" && typeof block.text === "string")
+		.map((block) => block.text)
+		.join("")
+}
+
+const toolCallId = "test-call"
+
+/**
+ * The cwd passed to create*ToolDefinition at registration time. Tools should
+ * ignore this when execute receives a ctx.cwd override.
+ */
+const creationCwd = "/tmp"
+
+describe("patched cwd-sensitive tools use ctx.cwd from execute", () => {
+	let tempDir: string
+	let ctx: ExtensionContext
+
+	beforeEach(() => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "kimchi-tool-cwd-")))
+		ctx = fakeCtx(tempDir)
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("read resolves relative paths against ctx.cwd", async () => {
+		writeFileSync(join(tempDir, "hello.txt"), "world")
+		const tool = createReadToolDefinition(creationCwd)
+
+		const result = await tool.execute(toolCallId, { path: "hello.txt" }, undefined, undefined, ctx)
+
+		expect(getText(result)).toContain("world")
+	})
+
+	it("write creates files relative to ctx.cwd", async () => {
+		const tool = createWriteToolDefinition(creationCwd)
+
+		const result = await tool.execute(
+			toolCallId,
+			{ path: "new-file.txt", content: "written" },
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(getText(result)).toBeTruthy()
+		expect(readFileSync(join(tempDir, "new-file.txt"), "utf-8")).toBe("written")
+	})
+
+	it("edit modifies files relative to ctx.cwd", async () => {
+		writeFileSync(join(tempDir, "edit-me.txt"), "old content")
+		const tool = createEditToolDefinition(creationCwd)
+
+		const result = await tool.execute(
+			toolCallId,
+			{ path: "edit-me.txt", edits: [{ oldText: "old", newText: "new" }] },
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(getText(result)).toBeTruthy()
+		expect(readFileSync(join(tempDir, "edit-me.txt"), "utf-8")).toBe("new content")
+	})
+
+	it("grep searches under ctx.cwd", async () => {
+		writeFileSync(join(tempDir, "needle.txt"), "find me here")
+		const tool = createGrepToolDefinition(creationCwd)
+
+		const result = await tool.execute(toolCallId, { pattern: "find me" }, undefined, undefined, ctx)
+
+		expect(getText(result)).toContain("needle.txt")
+	})
+
+	it("find discovers files under ctx.cwd", async () => {
+		writeFileSync(join(tempDir, "target.txt"), "")
+		const tool = createFindToolDefinition(creationCwd)
+
+		const result = await tool.execute(toolCallId, { pattern: "*.txt" }, undefined, undefined, ctx)
+
+		expect(getText(result)).toContain("target.txt")
+	})
+
+	it("ls lists ctx.cwd", async () => {
+		writeFileSync(join(tempDir, "visible.txt"), "")
+		const tool = createLsToolDefinition(creationCwd)
+
+		const result = await tool.execute(toolCallId, { path: "." }, undefined, undefined, ctx)
+
+		expect(getText(result)).toContain("visible.txt")
+	})
+
+	it("bash executes with ctx.cwd as working directory", async () => {
+		// Disable session environment so resolveSpawnContext does not touch
+		// sessionManager internals; only cwd matters for this test.
+		const tool = createBashToolDefinition(creationCwd, { exposeSessionEnvironment: false })
+
+		const result = await tool.execute(
+			toolCallId,
+			{ command: process.platform === "win32" ? "cd" : "pwd" },
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(getText(result).trim()).toBe(tempDir)
+	})
+})


### PR DESCRIPTION
## Linked issue

Tracked internally: LLM-3185
Related upstream issue: https://github.com/earendil-works/pi/issues/8679

## What does this PR do?

Patches `@earendil-works/pi-coding-agent@0.84.1` so that built-in cwd-sensitive tools resolve paths using `ctx.cwd` from the `ExtensionContext` passed to `execute`, falling back to the cwd captured at tool creation time.

This works around the upstream bug where tools registered once by an extension (e.g. Kimchi) use `process.cwd()` at registration time instead of the session's current working directory during execution.

In ACP, [`defaultSessionFactory`](https://github.com/getkimchi/kimchi/blob/c04a4b28accedfad99e193cd995c5d89a112b195/src/modes/acp/server.ts#L2009) may use a user-provided `cwd` which wouldn't get used as the base path for tool call arguments.

Tools patched:
- `read`
- `write`
- `edit`
- `grep`
- `find`
- `ls`
- `bash` (`powershell` inherits via the shared shell implementation)

Added regression tests in `src/extensions/behaviours/tool-cwd-patch.test.ts` covering each patched tool.

The patch header now references the upstream issue so the hunks can be dropped once Pi merges a fix.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm vitest run --dir src src/extensions/behaviours/tool-cwd-patch.test.ts src/extensions/behaviours/tool-args.smoke.test.ts src/extensions/bash-tool-guard.integration.test.ts`)
- [x] Lint passes (`pnpm run check`)
- [x] Frozen install passes (`pnpm install --frozen-lockfile`)
- [x] Documentation updated if behavior changed (patch header references upstream issue)