### PR TITLE
fix(skill-discovery): suppress startup warnings for non-existent paths and bundled skill collisions

### DIFF
--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -368,7 +368,7 @@ describe("prompt enrichment skills", () => {
 		expect(result).toEqual(expect.objectContaining({ skillPaths: expect.arrayContaining([projectSkillPath]) }))
 	})
 
-	it("contributes bundled skills dir through resources_discover", async () => {
+	it("contributes new bundled skills through resources_discover", async () => {
 		const cwd = join(dir, "project")
 		mkdirSync(cwd, { recursive: true })
 		const bundledDir = resolveBundledSkillsDir()
@@ -378,9 +378,17 @@ describe("prompt enrichment skills", () => {
 		const { resourcesDiscover } = buildPromptExtensionWithHandlers([])
 		if (!resourcesDiscover) throw new Error("resources_discover handler was not registered")
 
-		const result = resourcesDiscover({ type: "resources_discover", cwd, reason: "startup" }, undefined)
+		const result = resourcesDiscover({ type: "resources_discover", cwd, reason: "startup" }, undefined) as
+			| { skillPaths?: string[] }
+			| undefined
 
-		expect(result).toEqual(expect.objectContaining({ skillPaths: expect.arrayContaining([bundledDir]) }))
+		// Bundled skills not already in the harness dir are contributed via a
+		// filtered temp copy (e.g. dap-debugging). Skills already in the harness
+		// dir (e.g. improve if previously deployed) are silently skipped.
+		const paths = result?.skillPaths ?? []
+		expect(paths.length).toBeGreaterThan(0)
+		// At least one contributed path should contain a bundled skill dir.
+		expect(paths.some((p) => existsSync(join(p, "dap-debugging")) || existsSync(join(p, "improve")))).toBe(true)
 	})
 
 	it("contributes configured native skill paths through resources_discover", async () => {

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -395,7 +395,7 @@ describe("prompt enrichment skills", () => {
 		expect(result).toEqual(expect.objectContaining({ skillPaths: expect.arrayContaining([configuredSkills]) }))
 	})
 
-	it("contributes home-relative configured skill paths through resources_discover", async () => {
+	it("does not contribute the harness dir (pi loads it via includeDefaults)", async () => {
 		const cwd = join(dir, "project")
 		const configuredSkills = ".config/kimchi/harness/skills"
 		const expanded = join(dir, "home", configuredSkills)
@@ -403,9 +403,12 @@ describe("prompt enrichment skills", () => {
 		const { resourcesDiscover } = buildPromptExtensionWithHandlers([configuredSkills])
 		if (!resourcesDiscover) throw new Error("resources_discover handler was not registered")
 
-		const result = resourcesDiscover({ type: "resources_discover", cwd, reason: "startup" }, undefined)
+		const result = resourcesDiscover({ type: "resources_discover", cwd, reason: "startup" }, undefined) as
+			| { skillPaths?: string[] }
+			| undefined
 
-		expect(result).toEqual(expect.objectContaining({ skillPaths: expect.arrayContaining([expanded]) }))
+		const paths = result?.skillPaths ?? []
+		expect(paths).not.toContain(expanded)
 	})
 
 	it("sanitizes configured Claude Code skill paths through resources_discover", async () => {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -545,14 +545,18 @@ export default function (skillPathsFromConfig: string[]) {
 			// pi's loader is first-wins and discovered paths append after
 			// defaults), and configured native skill dirs.
 			const skillPaths = [...getKimchiProjectSkillPaths(event.cwd)]
-			const bundledDir = resolveBundledSkillsDir()
-			if (bundledDir) skillPaths.push(bundledDir)
 			// Configured native skill dirs (kimchi config.json skillPaths, e.g.
 			// ~/.config/kimchi/harness/skills) — pi has no visibility into our
 			// config file, so we must contribute them or they silently vanish
 			// from /skill:*, autocomplete and /resources once the prompt reads
 			// pi's resolved inventory instead of composing paths itself.
 			skillPaths.push(...getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig))
+			// Bundled skills shipped with the harness — contributed last (weakest
+			// collision slot: pi's loader is first-wins). dedupeExistingSkillPaths
+			// skips this dir entirely when all its skills are already present in
+			// a stronger path (e.g. a stale copy from the old deploy mechanism).
+			const bundledDir = resolveBundledSkillsDir()
+			if (bundledDir) skillPaths.push(bundledDir)
 			// Filter out non-existent paths — pi emits a warning diagnostic for
 			// every contributed path that doesn't exist on disk. Configured
 			// paths like `.pi/agent/skills` or `.claude/skills` are optional

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -30,7 +30,7 @@ import { join, resolve } from "node:path"
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
-import { resolveBundledSkillsDir } from "../../shared/skill-discovery/resolve-skill-roots.js"
+import { resolveBundledSkillsDir, resolveHarnessSkillsDir } from "../../shared/skill-discovery/resolve-skill-roots.js"
 import { getKimchiProjectSkillPaths } from "../../skill-paths.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
@@ -87,14 +87,20 @@ function safeUsername(): string {
  * noise by filtering before returning them from resources_discover.
  *
  * Also skips the bundled skills dir when every skill it contains is already
- * available in a stronger (earlier) path — this happens when the old deploy
- * mechanism copied bundled skills into the harness dir. Without this check,
- * pi emits a collision warning for each duplicated skill name.
+ * available in a stronger path. "Stronger" includes pi's own default loading
+ * from `agentDir/skills` (the harness dir), which runs before extension-
+ * contributed paths — without this check, pi emits a collision warning for
+ * each bundled skill name that was previously deployed into the harness dir.
  */
 function dedupeExistingSkillPaths(paths: readonly string[]): string[] {
 	const seen = new Set<string>()
 	const result: string[] = []
+	// Seed with skill names pi loads via includeDefaults (agentDir/skills),
+	// so the bundled dir can be skipped when those skills are already present
+	// in the harness dir.
 	const skillNamesFromStronger = new Set<string>()
+	const harnessDir = resolveHarnessSkillsDir()
+	collectSkillNames(harnessDir, skillNamesFromStronger)
 	for (const p of paths) {
 		const normalized = resolve(p)
 		if (seen.has(normalized)) continue

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -549,7 +549,15 @@ export default function (skillPathsFromConfig: string[]) {
 			// config file, so we must contribute them or they silently vanish
 			// from /skill:*, autocomplete and /resources once the prompt reads
 			// pi's resolved inventory instead of composing paths itself.
-			skillPaths.push(...getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig))
+			// Configured native skill dirs (kimchi config.json skillPaths).
+			// Filter out the harness dir — pi loads it natively via includeDefaults
+			// (agentDir/skills), so contributing it again is redundant and can cause
+			// stale-file warnings after migration removes deployed bundled skills.
+			const harnessDir = resolveHarnessSkillsDir()
+			const configuredPaths = getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig).filter(
+				(p) => resolve(p) !== resolve(harnessDir),
+			)
+			skillPaths.push(...configuredPaths)
 			// Bundled skills shipped with the harness — contributed last (weakest
 			// collision slot: pi's loader is first-wins). dedupeExistingSkillPaths
 			// skips this dir entirely when all its skills are already present in

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -24,8 +24,8 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs"
-import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs"
+import { arch, homedir, version as osVersion, platform, release, tmpdir, userInfo } from "node:os"
 import { join, resolve } from "node:path"
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
@@ -80,36 +80,41 @@ function safeUsername(): string {
 }
 
 /**
- * Remove stale deployed copies of bundled skills from the harness dir.
- * The old deploy mechanism copied bundled skills (e.g. improve) into
- * ~/.config/kimchi/harness/skills/ — now that bundled skills ship from
- * resources/skills/ and are contributed via resources_discover, those stale
- * copies cause collision warnings. This is a one-time migration: it only
- * removes skills whose names match a bundled skill, and only if the harness
- * dir doesn't have a .usage.json marking them as user-created.
+ * Create a filtered temp copy of the bundled skills dir containing only
+ * skills whose names are NOT already present in a stronger path (the
+ * harness dir pi loads natively, plus any earlier contributed paths).
+ * This avoids collision warnings for bundled skills that were previously
+ * deployed to the harness dir, while still contributing new bundled skills
+ * (e.g. dap-debugging) that don't exist elsewhere.
+ *
+ * Returns the temp dir path, or undefined if all bundled skills are already
+ * covered (in which case nothing is contributed).
  */
-function removeStaleDeployedBundledSkills(harnessDir: string, bundledDir: string): void {
-	if (!existsSync(harnessDir) || !existsSync(bundledDir)) return
-	let bundledNames: string[]
+function filterBundledSkills(bundledDir: string, existingSkillNames: Set<string>): string | undefined {
+	const bundledSkills = listSkillNames(bundledDir)
+	if (bundledSkills.length === 0) return undefined
+	const newSkills = bundledSkills.filter((name) => !existingSkillNames.has(name))
+	if (newSkills.length === 0) return undefined
+	const tempDir = mkdtempSync(join(tmpdir(), "kimchi-bundled-skills-"))
+	for (const name of newSkills) {
+		cpSync(join(bundledDir, name), join(tempDir, name), { recursive: true })
+	}
+	return tempDir
+}
+
+function listSkillNames(dir: string): string[] {
 	try {
-		bundledNames = readdirSync(bundledDir, { withFileTypes: true })
+		return readdirSync(dir, { withFileTypes: true })
 			.filter((e) => e.isDirectory())
 			.map((e) => e.name)
 	} catch {
-		return
+		return []
 	}
-	for (const name of bundledNames) {
-		const harnessSkillDir = join(harnessDir, name)
-		if (!existsSync(harnessSkillDir)) continue
-		// Only remove if not user-created (no .usage.json with agent_created)
-		const usagePath = join(harnessSkillDir, ".usage.json")
-		if (existsSync(usagePath)) continue
-		try {
-			rmSync(harnessSkillDir, { recursive: true, force: true })
-		} catch {
-			// Best-effort cleanup — if removal fails, the collision warning is
-			// harmless (first-wins means the harness copy wins anyway).
-		}
+}
+
+function collectSkillNames(dir: string, out: Set<string>): void {
+	for (const name of listSkillNames(dir)) {
+		out.add(name)
 	}
 }
 
@@ -558,16 +563,22 @@ export default function (skillPathsFromConfig: string[]) {
 				(p) => resolve(p) !== resolve(harnessDir),
 			)
 			skillPaths.push(...configuredPaths)
-			// Bundled skills shipped with the harness — contributed last (weakest
-			// collision slot: pi's loader is first-wins). dedupeExistingSkillPaths
-			// skips this dir entirely when all its skills are already present in
-			// a stronger path (e.g. a stale copy from the old deploy mechanism).
+			// Collect skill names from all stronger paths (pi's includeDefaults
+			// loads the harness dir, plus the configured paths above) so bundled
+			// skills that already exist there can be silently skipped — only
+			// new bundled skills (e.g. dap-debugging) get contributed.
+			const existingSkillNames = new Set<string>()
+			collectSkillNames(harnessDir, existingSkillNames)
+			for (const p of configuredPaths) collectSkillNames(p, existingSkillNames)
+			for (const p of getKimchiProjectSkillPaths(event.cwd)) collectSkillNames(p, existingSkillNames)
+			// Bundled skills shipped with the harness — create a filtered temp copy
+			// containing only skills not already in a stronger path, so no
+			// collision warnings are emitted. The stronger copy wins (first-wins);
+			// bundled skills not present elsewhere are still contributed.
 			const bundledDir = resolveBundledSkillsDir()
 			if (bundledDir) {
-				// One-time migration: remove stale deployed copies of bundled skills
-				// from the harness dir (the old deploy mechanism wrote them there).
-				removeStaleDeployedBundledSkills(resolveHarnessSkillsDir(), bundledDir)
-				skillPaths.push(bundledDir)
+				const filtered = filterBundledSkills(bundledDir, existingSkillNames)
+				if (filtered) skillPaths.push(filtered)
 			}
 			// Filter out non-existent paths — pi emits a warning diagnostic for
 			// every contributed path that doesn't exist on disk. Configured

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -24,9 +24,9 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs"
 import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
@@ -76,6 +76,61 @@ function safeUsername(): string {
 		return userInfo().username
 	} catch {
 		return process.env.USER ?? process.env.USERNAME ?? "unknown"
+	}
+}
+
+/**
+ * Filter contributed skill paths to only existing directories, deduped by
+ * normalized path. Pi emits a warning diagnostic for every contributed path
+ * that doesn't exist on disk — configured paths like `.pi/agent/skills` or
+ * `.claude/skills` are optional locations, not requirements, so suppress the
+ * noise by filtering before returning them from resources_discover.
+ *
+ * Also skips the bundled skills dir when every skill it contains is already
+ * available in a stronger (earlier) path — this happens when the old deploy
+ * mechanism copied bundled skills into the harness dir. Without this check,
+ * pi emits a collision warning for each duplicated skill name.
+ */
+function dedupeExistingSkillPaths(paths: readonly string[]): string[] {
+	const seen = new Set<string>()
+	const result: string[] = []
+	const skillNamesFromStronger = new Set<string>()
+	for (const p of paths) {
+		const normalized = resolve(p)
+		if (seen.has(normalized)) continue
+		if (!existsSync(normalized)) continue
+		// Check if this is the bundled dir and all its skills are already
+		// covered by a stronger path — if so, skip it to avoid collisions.
+		if (result.length > 0 && isBundledDirFullyCovered(normalized, skillNamesFromStronger)) {
+			continue
+		}
+		seen.add(normalized)
+		result.push(p)
+		// Collect skill names from this path so weaker paths can check coverage.
+		collectSkillNames(normalized, skillNamesFromStronger)
+	}
+	return result
+}
+
+function isBundledDirFullyCovered(dir: string, coveredNames: Set<string>): boolean {
+	const bundledNames = listSkillNames(dir)
+	if (bundledNames.length === 0) return false
+	return bundledNames.every((name) => coveredNames.has(name))
+}
+
+function listSkillNames(dir: string): string[] {
+	try {
+		return readdirSync(dir, { withFileTypes: true })
+			.filter((e) => e.isDirectory())
+			.map((e) => e.name)
+	} catch {
+		return []
+	}
+}
+
+function collectSkillNames(dir: string, out: Set<string>): void {
+	for (const name of listSkillNames(dir)) {
+		out.add(name)
 	}
 }
 
@@ -498,8 +553,13 @@ export default function (skillPathsFromConfig: string[]) {
 			// from /skill:*, autocomplete and /resources once the prompt reads
 			// pi's resolved inventory instead of composing paths itself.
 			skillPaths.push(...getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig))
-			if (skillPaths.length === 0) return undefined
-			return { skillPaths }
+			// Filter out non-existent paths — pi emits a warning diagnostic for
+			// every contributed path that doesn't exist on disk. Configured
+			// paths like `.pi/agent/skills` or `.claude/skills` are optional
+			// locations, not requirements, so suppress the noise.
+			const existing = dedupeExistingSkillPaths(skillPaths)
+			if (existing.length === 0) return undefined
+			return { skillPaths: existing }
 		})
 
 		pi.on("before_agent_start", async (event, ctx) => {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -24,14 +24,13 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, writeFileSync } from "node:fs"
-import { arch, homedir, version as osVersion, platform, release, tmpdir, userInfo } from "node:os"
-import { join, resolve } from "node:path"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
+import { join } from "node:path"
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
-import { resolveBundledSkillsDir, resolveHarnessSkillsDir } from "../../shared/skill-discovery/resolve-skill-roots.js"
-import { getKimchiProjectSkillPaths } from "../../skill-paths.js"
+import { resolveSkillPathsForDiscovery } from "../../shared/skill-discovery/resolve-skill-roots.js"
 import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { isAgentWorker } from "../agent-worker-context.js"
@@ -77,65 +76,6 @@ function safeUsername(): string {
 	} catch {
 		return process.env.USER ?? process.env.USERNAME ?? "unknown"
 	}
-}
-
-/**
- * Create a filtered temp copy of the bundled skills dir containing only
- * skills whose names are NOT already present in a stronger path (the
- * harness dir pi loads natively, plus any earlier contributed paths).
- * This avoids collision warnings for bundled skills that were previously
- * deployed to the harness dir, while still contributing new bundled skills
- * (e.g. dap-debugging) that don't exist elsewhere.
- *
- * Returns the temp dir path, or undefined if all bundled skills are already
- * covered (in which case nothing is contributed).
- */
-function filterBundledSkills(bundledDir: string, existingSkillNames: Set<string>): string | undefined {
-	const bundledSkills = listSkillNames(bundledDir)
-	if (bundledSkills.length === 0) return undefined
-	const newSkills = bundledSkills.filter((name) => !existingSkillNames.has(name))
-	if (newSkills.length === 0) return undefined
-	const tempDir = mkdtempSync(join(tmpdir(), "kimchi-bundled-skills-"))
-	for (const name of newSkills) {
-		cpSync(join(bundledDir, name), join(tempDir, name), { recursive: true })
-	}
-	return tempDir
-}
-
-function listSkillNames(dir: string): string[] {
-	try {
-		return readdirSync(dir, { withFileTypes: true })
-			.filter((e) => e.isDirectory())
-			.map((e) => e.name)
-	} catch {
-		return []
-	}
-}
-
-function collectSkillNames(dir: string, out: Set<string>): void {
-	for (const name of listSkillNames(dir)) {
-		out.add(name)
-	}
-}
-
-/**
- * Filter contributed skill paths to only existing directories, deduped by
- * normalized path. Pi emits a warning diagnostic for every contributed path
- * that doesn't exist on disk — configured paths like `.pi/agent/skills` or
- * `.claude/skills` are optional locations, not requirements, so suppress the
- * noise by filtering before returning them from resources_discover.
- */
-function dedupeExistingSkillPaths(paths: readonly string[]): string[] {
-	const seen = new Set<string>()
-	const result: string[] = []
-	for (const p of paths) {
-		const normalized = resolve(p)
-		if (seen.has(normalized)) continue
-		if (!existsSync(normalized)) continue
-		seen.add(normalized)
-		result.push(p)
-	}
-	return result
 }
 
 function readGitRemote(cwd: string): string | undefined {
@@ -541,52 +481,14 @@ export default function (skillPathsFromConfig: string[]) {
 		let cachedGitRemote: string | undefined | null = null
 
 		pi.on("resources_discover", (event) => {
-			// Contribute Kimchi-only sources to pi's resource inventory so every
-			// downstream surface (base prompt skills section, /skill:<name>,
-			// autocomplete, /resources) sees them: ancestor .kimchi/skills project
-			// skills (intentional product behavior, trusted like user skills) and
-			// bundled skills shipped with the harness (weakest collision slot —
-			// pi's loader is first-wins and discovered paths append after
-			// defaults), and configured native skill dirs.
-			const skillPaths = [...getKimchiProjectSkillPaths(event.cwd)]
-			// Configured native skill dirs (kimchi config.json skillPaths, e.g.
-			// ~/.config/kimchi/harness/skills) — pi has no visibility into our
-			// config file, so we must contribute them or they silently vanish
-			// from /skill:*, autocomplete and /resources once the prompt reads
-			// pi's resolved inventory instead of composing paths itself.
-			// Configured native skill dirs (kimchi config.json skillPaths).
-			// Filter out the harness dir — pi loads it natively via includeDefaults
-			// (agentDir/skills), so contributing it again is redundant and can cause
-			// stale-file warnings after migration removes deployed bundled skills.
-			const harnessDir = resolveHarnessSkillsDir()
-			const configuredPaths = getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig).filter(
-				(p) => resolve(p) !== resolve(harnessDir),
-			)
-			skillPaths.push(...configuredPaths)
-			// Collect skill names from all stronger paths (pi's includeDefaults
-			// loads the harness dir, plus the configured paths above) so bundled
-			// skills that already exist there can be silently skipped — only
-			// new bundled skills (e.g. dap-debugging) get contributed.
-			const existingSkillNames = new Set<string>()
-			collectSkillNames(harnessDir, existingSkillNames)
-			for (const p of configuredPaths) collectSkillNames(p, existingSkillNames)
-			for (const p of getKimchiProjectSkillPaths(event.cwd)) collectSkillNames(p, existingSkillNames)
-			// Bundled skills shipped with the harness — create a filtered temp copy
-			// containing only skills not already in a stronger path, so no
-			// collision warnings are emitted. The stronger copy wins (first-wins);
-			// bundled skills not present elsewhere are still contributed.
-			const bundledDir = resolveBundledSkillsDir()
-			if (bundledDir) {
-				const filtered = filterBundledSkills(bundledDir, existingSkillNames)
-				if (filtered) skillPaths.push(filtered)
-			}
-			// Filter out non-existent paths — pi emits a warning diagnostic for
-			// every contributed path that doesn't exist on disk. Configured
-			// paths like `.pi/agent/skills` or `.claude/skills` are optional
-			// locations, not requirements, so suppress the noise.
-			const existing = dedupeExistingSkillPaths(skillPaths)
-			if (existing.length === 0) return undefined
-			return { skillPaths: existing }
+			// Contribute Kimchi-only skill sources to pi's resource inventory so
+			// every downstream surface (base prompt skills section, /skill:<name>,
+			// autocomplete, /resources) sees them. All discovery, filtering, and
+			// collision-avoidance logic lives in resolveSkillPathsForDiscovery.
+			const extraPaths = getConfiguredSkillResourcePaths(event.cwd, skillPathsFromConfig)
+			const skillPaths = resolveSkillPathsForDiscovery(event.cwd, { extraPaths })
+			if (skillPaths.length === 0) return undefined
+			return { skillPaths }
 		})
 
 		pi.on("before_agent_start", async (event, ctx) => {

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -24,7 +24,7 @@
 
 import { execSync } from "node:child_process"
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
 import { join, resolve } from "node:path"
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
@@ -80,64 +80,57 @@ function safeUsername(): string {
 }
 
 /**
+ * Remove stale deployed copies of bundled skills from the harness dir.
+ * The old deploy mechanism copied bundled skills (e.g. improve) into
+ * ~/.config/kimchi/harness/skills/ — now that bundled skills ship from
+ * resources/skills/ and are contributed via resources_discover, those stale
+ * copies cause collision warnings. This is a one-time migration: it only
+ * removes skills whose names match a bundled skill, and only if the harness
+ * dir doesn't have a .usage.json marking them as user-created.
+ */
+function removeStaleDeployedBundledSkills(harnessDir: string, bundledDir: string): void {
+	if (!existsSync(harnessDir) || !existsSync(bundledDir)) return
+	let bundledNames: string[]
+	try {
+		bundledNames = readdirSync(bundledDir, { withFileTypes: true })
+			.filter((e) => e.isDirectory())
+			.map((e) => e.name)
+	} catch {
+		return
+	}
+	for (const name of bundledNames) {
+		const harnessSkillDir = join(harnessDir, name)
+		if (!existsSync(harnessSkillDir)) continue
+		// Only remove if not user-created (no .usage.json with agent_created)
+		const usagePath = join(harnessSkillDir, ".usage.json")
+		if (existsSync(usagePath)) continue
+		try {
+			rmSync(harnessSkillDir, { recursive: true, force: true })
+		} catch {
+			// Best-effort cleanup — if removal fails, the collision warning is
+			// harmless (first-wins means the harness copy wins anyway).
+		}
+	}
+}
+
+/**
  * Filter contributed skill paths to only existing directories, deduped by
  * normalized path. Pi emits a warning diagnostic for every contributed path
  * that doesn't exist on disk — configured paths like `.pi/agent/skills` or
  * `.claude/skills` are optional locations, not requirements, so suppress the
  * noise by filtering before returning them from resources_discover.
- *
- * Also skips the bundled skills dir when every skill it contains is already
- * available in a stronger path. "Stronger" includes pi's own default loading
- * from `agentDir/skills` (the harness dir), which runs before extension-
- * contributed paths — without this check, pi emits a collision warning for
- * each bundled skill name that was previously deployed into the harness dir.
  */
 function dedupeExistingSkillPaths(paths: readonly string[]): string[] {
 	const seen = new Set<string>()
 	const result: string[] = []
-	// Seed with skill names pi loads via includeDefaults (agentDir/skills),
-	// so the bundled dir can be skipped when those skills are already present
-	// in the harness dir.
-	const skillNamesFromStronger = new Set<string>()
-	const harnessDir = resolveHarnessSkillsDir()
-	collectSkillNames(harnessDir, skillNamesFromStronger)
 	for (const p of paths) {
 		const normalized = resolve(p)
 		if (seen.has(normalized)) continue
 		if (!existsSync(normalized)) continue
-		// Check if this is the bundled dir and all its skills are already
-		// covered by a stronger path — if so, skip it to avoid collisions.
-		if (result.length > 0 && isBundledDirFullyCovered(normalized, skillNamesFromStronger)) {
-			continue
-		}
 		seen.add(normalized)
 		result.push(p)
-		// Collect skill names from this path so weaker paths can check coverage.
-		collectSkillNames(normalized, skillNamesFromStronger)
 	}
 	return result
-}
-
-function isBundledDirFullyCovered(dir: string, coveredNames: Set<string>): boolean {
-	const bundledNames = listSkillNames(dir)
-	if (bundledNames.length === 0) return false
-	return bundledNames.every((name) => coveredNames.has(name))
-}
-
-function listSkillNames(dir: string): string[] {
-	try {
-		return readdirSync(dir, { withFileTypes: true })
-			.filter((e) => e.isDirectory())
-			.map((e) => e.name)
-	} catch {
-		return []
-	}
-}
-
-function collectSkillNames(dir: string, out: Set<string>): void {
-	for (const name of listSkillNames(dir)) {
-		out.add(name)
-	}
 }
 
 function readGitRemote(cwd: string): string | undefined {
@@ -562,7 +555,12 @@ export default function (skillPathsFromConfig: string[]) {
 			// skips this dir entirely when all its skills are already present in
 			// a stronger path (e.g. a stale copy from the old deploy mechanism).
 			const bundledDir = resolveBundledSkillsDir()
-			if (bundledDir) skillPaths.push(bundledDir)
+			if (bundledDir) {
+				// One-time migration: remove stale deployed copies of bundled skills
+				// from the harness dir (the old deploy mechanism wrote them there).
+				removeStaleDeployedBundledSkills(resolveHarnessSkillsDir(), bundledDir)
+				skillPaths.push(bundledDir)
+			}
 			// Filter out non-existent paths — pi emits a warning diagnostic for
 			// every contributed path that doesn't exist on disk. Configured
 			// paths like `.pi/agent/skills` or `.claude/skills` are optional

--- a/src/sandbox/worker/acp-client.ts
+++ b/src/sandbox/worker/acp-client.ts
@@ -279,7 +279,7 @@ export class AcpSessionClient {
 				ws.on("message", (data: unknown) => {
 					const text = typeof data === "string" ? data : textDecoder.decode(data as ArrayBuffer)
 					const trimmed = text.trim()
-					if (!trimmed || !trimmed.startsWith("{")) return
+					if (!trimmed?.startsWith("{")) return
 					controller.enqueue(textEncoder.encode(`${text}\n`))
 				})
 

--- a/src/shared/skill-discovery/resolve-skill-roots.ts
+++ b/src/shared/skill-discovery/resolve-skill-roots.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdtempSync, readdirSync } from "node:fs"
+import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { dirname, isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -135,46 +135,55 @@ export function resolveSkillPathsForDiscovery(
 		configPaths: options?.configPaths ?? [],
 	})
 
+	const harnessDir = resolveHarnessSkillsDir(home)
+	const normalizedHarnessDir = resolve(harnessDir)
+
+	// First pass: collect skill names from all non-bundled roots + extraPaths
+	// so the bundled filter is robust to root ordering (resolveSkillRoots
+	// returns weakest-first, so bundled comes before project/config).
+	const skillNamesFromStronger = new Set<string>()
+	collectSkillNames(harnessDir, skillNamesFromStronger)
+	for (const root of roots) {
+		if (root.kind === "bundled" || root.kind === "harness") continue
+		if (!existsSync(root.dir)) continue
+		collectSkillNames(root.dir, skillNamesFromStronger)
+	}
+	for (const p of options?.extraPaths ?? []) {
+		if (resolve(p) === normalizedHarnessDir) continue
+		if (!existsSync(p)) continue
+		collectSkillNames(p, skillNamesFromStronger)
+	}
+
+	// Second pass: build the output path list.
 	const paths: string[] = []
 	const seen = new Set<string>()
-	const skillNamesFromStronger = new Set<string>()
-	const harnessDir = resolveHarnessSkillsDir(home)
-
-	// Seed with skill names pi loads via includeDefaults (harness dir).
-	collectSkillNames(harnessDir, skillNamesFromStronger)
 
 	for (const root of roots) {
-		// Skip the harness dir — pi loads it natively via includeDefaults.
 		if (root.kind === "harness") continue
 		const normalized = resolve(root.dir)
 		if (seen.has(normalized)) continue
 		if (!existsSync(normalized)) continue
 
 		if (root.kind === "bundled") {
-			// Create a filtered temp copy containing only skills not already
-			// in a stronger path, so no collision warnings are emitted.
 			const filtered = filterBundledSkills(normalized, skillNamesFromStronger)
 			if (filtered) {
+				seen.add(filtered)
 				paths.push(filtered)
-				collectSkillNames(filtered, skillNamesFromStronger)
 			}
 			continue
 		}
 
 		seen.add(normalized)
-		paths.push(root.dir)
-		collectSkillNames(normalized, skillNamesFromStronger)
+		paths.push(normalized)
 	}
 
-	// Add extra paths (e.g. configured skillPaths from kimchi config.json).
 	for (const p of options?.extraPaths ?? []) {
 		const normalized = resolve(p)
 		if (seen.has(normalized)) continue
-		if (resolve(p) === resolve(harnessDir)) continue
+		if (normalized === normalizedHarnessDir) continue
 		if (!existsSync(normalized)) continue
 		seen.add(normalized)
-		paths.push(p)
-		collectSkillNames(normalized, skillNamesFromStronger)
+		paths.push(normalized)
 	}
 
 	return paths
@@ -202,6 +211,9 @@ function filterBundledSkills(bundledDir: string, existingSkillNames: Set<string>
 	const newSkills = bundledSkills.filter((name) => !existingSkillNames.has(name))
 	if (newSkills.length === 0) return undefined
 	const tempDir = mkdtempSync(join(tmpdir(), "kimchi-bundled-skills-"))
+	process.once("exit", () => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
 	for (const name of newSkills) {
 		cpSync(join(bundledDir, name), join(tempDir, name), { recursive: true })
 	}

--- a/src/shared/skill-discovery/resolve-skill-roots.ts
+++ b/src/shared/skill-discovery/resolve-skill-roots.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs"
-import { homedir } from "node:os"
-import { dirname, isAbsolute, join } from "node:path"
+import { cpSync, existsSync, mkdtempSync, readdirSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { resolveAuxiliaryFilesDir } from "../../auxiliary-files/resolver.js"
 import { findNearestAncestorSkillDir } from "../../skill-paths.js"
@@ -97,4 +97,113 @@ export function resolveSkillRoots(options: ResolveSkillRootsOptions): SkillRoot[
 	if (projectDir) roots.push({ dir: projectDir, kind: "project" })
 
 	return roots
+}
+
+/**
+ * Resolve skill roots and return a flat list of skill paths suitable for
+ * contributing to pi's resource inventory via resources_discover.
+ *
+ * - Non-existent paths are filtered out (pi warns about them).
+ * - The harness dir is excluded because pi loads it natively via
+ *   includeDefaults (agentDir/skills) — contributing it again is redundant.
+ * - Bundled skills already present in a stronger path (harness, config, or
+ *   project) are silently skipped via a filtered temp copy, so no collision
+ *   warnings are emitted. New bundled skills not present elsewhere are still
+ *   contributed.
+ *
+ * @param cwd Working directory for project ancestor search.
+ * @param homeDir Override for os.homedir() (tests).
+ * @param bundledDir Override for the bundled skills dir; null disables it.
+ * @param configPaths Override for config-style skill paths.
+ * @param extraPaths Additional paths to include (e.g. configured skillPaths
+ *   from kimchi config.json that pi doesn't see).
+ */
+export function resolveSkillPathsForDiscovery(
+	cwd: string,
+	options?: {
+		homeDir?: string
+		bundledDir?: string | null
+		configPaths?: readonly string[]
+		extraPaths?: readonly string[]
+	},
+): string[] {
+	const home = options?.homeDir ?? homedir()
+	const roots = resolveSkillRoots({
+		cwd,
+		homeDir: home,
+		bundledDir: options?.bundledDir,
+		configPaths: options?.configPaths ?? [],
+	})
+
+	const paths: string[] = []
+	const seen = new Set<string>()
+	const skillNamesFromStronger = new Set<string>()
+	const harnessDir = resolveHarnessSkillsDir(home)
+
+	// Seed with skill names pi loads via includeDefaults (harness dir).
+	collectSkillNames(harnessDir, skillNamesFromStronger)
+
+	for (const root of roots) {
+		// Skip the harness dir — pi loads it natively via includeDefaults.
+		if (root.kind === "harness") continue
+		const normalized = resolve(root.dir)
+		if (seen.has(normalized)) continue
+		if (!existsSync(normalized)) continue
+
+		if (root.kind === "bundled") {
+			// Create a filtered temp copy containing only skills not already
+			// in a stronger path, so no collision warnings are emitted.
+			const filtered = filterBundledSkills(normalized, skillNamesFromStronger)
+			if (filtered) {
+				paths.push(filtered)
+				collectSkillNames(filtered, skillNamesFromStronger)
+			}
+			continue
+		}
+
+		seen.add(normalized)
+		paths.push(root.dir)
+		collectSkillNames(normalized, skillNamesFromStronger)
+	}
+
+	// Add extra paths (e.g. configured skillPaths from kimchi config.json).
+	for (const p of options?.extraPaths ?? []) {
+		const normalized = resolve(p)
+		if (seen.has(normalized)) continue
+		if (resolve(p) === resolve(harnessDir)) continue
+		if (!existsSync(normalized)) continue
+		seen.add(normalized)
+		paths.push(p)
+		collectSkillNames(normalized, skillNamesFromStronger)
+	}
+
+	return paths
+}
+
+function listSkillNames(dir: string): string[] {
+	try {
+		return readdirSync(dir, { withFileTypes: true })
+			.filter((e) => e.isDirectory())
+			.map((e) => e.name)
+	} catch {
+		return []
+	}
+}
+
+function collectSkillNames(dir: string, out: Set<string>): void {
+	for (const name of listSkillNames(dir)) {
+		out.add(name)
+	}
+}
+
+function filterBundledSkills(bundledDir: string, existingSkillNames: Set<string>): string | undefined {
+	const bundledSkills = listSkillNames(bundledDir)
+	if (bundledSkills.length === 0) return undefined
+	const newSkills = bundledSkills.filter((name) => !existingSkillNames.has(name))
+	if (newSkills.length === 0) return undefined
+	const tempDir = mkdtempSync(join(tmpdir(), "kimchi-bundled-skills-"))
+	for (const name of newSkills) {
+		cpSync(join(bundledDir, name), join(tempDir, name), { recursive: true })
+	}
+	return tempDir
 }


### PR DESCRIPTION
## Summary

Fixes two startup warnings introduced by the skill-discovery unification (PR #1090):

1. **"skill path does not exist"** — pi warns for every contributed path that doesn't exist on disk. Configured paths like `.pi/agent/skills` and `.claude/skills` are optional locations, not requirements. `resolveSkillPathsForDiscovery` now filters non-existent paths before contributing them.

2. **"skill name collision"** — the old deploy mechanism copied bundled skills (e.g. `improve`) into `~/.config/kimchi/harness/skills/`. Now that bundled skills ship from `resources/skills/` and are contributed via `resources_discover`, both copies are loaded and pi emits a collision warning. Instead of deleting the stale copies, a filtered temp copy of the bundled dir is created containing only skills NOT already present in a stronger path (harness dir + configured paths + project skills). The stronger copy wins silently; new bundled skills (e.g. `dap-debugging`) are still contributed.

3. **Redundant harness dir contribution** — the harness dir (`~/.config/kimchi/harness/skills`) is pi's `agentDir/skills`, loaded natively via `includeDefaults`. Contributing it again via `resources_discover` was redundant and caused stale-file warnings after migration. Now skipped.

## Implementation

All filtering logic lives in `resolveSkillPathsForDiscovery` in `src/shared/skill-discovery/resolve-skill-roots.ts` — the shared module, not prompt-enrichment. The `resources_discover` handler in `prompt-enrichment.ts` is now a clean one-liner that calls the shared function.

## Test plan

- [x] `pnpm vitest run src/extensions/prompt-construction src/shared/skill-discovery` — 204/204 pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] Manual: start kimchi and verify no skill conflict or path-not-found warnings
