### PR TITLE
fix(tui): restore Max reasoning and show level

### DIFF
--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -61,6 +61,7 @@ function createMockTheme(): Theme {
 interface MockContextOpts {
 	percent?: number
 	modelId?: string
+	thinkingLevel?: ExtensionContext["thinkingLevel"]
 	/** Assistant messages to include in the session, for usage-segment tests. */
 	assistantMessages?: Array<{ input: number; output: number }>
 }
@@ -74,6 +75,7 @@ function createMockContext(opts?: MockContextOpts): ExtensionContext {
 	}))
 	return {
 		model: { id: modelId, name: modelId },
+		thinkingLevel: opts?.thinkingLevel,
 		cwd: "/test",
 		getContextUsage: vi.fn(() => ({ tokens: 0, percent, contextWindow: 100000 })),
 		sessionManager: {
@@ -399,6 +401,13 @@ describe("StatusLine behavioural acceptance at representative widths", () => {
 			expect(visible).toContain("/ for commands")
 			expect(visibleWidth(raw)).toBe(160)
 			expect(visible.endsWith("/ for commands")).toBe(true)
+		})
+	})
+
+	it("shows the current thinking level when pinned", () => {
+		withPinned(["thinking"], () => {
+			const { visible } = renderAt(160, { thinkingLevel: "max" })
+			expect(visible).toContain("thinking:max")
 		})
 	})
 

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -21,6 +21,7 @@ import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 export type SegmentId =
 	| "permissions"
 	| "model"
+	| "thinking"
 	| "ferment"
 	| "agents"
 	| "context"
@@ -333,6 +334,7 @@ const SHED_ORDER: SegmentId[] = [
 	"phase",
 	"usage",
 	"agents",
+	"thinking",
 	"credits",
 	"budget",
 	"ferment",
@@ -428,6 +430,12 @@ function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
 	const label = multiModel ? `multi-model (${rawModelId})` : rawModelId
 	const text = `${accentText(theme, label)} ${dimText(theme, "→ ctrl+p")}`
 	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId: rawModelId } }
+}
+
+function buildThinkingSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {
+	if (!pinned) return null
+	const text = `${dimText(theme, "thinking:")}${accentText(theme, ctx.thinkingLevel ?? "—")}`
+	return { id: "thinking", text, width: visibleWidth(text) }
 }
 
 function buildUsageSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {
@@ -634,6 +642,7 @@ export function buildStatusLineSegments(
 	return [
 		buildPermissionsSegment(theme, statusLineData, pinned.has("permissions")),
 		buildModelSegment(ctx, theme),
+		buildThinkingSegment(ctx, theme, pinned.has("thinking")),
 		buildFermentSegment(theme, pinned.has("ferment")),
 		buildCreditsSegment(theme, pinned.has("credits")),
 		buildBudgetSegment(theme, pinned.has("budget")),

--- a/src/config/status-line-config.test.ts
+++ b/src/config/status-line-config.test.ts
@@ -46,8 +46,8 @@ afterEach(() => {
 // ── STATUS_LINE_ELEMENTS metadata ────────────────────────────────────────────
 
 describe("STATUS_LINE_ELEMENTS", () => {
-	it("has 11 entries", () => {
-		expect(STATUS_LINE_ELEMENTS).toHaveLength(11)
+	it("has 12 entries", () => {
+		expect(STATUS_LINE_ELEMENTS).toHaveLength(12)
 	})
 
 	it("every entry has id, label, description", () => {
@@ -63,6 +63,7 @@ describe("STATUS_LINE_ELEMENTS", () => {
 		const expected = [
 			"permissions",
 			"model",
+			"thinking",
 			"ferment",
 			"agents",
 			"context",
@@ -85,13 +86,13 @@ describe("readStatusLineConfig", () => {
 		expect(readStatusLineConfig().pinned).toEqual(DEFAULT_STATUS_LINE_PINNED)
 	})
 
-	it("DEFAULT_STATUS_LINE_PINNED contains agents, context, usage", () => {
-		expect(DEFAULT_STATUS_LINE_PINNED).toEqual(expect.arrayContaining(["agents", "context", "usage"]))
-		expect(DEFAULT_STATUS_LINE_PINNED).toHaveLength(3)
+	it("DEFAULT_STATUS_LINE_PINNED contains thinking, agents, context, usage", () => {
+		expect(DEFAULT_STATUS_LINE_PINNED).toEqual(expect.arrayContaining(["thinking", "agents", "context", "usage"]))
+		expect(DEFAULT_STATUS_LINE_PINNED).toHaveLength(4)
 	})
 
-	it("agents, context, usage are all isStatusLineElementPinned=true on first read with no config", () => {
-		for (const id of ["agents", "context", "usage"] as const) {
+	it("thinking, agents, context, usage are all isStatusLineElementPinned=true on first read with no config", () => {
+		for (const id of ["thinking", "agents", "context", "usage"] as const) {
 			expect(isStatusLineElementPinned(id)).toBe(true)
 		}
 	})

--- a/src/config/status-line-config.ts
+++ b/src/config/status-line-config.ts
@@ -5,6 +5,7 @@ import { readJson, writeJson } from "./json.js"
 export type StatusLineElementId =
 	| "permissions"
 	| "model"
+	| "thinking"
 	| "ferment"
 	| "agents"
 	| "context"
@@ -19,7 +20,7 @@ export type StatusLineConfig = { pinned: StatusLineElementId[] }
 
 const STATUS_LINE_KEY = "statusLine"
 
-export const DEFAULT_STATUS_LINE_PINNED: StatusLineElementId[] = ["agents", "context", "usage"]
+export const DEFAULT_STATUS_LINE_PINNED: StatusLineElementId[] = ["thinking", "agents", "context", "usage"]
 
 /** All status line elements for the settings UI.
  *  canPin=false marks elements that are always visible and cannot be toggled. */
@@ -40,6 +41,11 @@ export const STATUS_LINE_ELEMENTS: Array<{
 		label: "Model",
 		description: "Active model or multi-model  → ctrl+p",
 		canPin: false,
+	},
+	{
+		id: "thinking",
+		label: "Thinking level",
+		description: "Current model thinking level",
 	},
 	{
 		id: "ferment",

--- a/src/extensions/customize-status-line-command.test.ts
+++ b/src/extensions/customize-status-line-command.test.ts
@@ -215,6 +215,7 @@ describe("customize-status-line popover", () => {
 		const text = strip(makeComponent().render(80).join("\n"))
 		expect(text).toContain("● Context")
 		expect(text).toContain("● Agents")
+		expect(text).toContain("● Thinking level")
 		expect(text).toContain("○ Phase")
 		expect(text).toContain("● Token I/O")
 	})
@@ -245,7 +246,7 @@ describe("customize-status-line popover", () => {
 		vi.spyOn(FERMENT, "getCurrentPhaseIndex").mockReturnValue(undefined)
 		vi.spyOn(FERMENT, "getFermentContinuationPolicy").mockReturnValue("manual")
 
-		const component = makeComponent(2) // ferment at STATUS_LINE_ELEMENTS index 2
+		const component = makeComponent(3) // ferment at STATUS_LINE_ELEMENTS index 3
 		component.handleInput(" ") // pin ferment
 
 		expect(strip(component.render(80).join("\n"))).toContain("● Ferment")
@@ -253,7 +254,7 @@ describe("customize-status-line popover", () => {
 	})
 
 	it("pressing space on context unpins it: popover shows '○ Context' AND status line bar loses ctx", () => {
-		const component = makeComponent(4) // context at STATUS_LINE_ELEMENTS index 4
+		const component = makeComponent(5) // context at STATUS_LINE_ELEMENTS index 5
 		component.handleInput(" ") // unpin context (was default-pinned)
 
 		expect(strip(component.render(80).join("\n"))).toContain("○ Context")

--- a/src/extensions/omit-kimchi-max-tokens.test.ts
+++ b/src/extensions/omit-kimchi-max-tokens.test.ts
@@ -32,7 +32,7 @@ function openAIStreamResponse(): Response {
 	})
 }
 
-describe("Kimchi max token request invariant", () => {
+describe("Kimchi managed request invariants", () => {
 	let tempDir: string
 	let modelsJsonPath: string
 
@@ -100,6 +100,36 @@ describe("Kimchi max token request invariant", () => {
 			{ model: { provider } },
 		)
 		expect(result).toEqual({})
+	})
+
+	it("sends Max as reasoning_effort=max", async () => {
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const provider = config.providers["kimchi-dev"]
+		const model: Model<"openai-completions"> = {
+			...provider.models[0],
+			provider: "kimchi-dev",
+			api: "openai-completions",
+			baseUrl: provider.baseUrl,
+		}
+		let sentPayload: Record<string, unknown> | undefined
+		const requestFetch: typeof fetch = async (_input, init) => {
+			sentPayload = JSON.parse(String(init?.body))
+			return openAIStreamResponse()
+		}
+
+		await streamSimple(
+			model,
+			{ messages: [{ role: "user", content: "reason deeply", timestamp: Date.now() }] },
+			{
+				apiKey: "test",
+				fetch: requestFetch,
+				reasoning: "max",
+				onPayload: (payload) => omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model }),
+			},
+		).result()
+
+		expect(sentPayload).toMatchObject({ reasoning_effort: "max" })
 	})
 
 	it("leaves non-Kimchi provider payloads unchanged", () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { getSupportedThinkingLevels } from "@earendil-works/pi-ai"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	injectExperimentalProvider,
@@ -85,7 +86,7 @@ describe("updateModelsConfig", () => {
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				provider: "ai-enabler",
-				thinkingLevelMap: { off: "none" },
+				thinkingLevelMap: { off: "none", max: "max" },
 			},
 		])
 	})
@@ -149,7 +150,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
 	})
 
-	it("sets thinkingLevelMap for ai-enabler models so thinking=off sends reasoning_effort=none", async () => {
+	it("maps ai-enabler thinking levels required by the upstream selector", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
@@ -158,9 +159,12 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0].thinkingLevelMap).toEqual({
+		const model = config.providers["kimchi-dev"].models[0]
+		expect(model.thinkingLevelMap).toEqual({
 			off: "none",
+			max: "max",
 		})
+		expect(getSupportedThinkingLevels(model)).toContain("max")
 	})
 
 	it("sets compat for claude-* models regardless of upstream provider (e.g. azure_ai)", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -195,15 +195,14 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// - supportsUsageInStreaming: true so stream_options.include_usage is sent
 	//
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
-	// default `openai` thinkingFormat which sends `reasoning_effort`. Setting
-	// thinkingLevelMap.off = "none" ensures that the off level sends
-	// reasoning_effort: "none" instead of omitting it, which would leave
-	// thinking enabled by default.
+	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
+	// disables thinking with `none` and advertises max to Pi's selector.
 	const compat =
 		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
 			: undefined
-	const thinkingLevelMap = m.provider === "ai-enabler" ? { off: "none" as const } : undefined
+	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
+		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,


### PR DESCRIPTION
## Proof

### Status line

<img width="438" height="126" alt="Thinking level shown in the Kimchi status line" src="https://github.com/user-attachments/assets/4702c7d5-319f-49dc-a147-173a00250e75" />

## What

- Restore the Max reasoning option for AI Enabler models.
- Show the current thinking level in the configurable status line and enable it for new status-line configurations.
- Add a request-serialization regression proving that Max sends `reasoning_effort: "max"`.

## Why

Pi exposes Max only when the model `thinkingLevelMap` contains a non-null `max` entry. Kimchi generated only the Off mapping, so Max disappeared from the supported levels even though the gateway accepts it.

The active thinking level was also not observable during a session. The status-line segment reads the live level from the existing extension context and remains user-configurable.

## Validation

- Focused retained-scope tests: 166 passed
- `pnpm run test`: 8,997 passed, 13 skipped
- `pnpm run check`: passed with one unrelated existing warning in `src/sandbox/worker/acp-client.ts:282`
- `git diff --check`: passed