### PR TITLE
feat(tui): prompt for reasoning after model selection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import "./uncaught-epipe-patch.js"
 import "./paste-to-editor-patch.js"
 import {
 	DEFAULT_SKILL_PATHS,
+	ensureDefaultThinkingLevel,
 	ensureHideThinkingBlockDefault,
 	ensureQuietStartupDefault,
 	loadConfig,
@@ -409,7 +410,7 @@ try {
 			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
 				writeFileSync(
 					settingsPath,
-					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true }, null, 2)}\n`,
+					`${JSON.stringify({ quietStartup: true, theme: "kimchi-minimal", retry: RETRY_DEFAULTS, hideThinkingBlock: true, defaultThinkingLevel: "high", kimchiHighThinkingDefaultApplied: true }, null, 2)}\n`,
 				)
 			} else {
 				console.error(`Warning: could not read ${settingsPath}: ${(err as Error).message}`)
@@ -420,6 +421,7 @@ try {
 		try {
 			const existing = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>
 			let changed = ensureHideThinkingBlockDefault(existing)
+			if (ensureDefaultThinkingLevel(existing)) changed = true
 			if (ensureQuietStartupDefault(existing)) changed = true
 			const upgraded = upgradeLegacyRetrySettings(existing.retry)
 			if (upgraded) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,8 @@ import { dispatchSubcommand } from "./commands/dispatch.js"
 // IMPORTANT: must be first local import — patches InteractiveMode.prototype
 // before any module can construct an InteractiveMode instance.
 import "./login-command-patch.js"
+// Restores the user-selection signal when /model chooses the already-active model.
+import "./same-model-select-patch.js"
 // Patches InteractiveMode.prototype so a broken pipe (EPIPE/ECONNRESET) from a
 // child process does not crash the CLI. Load early for the same reason as above.
 import "./uncaught-epipe-patch.js"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,6 +6,7 @@ import {
 	buildSkillPathOptions,
 	checkConfigFilePermissions,
 	clearApiKey,
+	ensureDefaultThinkingLevel,
 	ensureHideThinkingBlockDefault,
 	ensureQuietStartupDefault,
 	loadConfig,
@@ -905,6 +906,35 @@ describe("ensureHideThinkingBlockDefault", () => {
 		const visible = { hideThinkingBlock: false }
 		expect(ensureHideThinkingBlockDefault(visible)).toBe(false)
 		expect(visible.hideThinkingBlock).toBe(false)
+	})
+})
+
+describe("ensureDefaultThinkingLevel", () => {
+	it("seeds high when the key is absent", () => {
+		const settings: Record<string, unknown> = { statusLine: { pinned: [] } }
+		expect(ensureDefaultThinkingLevel(settings)).toBe(true)
+		expect(settings.defaultThinkingLevel).toBe("high")
+		expect(settings.kimchiHighThinkingDefaultApplied).toBe(true)
+	})
+
+	it("migrates the legacy medium default to high", () => {
+		const settings: Record<string, unknown> = { defaultThinkingLevel: "medium" }
+		expect(ensureDefaultThinkingLevel(settings)).toBe(true)
+		expect(settings.defaultThinkingLevel).toBe("high")
+		expect(settings.kimchiHighThinkingDefaultApplied).toBe(true)
+	})
+
+	it("leaves an explicit non-medium thinking level alone", () => {
+		const settings: Record<string, unknown> = { defaultThinkingLevel: "low" }
+		expect(ensureDefaultThinkingLevel(settings)).toBe(true)
+		expect(settings.defaultThinkingLevel).toBe("low")
+		expect(settings.kimchiHighThinkingDefaultApplied).toBe(true)
+	})
+
+	it("preserves a later explicit medium choice", () => {
+		const settings = { defaultThinkingLevel: "medium", kimchiHighThinkingDefaultApplied: true }
+		expect(ensureDefaultThinkingLevel(settings)).toBe(false)
+		expect(settings.defaultThinkingLevel).toBe("medium")
 	})
 })
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,18 @@ export const RETRY_DEFAULTS = {
 /** What older kimchi versions wrote into pi's settings.json on every startup. */
 const LEGACY_KIMCHI_MAX_RETRIES = 10
 
+const HIGH_THINKING_DEFAULT_APPLIED = "kimchiHighThinkingDefaultApplied"
+
+/** Apply Kimchi's high default once, including settings carrying Pi's legacy medium default. */
+export function ensureDefaultThinkingLevel(settings: Record<string, unknown>): boolean {
+	if (settings[HIGH_THINKING_DEFAULT_APPLIED] === true) return false
+	if (settings.defaultThinkingLevel === undefined || settings.defaultThinkingLevel === "medium") {
+		settings.defaultThinkingLevel = "high"
+	}
+	settings[HIGH_THINKING_DEFAULT_APPLIED] = true
+	return true
+}
+
 /**
  * Returns the `retry` block to write into pi's settings.json, or undefined if
  * the existing block should be left alone. A missing block gets the defaults.

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -516,6 +516,25 @@ describe("registerFermentEvents", () => {
 		expect(captureJudgeContext).toHaveBeenCalledWith(newModel, modelRegistry)
 	})
 
+	it("model_select ignores a same-model reselect", () => {
+		const captureJudgeContext = vi.fn()
+		const runtime: FermentRuntime = {
+			...createDefaultFermentRuntime(),
+			captureJudgeContext,
+		}
+		const { handlers, pi } = createPi()
+		registerFermentEvents(pi, runtime)
+
+		const handler = handlers.get("model_select")
+		if (!handler) throw new Error("model_select handler was not registered")
+
+		const model = { id: "same-model", provider: "fake" } as unknown as Model<Api>
+		const modelRegistry = {} as ModelRegistry
+		handler({ model, previousModel: model }, createContext({ modelRegistry }))
+
+		expect(captureJudgeContext).not.toHaveBeenCalled()
+	})
+
 	it("transitions profile from planning to implementation when activate_ferment_phase succeeds", async () => {
 		// Build a Ferment with all phases in "planned" status.
 		const basePhase: Phase = {

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -1,3 +1,4 @@
+import { modelsAreEqual } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { clearFermentCache } from "../../ferment/store.js"
 import { deriveDraftFermentTitle } from "../../ferment/title.js"
@@ -521,6 +522,8 @@ export function registerFermentEvents(
 	})
 
 	pi.on("model_select", (event, ctx) => {
+		// A same-model reselect (reasoning picker flow) leaves judge context unchanged.
+		if (modelsAreEqual(event.previousModel, event.model)) return
 		runtime.captureJudgeContext(event.model, ctx?.modelRegistry)
 	})
 

--- a/src/extensions/hook-adapters/adapter.test.ts
+++ b/src/extensions/hook-adapters/adapter.test.ts
@@ -768,6 +768,21 @@ describe("hook adapter command execution", () => {
 		expect(mockSpawn).not.toHaveBeenCalled()
 	})
 
+	it("does not run ModelSelect hooks for a same-model reselect", async () => {
+		writeJson(join(dir, "home", ".claude", "settings.json"), {
+			hooks: {
+				ModelSelect: [{ hooks: [{ type: "command", command: "model-select" }] }],
+			},
+		})
+		const pi = fakePi()
+		claudeCodeHooksAdapter(pi as never)
+
+		const model = { id: "same-model", provider: "fake" }
+		await pi.handlers.model_select[0]({ type: "model_select", model, previousModel: model, source: "set" }, fakeCtx())
+
+		expect(mockSpawn).not.toHaveBeenCalled()
+	})
+
 	it("runs observer hooks for TurnStart, MessageEnd, ModelSelect, and UserBash", async () => {
 		writeJson(join(dir, "home", ".claude", "settings.json"), {
 			hooks: {

--- a/src/extensions/hook-adapters/adapter.ts
+++ b/src/extensions/hook-adapters/adapter.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { modelsAreEqual } from "@earendil-works/pi-ai"
 import type {
 	AgentEndEvent,
 	BeforeAgentStartEvent,
@@ -147,6 +148,8 @@ export function createCommandHookAdapter(definition: CommandHookAdapterDefinitio
 			await runObserver(definition, "MessageEnd", ctx, messagePayload(event.message))
 		})
 		pi.on("model_select", async (event, ctx) => {
+			// A same-model reselect (reasoning picker flow) is not a model change.
+			if (modelsAreEqual(event.previousModel, event.model)) return
 			await runObserver(definition, "ModelSelect", ctx, {
 				model: modelIdValue(event.model),
 				previous_model: modelIdValue(event.previousModel),

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -1055,8 +1055,8 @@ describe("modelSwitchExtension", () => {
 			expect(component).toBeInstanceOf(ThinkingSelectorComponent)
 			expect(component.getSelectList().getSelectedItem()?.value).toBe("high")
 			const rendered = component.render(80).join("\n")
-			expect(rendered).toContain("Deep reasoning")
-			expect(rendered).not.toMatch(/~\d+k tokens/)
+			expect(rendered).toContain("→ high")
+			expect(rendered).not.toMatch(/\b(?:No|Very brief|Light|Moderate|Deep|Extra-high|Maximum) reasoning\b/)
 			component.handleInput?.("\r")
 			expect(done).toHaveBeenCalledWith("high")
 			expect(setThinkingLevel).toHaveBeenCalledWith("max")
@@ -1089,6 +1089,82 @@ describe("modelSwitchExtension", () => {
 			)
 
 			expect(custom).not.toHaveBeenCalled()
+		})
+
+		it("does not open the reasoning picker when effort selection is unsupported", async () => {
+			const { pi, trigger } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+			const custom = vi.fn()
+			await trigger(
+				"model_select",
+				{
+					type: "model_select",
+					model: {
+						id: "fixed-reasoning-model",
+						provider: "kimchi-dev",
+						input: ["text", "image"],
+						contextWindow: 262_144,
+						reasoning: true,
+						compat: { supportsReasoningEffort: false },
+					},
+					previousModel: { id: "adjustable-reasoning-model", provider: "kimchi-dev", input: ["text", "image"] },
+					source: "set",
+				},
+				createContext({ tokens: 10_000, hasUI: true, mode: "tui", ui: { custom } }),
+			)
+
+			expect(custom).not.toHaveBeenCalled()
+		})
+
+		it("does not open the reasoning picker when only one level is supported", async () => {
+			const { pi, trigger } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+			const custom = vi.fn()
+			await trigger(
+				"model_select",
+				{
+					type: "model_select",
+					model: {
+						id: "fixed-reasoning-model",
+						provider: "kimchi-dev",
+						input: ["text"],
+						contextWindow: 100_000,
+						reasoning: true,
+						thinkingLevelMap: { minimal: null, low: null, medium: null, high: null },
+					},
+					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+					source: "set",
+				},
+				createContext({ tokens: 10_000, hasUI: true, mode: "tui", ui: { custom } }),
+			)
+
+			expect(custom).not.toHaveBeenCalled()
+		})
+
+		it("skips the context and vision guards when reselecting the active model", async () => {
+			const { pi, trigger, setModel } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+			const custom = vi.fn().mockResolvedValue("high")
+			const select = vi.fn()
+			const model = {
+				id: "minimax-m2.7",
+				provider: "kimchi-dev",
+				input: ["text"],
+				contextWindow: 100_000,
+				reasoning: true,
+				thinkingLevelMap: { max: "max" },
+			}
+			// Tokens exceed the model's safe window — the overflow guard must fire
+			// for a real switch but not when the user reselects the active model.
+			await trigger(
+				"model_select",
+				{ type: "model_select", model, previousModel: model, source: "set" },
+				createContext({ tokens: 95_000, hasUI: true, mode: "tui", ui: { custom, select } }),
+			)
+
+			expect(setModel).not.toHaveBeenCalled()
+			expect(select).not.toHaveBeenCalled()
+			expect(custom).toHaveBeenCalledOnce()
 		})
 
 		it("keeps the current level when the reasoning picker is cancelled or fails", async () => {

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -1,5 +1,11 @@
-import type { ExtensionAPI, ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+	type ExtensionAPI,
+	type ExtensionContext,
+	initTheme,
+	type ModelRegistry,
+	ThinkingSelectorComponent,
+} from "@earendil-works/pi-coding-agent"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { createContext } from "./__mocks__/context.js"
 import createModelGuardExtension, {
 	__resetImagesDetectedForTest,
@@ -44,6 +50,10 @@ interface Harness {
 		opts?: { currentModel?: ModelEntry; imagesPresent?: boolean },
 	) => Promise<{ content: Array<{ type: string; text: string }>; details: unknown }>
 }
+
+beforeAll(() => {
+	initTheme("default")
+})
 
 const MODELS: ModelEntry[] = [
 	{ id: "kimi-k2.6", provider: "kimchi-dev", name: "Kimi K2.6", input: ["text", "image"], contextWindow: 200_000 },
@@ -122,6 +132,8 @@ function createHarnessWithTrigger(options: { setModelResult?: boolean } = {}) {
 		handlers.get(event)?.add(handler)
 	}
 	const setModel = vi.fn(async () => setModelResult)
+	const getThinkingLevel = vi.fn<ExtensionAPI["getThinkingLevel"]>(() => "high")
+	const setThinkingLevel = vi.fn()
 	const trigger = async (event: string, data: unknown, ctx: unknown) => {
 		const set = handlers.get(event)
 		if (set) for (const h of set) await h(data, ctx)
@@ -129,11 +141,13 @@ function createHarnessWithTrigger(options: { setModelResult?: boolean } = {}) {
 	const pi = {
 		on,
 		setModel,
+		getThinkingLevel,
+		setThinkingLevel,
 		registerTool: vi.fn(),
 		registerCommand: vi.fn(),
 		appendEntry: vi.fn(),
 	} as unknown as ExtensionAPI
-	return { pi, trigger, setModel }
+	return { pi, trigger, setModel, getThinkingLevel, setThinkingLevel }
 }
 
 /** Returns a mock ExtensionContext for triggering context events. */
@@ -931,11 +945,13 @@ describe("modelSwitchExtension", () => {
 				modelProvider: string
 				hasUI: boolean
 				mode: ExtensionContext["mode"]
+				thinkingLevel: ExtensionContext["thinkingLevel"]
 				compact: ExtensionContext["compact"]
 				ui: {
-					notify: (...args: unknown[]) => unknown
+					notify?: (...args: unknown[]) => unknown
 					select?: (...args: unknown[]) => unknown
 					input?: (...args: unknown[]) => unknown
+					custom?: (...args: unknown[]) => unknown
 				}
 			}> = {},
 		) => {
@@ -947,7 +963,7 @@ describe("modelSwitchExtension", () => {
 				getContextUsage: () => ({ tokens }),
 				sessionManager: { getSessionId: () => "test-session" },
 				hasUI,
-				ui: { notify: vi.fn(), select: vi.fn(), input: vi.fn(), ...overrides.ui },
+				ui: { notify: vi.fn(), select: vi.fn(), input: vi.fn(), custom: vi.fn(), ...overrides.ui },
 				...overrides,
 			} as ExtensionContext
 		}
@@ -1004,21 +1020,130 @@ describe("modelSwitchExtension", () => {
 			expect(setModel).not.toHaveBeenCalled()
 		})
 
-		it("allows source=cycle when tokens fit", async () => {
+		it("uses Normal for a new model and the current level when reselecting the active model", async () => {
+			const { pi, trigger, getThinkingLevel, setThinkingLevel } = createHarnessWithTrigger()
+			getThinkingLevel.mockReturnValue("max")
+			modelSwitchExtension(pi)
+			const custom = vi.fn().mockResolvedValue("max")
+			const model = {
+				id: "minimax-m2.7",
+				provider: "kimchi-dev",
+				input: ["text"],
+				contextWindow: 100_000,
+				reasoning: true,
+				thinkingLevelMap: { max: "max" },
+			}
+			const event = {
+				type: "model_select",
+				model,
+				previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+				source: "set",
+			}
+			const ctx = createContext({
+				tokens: 10_000,
+				hasUI: true,
+				mode: "tui",
+				thinkingLevel: "high",
+				ui: { custom },
+			})
+			await trigger("model_select", event, ctx)
+
+			expect(custom).toHaveBeenCalledOnce()
+			const factory = custom.mock.calls[0]?.[0]
+			const done = vi.fn()
+			const component = await factory(undefined, undefined, undefined, done)
+			expect(component).toBeInstanceOf(ThinkingSelectorComponent)
+			expect(component.getSelectList().getSelectedItem()?.value).toBe("medium")
+			const rendered = component.render(80).join("\n")
+			expect(rendered).toContain("Deep reasoning")
+			expect(rendered).not.toMatch(/~\d+k tokens/)
+			component.handleInput?.("\r")
+			expect(done).toHaveBeenCalledWith("medium")
+			expect(setThinkingLevel).toHaveBeenCalledWith("max")
+
+			await trigger("model_select", { ...event, previousModel: model }, ctx)
+			const reselectFactory = custom.mock.calls[1]?.[0]
+			const reselected = await reselectFactory(undefined, undefined, undefined, vi.fn())
+			expect(reselected.getSelectList().getSelectedItem()?.value).toBe("max")
+		})
+
+		it("does not open the reasoning picker for a non-reasoning model", async () => {
 			const { pi, trigger } = createHarnessWithTrigger()
 			modelSwitchExtension(pi)
-			const setModel = pi.setModel as ReturnType<typeof vi.fn>
+			const custom = vi.fn()
 			await trigger(
 				"model_select",
 				{
 					type: "model_select",
-					model: { id: "minimax-m2.7", provider: "kimchi-dev", input: ["text"], contextWindow: 100_000 },
+					model: {
+						id: "minimax-m2.7",
+						provider: "kimchi-dev",
+						input: ["text"],
+						contextWindow: 100_000,
+						reasoning: false,
+					},
+					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+					source: "set",
+				},
+				createContext({ tokens: 10_000, hasUI: true, mode: "tui", ui: { custom } }),
+			)
+
+			expect(custom).not.toHaveBeenCalled()
+		})
+
+		it("keeps the current level when the reasoning picker is cancelled or fails", async () => {
+			const { pi, trigger, setThinkingLevel } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+			const custom = vi.fn().mockResolvedValue(undefined)
+			const event = {
+				type: "model_select",
+				model: {
+					id: "minimax-m2.7",
+					provider: "kimchi-dev",
+					input: ["text"],
+					contextWindow: 100_000,
+					reasoning: true,
+				},
+				previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
+				source: "set",
+			}
+			const ctx = createContext({ tokens: 10_000, hasUI: true, mode: "tui", ui: { custom } })
+			await trigger("model_select", event, ctx)
+
+			expect(custom).toHaveBeenCalledOnce()
+			expect(setThinkingLevel).not.toHaveBeenCalled()
+
+			const warning = vi.spyOn(console, "warn").mockImplementation(() => {})
+			custom.mockRejectedValueOnce(new Error("terminal closed"))
+			await expect(trigger("model_select", event, ctx)).resolves.toBeUndefined()
+			expect(warning).toHaveBeenCalledWith("[model-switch] reasoning picker failed:", expect.any(Error))
+			expect(setThinkingLevel).not.toHaveBeenCalled()
+			warning.mockRestore()
+		})
+
+		it("allows source=cycle when tokens fit", async () => {
+			const { pi, trigger } = createHarnessWithTrigger()
+			modelSwitchExtension(pi)
+			const setModel = pi.setModel as ReturnType<typeof vi.fn>
+			const custom = vi.fn()
+			await trigger(
+				"model_select",
+				{
+					type: "model_select",
+					model: {
+						id: "minimax-m2.7",
+						provider: "kimchi-dev",
+						input: ["text"],
+						contextWindow: 100_000,
+						reasoning: true,
+					},
 					previousModel: { id: "kimi-k2.6", provider: "kimchi-dev", input: ["text", "image"] },
 					source: "cycle",
 				},
-				createContext({ tokens: 10_000 }),
+				createContext({ tokens: 10_000, hasUI: true, mode: "tui", ui: { custom } }),
 			)
 			expect(setModel).not.toHaveBeenCalled()
+			expect(custom).not.toHaveBeenCalled()
 		})
 
 		it("skips when source is restore", async () => {

--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -1020,7 +1020,7 @@ describe("modelSwitchExtension", () => {
 			expect(setModel).not.toHaveBeenCalled()
 		})
 
-		it("uses Normal for a new model and the current level when reselecting the active model", async () => {
+		it("uses High for a new model and the current level when reselecting the active model", async () => {
 			const { pi, trigger, getThinkingLevel, setThinkingLevel } = createHarnessWithTrigger()
 			getThinkingLevel.mockReturnValue("max")
 			modelSwitchExtension(pi)
@@ -1053,12 +1053,12 @@ describe("modelSwitchExtension", () => {
 			const done = vi.fn()
 			const component = await factory(undefined, undefined, undefined, done)
 			expect(component).toBeInstanceOf(ThinkingSelectorComponent)
-			expect(component.getSelectList().getSelectedItem()?.value).toBe("medium")
+			expect(component.getSelectList().getSelectedItem()?.value).toBe("high")
 			const rendered = component.render(80).join("\n")
 			expect(rendered).toContain("Deep reasoning")
 			expect(rendered).not.toMatch(/~\d+k tokens/)
 			component.handleInput?.("\r")
-			expect(done).toHaveBeenCalledWith("medium")
+			expect(done).toHaveBeenCalledWith("high")
 			expect(setThinkingLevel).toHaveBeenCalledWith("max")
 
 			await trigger("model_select", { ...event, previousModel: model }, ctx)

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -45,7 +45,7 @@ async function selectThinkingLevel(
 	if (!ctx.hasUI || ctx.mode !== "tui" || !model.reasoning) return
 	const levels = getSupportedThinkingLevels(model)
 	if (levels.length <= 1) return
-	const preferredLevel = modelsAreEqual(previousModel, model) ? pi.getThinkingLevel() : "medium"
+	const preferredLevel = modelsAreEqual(previousModel, model) ? pi.getThinkingLevel() : "high"
 	const defaultLevel = levels.includes(preferredLevel) ? preferredLevel : (levels.at(-1) ?? preferredLevel)
 	let selected: ModelThinkingLevel | undefined
 	try {

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -1,5 +1,11 @@
-import type { Api, Model } from "@earendil-works/pi-ai"
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import {
+	type Api,
+	getSupportedThinkingLevels,
+	type Model,
+	type ModelThinkingLevel,
+	modelsAreEqual,
+} from "@earendil-works/pi-ai"
+import { type ExtensionAPI, type ExtensionContext, ThinkingSelectorComponent } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import { startNewInteractiveSessionWithModel } from "./interactive-model-session.js"
 import { findModelByRef, refFromModel, splitModelRef } from "./model-catalog/ref-utils.js"
@@ -29,6 +35,34 @@ export async function withSuppressedModelSelectGuard<T>(fn: () => Promise<T>): P
 
 /** Recursion guard — true while our own revert is in progress. */
 let isRevertingModel = false
+
+async function selectThinkingLevel(
+	pi: ExtensionAPI,
+	model: Model<Api>,
+	previousModel: Model<Api> | undefined,
+	ctx: ExtensionContext,
+): Promise<void> {
+	if (!ctx.hasUI || ctx.mode !== "tui" || !model.reasoning) return
+	const levels = getSupportedThinkingLevels(model)
+	if (levels.length <= 1) return
+	const preferredLevel = modelsAreEqual(previousModel, model) ? pi.getThinkingLevel() : "medium"
+	const defaultLevel = levels.includes(preferredLevel) ? preferredLevel : (levels.at(-1) ?? preferredLevel)
+	let selected: ModelThinkingLevel | undefined
+	try {
+		selected = await ctx.ui.custom<ModelThinkingLevel | undefined>((_tui, _theme, _keybindings, done) => {
+			const selector = new ThinkingSelectorComponent(defaultLevel, levels, done, () => done(undefined))
+			const render = selector.render.bind(selector)
+			return Object.assign(selector, {
+				handleInput: (data: string) => selector.getSelectList().handleInput(data),
+				render: (width: number) => render(width).map((line) => line.replace(/ \(~\d+k tokens\)/g, "")),
+			})
+		})
+	} catch (error) {
+		console.warn("[model-switch] reasoning picker failed:", error)
+		return
+	}
+	if (selected !== undefined) pi.setThinkingLevel(selected)
+}
 
 /** Resets module state between tests. */
 export function __resetModelSwitchStateForTest(): void {
@@ -289,6 +323,7 @@ export default function modelSwitchExtension(
 			if (selectedRef !== orchRef) {
 				setMultiModelEnabled(sessionId, false)
 			}
+			await selectThinkingLevel(pi, event.model, event.previousModel, ctx)
 		}
 	})
 }

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -42,7 +42,13 @@ async function selectThinkingLevel(
 	previousModel: Model<Api> | undefined,
 	ctx: ExtensionContext,
 ): Promise<void> {
-	if (!ctx.hasUI || ctx.mode !== "tui" || !model.reasoning) return
+	if (
+		!ctx.hasUI ||
+		ctx.mode !== "tui" ||
+		!model.reasoning ||
+		(model.compat && "supportsReasoningEffort" in model.compat && model.compat.supportsReasoningEffort === false)
+	)
+		return
 	const levels = getSupportedThinkingLevels(model)
 	if (levels.length <= 1) return
 	const preferredLevel = modelsAreEqual(previousModel, model) ? pi.getThinkingLevel() : "high"
@@ -51,10 +57,12 @@ async function selectThinkingLevel(
 	try {
 		selected = await ctx.ui.custom<ModelThinkingLevel | undefined>((_tui, _theme, _keybindings, done) => {
 			const selector = new ThinkingSelectorComponent(defaultLevel, levels, done, () => done(undefined))
-			const render = selector.render.bind(selector)
+			const selectList = selector.getSelectList()
+			const render = selectList.render.bind(selectList)
+			// Pi omits descriptions at 40 columns; keep this picker label-only at every terminal width.
+			selectList.render = (width: number) => render(Math.min(width, 40))
 			return Object.assign(selector, {
-				handleInput: (data: string) => selector.getSelectList().handleInput(data),
-				render: (width: number) => render(width).map((line) => line.replace(/ \(~\d+k tokens\)/g, "")),
+				handleInput: (data: string) => selectList.handleInput(data),
 			})
 		})
 	} catch (error) {
@@ -248,6 +256,16 @@ export default function modelSwitchExtension(
 		if (event.source === "restore") return
 		// Nothing to revert to
 		if (!event.previousModel) return
+
+		// Reselecting the active model is not a switch: the guards below protect
+		// against switching *into* an unfit model, and the user is already on it.
+		// Offer the reasoning picker and skip the rest.
+		if (modelsAreEqual(event.previousModel, event.model)) {
+			if (event.source === "set") {
+				await selectThinkingLevel(pi, event.model, event.previousModel, ctx)
+			}
+			return
+		}
 
 		const sessionId = ctx.sessionManager.getSessionId()
 		const usage = ctx.getContextUsage?.()

--- a/src/extensions/prompt-construction/prompt-enrichment.test.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.test.ts
@@ -1036,6 +1036,26 @@ describe("continuation nudge turn_end handler", () => {
 		expect(sendMessageCalls.length).toBe(0)
 	})
 
+	it("still nudges when the user reselects the active model", async () => {
+		const { fire, sendMessageCalls } = buildNudgeHandlers()
+
+		// Previous model called a tool during the session.
+		await fire("tool_execution_start", {})
+
+		// Reselecting the active model (reasoning picker flow) is not a switch,
+		// so the session-level latch must survive.
+		const model = { id: "kimi-k2.7", provider: "kimchi-dev" }
+		await fire("model_select", { model, previousModel: model, source: "set" })
+
+		await fire("input", { source: "user" })
+		await fire("turn_end", {
+			message: makeAssistantWithStop([{ type: "text", text: "I will delegate this." }]),
+		})
+
+		// Latch preserved: the continuation nudge still fires.
+		expect(sendMessageCalls.length).toBe(1)
+	})
+
 	it("does not nudge after a model cycle when the previous model called tools", async () => {
 		const { fire, sendMessageCalls } = buildNudgeHandlers()
 

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -27,7 +27,7 @@ import { randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { arch, homedir, version as osVersion, platform, release, userInfo } from "node:os"
 import { join } from "node:path"
-import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai"
+import { type AssistantMessage, modelsAreEqual, type ToolCall } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../config.js"
 import { resolveSkillPathsForDiscovery } from "../../shared/skill-discovery/resolve-skill-roots.js"
@@ -281,6 +281,9 @@ export default function (skillPathsFromConfig: string[]) {
 			})
 
 			pi.on("model_select", async (event, ctx) => {
+				// A same-model reselect (reasoning picker flow) is not a switch.
+				if (modelsAreEqual(event.previousModel, event.model)) return
+
 				notifyIfDeprecated(ctx)
 
 				// A user-initiated model switch (UI picker, /model, or cycling)

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -21,6 +21,16 @@ const KIMI: unknown = {
 	limits: { context_window: 262144, max_output_tokens: 262144 },
 }
 
+const GPT_LUNA: unknown = {
+	slug: "gpt-5.6-luna",
+	display_name: "GPT-5.6 Luna",
+	provider: "ai-enabler",
+	reasoning: true,
+	input_modalities: ["text"],
+	is_serverless: true,
+	limits: { context_window: 200000, max_output_tokens: 128000 },
+}
+
 const GLM: unknown = {
 	slug: "glm-5-fp8",
 	display_name: "GLM-5 FP8",
@@ -86,7 +96,7 @@ describe("updateModelsConfig", () => {
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				provider: "ai-enabler",
-				thinkingLevelMap: { off: "none", max: "max" },
+				compat: { supportsReasoningEffort: false },
 			},
 		])
 	})
@@ -138,7 +148,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")
 	})
 
-	it("does not set compat for non-anthropic ai-enabler models", async () => {
+	it("marks fixed-effort AI Enabler models as not adjustable", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
@@ -147,13 +157,13 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
+		expect(config.providers["kimchi-dev"].models[0].compat).toEqual({ supportsReasoningEffort: false })
 	})
 
-	it("maps ai-enabler thinking levels required by the upstream selector", async () => {
+	it("maps adjustable GPT thinking levels required by the upstream selector", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: [KIMI] }),
+			json: async () => ({ models: [GPT_LUNA] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "test-key")

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -21,16 +21,6 @@ const KIMI: unknown = {
 	limits: { context_window: 262144, max_output_tokens: 262144 },
 }
 
-const GPT_LUNA: unknown = {
-	slug: "gpt-5.6-luna",
-	display_name: "GPT-5.6 Luna",
-	provider: "ai-enabler",
-	reasoning: true,
-	input_modalities: ["text"],
-	is_serverless: true,
-	limits: { context_window: 200000, max_output_tokens: 128000 },
-}
-
 const GLM: unknown = {
 	slug: "glm-5-fp8",
 	display_name: "GLM-5 FP8",
@@ -96,7 +86,7 @@ describe("updateModelsConfig", () => {
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				provider: "ai-enabler",
-				compat: { supportsReasoningEffort: false },
+				thinkingLevelMap: { off: "none", max: "max" },
 			},
 		])
 	})
@@ -148,7 +138,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")
 	})
 
-	it("marks fixed-effort AI Enabler models as not adjustable", async () => {
+	it("does not set compat for non-anthropic ai-enabler models", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [KIMI] }),
@@ -157,13 +147,13 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0].compat).toEqual({ supportsReasoningEffort: false })
+		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
 	})
 
-	it("maps adjustable GPT thinking levels required by the upstream selector", async () => {
+	it("maps ai-enabler thinking levels required by the upstream selector", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: [GPT_LUNA] }),
+			json: async () => ({ models: [KIMI] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "test-key")

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -21,6 +21,22 @@ const KIMI: unknown = {
 	limits: { context_window: 262144, max_output_tokens: 262144 },
 }
 
+const KIMI_27: unknown = {
+	...(KIMI as object),
+	slug: "kimi-k2.7",
+	display_name: "Kimi K2.7",
+}
+
+const DEEPSEEK: unknown = {
+	slug: "deepseek-v4-flash",
+	display_name: "DeepSeek V4 Flash",
+	provider: "ai-enabler",
+	reasoning: true,
+	input_modalities: ["text"],
+	is_serverless: true,
+	limits: { context_window: 1_000_000, max_output_tokens: 384_000 },
+}
+
 const GLM: unknown = {
 	slug: "glm-5-fp8",
 	display_name: "GLM-5 FP8",
@@ -86,7 +102,7 @@ describe("updateModelsConfig", () => {
 				maxTokens: 262144,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				provider: "ai-enabler",
-				thinkingLevelMap: { off: "none", max: "max" },
+				compat: { supportsReasoningEffort: false },
 			},
 		])
 	})
@@ -138,22 +154,28 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")
 	})
 
-	it("does not set compat for non-anthropic ai-enabler models", async () => {
+	it.each([
+		["Kimi 2.7", KIMI_27],
+		["GLM", GLM],
+	])("marks fixed-effort %s models as not adjustable", async (_name, model) => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: [KIMI] }),
+			json: async () => ({ models: [model] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		expect(config.providers["kimchi-dev"].models[0]).not.toHaveProperty("compat")
+		const generatedModel = config.providers["kimchi-dev"].models[0]
+		expect(generatedModel.reasoning).toBe(true)
+		expect(generatedModel.compat).toEqual({ supportsReasoningEffort: false })
+		expect(generatedModel).not.toHaveProperty("thinkingLevelMap")
 	})
 
-	it("maps ai-enabler thinking levels required by the upstream selector", async () => {
+	it("maps adjustable AI Enabler thinking levels required by the upstream selector", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
-			json: async () => ({ models: [KIMI] }),
+			json: async () => ({ models: [DEEPSEEK] }),
 		} as Response)
 
 		await updateModelsConfig(modelsJsonPath, "test-key")

--- a/src/models.ts
+++ b/src/models.ts
@@ -196,13 +196,18 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	//
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
 	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
-	// disables thinking with `none` and advertises max to Pi's selector.
+	// disables thinking with `none` and advertises max to Pi's selector for
+	// GPT models, the AI Enabler family that supports adjustable effort.
+	const supportsReasoningEffort = m.provider === "ai-enabler" && m.slug.startsWith("gpt-")
 	const compat =
 		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
-			: undefined
-	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
-		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
+			: m.provider === "ai-enabler" && m.reasoning && !supportsReasoningEffort
+				? ({ supportsReasoningEffort: false } as const)
+				: undefined
+	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] = supportsReasoningEffort
+		? { off: "none", max: "max" }
+		: undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,

--- a/src/models.ts
+++ b/src/models.ts
@@ -94,6 +94,8 @@ interface ModelsMetadataResponse {
 	models: ModelMetadata[]
 }
 
+const AI_ENABLER_REASONING_EFFORT_MODELS = new Set(["deepseek-v4-flash", "deepseek-v4-flash-0731"])
+
 function sortModels(models: ModelMetadata[]): ModelMetadata[] {
 	const serverless = models.filter((m) => m.is_serverless)
 	const rest = models.filter((m) => !m.is_serverless)
@@ -194,15 +196,19 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// - cacheControlFormat: "anthropic" so pi injects cache_control markers
 	// - supportsUsageInStreaming: true so stream_options.include_usage is sent
 	//
-	// ai-enabler models don't support chat_template_kwargs, so we rely on the
-	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
-	// disables thinking with `none` and advertises max to Pi's selector.
+	// AI Enabler models don't support chat_template_kwargs, so adjustable models
+	// use the default `openai` thinkingFormat, which sends `reasoning_effort`.
+	const supportsReasoningEffort =
+		m.provider === "ai-enabler" && m.reasoning && AI_ENABLER_REASONING_EFFORT_MODELS.has(m.slug)
 	const compat =
 		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
-			: undefined
-	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
-		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
+			: m.provider === "ai-enabler" && m.reasoning
+				? { supportsReasoningEffort }
+				: undefined
+	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] = supportsReasoningEffort
+		? { off: "none", max: "max" }
+		: undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,

--- a/src/models.ts
+++ b/src/models.ts
@@ -196,18 +196,13 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	//
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
 	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
-	// disables thinking with `none` and advertises max to Pi's selector for
-	// GPT models, the AI Enabler family that supports adjustable effort.
-	const supportsReasoningEffort = m.provider === "ai-enabler" && m.slug.startsWith("gpt-")
+	// disables thinking with `none` and advertises max to Pi's selector.
 	const compat =
 		m.provider === "anthropic" || m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
-			: m.provider === "ai-enabler" && m.reasoning && !supportsReasoningEffort
-				? ({ supportsReasoningEffort: false } as const)
-				: undefined
-	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] = supportsReasoningEffort
-		? { off: "none", max: "max" }
-		: undefined
+			: undefined
+	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
+		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,

--- a/src/same-model-select-patch.test.ts
+++ b/src/same-model-select-patch.test.ts
@@ -1,0 +1,46 @@
+import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { expect, it, vi } from "vitest"
+import { applySameModelSelectPatch } from "./same-model-select-patch.js"
+
+it("emits model_select when the user reselects the active model", async () => {
+	const model = {
+		id: "thinker",
+		name: "Thinker",
+		provider: "fake",
+		api: "openai-completions",
+		baseUrl: "http://127.0.0.1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_000,
+	} as const
+	const emit = vi.fn().mockResolvedValue(undefined)
+	const session = { _extensionRunner: { emit } }
+	// biome-ignore lint/suspicious/noExplicitAny: invoking the patched private upstream method on a focused fake
+	const patched = (AgentSession.prototype as any)._emitModelSelect
+
+	await patched.call(session, model, model, "set")
+
+	expect(emit).toHaveBeenCalledOnce()
+	expect(emit).toHaveBeenCalledWith({
+		type: "model_select",
+		model,
+		previousModel: model,
+		source: "set",
+	})
+})
+
+it("does not patch when Pi's private model-select hook is unavailable", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: simulating a future Pi version without the private hook
+	const prototype = AgentSession.prototype as any
+	const current = prototype._emitModelSelect
+	prototype._emitModelSelect = undefined
+
+	try {
+		applySameModelSelectPatch()
+		expect(prototype._emitModelSelect).toBeUndefined()
+	} finally {
+		prototype._emitModelSelect = current
+	}
+})

--- a/src/same-model-select-patch.test.ts
+++ b/src/same-model-select-patch.test.ts
@@ -1,28 +1,59 @@
-import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { AgentSession, ModelSelectorComponent } from "@earendil-works/pi-coding-agent"
 import { expect, it, vi } from "vitest"
 import { applySameModelSelectPatch } from "./same-model-select-patch.js"
 
-it("emits model_select when the user reselects the active model", async () => {
-	const model = {
-		id: "thinker",
-		name: "Thinker",
-		provider: "fake",
-		api: "openai-completions",
-		baseUrl: "http://127.0.0.1",
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128_000,
-		maxTokens: 16_000,
-	} as const
+const model = {
+	id: "thinker",
+	name: "Thinker",
+	provider: "fake",
+	api: "openai-completions",
+	baseUrl: "http://127.0.0.1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_000,
+} as const
+
+function createSession() {
 	const emit = vi.fn().mockResolvedValue(undefined)
-	const session = { _extensionRunner: { emit } }
-	// biome-ignore lint/suspicious/noExplicitAny: invoking the patched private upstream method on a focused fake
-	const patched = (AgentSession.prototype as any)._emitModelSelect
+	const session = {
+		model,
+		agent: { state: { model } },
+		_modelRuntime: { checkAuth: vi.fn().mockResolvedValue(true) },
+		_getThinkingLevelForModelSwitch: vi.fn().mockReturnValue("high"),
+		setThinkingLevel: vi.fn(),
+		sessionManager: { appendModelChange: vi.fn() },
+		settingsManager: { setDefaultModelAndProvider: vi.fn() },
+		_extensionRunner: { emit },
+		// biome-ignore lint/suspicious/noExplicitAny: focused fake delegates to Pi's private hook
+		_emitModelSelect: (AgentSession.prototype as any)._emitModelSelect,
+	}
+	return { emit, session }
+}
 
-	await patched.call(session, model, model, "set")
+it("emits model_select when the user reselects the active model in the model menu", async () => {
+	const { emit, session } = createSession()
+	// biome-ignore lint/suspicious/noExplicitAny: invoking patched upstream methods on focused fakes
+	const setModel = (AgentSession.prototype as any).setModel
+	// biome-ignore lint/suspicious/noExplicitAny: invoking patched upstream methods on focused fakes
+	const handleSelect = (ModelSelectorComponent.prototype as any).handleSelect
+	let selection: Promise<void> | undefined
+	const selector = {
+		dispose: vi.fn(),
+		filteredModels: [{ model }],
+		selectedIndex: 0,
+		sessionId: "session-1",
+		settingsManager: { setDefaultModelAndProvider: vi.fn() },
+		onSelectCallback: (selectedModel: typeof model) => {
+			selection = setModel.call(session, selectedModel)
+			return selection
+		},
+	}
 
-	expect(emit).toHaveBeenCalledOnce()
+	handleSelect.call(selector, model)
+	await selection
+
 	expect(emit).toHaveBeenCalledWith({
 		type: "model_select",
 		model,
@@ -31,16 +62,26 @@ it("emits model_select when the user reselects the active model", async () => {
 	})
 })
 
-it("does not patch when Pi's private model-select hook is unavailable", () => {
+it("does not emit model_select when a programmatic call reselects the active model", async () => {
+	const { emit, session } = createSession()
+	// biome-ignore lint/suspicious/noExplicitAny: invoking the patched upstream method on a focused fake
+	const setModel = (AgentSession.prototype as any).setModel
+
+	await setModel.call(session, model)
+
+	expect(emit).not.toHaveBeenCalled()
+})
+
+it("does not patch when Pi's private model-selector hook is unavailable", () => {
 	// biome-ignore lint/suspicious/noExplicitAny: simulating a future Pi version without the private hook
-	const prototype = AgentSession.prototype as any
-	const current = prototype._emitModelSelect
-	prototype._emitModelSelect = undefined
+	const prototype = ModelSelectorComponent.prototype as any
+	const current = prototype.handleSelect
+	prototype.handleSelect = undefined
 
 	try {
 		applySameModelSelectPatch()
-		expect(prototype._emitModelSelect).toBeUndefined()
+		expect(prototype.handleSelect).toBeUndefined()
 	} finally {
-		prototype._emitModelSelect = current
+		prototype.handleSelect = current
 	}
 })

--- a/src/same-model-select-patch.ts
+++ b/src/same-model-select-patch.ts
@@ -1,0 +1,38 @@
+import { type Api, type Model, modelsAreEqual } from "@earendil-works/pi-ai"
+import { AgentSession, type ExtensionEvent } from "@earendil-works/pi-coding-agent"
+
+type ModelSelectEvent = Extract<ExtensionEvent, { type: "model_select" }>
+type EmitModelSelect = (
+	this: AgentSession,
+	nextModel: Model<Api>,
+	previousModel: Model<Api> | undefined,
+	source: ModelSelectEvent["source"],
+) => Promise<void>
+
+// biome-ignore lint/suspicious/noExplicitAny: private upstream prototype method patched for Pi 0.84.1
+const agentSessionPrototype = AgentSession.prototype as any
+const originalEmitModelSelect = agentSessionPrototype._emitModelSelect as EmitModelSelect
+
+async function patchedEmitModelSelect(
+	this: AgentSession,
+	nextModel: Model<Api>,
+	previousModel: Model<Api> | undefined,
+	source: ModelSelectEvent["source"],
+): Promise<void> {
+	if (source !== "set" || !modelsAreEqual(previousModel, nextModel)) {
+		return originalEmitModelSelect.call(this, nextModel, previousModel, source)
+	}
+
+	// Pi 0.84.1's original method only guards equal models, then forwards this event.
+	const extensionRunner = (this as unknown as { _extensionRunner: { emit(event: ModelSelectEvent): Promise<void> } })
+		._extensionRunner
+	await extensionRunner.emit({ type: "model_select", model: nextModel, previousModel, source })
+}
+
+/** Remove when upstream emits a user-selection event for the active model. */
+export function applySameModelSelectPatch(): void {
+	if (typeof agentSessionPrototype._emitModelSelect !== "function") return
+	agentSessionPrototype._emitModelSelect = patchedEmitModelSelect
+}
+
+applySameModelSelectPatch()

--- a/src/same-model-select-patch.ts
+++ b/src/same-model-select-patch.ts
@@ -1,38 +1,53 @@
+/**
+ * Patches the upstream pi SDK so re-selecting the active model in the TUI model
+ * menu still emits `model_select`. Pi 0.84.1 drops equal-model events, while
+ * every direct `setModel()` call uses the same `"set"` source.
+ *
+ * Upstream: https://github.com/earendil-works/pi — no tracking issue filed
+ * yet. Remove this module and its import in cli.ts once pi emits a
+ * user-selection event for the already-active model itself.
+ *
+ * This module is imported for side effects. It must be loaded **before** any
+ * model selection occurs so the prototype patch takes effect.
+ */
+
 import { type Api, type Model, modelsAreEqual } from "@earendil-works/pi-ai"
-import { AgentSession, type ExtensionEvent } from "@earendil-works/pi-coding-agent"
+import { AgentSession, type ExtensionEvent, ModelSelectorComponent } from "@earendil-works/pi-coding-agent"
 
 type ModelSelectEvent = Extract<ExtensionEvent, { type: "model_select" }>
-type EmitModelSelect = (
-	this: AgentSession,
-	nextModel: Model<Api>,
-	previousModel: Model<Api> | undefined,
-	source: ModelSelectEvent["source"],
-) => Promise<void>
+type SetModel = (this: AgentSession, model: Model<Api>) => Promise<void>
+type HandleSelect = (this: ModelSelectorComponent, model: Model<Api>) => void
 
 // biome-ignore lint/suspicious/noExplicitAny: private upstream prototype method patched for Pi 0.84.1
 const agentSessionPrototype = AgentSession.prototype as any
-const originalEmitModelSelect = agentSessionPrototype._emitModelSelect as EmitModelSelect
+// biome-ignore lint/suspicious/noExplicitAny: private upstream prototype method patched for Pi 0.84.1
+const modelSelectorPrototype = ModelSelectorComponent.prototype as any
+const originalSetModel = agentSessionPrototype.setModel as SetModel
+const originalHandleSelect = modelSelectorPrototype.handleSelect as HandleSelect
+const modelMenuSelections = new WeakSet<Model<Api>>()
 
-async function patchedEmitModelSelect(
-	this: AgentSession,
-	nextModel: Model<Api>,
-	previousModel: Model<Api> | undefined,
-	source: ModelSelectEvent["source"],
-): Promise<void> {
-	if (source !== "set" || !modelsAreEqual(previousModel, nextModel)) {
-		return originalEmitModelSelect.call(this, nextModel, previousModel, source)
-	}
+async function patchedSetModel(this: AgentSession, model: Model<Api>): Promise<void> {
+	const previousModel = this.model
+	const selectedFromMenu = modelMenuSelections.delete(model)
+	await originalSetModel.call(this, model)
+	if (!selectedFromMenu || !modelsAreEqual(previousModel, model)) return
 
-	// Pi 0.84.1's original method only guards equal models, then forwards this event.
 	const extensionRunner = (this as unknown as { _extensionRunner: { emit(event: ModelSelectEvent): Promise<void> } })
 		._extensionRunner
-	await extensionRunner.emit({ type: "model_select", model: nextModel, previousModel, source })
+	await extensionRunner.emit({ type: "model_select", model, previousModel, source: "set" })
+}
+
+function patchedHandleSelect(this: ModelSelectorComponent, model: Model<Api>): void {
+	modelMenuSelections.add(model)
+	originalHandleSelect.call(this, model)
 }
 
 /** Remove when upstream emits a user-selection event for the active model. */
 export function applySameModelSelectPatch(): void {
-	if (typeof agentSessionPrototype._emitModelSelect !== "function") return
-	agentSessionPrototype._emitModelSelect = patchedEmitModelSelect
+	if (typeof agentSessionPrototype.setModel !== "function" || typeof modelSelectorPrototype.handleSelect !== "function")
+		return
+	agentSessionPrototype.setModel = patchedSetModel
+	modelSelectorPrototype.handleSelect = patchedHandleSelect
 }
 
 applySameModelSelectPatch()

--- a/tests/e2e/tui/model-reasoning-picker.test.ts
+++ b/tests/e2e/tui/model-reasoning-picker.test.ts
@@ -30,9 +30,8 @@ test("model selection opens reasoning on High and preserves it on reselection", 
 		},
 		async (fixture, trace) => {
 			terminal.submit("/model fake/thinker")
-			await waitForText(terminal, "Deep reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).toMatch(/→ high\s+Deep reasoning/)
-			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			await waitForText(terminal, /→ high[ \t]*$/m, { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toMatch(/\b(?:No|Very brief|Light|Moderate|Deep|Extra-high|Maximum) reasoning\b/)
 			trace.step("reasoning picker opened after model choice")
 
 			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8")) as {
@@ -43,14 +42,13 @@ test("model selection opens reasoning on High and preserves it on reselection", 
 			expect(settings.kimchiHighThinkingDefaultApplied).toBe(true)
 
 			terminal.keyUp()
-			await waitForText(terminal, /→ medium\s+Moderate reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, /→ medium[ \t]*$/m, { timeoutMs: STREAM_TIMEOUT_MS })
 			terminal.write("\r")
 			await waitForText(terminal, "Model: thinker", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("Normal reasoning selected on the first model")
 
 			terminal.submit("/model fake/thinker-two")
-			await waitForText(terminal, /→ high\s+Deep reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			await waitForText(terminal, /→ high[ \t]*$/m, { timeoutMs: STREAM_TIMEOUT_MS })
 			terminal.write("\r")
 			await waitForText(terminal, "Model: thinker-two", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("second model reset to default High reasoning")
@@ -58,9 +56,7 @@ test("model selection opens reasoning on High and preserves it on reselection", 
 			terminal.submit("/model")
 			await waitForText(terminal, "Model Name: Fake Thinker Two", { timeoutMs: STREAM_TIMEOUT_MS })
 			terminal.write("\r")
-			await waitForText(terminal, "Deep reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).toMatch(/→ high\s+Deep reasoning/)
-			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			await waitForText(terminal, /→ high[ \t]*$/m, { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("reasoning picker reopened after selecting the active model")
 		},
 	)

--- a/tests/e2e/tui/model-reasoning-picker.test.ts
+++ b/tests/e2e/tui/model-reasoning-picker.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { STREAM_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("model selection opens reasoning with a fresh default and preserves it on reselection", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "model-then-reasoning-picker",
+			models: [
+				{ slug: "basic", displayName: "Fake Basic", reasoning: false },
+				{ slug: "thinker", displayName: "Fake Thinker", reasoning: true },
+				{ slug: "thinker-two", displayName: "Fake Thinker Two", reasoning: true },
+			],
+			responses: [],
+			seedHome: (homeDir) => {
+				writeFileSync(
+					join(homeDir, ".config", "kimchi", "harness", "settings.json"),
+					JSON.stringify({
+						statusLine: { pinned: [] },
+						hideThinkingBlock: true,
+						defaultThinkingLevel: "medium",
+					}),
+				)
+			},
+		},
+		async (fixture, trace) => {
+			terminal.submit("/model fake/thinker")
+			await waitForText(terminal, "Moderate reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).toMatch(/→ medium\s+Moderate reasoning/)
+			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			trace.step("reasoning picker opened after model choice")
+
+			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8")) as {
+				defaultThinkingLevel?: string
+			}
+			expect(settings.defaultThinkingLevel).toBe("medium")
+
+			terminal.keyDown()
+			await waitForText(terminal, /→ high\s+Deep reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.write("\r")
+			await waitForText(terminal, "Model: thinker", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("High reasoning selected on the first model")
+
+			terminal.submit("/model fake/thinker-two")
+			await waitForText(terminal, /→ medium\s+Moderate reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			terminal.write("\r")
+			await waitForText(terminal, "Model: thinker-two", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("second model reset to default Normal reasoning")
+
+			terminal.submit("/model")
+			await waitForText(terminal, "Model Name: Fake Thinker Two", { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.write("\r")
+			await waitForText(terminal, "Moderate reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).toMatch(/→ medium\s+Moderate reasoning/)
+			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
+			trace.step("reasoning picker reopened after selecting the active model")
+		},
+	)
+})

--- a/tests/e2e/tui/model-reasoning-picker.test.ts
+++ b/tests/e2e/tui/model-reasoning-picker.test.ts
@@ -6,7 +6,7 @@ import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
-test("model selection opens reasoning with a fresh default and preserves it on reselection", async ({ terminal }) => {
+test("model selection opens reasoning on High and preserves it on reselection", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
 		{
@@ -30,34 +30,36 @@ test("model selection opens reasoning with a fresh default and preserves it on r
 		},
 		async (fixture, trace) => {
 			terminal.submit("/model fake/thinker")
-			await waitForText(terminal, "Moderate reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).toMatch(/→ medium\s+Moderate reasoning/)
+			await waitForText(terminal, "Deep reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).toMatch(/→ high\s+Deep reasoning/)
 			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
 			trace.step("reasoning picker opened after model choice")
 
 			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8")) as {
 				defaultThinkingLevel?: string
+				kimchiHighThinkingDefaultApplied?: boolean
 			}
-			expect(settings.defaultThinkingLevel).toBe("medium")
+			expect(settings.defaultThinkingLevel).toBe("high")
+			expect(settings.kimchiHighThinkingDefaultApplied).toBe(true)
 
-			terminal.keyDown()
-			await waitForText(terminal, /→ high\s+Deep reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
+			terminal.keyUp()
+			await waitForText(terminal, /→ medium\s+Moderate reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
 			terminal.write("\r")
 			await waitForText(terminal, "Model: thinker", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("High reasoning selected on the first model")
+			trace.step("Normal reasoning selected on the first model")
 
 			terminal.submit("/model fake/thinker-two")
-			await waitForText(terminal, /→ medium\s+Moderate reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, /→ high\s+Deep reasoning/, { timeoutMs: STREAM_TIMEOUT_MS })
 			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
 			terminal.write("\r")
 			await waitForText(terminal, "Model: thinker-two", { timeoutMs: STREAM_TIMEOUT_MS })
-			trace.step("second model reset to default Normal reasoning")
+			trace.step("second model reset to default High reasoning")
 
 			terminal.submit("/model")
 			await waitForText(terminal, "Model Name: Fake Thinker Two", { timeoutMs: STREAM_TIMEOUT_MS })
 			terminal.write("\r")
-			await waitForText(terminal, "Moderate reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).toMatch(/→ medium\s+Moderate reasoning/)
+			await waitForText(terminal, "Deep reasoning", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).toMatch(/→ high\s+Deep reasoning/)
 			expect(viewText(terminal)).not.toMatch(/~\d+k tokens/)
 			trace.step("reasoning picker reopened after selecting the active model")
 		},


### PR DESCRIPTION
## Proof

### /model

<img width="1700" height="690" alt="image" src="https://github.com/user-attachments/assets/4b303d21-d8f2-4e37-ab29-01fd4c87b87a" />

### After selecting the model

<img width="1750" height="432" alt="image" src="https://github.com/user-attachments/assets/4e96efa7-0bf6-44c1-9044-ab9e9b5f1fb2" />

## What

- Open the reasoning-effort menu after selecting a reasoning-capable model in the TUI, including when reselecting the active model.
- Make High the one-time default for fresh and legacy Normal settings while preserving later explicit choices.
- Preselect High for a different model instead of carrying over the previous model's effort; preserve the current effort when reselecting the same model.
- Remove token estimates from the embedded reasoning menu.

## Why

Pi defaults to Normal, carries the current reasoning level across model switches, and suppresses `model_select` when the chosen model is already active. This made Kimchi start below its intended default, let one model's effort leak into another model's menu, and made active-model reselection skip the menu entirely.

This reuses Pi's existing selector and capability helpers, adds a one-time settings migration that does not overwrite later choices, and uses a small compatibility adapter for the missing same-model event.

## Validation

- Focused unit tests: 138 passed
- TUI model-selection workflow: passed
- Full unit suite: 9,006 passed, 13 skipped
- `pnpm run check`: passed
- `git diff --check`: passed
