### PR TITLE
feat(router): route first prompt of each session and subagent to the optimal model

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -49,9 +49,9 @@ The interface continues to show Auto as your selected model before and after rou
 auto
 ```
 
-Kimchi displays an “Auto is ready” notification when routing finishes, without revealing the selected model. From that point onward, the concrete model's capabilities and limits apply, including vision support, context window, reasoning support, and provider availability.
+After routing, the concrete model's capabilities and limits apply without revealing its identity, including vision support, context window, reasoning support, and provider availability.
 
-Auto is a virtual model, but its reasoning-level control remains available as a session preference. After routing, Kimchi applies that preference when the selected model supports configurable reasoning and ignores it when the model does not.
+Before routing, Auto exposes reasoning levels as a session preference. After routing, the available controls follow the selected model's supported levels. If that model does not support reasoning, Kimchi changes the session level to `off` and only offers `off` in the settings UI.
 
 ## Failures and retries
 

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -1,0 +1,90 @@
+# Model Routing
+
+Auto (`kimchi-dev/auto`) is a virtual model that asks the Kimchi router to choose a concrete model for each session.
+
+Auto is useful when you want Kimchi to choose between the models available to you without changing models manually for every new task.
+
+## Enable model routing
+
+Start Kimchi with experimental features enabled, then select Auto:
+
+```sh
+kimchi --enable-experimental-features --model auto
+```
+
+You can also start Kimchi with `--enable-experimental-features` and select **Auto (Kimchi Router)** from `/model`.
+
+The experimental flag controls whether Auto is offered as a new choice. It does not disable Auto if you already selected it:
+
+- a saved Auto default continues to work without the flag;
+- a session saved with Auto can be resumed without the flag;
+- explicitly selecting Auto for a new session still requires the flag.
+
+The router uses your existing Kimchi API key. There is no separate router authentication to configure.
+
+## How Auto chooses a model
+
+Auto waits until you send the first prompt that needs a model response. It then:
+
+1. sends the prompt text to the Kimchi router;
+2. receives a ranked list of candidate models;
+3. selects the first eligible candidate;
+4. uses that concrete model for the rest of the session.
+
+The router identifies its preferred model and supplies scores for the other candidates. Kimchi considers the preferred model first, followed by the remaining candidates from highest to lowest score.
+
+A candidate is eligible only when it:
+
+- is an available concrete model in the `kimchi-dev` model catalog;
+- belongs to the active model scope, if you used `--models` to limit the session;
+- supports the input required by the first prompt.
+
+For example, suppose the router ranks models A, B, and C. If A is outside your `--models` scope and the prompt contains an image that B cannot read, Kimchi selects C if C is scoped, available, and supports vision.
+
+Skipping an ineligible candidate from the ranked response is part of the routing decision, not a fallback after inference.
+
+The interface continues to show Auto as your selected model. Before routing, the footer shows `auto`. After a model is selected, it shows both names, for example:
+
+```text
+auto (kimi-k2.7)
+```
+
+Kimchi also displays a notification when the model is selected. From that point onward, the concrete model's capabilities and limits apply, including vision support, context window, reasoning support, and provider availability.
+
+Auto is a virtual model, but its reasoning-level control remains available as a session preference. After routing, Kimchi applies that preference when the selected model supports configurable reasoning and ignores it when the model does not.
+
+## Failures and retries
+
+Routing can fail because the router cannot be reached, times out, rejects the request, or returns an invalid response. It also fails when routing is cancelled, prompt redaction fails, or no ranked candidate meets the prompt's requirements.
+
+When routing fails, Auto stops the current prompt before inference and the model remains unresolved. Kimchi does not automatically replay the prompt or send it to a fallback model. If you submit another prompt while Auto is still selected, Kimchi tries the router again. You can instead select a concrete model with `/model`.
+
+After a model is selected, there is no automatic fallback if that model is rate limited, returns an inference error, or becomes unavailable. Select another model with `/model` if you want to continue with a different model.
+
+## Session lifecycle
+
+The routing decision belongs to the session:
+
+- A new Auto session remains unresolved until you send the first prompt that needs a model response.
+- A successful recommendation is saved with the session. Resuming it restores the same concrete model without contacting the router again.
+- Routing attempts and failures are not saved. If the process exits during routing, the next prompt after resuming can try again.
+- Switching away from Auto and back to it reuses a successful recommendation. If no model was selected, Auto remains unresolved.
+- If the saved concrete model is no longer available, Auto does not reroute. Select another model with `/model` to continue.
+- A concrete model provided on the command line when resuming overrides Auto.
+
+Each local subagent that inherits Auto has its own session and chooses a model independently. A subagent started with an explicit concrete model does not use the router. Remote subagent routing is not currently supported.
+
+## Prompts, redaction, and images
+
+The router receives the full text of the prompt that triggers routing. Kimchi does not apply a client-side token limit, and it does not shorten the prompt sent to the selected model.
+
+When PII redaction is enabled, the router copy receives the same PII and secret redaction policy as normal provider traffic. If that copy cannot be redacted safely, routing stops.
+
+The router never receives image bytes. Kimchi still uses the presence of an image when checking candidate capabilities:
+
+- for an initial prompt with text and images, candidates without vision support are skipped;
+- an image-only initial prompt cannot be routed because Auto requires prompt text for the router;
+- after Auto resolves to a vision-capable model, later image prompts continue normally;
+- after Auto resolves to a text-only model, a later image prompt is blocked without rerouting.
+
+If a later image is blocked, select a vision-capable model with `/model`, or use `/strip-images` when removing existing images is appropriate.

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -76,14 +76,14 @@ Each local subagent that inherits Auto has its own session and chooses a model i
 
 ## Prompts, redaction, and images
 
-The router receives the full text of the prompt that triggers routing. Kimchi does not apply a client-side token limit, and it does not shorten the prompt sent to the selected model.
+The router receives the full text of the prompt that triggers routing. When the effective prompt contains images, Kimchi appends `[Routing metadata: the prompt contains images.]` to the router copy. Kimchi does not apply a client-side token limit, and it does not shorten or otherwise change the prompt sent to the selected model.
 
 When PII redaction is enabled, the router copy receives the same PII and secret redaction policy as normal provider traffic. If that copy cannot be redacted safely, routing stops.
 
 The router never receives image bytes. Kimchi still uses the presence of an image when checking candidate capabilities:
 
 - for an initial prompt with text and images, candidates without vision support are skipped;
-- an image-only initial prompt cannot be routed because Auto requires prompt text for the router;
+- an image-only initial prompt routes using the image metadata marker;
 - after Auto resolves to a vision-capable model, later image prompts continue normally;
 - after Auto resolves to a text-only model, a later image prompt is blocked without rerouting.
 

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -43,13 +43,13 @@ For example, suppose the router ranks models A, B, and C. If A is outside your `
 
 Skipping an ineligible candidate from the ranked response is part of the routing decision, not a fallback after inference.
 
-The interface continues to show Auto as your selected model. Before routing, the footer shows `auto`. After a model is selected, it shows both names, for example:
+The interface continues to show Auto as your selected model before and after routing:
 
 ```text
-auto (kimi-k2.7)
+auto
 ```
 
-Kimchi also displays a notification when the model is selected. From that point onward, the concrete model's capabilities and limits apply, including vision support, context window, reasoning support, and provider availability.
+Kimchi displays an “Auto is ready” notification when routing finishes, without revealing the selected model. From that point onward, the concrete model's capabilities and limits apply, including vision support, context window, reasoning support, and provider availability.
 
 Auto is a virtual model, but its reasoning-level control remains available as a session preference. After routing, Kimchi applies that preference when the selected model supports configurable reasoning and ignores it when the model does not.
 

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -7,6 +7,7 @@ import {
 	getParsedCliArgs,
 	isCliAtFileArg,
 	isExperimentalFeaturesArg,
+	isExplicitAutoModelSelection,
 	isHelpOrVersionArgs,
 	isPreDispatchValueFlag,
 	isProtocolOrPrintMode,
@@ -316,5 +317,20 @@ describe("populateCliArgs / getParsedCliArgs", () => {
 		expect(getParsedCliArgs()).toEqual({ options: { "multi-model": true }, positionals: [] })
 		// Subsequent calls return the same cached result without re-parsing.
 		expect(getParsedCliArgs()).toEqual({ options: { "multi-model": true }, positionals: [] })
+	})
+
+	it.each([
+		["canonical", ["--model", "kimchi-dev/auto"]],
+		["provider and id", ["--provider", "kimchi-dev", "--model", "auto"]],
+		["bare id", ["--model", "auto"]],
+		["thinking suffix", ["--model", "kimchi-dev/auto:high"]],
+	] as const)("recognizes an explicit Auto selection in %s form", (_label, args) => {
+		populateCliArgs([...args])
+		expect(isExplicitAutoModelSelection(getParsedCliArgs())).toBe(true)
+	})
+
+	it("does not mistake another provider's auto model for kimchi-dev/auto", () => {
+		populateCliArgs(["--provider", "custom", "--model", "auto"])
+		expect(isExplicitAutoModelSelection(getParsedCliArgs())).toBe(false)
 	})
 })

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util"
 import { parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
 import { type CliMode, getCliModeArg, PROTOCOL_MODES } from "./cli-modes.js"
+import { AUTO_MODEL_ID, AUTO_MODEL_PROVIDER, AUTO_MODEL_REF } from "./extensions/router/constants.js"
 
 // Re-export the shared leaf-module helpers so existing callers can keep
 // importing them from cli-args.ts without touching their import paths.
@@ -102,6 +103,10 @@ export const CLI_OPTIONS: Record<string, CliOptionDef> = {
 	"multi-model": {
 		type: "boolean",
 		description: "Explicitly select multi-model orchestration (same as `--model multi-model`)",
+	},
+	"enable-experimental-features": {
+		type: "boolean",
+		description: "Enable experimental features, including the kimchi-dev/auto model",
 	},
 	thinking: {
 		type: "string",
@@ -291,6 +296,15 @@ export function getParsedCliArgs(): SessionCliArgs {
 		cachedCliArgs = parseCliArgs(process.argv.slice(2))
 	}
 	return cachedCliArgs
+}
+
+/** True when launch arguments explicitly request the gated Auto model. */
+export function isExplicitAutoModelSelection(args: SessionCliArgs): boolean {
+	const provider = args.options.provider?.toLowerCase()
+	const model = args.options.model?.toLowerCase().replace(/:(off|minimal|low|medium|high|xhigh|max)$/, "")
+	if (!model) return false
+	if (model === AUTO_MODEL_REF) return true
+	return model === AUTO_MODEL_ID && (!provider || provider === AUTO_MODEL_PROVIDER)
 }
 
 export function normalizeResumeIdArgs(args: string[]): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,8 +6,10 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { AgentSession, parseArgs as parsePiArgs } from "@earendil-works/pi-coding-agent"
 import {
+	getParsedCliArgs,
 	isCliAtFileArg,
 	isExperimentalFeaturesArg,
+	isExplicitAutoModelSelection,
 	isHelpOrVersionArgs,
 	isTerminalUiMode,
 	normalizeResumeIdArgs,
@@ -98,6 +100,8 @@ import remoteRunExtension from "./extensions/remote-run/index.js"
 import reportBugExtension from "./extensions/report-bug.js"
 import requestTimingExtension from "./extensions/request-timing.js"
 import reviewWriteGuardExtension from "./extensions/review-write-guard.js"
+import { installAutoModelAdapters } from "./extensions/router/adapters.js"
+import autoModelExtension from "./extensions/router/index.js"
 import rtkRewriteExtension from "./extensions/rtk-rewrite.js"
 import sessionMetadataExtension from "./extensions/session-metadata/index.js"
 import sessionNameExtension from "./extensions/session-name.js"
@@ -134,6 +138,7 @@ import {
 	KIMCHI_INFRA_ERROR_EXIT_CODE,
 } from "./infrastructure-error.js"
 import {
+	injectAutoModel,
 	injectExperimentalProvider,
 	isTransientModelsError,
 	readExperimentalModels,
@@ -274,6 +279,7 @@ try {
 		// steering text) can gate on it — the CLI arg is stripped from the
 		// args that reach main(), so pi.getFlag can't discover it.
 		setExperimentalFeaturesEnabled(experimentalFeatures)
+		installAutoModelAdapters()
 		let config = loadConfig()
 
 		const envKey = process.env.KIMCHI_API_KEY || undefined
@@ -343,6 +349,7 @@ try {
 				injectExperimentalProvider(modelsJsonPath, currentApiKey ?? "")
 				models = [...models, ...readExperimentalModels(modelsJsonPath)]
 			}
+			injectAutoModel(modelsJsonPath)
 			// Auto-discover a local Ollama server and merge its models into the
 			// registry. Probe is silent on failure — startup is never blocked.
 			await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
@@ -367,6 +374,7 @@ try {
 					injectExperimentalProvider(modelsJsonPath, currentApiKey)
 					models = [...models, ...readExperimentalModels(modelsJsonPath)]
 				}
+				injectAutoModel(modelsJsonPath)
 				await injectOllamaProvider(modelsJsonPath, resolveOllamaHost())
 				models = [...models, ...readOllamaModelMetadata(modelsJsonPath)]
 			} else if (isTransientModelsError(err)) {
@@ -476,6 +484,9 @@ try {
 		// before upstream pi-mono sees them (it does not recognize "multi-model"
 		// as a model id).
 		populateCliArgs(rawArgs)
+		if (!experimentalFeatures && isExplicitAutoModelSelection(getParsedCliArgs())) {
+			throw new Error("kimchi-dev/auto is experimental. Re-run with --enable-experimental-features to select it.")
+		}
 		const rawArgsWithoutMultiModel = stripMultiModelArgs(rawArgs)
 
 		const terminalIo = {
@@ -606,6 +617,8 @@ try {
 				{ id: "extensions.ferment", factory: fermentExtension },
 			] satisfies ManagedExtensionFactory[]),
 			questionnaireExtension,
+			// Resolve kimchi-dev/auto before prompt construction needs concrete model behavior.
+			autoModelExtension,
 			...enabledExtensionFactories([
 				{ id: "extensions.claude-code-skills", factory: (pi) => claudeCodeSkillsExtension(pi, effectiveSkillPaths) },
 			] satisfies ManagedExtensionFactory[]),

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -858,20 +858,18 @@ describe("status line pinning", () => {
 		return new StatusLine(createMockContext(opts), theme, createMockStatusLineData())
 	}
 
-	it("keeps Auto as the displayed model after routing", () => {
+	it("shows Auto without a suffix after routing", () => {
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
 		expect(visible).toContain("auto → ctrl+p")
-		expect(visible).not.toContain("kimi-k2.6")
 	})
 
 	it("shows only Auto before routing resolves", () => {
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
 		expect(visible).toContain("auto → ctrl+p")
-		expect(visible).not.toContain("auto (")
 	})
 
 	it("pinned usage shows '↑0 ↓0' when no tokens are present", () => {

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -1,3 +1,4 @@
+import type { Model } from "@earendil-works/pi-ai"
 import type { ExtensionContext, ReadonlyFooterDataProvider, Theme } from "@earendil-works/pi-coding-agent"
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -6,6 +7,7 @@ import * as AGENTS from "../extensions/agents/index.js"
 import { setBillingStatusForTest } from "../extensions/billing/status.js"
 import * as FERMENT from "../extensions/ferment/index.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
+import { clearAutoRoutingState, setAutoRoutingState } from "../extensions/router/state.js"
 import * as TAGS from "../extensions/tags.js"
 import type { Ferment } from "../ferment/types.js"
 import {
@@ -61,6 +63,7 @@ function createMockTheme(): Theme {
 interface MockContextOpts {
 	percent?: number
 	modelId?: string
+	modelProvider?: string
 	thinkingLevel?: ExtensionContext["thinkingLevel"]
 	/** Assistant messages to include in the session, for usage-segment tests. */
 	assistantMessages?: Array<{ input: number; output: number }>
@@ -74,7 +77,7 @@ function createMockContext(opts?: MockContextOpts): ExtensionContext {
 		message: { role: "assistant", usage: { input: u.input, output: u.output } },
 	}))
 	return {
-		model: { id: modelId, name: modelId },
+		model: { id: modelId, name: modelId, provider: opts?.modelProvider ?? "kimchi-dev" },
 		thinkingLevel: opts?.thinkingLevel,
 		cwd: "/test",
 		getContextUsage: vi.fn(() => ({ tokens: 0, percent, contextWindow: 100000 })),
@@ -86,6 +89,21 @@ function createMockContext(opts?: MockContextOpts): ExtensionContext {
 			getSessionFile: vi.fn(() => "/test/session.md"),
 		},
 	} as unknown as ExtensionContext
+}
+
+function concreteModel(id: string): Model<string> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_000,
+	}
 }
 
 function createMockStatusLineData(opts?: {
@@ -830,6 +848,7 @@ describe("status line pinning", () => {
 	})
 
 	afterEach(() => {
+		clearAutoRoutingState("test-session")
 		vi.restoreAllMocks()
 		restorePlatform()
 		pinnedElements = []
@@ -838,6 +857,21 @@ describe("status line pinning", () => {
 	function makeStatusLine(opts?: MockContextOpts): StatusLine {
 		return new StatusLine(createMockContext(opts), theme, createMockStatusLineData())
 	}
+
+	it("shows Auto with its effective model after routing", () => {
+		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+
+		expect(visible).toContain("auto (kimi-k2.6) → ctrl+p")
+	})
+
+	it("shows only Auto before routing resolves", () => {
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+
+		expect(visible).toContain("auto → ctrl+p")
+		expect(visible).not.toContain("auto (")
+	})
 
 	it("pinned usage shows '↑0 ↓0' when no tokens are present", () => {
 		withPinned(["usage"], () => {

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -858,12 +858,13 @@ describe("status line pinning", () => {
 		return new StatusLine(createMockContext(opts), theme, createMockStatusLineData())
 	}
 
-	it("shows Auto with its effective model after routing", () => {
+	it("keeps Auto as the displayed model after routing", () => {
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
-		expect(visible).toContain("auto (kimi-k2.6) → ctrl+p")
+		expect(visible).toContain("auto → ctrl+p")
+		expect(visible).not.toContain("kimi-k2.6")
 	})
 
 	it("shows only Auto before routing resolves", () => {

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -15,8 +15,6 @@ import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-lin
 import { formatCount } from "../extensions/format.js"
 import { getMultiModelEnabled } from "../extensions/multi-model.js"
 import { getPermissionMode } from "../extensions/permissions/mode-controller.js"
-import { isAutoModel } from "../extensions/router/constants.js"
-import { getEffectiveModel } from "../extensions/router/state.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
@@ -429,12 +427,7 @@ function fitWithBudgetStep(segments: Segment[], width: number, theme: Theme): Se
 function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
 	const multiModel = getMultiModelEnabled(ctx.sessionManager)
 	const selectedModelId = ctx.model?.id ?? "n/a"
-	const effectiveModel = getEffectiveModel(ctx)
-	const displayedModelId =
-		isAutoModel(ctx.model) && effectiveModel && !isAutoModel(effectiveModel)
-			? `${selectedModelId} (${effectiveModel.id})`
-			: selectedModelId
-	const modelId = multiModel ? selectedModelId : displayedModelId
+	const modelId = selectedModelId
 	const label = multiModel ? `multi-model (${modelId})` : modelId
 	const text = `${accentText(theme, label)} ${dimText(theme, "→ ctrl+p")}`
 	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId } }

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -15,6 +15,8 @@ import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-lin
 import { formatCount } from "../extensions/format.js"
 import { getMultiModelEnabled } from "../extensions/multi-model.js"
 import { getPermissionMode } from "../extensions/permissions/mode-controller.js"
+import { isAutoModel } from "../extensions/router/constants.js"
+import { getEffectiveModel } from "../extensions/router/state.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
@@ -426,10 +428,16 @@ function fitWithBudgetStep(segments: Segment[], width: number, theme: Theme): Se
 
 function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
 	const multiModel = getMultiModelEnabled(ctx.sessionManager)
-	const rawModelId = ctx.model?.id ?? "n/a"
-	const label = multiModel ? `multi-model (${rawModelId})` : rawModelId
+	const selectedModelId = ctx.model?.id ?? "n/a"
+	const effectiveModel = getEffectiveModel(ctx)
+	const displayedModelId =
+		isAutoModel(ctx.model) && effectiveModel && !isAutoModel(effectiveModel)
+			? `${selectedModelId} (${effectiveModel.id})`
+			: selectedModelId
+	const modelId = multiModel ? selectedModelId : displayedModelId
+	const label = multiModel ? `multi-model (${modelId})` : modelId
 	const text = `${accentText(theme, label)} ${dimText(theme, "→ ctrl+p")}`
-	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId: rawModelId } }
+	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId } }
 }
 
 function buildThinkingSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {

--- a/src/extensions/__mocks__/extension-api.ts
+++ b/src/extensions/__mocks__/extension-api.ts
@@ -9,6 +9,7 @@ export function createExtensionApi(): {
 	getHandlers<E, R = undefined>(event: string): ExtensionHandler<E, R>[]
 	sendMessage: ReturnType<typeof vi.fn<ExtensionAPI["sendMessage"]>>
 	appendEntry: ReturnType<typeof vi.fn<ExtensionAPI["appendEntry"]>>
+	setModel: ReturnType<typeof vi.fn<ExtensionAPI["setModel"]>>
 	emitEvent: ReturnType<typeof vi.fn>
 } {
 	const handlers = new Map<string, RegisteredHandler[]>()
@@ -19,6 +20,7 @@ export function createExtensionApi(): {
 	})
 	const sendMessage = vi.fn<ExtensionAPI["sendMessage"]>()
 	const appendEntry = vi.fn<ExtensionAPI["appendEntry"]>()
+	const setModel = vi.fn<ExtensionAPI["setModel"]>(async () => true)
 	const registerCommand = vi.fn<ExtensionAPI["registerCommand"]>()
 	const registerTool = vi.fn<ExtensionAPI["registerTool"]>()
 	const emitEvent = vi.fn()
@@ -30,6 +32,7 @@ export function createExtensionApi(): {
 			registerTool,
 			sendMessage,
 			appendEntry,
+			setModel,
 			events: { emit: emitEvent },
 		} as unknown as ExtensionAPI,
 		getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R> {
@@ -42,6 +45,7 @@ export function createExtensionApi(): {
 		},
 		sendMessage,
 		appendEntry,
+		setModel,
 		emitEvent,
 	}
 }

--- a/src/extensions/__mocks__/extension-api.ts
+++ b/src/extensions/__mocks__/extension-api.ts
@@ -8,6 +8,7 @@ export function createExtensionApi(): {
 	getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R>
 	getHandlers<E, R = undefined>(event: string): ExtensionHandler<E, R>[]
 	sendMessage: ReturnType<typeof vi.fn<ExtensionAPI["sendMessage"]>>
+	appendEntry: ReturnType<typeof vi.fn<ExtensionAPI["appendEntry"]>>
 	emitEvent: ReturnType<typeof vi.fn>
 } {
 	const handlers = new Map<string, RegisteredHandler[]>()
@@ -17,12 +18,20 @@ export function createExtensionApi(): {
 		handlers.set(event, registered)
 	})
 	const sendMessage = vi.fn<ExtensionAPI["sendMessage"]>()
+	const appendEntry = vi.fn<ExtensionAPI["appendEntry"]>()
 	const registerCommand = vi.fn<ExtensionAPI["registerCommand"]>()
 	const registerTool = vi.fn<ExtensionAPI["registerTool"]>()
 	const emitEvent = vi.fn()
 
 	return {
-		api: { on, registerCommand, registerTool, sendMessage, events: { emit: emitEvent } } as unknown as ExtensionAPI,
+		api: {
+			on,
+			registerCommand,
+			registerTool,
+			sendMessage,
+			appendEntry,
+			events: { emit: emitEvent },
+		} as unknown as ExtensionAPI,
 		getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R> {
 			const handler = handlers.get(event)?.[0]
 			if (!handler) throw new Error(`Extension did not register a ${event} handler`)
@@ -32,6 +41,7 @@ export function createExtensionApi(): {
 			return (handlers.get(event) ?? []) as ExtensionHandler<E, R>[]
 		},
 		sendMessage,
+		appendEntry,
 		emitEvent,
 	}
 }

--- a/src/extensions/agents/index.test.ts
+++ b/src/extensions/agents/index.test.ts
@@ -149,6 +149,7 @@ vi.mock("../orchestration/model-roles.js", () => ({
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Component } from "@earendil-works/pi-tui"
 import { createContext } from "../__mocks__/context.js"
+import { sessionHasImages } from "../model-guard.js"
 import { getMultiModelEnabled } from "../multi-model.js"
 import { getAllowedMultiModelRefs, getModelRoles } from "../orchestration/model-roles.js"
 import agentsExtension from "./index.js"
@@ -340,14 +341,14 @@ function makeMockModelRegistry(entries: MockModelEntry[]): unknown {
  * spinner/await-promise machinery which the AgentManager mock does not
  * fully satisfy.
  */
-function makeMockCtx(modelRegistry: unknown, parentModel?: unknown): unknown {
+function makeMockCtx(modelRegistry: unknown, parentModel?: unknown, branch: unknown[] = []): unknown {
 	return {
 		ui: undefined,
 		mode: "json",
 		hasUI: false,
 		cwd: "/tmp",
 		sessionManager: {
-			getBranch: () => [],
+			getBranch: () => branch,
 			getSessionDir: () => "/tmp",
 			getSessionFile: () => "/tmp/session.json",
 			getSessionId: () => "test-session",
@@ -418,6 +419,7 @@ describe("Agent tool multi-mode model guard", () => {
 		vi.useRealTimers()
 		vi.clearAllMocks()
 		vi.mocked(getMultiModelEnabled).mockReturnValue(false)
+		vi.mocked(sessionHasImages).mockReturnValue(false)
 		vi.mocked(getAllowedMultiModelRefs).mockReturnValue([
 			"kimchi-dev/kimi-k2.7",
 			"kimchi-dev/minimax-m3",
@@ -557,6 +559,60 @@ describe("Agent tool multi-mode model guard", () => {
 		expect(managerInstance.spawn).toHaveBeenCalledTimes(1)
 		const text = result.content[0]?.text ?? ""
 		expect(text).not.toContain("not allowed in multi-model mode")
+	})
+
+	it("marks an Auto child as requiring vision when forwarding parent image paths", async () => {
+		vi.mocked(sessionHasImages).mockReturnValue(true)
+		const pi = makeMockPi()
+		agentsExtension(pi)
+
+		const managerInstance = (MockedAgentManager as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+		expect(managerInstance).toBeDefined()
+
+		const registry = makeMockModelRegistry([
+			{ id: "auto", name: "Auto (Kimchi Router)", provider: "kimchi-dev", input: ["text", "image"] },
+		])
+		const branch = [
+			{
+				type: "message",
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "read-image", name: "read", arguments: { path: "/tmp/reference.png" } }],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolCallId: "read-image",
+					content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+				},
+			},
+		]
+		const ctx = makeMockCtx(registry, { id: "kimi-k2.7", provider: "kimchi-dev" }, branch)
+		const tool = getRegisteredAgentTool(pi)
+
+		await tool.execute(
+			"call-with-image",
+			{
+				prompt: "inspect the reference",
+				description: "test",
+				subagent_type: "general-purpose",
+				model: "kimchi-dev/auto",
+				run_in_background: true,
+			},
+			undefined,
+			undefined,
+			ctx,
+		)
+
+		expect(managerInstance.spawn).toHaveBeenCalledWith(
+			pi,
+			ctx,
+			"General-Purpose",
+			expect.stringContaining("Context images from parent session: /tmp/reference.png"),
+			expect.objectContaining({ requiresVision: true }),
+		)
 	})
 })
 

--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -34,6 +34,7 @@ import {
 	getModelRoles,
 	normalizeRoleModels,
 } from "../orchestration/model-roles.js"
+import { isAutoModel } from "../router/constants.js"
 import { isRawInputCaptureActive } from "../shared-input.js"
 import { isStaleCtxError } from "../stale-ctx.js"
 import { trackSubagentSpawned } from "../telemetry/index.js"
@@ -1480,18 +1481,13 @@ ${AGENT_TOOL_GUIDELINES}`,
 
 				// Image forwarding: when session has images and subagent model supports vision,
 				// extract image paths from read tool calls and prepend them to the prompt.
-				const effectivePrompt = (() => {
-					const base = params.prompt as string
-					if (!sessionHasImages()) return base
-					const modelInput = (model as { input?: string[] } | undefined)?.input
-					if (!modelInput?.includes("image")) return base
-
-					const imagePaths = extractImagePathsFromSession(ctx)
-					if (imagePaths.length === 0) return base
-
-					const pathList = imagePaths.join(", ")
-					return `Context images from parent session: ${pathList}. Read them if needed for your task.\n\n${base}`
-				})()
+				const modelInput = (model as { input?: string[] } | undefined)?.input
+				const imagePaths = sessionHasImages() && modelInput?.includes("image") ? extractImagePathsFromSession(ctx) : []
+				const requiresVision = imagePaths.length > 0 && isAutoModel(model)
+				const effectivePrompt =
+					imagePaths.length > 0
+						? `Context images from parent session: ${imagePaths.join(", ")}. Read them if needed for your task.\n\n${params.prompt as string}`
+						: (params.prompt as string)
 
 				const parentModelId = ctx.model?.id
 				const effectiveModelId = (model as { id?: string } | undefined)?.id
@@ -1550,6 +1546,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 							description: params.description as string,
 							visibility,
 							model: model as Parameters<typeof manager.spawn>[4]["model"],
+							requiresVision,
 							maxTurns: effectiveMaxTurns,
 							tokenBudget: resolvedConfig.tokenBudget,
 							taskRef,
@@ -1696,6 +1693,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 						description: params.description as string,
 						visibility,
 						model: model as Parameters<typeof manager.spawn>[4]["model"],
+						requiresVision,
 						maxTurns: effectiveMaxTurns,
 						tokenBudget: resolvedConfig.tokenBudget,
 						taskRef,

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -56,6 +56,7 @@ interface SpawnOptions {
 	description: string
 	visibility?: AgentVisibility
 	model?: Model<Api>
+	requiresVision?: boolean
 	maxTurns?: number
 	isolated?: boolean
 	inheritContext?: boolean
@@ -245,6 +246,7 @@ export class AgentManager {
 				: runAgent(ctx, type, prompt, {
 						pi,
 						model: options.model,
+						requiresVision: options.requiresVision,
 						maxTurns: options.maxTurns,
 						tokenBudget: options.tokenBudget,
 						inactivityTimeout: options.inactivityTimeout,

--- a/src/extensions/agents/manager/agent-runner.test.ts
+++ b/src/extensions/agents/manager/agent-runner.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { Api, Model } from "@earendil-works/pi-ai"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import dapExtension from "../../dap.js"
 import omitKimchiMaxTokensExtension from "../../omit-kimchi-max-tokens.js"
@@ -111,6 +112,10 @@ vi.mock("../../orchestration/model-registry/guidelines/guidelines-resolver.js", 
 	buildPhaseGuidelinesSection: vi.fn().mockReturnValue(""),
 }))
 
+vi.mock("../../router/index.js", () => ({
+	createAutoModelExtension: vi.fn(() => () => {}),
+}))
+
 import {
 	type AgentSession,
 	type CreateAgentSessionResult,
@@ -124,6 +129,7 @@ import { DEFAULT_BASH_TIMEOUT_SECONDS } from "../../bash-default-timeout.js"
 import { FERMENT_TOOL_NAMES } from "../../ferment/tool-names.js"
 import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/guidelines/guidelines-resolver.js"
 import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
+import { createAutoModelExtension } from "../../router/index.js"
 import { getCurrentPhase, setCurrentPhase } from "../../tags.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { getAgentConfig, getConfig, getToolNamesForType } from "../personas/agent-types.js"
@@ -138,6 +144,7 @@ const mockGetToolNamesForType = vi.mocked(getToolNamesForType)
 const mockLoadProjectContextFiles = vi.mocked(loadProjectContextFiles)
 const mockBuildAgentPrompt = vi.mocked(buildAgentPrompt)
 const mockBuildPhaseGuidelinesSection = vi.mocked(buildPhaseGuidelinesSection)
+const mockCreateAutoModelExtension = vi.mocked(createAutoModelExtension)
 const mockDefaultResourceLoader = vi.mocked(DefaultResourceLoader)
 const mockTelemetryExtension = vi.mocked(telemetryExtension)
 const mockReadTelemetryConfig = vi.mocked(readTelemetryConfig)
@@ -153,6 +160,19 @@ function runInlineExtension(extension: InlineExtension | undefined, pi: Extensio
 }
 
 const DEFAULT_REGISTERED_TOOL_NAMES = ["read", "bash", "edit", "write", "grep", "find", "ls"]
+
+const AUTO_MODEL: Model<Api> = {
+	id: "auto",
+	name: "Auto (Kimchi Router)",
+	api: "kimchi-auto",
+	provider: "kimchi-dev",
+	baseUrl: "https://llm.kimchi.dev/openai/v1",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_384,
+}
 
 function makeFakeSession({
 	promptTokens = 0,
@@ -354,6 +374,59 @@ describe("runAgent — telemetry extension", () => {
 		expect(ctorArg?.extensionFactories).toContain(omitKimchiMaxTokensExtension)
 		expect(mockReadTelemetryConfig).toHaveBeenCalled()
 		expect(mockTelemetryExtension).toHaveBeenCalledWith(mockReadTelemetryConfig.mock.results[0]?.value)
+	})
+
+	it("registers Auto routing only for children that use Auto", async () => {
+		const concreteSession = makeFakeSession({})
+		const autoSession = makeFakeSession({})
+		mockCreateAgentSession
+			.mockResolvedValueOnce({
+				session: concreteSession as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+				extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+					ReturnType<typeof createAgentSession>
+				>["extensionsResult"],
+			})
+			.mockResolvedValueOnce({
+				session: autoSession as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+				extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+					ReturnType<typeof createAgentSession>
+				>["extensionsResult"],
+			})
+		const autoRoutingExtension: InlineExtension = () => {}
+		mockCreateAutoModelExtension.mockReturnValueOnce(autoRoutingExtension)
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "General-Purpose", "concrete work", {
+			pi: pi as unknown as RunOptions["pi"],
+		})
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "General-Purpose", "do something", {
+			pi: pi as unknown as RunOptions["pi"],
+			model: AUTO_MODEL,
+		})
+
+		const concreteFactories = mockDefaultResourceLoader.mock.calls[0]?.[0]?.extensionFactories ?? []
+		const autoFactories = mockDefaultResourceLoader.mock.calls[1]?.[0]?.extensionFactories ?? []
+		expect(mockCreateAutoModelExtension).toHaveBeenCalledOnce()
+		expect(mockCreateAutoModelExtension).toHaveBeenCalledWith({ requiresVision: undefined })
+		expect(concreteFactories).not.toContain(autoRoutingExtension)
+		expect(autoFactories).toContain(autoRoutingExtension)
+	})
+
+	it("passes forwarded-image vision requirements to the child Auto extension", async () => {
+		const session = makeFakeSession({})
+		mockCreateAgentSession.mockResolvedValue({
+			session: session as unknown as Awaited<ReturnType<typeof createAgentSession>>["session"],
+			extensionsResult: { extensions: [], tools: [] } as unknown as Awaited<
+				ReturnType<typeof createAgentSession>
+			>["extensionsResult"],
+		})
+
+		await runAgent(ctx as unknown as Parameters<typeof runAgent>[0], "General-Purpose", "inspect the image", {
+			pi: pi as unknown as RunOptions["pi"],
+			model: AUTO_MODEL,
+			requiresVision: true,
+		})
+
+		expect(mockCreateAutoModelExtension).toHaveBeenCalledOnce()
+		expect(mockCreateAutoModelExtension).toHaveBeenCalledWith({ requiresVision: true })
 	})
 
 	it("adds the dap extension when the persona requests debug tools", async () => {

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -12,6 +12,7 @@ import {
 	getAgentDir,
 	type InlineExtension,
 	type ModelRuntime,
+	type ModelRegistry as PiModelRegistry,
 	SessionManager,
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
@@ -33,6 +34,9 @@ import { buildPhaseGuidelinesSection } from "../../orchestration/model-registry/
 import { ModelRegistry } from "../../orchestration/model-registry/index.js"
 import type { Phase } from "../../orchestration/model-registry/types.js"
 import { loadProjectContextFiles } from "../../prompt-construction/context-files.js"
+import { isAutoModel } from "../../router/constants.js"
+import { createAutoModelExtension } from "../../router/index.js"
+import { getEffectiveModel } from "../../router/state.js"
 import { getCurrentPhase, setCurrentPhase } from "../../tags.js"
 import telemetryExtension from "../../telemetry/index.js"
 import { detectEnv } from "../env.js"
@@ -167,7 +171,7 @@ export function setGraceTurns(n: number): void {
  */
 function resolveDefaultModel(
 	parentModel: Model<Api> | undefined,
-	registry: { find(provider: string, modelId: string): Model<Api> | undefined; getAvailable?(): Model<Api>[] },
+	registry: Pick<PiModelRegistry, "find" | "getAvailable">,
 	configModel?: string,
 ): Model<Api> | undefined {
 	if (configModel) {
@@ -176,16 +180,8 @@ function resolveDefaultModel(
 			const provider = configModel.slice(0, slashIdx)
 			const modelId = configModel.slice(slashIdx + 1)
 
-			const available = registry.getAvailable?.()
-			const availableKeys = available
-				? new Set(
-						available.map(
-							(m: unknown) =>
-								`${(m as { provider: string; id: string }).provider}/${(m as { provider: string; id: string }).id}`,
-						),
-					)
-				: undefined
-			const isAvailable = (p: string, id: string) => !availableKeys || availableKeys.has(`${p}/${id}`)
+			const availableKeys = new Set(registry.getAvailable().map((model) => `${model.provider}/${model.id}`))
+			const isAvailable = (p: string, id: string) => availableKeys.has(`${p}/${id}`)
 
 			const found = registry.find(provider, modelId)
 			if (found && isAvailable(provider, modelId)) return found
@@ -212,6 +208,8 @@ export interface RunOptions {
 	/** ExtensionAPI instance — used for pi.exec() instead of execSync. */
 	pi: ExtensionAPI
 	model?: Model<Api>
+	/** The parent is forwarding image context as file paths to this child. */
+	requiresVision?: boolean
 	maxTurns?: number
 	signal?: AbortSignal
 	isolated?: boolean
@@ -421,10 +419,7 @@ ${skillLines}`
 
 	const disallowedSet = agentConfig?.disallowedTools ? new Set(agentConfig.disallowedTools) : undefined
 
-	const modelId = (options.model as { id?: string } | undefined)?.id
 	const guidelinePhase = agentConfig?.roles?.[0] as Phase | undefined
-	const guidelinesBlock = buildPhaseGuidelinesSection(modelId, guidelinePhase, getGuidelinesRegistry())
-	if (guidelinesBlock) extras.guidelinesBlock = guidelinesBlock
 
 	const effectiveMaxTurns = normalizeMaxTurns(options.maxTurns ?? agentConfig?.maxTurns ?? defaultMaxTurns)
 	const MIN_TOKEN_BUDGET = 1024
@@ -434,8 +429,12 @@ ${skillLines}`
 		extras.budget = { maxTurns: effectiveMaxTurns, tokenBudget: effectiveTokenBudget }
 	}
 
-	const buildSystemPrompt = (activeToolNames: string[]) => {
+	const model = options.model ?? resolveDefaultModel(ctx.model, ctx.modelRegistry, agentConfig?.models?.[0])
+
+	const buildSystemPrompt = (activeToolNames: string[], promptModelId = model?.id) => {
 		extras.activeToolNames = activeToolNames
+		const guidelinesBlock = buildPhaseGuidelinesSection(promptModelId, guidelinePhase, getGuidelinesRegistry())
+		extras.guidelinesBlock = guidelinesBlock
 		if (agentConfig) return buildAgentPrompt(agentConfig, effectiveCwd, env, parentSystemPrompt, extras)
 		const fallback = DEFAULT_AGENTS.get(AGENT_GENERAL_PURPOSE)
 		if (!fallback) throw new Error(`No fallback config available for unknown type "${type}"`)
@@ -477,8 +476,22 @@ ${skillLines}`
 			: bashDefaultTimeoutExtension
 	// Subagents share this process and its patched retry classifier, so their
 	// successes must close the shared infrastructure breaker just like the parent's.
+	const autoExtensionFactories: InlineExtension[] = isAutoModel(model)
+		? [
+				createAutoModelExtension({ requiresVision: options.requiresVision }),
+				(pi) => {
+					pi.on("before_agent_start", (_event, childCtx) => {
+						const effectiveModel = getEffectiveModel(childCtx)
+						const rebuilt = buildSystemPrompt(pi.getActiveTools(), effectiveModel?.id)
+						options.onSystemPrompt?.(rebuilt)
+						return { systemPrompt: rebuilt }
+					})
+				},
+			]
+		: []
 	const extensionFactories: InlineExtension[] = [
 		telemetryExtension(readTelemetryConfig()),
+		...autoExtensionFactories,
 		bashExtension,
 		infrastructureBreakerExtension,
 		omitKimchiMaxTokensExtension,
@@ -507,17 +520,6 @@ ${skillLines}`
 		extensionFactories,
 	})
 	await loader.reload()
-
-	const model =
-		options.model ??
-		resolveDefaultModel(
-			ctx.model as Model<Api> | undefined,
-			ctx.modelRegistry as {
-				find(provider: string, modelId: string): Model<Api> | undefined
-				getAvailable?(): Model<Api>[]
-			},
-			agentConfig?.models?.[0],
-		)
 
 	const thinkingLevel = options.thinkingLevel ?? agentConfig?.thinking
 

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -258,6 +258,23 @@ describe("clipboard-image extension", () => {
 			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
 		})
 
+		it("shows the image paste hint for the virtual Auto model", () => {
+			mockGetAvailableModels.mockReturnValue([])
+			mockGetNativeClipboard.mockReturnValue({
+				clipboard: { hasImage: () => true, availableFormats: () => [] },
+				error: null,
+			})
+
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(
+				void 0,
+				makeMockCtx({ model: { provider: "kimchi-dev", id: "auto" } as ExtensionContext["model"] }),
+			)
+
+			expect(mockSetPendingImageIndicator).toHaveBeenCalledWith("Image in clipboard · ctrl+v to paste")
+		})
+
 		it("does not duplicate indicator on repeated polls", () => {
 			mockGetNativeClipboard.mockReturnValue({
 				clipboard: { hasImage: () => true, availableFormats: () => [] },

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -7,6 +7,7 @@ import { getNativeClipboard } from "../utils/clipboard-native-harness.js"
 import { readClipboardImage } from "../utils/clipboard-read.js"
 import { addImage, clearAllImages, setImageCacheDir } from "../utils/image-registry.js"
 import { IMAGE_EXT_TO_MIME } from "../utils/image-utils.js"
+import { isAutoModel } from "./router/constants.js"
 import { setPasteImageHandler, setPendingImageIndicator } from "./ui.js"
 
 let pendingImages: ImageContent[] = []
@@ -24,10 +25,11 @@ let isCheckingFinder = false
 // preventing stale Finder checks from corrupting a newer session's state.
 let sessionGeneration = 0
 
-function modelSupportsImages(modelId: string | undefined): boolean {
-	if (!modelId) return false
+function modelSupportsImages(model: ExtensionContext["model"]): boolean {
+	if (!model) return false
+	if (isAutoModel(model)) return true
 	const models = getAvailableModels()
-	const meta = models.find((m) => m.slug === modelId)
+	const meta = models.find((m) => m.slug === model.id)
 	return meta?.input_modalities.includes("image") ?? false
 }
 
@@ -72,7 +74,7 @@ function checkClipboard(): void {
 	if (isCheckingFinder) return
 
 	try {
-		if (!modelSupportsImages(currentCtx.model?.id)) {
+		if (!modelSupportsImages(currentCtx.model)) {
 			if (clipboardHasImage) {
 				clipboardHasImage = false
 				updateIndicator()
@@ -160,7 +162,7 @@ setPasteImageHandler(() => {
 
 async function handlePaste(): Promise<void> {
 	const model = currentCtx?.model
-	if (!modelSupportsImages(model?.id)) {
+	if (!modelSupportsImages(model)) {
 		currentCtx?.ui?.notify(`${model?.id ?? "Current model"} does not support images`, "warning")
 		return
 	}

--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import type { ExtensionAPI, MessageRenderer } from "@earendil-works/pi-coding-agent"
 import { Container, Text } from "@earendil-works/pi-tui"
 import { isSubagent } from "../prompt-construction/prompt-enrichment.js"
+import { getEffectiveModel } from "../router/state.js"
 import { SkillManager } from "../skills-manager/skill-manager.js"
 import { UsageTracker } from "../skills-manager/usage.js"
 import { isStaleCtxError } from "../stale-ctx.js"
@@ -63,8 +64,9 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 	pi.on("before_provider_request", (_event, ctx) => {
 		if (providerModel) return
 		try {
-			if (ctx.model?.provider && ctx.model?.id) {
-				providerModel = { provider: ctx.model.provider, model: ctx.model.id }
+			const model = getEffectiveModel(ctx)
+			if (model?.provider && model.id) {
+				providerModel = { provider: model.provider, model: model.id }
 			}
 		} catch (err) {
 			if (isStaleCtxError(err)) return

--- a/src/extensions/ferment/events.test.ts
+++ b/src/extensions/ferment/events.test.ts
@@ -1,8 +1,7 @@
 import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { Api, Model } from "@earendil-works/pi-ai"
-import type { ExtensionAPI, ModelRegistry } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { commandToEvents } from "../../ferment/event-mapper.js"
 import { FermentEventStore } from "../../ferment/event-store.js"
@@ -506,14 +505,11 @@ describe("registerFermentEvents", () => {
 		const handler = handlers.get("model_select")
 		if (!handler) throw new Error("model_select handler was not registered")
 
-		const newModel = { id: "new-model" } as unknown as Model<Api>
-		const previousModel = { id: "previous-model" } as unknown as Model<Api>
-		const modelRegistry = {} as ModelRegistry
-		const ctx = createContext({ modelRegistry })
+		const ctx = createContext({ model: { id: "new-model" }, modelRegistry: {} })
 
-		handler({ model: newModel, previousModel }, ctx)
+		handler({ model: ctx.model, previousModel: undefined }, ctx)
 
-		expect(captureJudgeContext).toHaveBeenCalledWith(newModel, modelRegistry)
+		expect(captureJudgeContext).toHaveBeenCalledWith(ctx.model, ctx.modelRegistry)
 	})
 
 	it("transitions profile from planning to implementation when activate_ferment_phase succeeds", async () => {
@@ -1226,7 +1222,7 @@ describe("turn_end error recovery in one-shot mode", () => {
 		const turnEnd = handlers.get("turn_end")
 		if (!turnEnd) throw new Error("turn_end handler was not registered")
 		const notify = vi.fn()
-		const ctx = { ui: { notify } }
+		const ctx = createContext({ ui: { notify } })
 
 		await turnEnd(
 			{
@@ -1264,7 +1260,7 @@ describe("turn_end error recovery in one-shot mode", () => {
 		const turnEnd = handlers.get("turn_end")
 		if (!turnEnd) throw new Error("turn_end handler was not registered")
 		const notify = vi.fn()
-		const ctx = { ui: { notify } }
+		const ctx = createContext({ ui: { notify } })
 
 		await turnEnd(
 			{
@@ -1310,7 +1306,7 @@ describe("turn_end error recovery in one-shot mode", () => {
 		registerFermentEvents(pi, runtime)
 		const turnEnd = handlers.get("turn_end")
 		if (!turnEnd) throw new Error("turn_end handler was not registered")
-		const ctx = { ui: { notify: vi.fn() } }
+		const ctx = createContext({ ui: { notify: vi.fn() } })
 
 		await turnEnd(
 			{
@@ -1357,7 +1353,7 @@ describe("TUI /ferment one-shot without ferment-oneshot flag", () => {
 		const turnEnd = handlers.get("turn_end")
 		if (!turnEnd) throw new Error("turn_end handler was not registered")
 		const notify = vi.fn()
-		const ctx = { ui: { notify } }
+		const ctx = createContext({ ui: { notify } })
 
 		await turnEnd(
 			{

--- a/src/extensions/ferment/events.ts
+++ b/src/extensions/ferment/events.ts
@@ -6,6 +6,7 @@ import { isAgentWorker } from "../agent-worker-context.js"
 import { deferExtensionAction } from "../deferred-action.js"
 import { getMultiModelEnabled } from "../multi-model.js"
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
+import { getEffectiveModel } from "../router/state.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { maybeTriggerFermentCompaction, maybeTriggerMidTurnFermentCompaction } from "./auto-compaction.js"
 import { formatDuration } from "./colors.js"
@@ -520,13 +521,13 @@ export function registerFermentEvents(
 		return {}
 	})
 
-	pi.on("model_select", (event, ctx) => {
-		runtime.captureJudgeContext(event.model, ctx?.modelRegistry)
+	pi.on("model_select", (_event, ctx) => {
+		runtime.captureJudgeContext(getEffectiveModel(ctx), ctx.modelRegistry)
 	})
 
 	pi.on("turn_end", async (event, ctx) => {
 		if (isAgentWorker()) return
-		runtime.captureJudgeContext(ctx?.model, ctx?.modelRegistry)
+		runtime.captureJudgeContext(getEffectiveModel(ctx), ctx.modelRegistry)
 		if (event.message.role !== "assistant") return
 		const content = getAssistantContentParts(event.message.content)
 		const activeId = runtime.getActiveId()

--- a/src/extensions/ferment/tools/phases.ts
+++ b/src/extensions/ferment/tools/phases.ts
@@ -14,6 +14,7 @@ import type { Ferment, Grade, Phase } from "../../../ferment/types.js"
 import { runWithOverlay, spawnGraderAgent } from "../../agents/index.js"
 import { withBlocked } from "../../herdr-events.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
+import { getEffectiveModel } from "../../router/state.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm, createJudgeDecisionRecorder } from "../ask-user.js"
 import { gradeColor } from "../colors.js"
@@ -283,7 +284,11 @@ export async function completePhase(
 	services: PhaseHandlerServices = defaultPhaseHandlerServices,
 ): Promise<ToolResult> {
 	const applyAndPersist = createApplyAndPersist(runtime)
-	runtime.captureJudgeContext(ctx?.model, ctx?.modelRegistry, getMultiModelEnabled(ctx?.sessionManager ?? null))
+	runtime.captureJudgeContext(
+		ctx ? getEffectiveModel(ctx) : undefined,
+		ctx?.modelRegistry,
+		getMultiModelEnabled(ctx?.sessionManager ?? null),
+	)
 
 	// Step 1: resolve the phase (host concern — fuzzy lookup).
 	const f = runtime.getStorage().get(params.ferment_id)

--- a/src/extensions/ferment/tools/steps.ts
+++ b/src/extensions/ferment/tools/steps.ts
@@ -14,6 +14,7 @@ import { getAgentRecordForTaskValidation } from "../../agents/index.js"
 import { FERMENT_WORKER_BUDGETS, type FermentWorkerBudgetTier } from "../../agents/worker-budget-policy.js"
 import { withBlocked } from "../../herdr-events.js"
 import { getMultiModelEnabled } from "../../multi-model.js"
+import { getEffectiveModel } from "../../router/state.js"
 import { withWorkingHidden } from "../../ui.js"
 import { askUserForm, createJudgeDecisionRecorder } from "../ask-user.js"
 import { validateFsmTransitionWithFerment } from "../fsm-adapter.js"
@@ -511,7 +512,7 @@ export async function completeStep(
 	services: StepHandlerServices = defaultStepHandlerServices,
 ): Promise<ToolResult> {
 	const applyAndPersist = createApplyAndPersist(runtime)
-	runtime.captureJudgeContext(ctx.model, ctx.modelRegistry, getMultiModelEnabled(ctx.sessionManager))
+	runtime.captureJudgeContext(getEffectiveModel(ctx), ctx.modelRegistry, getMultiModelEnabled(ctx.sessionManager))
 
 	const f = runtime.getStorage().get(params.ferment_id)
 	if (!f) return toolErr("Ferment not found.")

--- a/src/extensions/pii-redaction/redactor.ts
+++ b/src/extensions/pii-redaction/redactor.ts
@@ -158,11 +158,15 @@ function applyCustomPatterns(text: string): string {
  * returned unchanged — redaction must never break the prompt pipeline.
  * The error is logged per the code-review-lessons rule: no empty catch blocks.
  */
+export async function redactTextOrThrow(text: string): Promise<string> {
+	const result = await getEngine().scan(text)
+	const afterEngine = result.redactedText ?? text
+	return applyCustomPatterns(afterEngine)
+}
+
 export async function redactText(text: string): Promise<string> {
 	try {
-		const result = await getEngine().scan(text)
-		const afterEngine = result.redactedText ?? text
-		return applyCustomPatterns(afterEngine)
+		return await redactTextOrThrow(text)
 	} catch (err) {
 		console.error("PII redaction scan failed, returning original text:", err)
 		return text

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -60,6 +60,7 @@ import {
 	validateModelRoles,
 } from "../orchestration/model-roles.js"
 import { registerModelRolesCommand } from "../orchestration/model-roles-command.js"
+import { getEffectiveModel } from "../router/state.js"
 import { type ContextFile, loadGlobalContextFiles, loadProjectContextFiles } from "./context-files.js"
 import { isKimiK2Model, normalizeKimiToolCallIds } from "./normalize-kimi-tool-call-ids.js"
 import {
@@ -436,13 +437,14 @@ export default function (skillPathsFromConfig: string[]) {
 			})
 
 			pi.on("context", async (event, ctx) => {
+				const effectiveModel = getEffectiveModel(ctx)
 				let messages = stripStaleNudges(event.messages)
 				messages = stripEmptyToolCalls(messages)
 				messages = stripUiOnlyMessages(messages)
 				// kimi-k2.x stalls on historical tool calls whose IDs are not in
 				// Moonshot's canonical format (issue #1063) — normalize for those
 				// targets only.
-				if (isKimiK2Model(ctx.model?.id)) {
+				if (isKimiK2Model(effectiveModel?.id)) {
 					messages = normalizeKimiToolCallIds(messages)
 				}
 				messages = tagSelfEchoes(messages)
@@ -458,8 +460,9 @@ export default function (skillPathsFromConfig: string[]) {
 			// which the runtime rejects with a "Tool  not found" result that would
 			// otherwise accumulate in the subagent's context across turns.
 			pi.on("context", async (event, ctx) => {
+				const effectiveModel = getEffectiveModel(ctx)
 				let messages = stripEmptyToolCalls(event.messages)
-				if (isKimiK2Model(ctx.model?.id)) {
+				if (isKimiK2Model(effectiveModel?.id)) {
 					messages = normalizeKimiToolCallIds(messages)
 				}
 				messages = brandUnmarkedSteers(messages)
@@ -495,6 +498,7 @@ export default function (skillPathsFromConfig: string[]) {
 			syncSessionModelState(pi, ctx)
 
 			const sessionId = ctx.sessionManager.getSessionId()
+			const effectiveModel = getEffectiveModel(ctx)
 
 			const activeToolNames = new Set(pi.getActiveTools())
 			const tools = pi.getAllTools().filter((tool) => activeToolNames.has(tool.name))
@@ -542,12 +546,12 @@ export default function (skillPathsFromConfig: string[]) {
 				env,
 				contextFiles: cachedContextFiles,
 				skills: skills,
-				currentModelId: mode === "orchestrator" ? getOrchestratorModelId(sessionId) : ctx.model?.id,
+				currentModelId: mode === "orchestrator" ? getOrchestratorModelId(sessionId) : effectiveModel?.id,
 				registry: registry,
 				mode,
 				roles,
 				customConfigs,
-				sessionId: ctx.sessionManager.getSessionId(),
+				sessionId,
 			})
 
 			// The rebuilt prompt replaces pi's base prompt entirely, which would

--- a/src/extensions/router/adapters.ts
+++ b/src/extensions/router/adapters.ts
@@ -1,0 +1,8 @@
+import { installAutoModelDiscoveryAdapter } from "./model-discovery.js"
+import { installAutoSummarizationModelAdapter } from "./summarization-model.js"
+
+/** Install all process-wide Pi adapters required by the Auto model. */
+export function installAutoModelAdapters(): void {
+	installAutoModelDiscoveryAdapter()
+	installAutoSummarizationModelAdapter()
+}

--- a/src/extensions/router/api-provider.test.ts
+++ b/src/extensions/router/api-provider.test.ts
@@ -1,0 +1,185 @@
+import {
+	type Api,
+	type AssistantMessage,
+	createAssistantMessageEventStream,
+	getApiProvider,
+	isRetryableAssistantError,
+	type Model,
+	registerApiProvider,
+	streamSimple,
+	unregisterApiProviders,
+} from "@earendil-works/pi-ai/compat"
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { clearAutoRoutingAttempt, registerAutoApiProvider, stageAutoRoutingAttempt } from "./api-provider.js"
+import { AUTO_MODEL_API } from "./constants.js"
+import { clearAutoRoutingState, getAutoRoutingState, setAutoRoutingState } from "./state.js"
+
+const SESSION_ID = "provider-test-session"
+const TARGET_API = "kimchi-auto-test-target"
+const TARGET_SOURCE = "kimchi-auto-test-target-source"
+
+function model(id: string, api: string, reasoning = true): Model<Api> {
+	return {
+		id,
+		name: id,
+		api,
+		provider: "kimchi-dev",
+		baseUrl: "https://llm.kimchi.dev/openai/v1",
+		reasoning,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4000,
+	}
+}
+
+function doneMessage(target: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "delegated" }],
+		api: target.api,
+		provider: target.provider,
+		model: target.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	}
+}
+
+const targetStream = vi.fn((target: Model<Api>) => {
+	const stream = createAssistantMessageEventStream()
+	queueMicrotask(() => stream.push({ type: "done", reason: "stop", message: doneMessage(target) }))
+	return stream
+})
+
+beforeAll(() => {
+	registerAutoApiProvider()
+	registerApiProvider({ api: TARGET_API, stream: targetStream, streamSimple: targetStream }, TARGET_SOURCE)
+})
+
+afterEach(() => {
+	clearAutoRoutingAttempt(SESSION_ID)
+	clearAutoRoutingState(SESSION_ID)
+	targetStream.mockClear()
+	vi.restoreAllMocks()
+})
+
+afterAll(() => unregisterApiProviders(TARGET_SOURCE))
+
+describe("Auto model API provider", () => {
+	it("delegates with the concrete model identity and preserves request options", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		const target = model("concrete", TARGET_API)
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+		const result = await provider
+			.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID, maxTokens: 3000, reasoning: "high" })
+			.result()
+
+		expect(result).toMatchObject({ provider: "kimchi-dev", model: "concrete", api: TARGET_API })
+		expect(targetStream).toHaveBeenCalledWith(
+			target,
+			{ messages: [] },
+			expect.objectContaining({ sessionId: SESSION_ID, maxTokens: 3000, reasoning: "high" }),
+		)
+	})
+
+	it("removes Auto's reasoning preference when the concrete model does not support it", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		const target = model("concrete", TARGET_API, false)
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+		await provider
+			.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID, maxTokens: 3000, reasoning: "low" })
+			.result()
+
+		expect(targetStream).toHaveBeenCalledWith(
+			target,
+			{ messages: [] },
+			expect.objectContaining({ sessionId: SESSION_ID, maxTokens: 3000, reasoning: undefined }),
+		)
+	})
+
+	it("returns an actionable terminal error when Auto has no usable resolution", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+
+		const result = await provider.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID }).result()
+
+		expect(result.stopReason).toBe("error")
+		expect(result.errorMessage).toContain("Auto is unavailable")
+		expect(result.errorMessage).toContain("retry Auto")
+		expect(result.errorMessage).toContain("/model")
+		expect(targetStream).not.toHaveBeenCalled()
+	})
+
+	it("stops a timed-out prompt without triggering Pi's automatic retry", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		setAutoRoutingState(SESSION_ID, { status: "attempting" })
+		stageAutoRoutingAttempt(SESSION_ID, async () => ({ status: "failed", reason: "timeout" }))
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+
+		const result = await provider.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID }).result()
+
+		expect(result.errorMessage).toContain("did not answer in time")
+		expect(isRetryableAssistantError(result)).toBe(false)
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+		expect(targetStream).not.toHaveBeenCalled()
+	})
+
+	it("uses Pi's model-request signal to cancel a staged routing attempt", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		const controller = new AbortController()
+		const attempt = vi.fn(
+			(signal: AbortSignal | undefined) =>
+				new Promise<{ status: "failed"; reason: "cancelled" }>((resolve) => {
+					expect(signal).toBe(controller.signal)
+					signal?.addEventListener("abort", () => resolve({ status: "failed", reason: "cancelled" }), {
+						once: true,
+					})
+				}),
+		)
+		setAutoRoutingState(SESSION_ID, { status: "attempting" })
+		stageAutoRoutingAttempt(SESSION_ID, attempt)
+
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+		const resultPromise = provider
+			.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID, signal: controller.signal })
+			.result()
+		controller.abort()
+		const result = await resultPromise
+
+		expect(result.stopReason).toBe("aborted")
+		expect(result.errorMessage).toContain("routing was cancelled")
+		expect(attempt).toHaveBeenCalledOnce()
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+		expect(targetStream).not.toHaveBeenCalled()
+	})
+
+	it("never intercepts a concrete kimchi-dev model with another model-level API", async () => {
+		const concrete = model("concrete", TARGET_API)
+		const autoProvider = getApiProvider(AUTO_MODEL_API)
+		if (!autoProvider) throw new Error("Auto API provider was not registered")
+		const autoSpy = vi.spyOn(autoProvider, "streamSimple")
+
+		const result = await streamSimple(concrete, { messages: [] }).result()
+
+		expect(result.model).toBe("concrete")
+		expect(targetStream).toHaveBeenCalledOnce()
+		expect(autoSpy).not.toHaveBeenCalled()
+	})
+})

--- a/src/extensions/router/api-provider.test.ts
+++ b/src/extensions/router/api-provider.test.ts
@@ -93,7 +93,7 @@ describe("Auto model API provider", () => {
 		)
 	})
 
-	it("removes Auto's reasoning preference when the concrete model does not support it", async () => {
+	it("does not forward the UI-selected reasoning option to a model that cannot use it", async () => {
 		const auto = model("auto", AUTO_MODEL_API)
 		const target = model("concrete", TARGET_API, false)
 		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
@@ -138,6 +138,17 @@ describe("Auto model API provider", () => {
 		expect(isRetryableAssistantError(result)).toBe(false)
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
 		expect(targetStream).not.toHaveBeenCalled()
+	})
+
+	it("reports a dedicated model application failure", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		setAutoRoutingState(SESSION_ID, { status: "failed", reason: "model_update_failed" })
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+
+		const result = await provider.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID }).result()
+
+		expect(result.errorMessage).toContain("Auto could not apply the routed model")
 	})
 
 	it("uses Pi's model-request signal to cancel a staged routing attempt", async () => {

--- a/src/extensions/router/api-provider.ts
+++ b/src/extensions/router/api-provider.ts
@@ -1,0 +1,185 @@
+import {
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
+	createAssistantMessageEventStream,
+	type Model,
+	type ProviderStreamOptions,
+	registerApiProvider,
+	type SimpleStreamOptions,
+	type StreamOptions,
+	stream as streamModel,
+	streamSimple as streamSimpleModel,
+} from "@earendil-works/pi-ai/compat"
+import { AUTO_MODEL_API } from "./constants.js"
+import { type AutoFailureReason, type AutoRoutingState, getAutoRoutingState, setAutoRoutingState } from "./state.js"
+
+const SOURCE_ID = "kimchi-auto-model"
+
+type AutoRoutingAttemptResult = Extract<AutoRoutingState, { status: "resolved" | "failed" }>
+type AutoRoutingAttempt = (signal: AbortSignal | undefined) => Promise<AutoRoutingAttemptResult>
+
+/**
+ * One pending router attempt per Pi session ID. Keying attempts by session ID
+ * keeps main-agent and subagent routing isolated. The extension stages the
+ * attempt before Pi starts the provider request; the Auto provider then consumes
+ * it once with that request's cancellation signal. Attempts remain in memory and
+ * are never written to the session log—only successful model selections persist.
+ */
+const routingAttempts = new Map<string, AutoRoutingAttempt>()
+
+/** Stage the one routing attempt that the Auto provider will run with Pi's model-request signal. */
+export function stageAutoRoutingAttempt(sessionId: string, attempt: AutoRoutingAttempt): void {
+	routingAttempts.set(sessionId, attempt)
+}
+
+/** Drop a staged attempt when its session ends or is reinitialized. */
+export function clearAutoRoutingAttempt(sessionId: string): void {
+	routingAttempts.delete(sessionId)
+}
+
+/** Claim a staged attempt before running it so concurrent provider calls cannot route twice. */
+export async function consumeAutoRoutingAttempt(
+	sessionId: string,
+	signal?: AbortSignal,
+): Promise<AutoRoutingAttemptResult | undefined> {
+	const attempt = routingAttempts.get(sessionId)
+	if (!attempt) return undefined
+	routingAttempts.delete(sessionId)
+	return attempt(signal)
+}
+
+function contextHasImages(context: Context): boolean {
+	return context.messages.some(
+		(message) =>
+			(message.role === "user" || message.role === "toolResult") &&
+			Array.isArray(message.content) &&
+			message.content.some((content) => content.type === "image"),
+	)
+}
+
+function failureDetail(reason: AutoFailureReason): string {
+	switch (reason) {
+		case "cancelled":
+			return "routing was cancelled"
+		case "redaction_failed":
+			return "the router query could not be redacted safely"
+		case "timeout":
+			return "the router did not answer in time"
+		case "vision_required":
+			return "none of the eligible router-ranked models can read images"
+		case "unavailable_recommendation":
+			return "none of the router-ranked models are eligible in the active model scope"
+		case "empty_prompt":
+			return "the prompt has no text for routing"
+		case "no_auth":
+			return "the Kimchi credential is unavailable"
+		case "malformed":
+			return "the router returned an invalid response"
+		case "network":
+			return "the router could not be reached"
+		case "router_http":
+			return "the router rejected the request"
+		case "interrupted":
+			return "the earlier routing attempt was interrupted"
+	}
+}
+
+function errorStream(model: Model<Api>, reason: AutoFailureReason) {
+	const stream = createAssistantMessageEventStream()
+	const aborted = reason === "cancelled"
+	const stopReason: "aborted" | "error" = aborted ? "aborted" : "error"
+	const message: AssistantMessage = {
+		role: "assistant",
+		content: [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		errorMessage: `Auto is unavailable: ${failureDetail(reason)}. Submit another prompt to retry Auto, or select a concrete model with /model.`,
+		timestamp: Date.now(),
+	}
+	queueMicrotask(() => stream.push({ type: "error", reason: stopReason, error: message }))
+	return stream
+}
+
+async function resolvedTarget(
+	context: Context,
+	sessionId: string | undefined,
+	signal: AbortSignal | undefined,
+): Promise<Model<Api> | AutoFailureReason> {
+	let state = getAutoRoutingState(sessionId)
+	if (state.status === "attempting" && sessionId) {
+		try {
+			const result = await consumeAutoRoutingAttempt(sessionId, signal)
+			if (!result) {
+				setAutoRoutingState(sessionId, { status: "unresolved" })
+				return "interrupted"
+			}
+			state = result
+		} catch {
+			setAutoRoutingState(sessionId, { status: "unresolved" })
+			return "interrupted"
+		}
+	}
+	if (state.status === "failed") {
+		if (sessionId) setAutoRoutingState(sessionId, { status: "unresolved" })
+		return state.reason
+	}
+	if (state.status !== "resolved") return "interrupted"
+	if (contextHasImages(context) && !state.model.input.includes("image")) return "vision_required"
+	return state.model
+}
+
+/** Remove Auto's session-level reasoning preference when the concrete target cannot honor it. */
+function optionsForTarget<T extends StreamOptions>(target: Model<Api>, options: T | undefined): T | undefined {
+	if (!options || target.reasoning || !("reasoning" in options)) return options
+	return { ...options, reasoning: undefined }
+}
+
+function routeAndStream<T extends StreamOptions>(
+	model: Model<Api>,
+	context: Context,
+	options: T | undefined,
+	delegate: (target: Model<Api>, context: Context, options?: T) => AssistantMessageEventStream,
+): AssistantMessageEventStream {
+	const output = createAssistantMessageEventStream()
+	void (async () => {
+		let source: AssistantMessageEventStream
+		try {
+			const target = await resolvedTarget(context, options?.sessionId, options?.signal)
+			source =
+				typeof target === "string"
+					? errorStream(model, target)
+					: delegate(target, context, optionsForTarget(target, options))
+		} catch {
+			source = errorStream(model, "interrupted")
+		}
+		for await (const event of source) output.push(event)
+	})()
+	return output
+}
+
+export function registerAutoApiProvider(): void {
+	registerApiProvider(
+		{
+			api: AUTO_MODEL_API,
+			stream(model: Model<Api>, context: Context, options?: ProviderStreamOptions) {
+				return routeAndStream(model, context, options, streamModel)
+			},
+			streamSimple(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+				return routeAndStream(model, context, options, streamSimpleModel)
+			},
+		},
+		SOURCE_ID,
+	)
+}

--- a/src/extensions/router/api-provider.ts
+++ b/src/extensions/router/api-provider.ts
@@ -75,6 +75,8 @@ function failureDetail(reason: AutoFailureReason): string {
 			return "the prompt has no text for routing"
 		case "no_auth":
 			return "the Kimchi credential is unavailable"
+		case "model_update_failed":
+			return "the routed model could not be applied"
 		case "malformed":
 			return "the router returned an invalid response"
 		case "network":
@@ -84,6 +86,11 @@ function failureDetail(reason: AutoFailureReason): string {
 		case "interrupted":
 			return "the earlier routing attempt was interrupted"
 	}
+}
+
+function failureMessage(reason: AutoFailureReason): string {
+	if (reason === "model_update_failed") return "Auto could not apply the routed model."
+	return `Auto is unavailable: ${failureDetail(reason)}.`
 }
 
 function errorStream(model: Model<Api>, reason: AutoFailureReason) {
@@ -105,7 +112,7 @@ function errorStream(model: Model<Api>, reason: AutoFailureReason) {
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason,
-		errorMessage: `Auto is unavailable: ${failureDetail(reason)}. Submit another prompt to retry Auto, or select a concrete model with /model.`,
+		errorMessage: `${failureMessage(reason)} Submit another prompt to retry Auto, or select a concrete model with /model.`,
 		timestamp: Date.now(),
 	}
 	queueMicrotask(() => stream.push({ type: "error", reason: stopReason, error: message }))
@@ -140,7 +147,7 @@ async function resolvedTarget(
 	return state.model
 }
 
-/** Remove Auto's session-level reasoning preference when the concrete target cannot honor it. */
+/** Clear the UI-selected reasoning option when the routed model does not support reasoning. */
 function optionsForTarget<T extends StreamOptions>(target: Model<Api>, options: T | undefined): T | undefined {
 	if (!options || target.reasoning || !("reasoning" in options)) return options
 	return { ...options, reasoning: undefined }

--- a/src/extensions/router/constants.ts
+++ b/src/extensions/router/constants.ts
@@ -6,6 +6,8 @@ export const AUTO_MODEL_REF = `${AUTO_MODEL_PROVIDER}/${AUTO_MODEL_ID}`
 export const AUTO_MODEL_API = "kimchi-auto"
 export const AUTO_MODEL_NAME = "Auto (Kimchi Router)"
 
-export function isAutoModel(model: Pick<Model<string>, "provider" | "id"> | undefined): boolean {
+export function isAutoModel<T extends Pick<Model<string>, "provider" | "id">>(
+	model: T | undefined,
+): model is T & { provider: typeof AUTO_MODEL_PROVIDER; id: typeof AUTO_MODEL_ID } {
 	return model?.provider === AUTO_MODEL_PROVIDER && model.id === AUTO_MODEL_ID
 }

--- a/src/extensions/router/constants.ts
+++ b/src/extensions/router/constants.ts
@@ -1,0 +1,11 @@
+import type { Model } from "@earendil-works/pi-ai"
+
+export const AUTO_MODEL_PROVIDER = "kimchi-dev"
+export const AUTO_MODEL_ID = "auto"
+export const AUTO_MODEL_REF = `${AUTO_MODEL_PROVIDER}/${AUTO_MODEL_ID}`
+export const AUTO_MODEL_API = "kimchi-auto"
+export const AUTO_MODEL_NAME = "Auto (Kimchi Router)"
+
+export function isAutoModel(model: Pick<Model<string>, "provider" | "id"> | undefined): boolean {
+	return model?.provider === AUTO_MODEL_PROVIDER && model.id === AUTO_MODEL_ID
+}

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -11,6 +11,7 @@ import { createContext } from "../__mocks__/context.js"
 import { createExtensionApi } from "../__mocks__/extension-api.js"
 import { clearAutoRoutingAttempt, consumeAutoRoutingAttempt } from "./api-provider.js"
 import autoModelExtension, { createAutoModelExtension } from "./index.js"
+import { ROUTER_IMAGE_METADATA } from "./router-query.js"
 import { AUTO_RESOLUTION_ENTRY, clearAutoRoutingState, getAutoRoutingState, resolvedEntry } from "./state.js"
 
 const SESSION_ID = "auto-session"
@@ -301,6 +302,35 @@ describe("Auto model extension", () => {
 		})
 
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+		expect(fetch).toHaveBeenCalledWith(
+			expect.any(URL),
+			expect.objectContaining({
+				body: JSON.stringify({ query: `implement the feature\n\n${ROUTER_IMAGE_METADATA}` }),
+			}),
+		)
+	})
+
+	it("routes an image-only initial prompt using image metadata", async () => {
+		const { getHandler, ctx, target } = harness()
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(
+			beforeEvent({ prompt: "", images: [{ type: "image", data: "abc", mimeType: "image/png" }] }),
+			ctx,
+		)
+
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({ status: "resolved", model: target })
+		expect(fetch).toHaveBeenCalledWith(
+			expect.any(URL),
+			expect.objectContaining({ body: JSON.stringify({ query: ROUTER_IMAGE_METADATA }) }),
+		)
 	})
 
 	it("requires a vision model when configured for forwarded image paths", async () => {

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -175,7 +175,7 @@ describe("Auto model extension", () => {
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
 	})
 
-	it("routes once, records the concrete model, and keeps its identity out of the notification", async () => {
+	it("routes once and records the concrete model without showing a notification", async () => {
 		const { getHandler, appendEntry, ctx, target } = harness()
 		vi.stubGlobal(
 			"fetch",
@@ -201,8 +201,7 @@ describe("Auto model extension", () => {
 			provider: "kimchi-dev",
 			modelId: target.id,
 		})
-		expect(ctx.ui.notify).toHaveBeenCalledWith("Auto is ready for this session", "info")
-		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(target.id), "info")
+		expect(ctx.ui.notify).not.toHaveBeenCalled()
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
 	})
 

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -1,0 +1,351 @@
+import type { Model } from "@earendil-works/pi-ai"
+import type {
+	BeforeAgentStartEvent,
+	InputEvent,
+	SessionEntry,
+	SessionStartEvent,
+} from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { populateCliArgs } from "../../cli-args.js"
+import { createContext } from "../__mocks__/context.js"
+import { createExtensionApi } from "../__mocks__/extension-api.js"
+import { clearAutoRoutingAttempt, consumeAutoRoutingAttempt } from "./api-provider.js"
+import autoModelExtension, { createAutoModelExtension } from "./index.js"
+import { AUTO_RESOLUTION_ENTRY, clearAutoRoutingState, getAutoRoutingState, resolvedEntry } from "./state.js"
+
+const SESSION_ID = "auto-session"
+
+function model(id: string, input: ("text" | "image")[] = ["text"]): Model<string> {
+	return {
+		id,
+		name: id,
+		api: id === "auto" ? "kimchi-auto" : "openai-completions",
+		provider: "kimchi-dev",
+		baseUrl: "https://llm.kimchi.dev/openai/v1",
+		reasoning: true,
+		input,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16000,
+	}
+}
+
+function harness(target = model("kimi-k2.5", ["text", "image"]), requiresVision = false) {
+	const extension = createExtensionApi()
+	if (requiresVision) createAutoModelExtension({ requiresVision })(extension.api)
+	else autoModelExtension(extension.api)
+	const ctx = createContext({
+		model: model("auto", ["text", "image"]),
+		sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [], getEntries: () => [] },
+		modelRegistry: {
+			getAvailable: () => [target],
+			find: (provider, id) => (provider === target.provider && id === target.id ? target : undefined),
+			getApiKeyForProvider: vi.fn(async () => "gateway-key"),
+		},
+		scopedModels: [],
+	})
+	return { ...extension, ctx, target }
+}
+
+function beforeEvent(overrides: Partial<BeforeAgentStartEvent> = {}): BeforeAgentStartEvent {
+	return {
+		type: "before_agent_start",
+		prompt: "implement the feature",
+		systemPrompt: "system",
+		systemPromptOptions: {},
+		...overrides,
+	} as BeforeAgentStartEvent
+}
+
+function custom(data: unknown): SessionEntry {
+	return {
+		type: "custom",
+		id: crypto.randomUUID(),
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		customType: AUTO_RESOLUTION_ENTRY,
+		data,
+	}
+}
+
+afterEach(() => {
+	populateCliArgs([])
+	clearAutoRoutingAttempt(SESSION_ID)
+	clearAutoRoutingState(SESSION_ID)
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+describe("Auto model extension", () => {
+	it("records an explicit Auto CLI selection once through Pi's normal model path", async () => {
+		populateCliArgs(["--model", "kimchi-dev/auto"])
+		const extension = createExtensionApi()
+		const setModel = vi.fn(async () => true)
+		Object.assign(extension.api, { setModel })
+		autoModelExtension(extension.api)
+		const auto = model("auto", ["text", "image"])
+		const ctx = createContext({
+			model: auto,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => [] },
+			modelRegistry: { find: () => auto, getAvailable: () => [] },
+		})
+		const start = extension.getHandler<SessionStartEvent>("session_start")
+
+		await start({ type: "session_start", reason: "startup" }, ctx)
+		await start({ type: "session_start", reason: "reload" }, ctx)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(auto)
+	})
+
+	it("does not persist an ordinary concrete CLI selection", async () => {
+		populateCliArgs(["--model", "kimi-k2.5"])
+		const extension = createExtensionApi()
+		const setModel = vi.fn(async () => true)
+		Object.assign(extension.api, { setModel })
+		autoModelExtension(extension.api)
+		const concrete = model("kimi-k2.5")
+		const ctx = createContext({
+			model: concrete,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => [] },
+		})
+
+		await extension.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		expect(setModel).not.toHaveBeenCalled()
+	})
+
+	it("records an explicit concrete CLI override of a saved Auto session", async () => {
+		populateCliArgs(["--model", "kimi-k2.5"])
+		const target = model("kimi-k2.5")
+		const entries = [custom(resolvedEntry(target))]
+		const extension = createExtensionApi()
+		const setModel = vi.fn(async () => true)
+		Object.assign(extension.api, { setModel })
+		autoModelExtension(extension.api)
+		const ctx = createContext({
+			model: target,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => entries },
+		})
+
+		await extension.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(target)
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+	})
+
+	it("keeps a concrete model when the session has no Auto state", async () => {
+		const extension = createExtensionApi()
+		autoModelExtension(extension.api)
+		const getEntries = vi.fn(() => [])
+		const ctx = createContext({
+			model: model("kimi-k2.5"),
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries },
+		})
+
+		await extension.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		expect(getEntries).toHaveBeenCalledOnce()
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+	})
+
+	it("restores the Auto selection that Pi inferred as the concrete assistant model", async () => {
+		const target = model("kimi-k2.5")
+		const auto = model("auto", ["text", "image"])
+		const entries = [custom(resolvedEntry(target))]
+		const extension = createExtensionApi()
+		const setModel = vi.fn(async () => true)
+		Object.assign(extension.api, { setModel })
+		autoModelExtension(extension.api)
+		const ctx = createContext({
+			model: target,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => entries },
+			modelRegistry: {
+				find: (provider, id) => [auto, target].find((item) => item.provider === provider && item.id === id),
+				getAvailable: () => [target],
+			},
+		})
+
+		await extension.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(auto)
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
+	})
+
+	it("routes once, records the concrete model, and reuses it for later prompts", async () => {
+		const { getHandler, appendEntry, ctx, target } = harness()
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		const routePrompt = getHandler<BeforeAgentStartEvent>("before_agent_start")
+		await routePrompt(beforeEvent(), ctx)
+		expect(fetch).not.toHaveBeenCalled()
+		await consumeAutoRoutingAttempt(SESSION_ID)
+		await routePrompt(beforeEvent({ prompt: "second prompt" }), ctx)
+		await consumeAutoRoutingAttempt(SESSION_ID)
+
+		expect(fetch).toHaveBeenCalledOnce()
+		expect(appendEntry).toHaveBeenCalledOnce()
+		expect(appendEntry).toHaveBeenCalledWith("kimchi_auto_resolution", {
+			version: 1,
+			status: "resolved",
+			provider: "kimchi-dev",
+			modelId: target.id,
+		})
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
+	})
+
+	it("does not persist a router failure and retries on the next user prompt", async () => {
+		const { getHandler, appendEntry, ctx, target } = harness()
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: false, json: async () => ({}) })
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})
+		vi.stubGlobal("fetch", fetchMock)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		const routePrompt = getHandler<BeforeAgentStartEvent>("before_agent_start")
+		await routePrompt(beforeEvent(), ctx)
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({ status: "failed", reason: "router_http" })
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+		expect(appendEntry).not.toHaveBeenCalled()
+
+		await routePrompt(beforeEvent({ prompt: "retry routing" }), ctx)
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({ status: "resolved", model: target })
+
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(appendEntry).toHaveBeenCalledOnce()
+		expect(appendEntry).toHaveBeenCalledWith("kimchi_auto_resolution", {
+			version: 1,
+			status: "resolved",
+			provider: "kimchi-dev",
+			modelId: target.id,
+		})
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
+	})
+
+	it("does not persist cancellation and retries on the next user prompt", async () => {
+		const { getHandler, appendEntry, ctx, target } = harness()
+		let requestNumber = 0
+		const fetchMock = vi.fn<typeof fetch>((_input, init) => {
+			requestNumber += 1
+			if (requestNumber === 1) {
+				return new Promise<Response>((_resolve, reject) => {
+					const abort = () => reject(new DOMException("aborted", "AbortError"))
+					if (init?.signal?.aborted) abort()
+					else init?.signal?.addEventListener("abort", abort, { once: true })
+				})
+			}
+			return Promise.resolve({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			} as Response)
+		})
+		vi.stubGlobal("fetch", fetchMock)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		const routePrompt = getHandler<BeforeAgentStartEvent>("before_agent_start")
+		await routePrompt(beforeEvent(), ctx)
+		const controller = new AbortController()
+		const attempt = consumeAutoRoutingAttempt(SESSION_ID, controller.signal)
+		controller.abort()
+		await expect(attempt).resolves.toEqual({ status: "failed", reason: "cancelled" })
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+		expect(appendEntry).not.toHaveBeenCalled()
+
+		await routePrompt(beforeEvent({ prompt: "corrected prompt" }), ctx)
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({ status: "resolved", model: target })
+
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(appendEntry).toHaveBeenCalledOnce()
+		expect(appendEntry).toHaveBeenCalledWith("kimchi_auto_resolution", {
+			version: 1,
+			status: "resolved",
+			provider: "kimchi-dev",
+			modelId: target.id,
+		})
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
+	})
+
+	it("rejects an initial image when the single recommendation is text-only", async () => {
+		const { getHandler, ctx, target } = harness(model("text-only"))
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(
+			beforeEvent({ images: [{ type: "image", data: "abc", mimeType: "image/png" }] }),
+			ctx,
+		)
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({
+			status: "failed",
+			reason: "vision_required",
+		})
+
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+	})
+
+	it("requires a vision model when configured for forwarded image paths", async () => {
+		const { getHandler, ctx, target } = harness(model("text-only"), true)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({
+			status: "failed",
+			reason: "vision_required",
+		})
+
+		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })
+	})
+
+	it("blocks later images after a text-only resolution without rerouting", async () => {
+		const { getHandler, ctx, target } = harness(model("text-only"))
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+		await consumeAutoRoutingAttempt(SESSION_ID)
+
+		const result = await getHandler<InputEvent>("input")(
+			{
+				type: "input",
+				text: "look",
+				images: [{ type: "image", data: "abc", mimeType: "image/png" }],
+				source: "interactive",
+			},
+			ctx,
+		)
+
+		expect(result).toEqual({ action: "handled" })
+		expect(fetch).toHaveBeenCalledOnce()
+		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("/strip-images"), "warning")
+	})
+})

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -377,7 +377,9 @@ describe("Auto model extension", () => {
 
 		expect(result).toEqual({ action: "handled" })
 		expect(fetch).toHaveBeenCalledOnce()
-		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("/strip-images"), "warning")
-		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(target.id), "warning")
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Auto cannot process images in this session. Select a vision model with /model, or use /strip-images for existing images.",
+			"warning",
+		)
 	})
 })

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -174,7 +174,7 @@ describe("Auto model extension", () => {
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
 	})
 
-	it("routes once, records the concrete model, and reuses it for later prompts", async () => {
+	it("routes once, records the concrete model, and keeps its identity out of the notification", async () => {
 		const { getHandler, appendEntry, ctx, target } = harness()
 		vi.stubGlobal(
 			"fetch",
@@ -200,6 +200,8 @@ describe("Auto model extension", () => {
 			provider: "kimchi-dev",
 			modelId: target.id,
 		})
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Auto is ready for this session", "info")
+		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(target.id), "info")
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
 	})
 
@@ -347,5 +349,6 @@ describe("Auto model extension", () => {
 		expect(result).toEqual({ action: "handled" })
 		expect(fetch).toHaveBeenCalledOnce()
 		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("/strip-images"), "warning")
+		expect(ctx.ui.notify).not.toHaveBeenCalledWith(expect.stringContaining(target.id), "warning")
 	})
 })

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -1,6 +1,7 @@
 import type { Model } from "@earendil-works/pi-ai"
 import type {
 	BeforeAgentStartEvent,
+	ExtensionEvent,
 	InputEvent,
 	SessionEntry,
 	SessionStartEvent,
@@ -12,18 +13,25 @@ import { createExtensionApi } from "../__mocks__/extension-api.js"
 import { clearAutoRoutingAttempt, consumeAutoRoutingAttempt } from "./api-provider.js"
 import autoModelExtension, { createAutoModelExtension } from "./index.js"
 import { ROUTER_IMAGE_METADATA } from "./router-query.js"
-import { AUTO_RESOLUTION_ENTRY, clearAutoRoutingState, getAutoRoutingState, resolvedEntry } from "./state.js"
+import {
+	AUTO_RESOLUTION_ENTRY,
+	clearAutoRoutingState,
+	getAutoRoutingState,
+	resolvedEntry,
+	setAutoRoutingState,
+} from "./state.js"
 
 const SESSION_ID = "auto-session"
+type ModelSelectEvent = Extract<ExtensionEvent, { type: "model_select" }>
 
-function model(id: string, input: ("text" | "image")[] = ["text"]): Model<string> {
+function model(id: string, input: ("text" | "image")[] = ["text"], reasoning = true): Model<string> {
 	return {
 		id,
 		name: id,
 		api: id === "auto" ? "kimchi-auto" : "openai-completions",
 		provider: "kimchi-dev",
 		baseUrl: "https://llm.kimchi.dev/openai/v1",
-		reasoning: true,
+		reasoning,
 		input,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128000,
@@ -175,6 +183,29 @@ describe("Auto model extension", () => {
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
 	})
 
+	it("restores Auto with the resolved model's reasoning capability", async () => {
+		const target = model("plain", ["text"], false)
+		const auto = model("auto", ["text", "image"])
+		const entries = [custom(resolvedEntry(target))]
+		const extension = createExtensionApi()
+		autoModelExtension(extension.api)
+		const ctx = createContext({
+			model: target,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => entries },
+			modelRegistry: {
+				find: (provider, id) => [auto, target].find((item) => item.provider === provider && item.id === id),
+				getAvailable: () => [target],
+			},
+		})
+
+		await extension.getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		expect(extension.setModel).toHaveBeenCalledOnce()
+		expect(extension.setModel).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "auto", api: "kimchi-auto", reasoning: false, thinkingLevelMap: undefined }),
+		)
+	})
+
 	it("routes once and records the concrete model without showing a notification", async () => {
 		const { getHandler, appendEntry, ctx, target } = harness()
 		vi.stubGlobal(
@@ -203,6 +234,94 @@ describe("Auto model extension", () => {
 		})
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "resolved", model: target })
+	})
+
+	it("applies the routed model's reasoning capability to the Auto session", async () => {
+		const { getHandler, setModel, ctx, target } = harness(model("plain", ["text"], false))
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+		await consumeAutoRoutingAttempt(SESSION_ID)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "auto", api: "kimchi-auto", reasoning: false, thinkingLevelMap: undefined }),
+		)
+	})
+
+	it("uses the routed model's supported thinking levels for Auto controls", async () => {
+		const target = model("reasoning")
+		target.thinkingLevelMap = { off: "none", low: "low", max: null }
+		const { getHandler, setModel, ctx } = harness(target)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+		await consumeAutoRoutingAttempt(SESSION_ID)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id: "auto",
+				reasoning: true,
+				thinkingLevelMap: { off: "none", low: "low", max: null },
+			}),
+		)
+	})
+
+	it("reports a model update failure when routed capabilities cannot be applied", async () => {
+		const { getHandler, setModel, ctx, target } = harness(model("plain", ["text"], false))
+		setModel.mockResolvedValue(false)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+
+		await expect(consumeAutoRoutingAttempt(SESSION_ID)).resolves.toEqual({
+			status: "failed",
+			reason: "model_update_failed",
+		})
+	})
+
+	it("restores resolved reasoning capabilities when Auto is selected again", async () => {
+		const target = model("plain", ["text"], false)
+		const auto = model("auto", ["text", "image"])
+		const extension = createExtensionApi()
+		autoModelExtension(extension.api)
+		const ctx = createContext({
+			model: auto,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => [] },
+		})
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+
+		await extension.getHandler<ModelSelectEvent>("model_select")(
+			{ type: "model_select", model: auto, previousModel: target, source: "set" },
+			ctx,
+		)
+
+		expect(extension.setModel).toHaveBeenCalledOnce()
+		expect(extension.setModel).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "auto", api: "kimchi-auto", reasoning: false, thinkingLevelMap: undefined }),
+		)
 	})
 
 	it("does not persist a router failure and retries on the next user prompt", async () => {

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -1,3 +1,4 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionFactory, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { getParsedCliArgs, MULTI_MODEL_ID } from "../../cli-args.js"
 import { setMultiModelEnabled } from "../multi-model.js"
@@ -33,6 +34,29 @@ function routeFailureReason(reason: "cancelled" | "timeout" | "network" | "http"
 	return reason === "http" ? "router_http" : reason
 }
 
+type ReasoningCapabilities = Pick<Model<Api>, "reasoning" | "thinkingLevelMap">
+
+function hasTargetReasoningCapabilities(autoModel: ReasoningCapabilities, target: ReasoningCapabilities): boolean {
+	return autoModel.reasoning === target.reasoning && autoModel.thinkingLevelMap === target.thinkingLevelMap
+}
+
+function autoModelForTarget<TApi extends Api>(autoModel: Model<TApi>, target: ReasoningCapabilities): Model<TApi> {
+	return {
+		...autoModel,
+		reasoning: target.reasoning,
+		thinkingLevelMap: target.thinkingLevelMap,
+	}
+}
+
+async function syncAutoReasoningCapabilities<TApi extends Api>(
+	pi: ExtensionAPI,
+	autoModel: Model<TApi>,
+	target: ReasoningCapabilities,
+): Promise<boolean> {
+	if (hasTargetReasoningCapabilities(autoModel, target)) return true
+	return pi.setModel(autoModelForTarget(autoModel, target))
+}
+
 export interface AutoModelExtensionOptions {
 	/** Require a vision-capable recommendation for context forwarded as image paths. */
 	requiresVision?: boolean
@@ -64,20 +88,40 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 					return
 				}
 			}
-			if (!isAutoModel(ctx.model)) {
+			let autoModel = ctx.model
+			if (!isAutoModel(autoModel)) {
 				if (!sessionSelectsAuto(entries)) {
 					clearAutoRoutingState(sessionId)
 					return
 				}
-				const autoModel = ctx.modelRegistry.find(AUTO_MODEL_PROVIDER, AUTO_MODEL_ID)
+				autoModel = ctx.modelRegistry.find(AUTO_MODEL_PROVIDER, AUTO_MODEL_ID)
 				if (!autoModel) {
 					clearAutoRoutingState(sessionId)
 					return
 				}
-				await pi.setModel(autoModel)
 			}
 			setMultiModelEnabled(sessionId, false)
-			hydrateAutoRoutingState(sessionId, entries, ctx.modelRegistry)
+			const state = hydrateAutoRoutingState(sessionId, entries, ctx.modelRegistry)
+			const sessionAutoModel = state.status === "resolved" ? autoModelForTarget(autoModel, state.model) : autoModel
+			const currentModel = ctx.model
+			if (
+				!currentModel ||
+				!isAutoModel(currentModel) ||
+				(state.status === "resolved" && !hasTargetReasoningCapabilities(currentModel, state.model))
+			) {
+				await pi.setModel(sessionAutoModel)
+			}
+		})
+
+		pi.on("model_select", async (event, ctx) => {
+			if (!isAutoModel(event.model)) return
+			const sessionId = ctx.sessionManager.getSessionId()
+			let state = getAutoRoutingState(sessionId)
+			if (state.status === "unresolved") {
+				state = hydrateAutoRoutingState(sessionId, ctx.sessionManager.getEntries(), ctx.modelRegistry)
+			}
+			if (state.status !== "resolved") return
+			await syncAutoReasoningCapabilities(pi, event.model, state.model)
 		})
 
 		pi.on("input", (event, ctx) => {
@@ -92,7 +136,8 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 		})
 
 		pi.on("before_agent_start", (event, ctx) => {
-			if (!isAutoModel(ctx.model)) return
+			const autoModel = ctx.model
+			if (!isAutoModel(autoModel)) return
 			const sessionId = ctx.sessionManager.getSessionId()
 			if (getAutoRoutingState(sessionId).status === "unresolved") {
 				hydrateAutoRoutingState(sessionId, ctx.sessionManager.getEntries(), ctx.modelRegistry)
@@ -128,6 +173,9 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 
 				const resolution = resolveRecommendation(route.recommendation, ctx, requiresVision)
 				if (!resolution.ok) return fail(resolution.reason)
+				if (!(await syncAutoReasoningCapabilities(pi, autoModel, resolution.model))) {
+					return fail("model_update_failed")
+				}
 
 				const state = { status: "resolved", model: resolution.model } satisfies AutoRoutingState
 				setAutoRoutingState(sessionId, state)

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -112,7 +112,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 					return { status: "failed", reason }
 				}
 
-				const query = await prepareRouterQuery(event.prompt)
+				const query = await prepareRouterQuery(event.prompt, { containsImages: requiresVision })
 				if (!query.ok) return fail(query.reason)
 
 				let config: RouterConfig | undefined

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -1,0 +1,150 @@
+import type { ExtensionAPI, ExtensionFactory, SessionEntry } from "@earendil-works/pi-coding-agent"
+import { getParsedCliArgs, MULTI_MODEL_ID } from "../../cli-args.js"
+import { setMultiModelEnabled } from "../multi-model.js"
+import { clearAutoRoutingAttempt, registerAutoApiProvider, stageAutoRoutingAttempt } from "./api-provider.js"
+import { AUTO_MODEL_ID, AUTO_MODEL_PROVIDER, isAutoModel } from "./constants.js"
+import { routeQuery } from "./router-client.js"
+import { getRouterConfig, type RouterConfig } from "./router-config.js"
+import { prepareRouterQuery } from "./router-query.js"
+import { resolveRecommendation } from "./selection.js"
+import {
+	AUTO_RESOLUTION_ENTRY,
+	type AutoFailureReason,
+	type AutoRoutingState,
+	clearAutoRoutingState,
+	getAutoRoutingState,
+	hydrateAutoRoutingState,
+	resolvedEntry,
+	sessionSelectsAuto,
+	setAutoRoutingState,
+} from "./state.js"
+
+function branchHasImages(entries: readonly SessionEntry[]): boolean {
+	return entries.some(
+		(entry) =>
+			entry.type === "message" &&
+			(entry.message.role === "user" || entry.message.role === "toolResult") &&
+			Array.isArray(entry.message.content) &&
+			entry.message.content.some((content) => content.type === "image"),
+	)
+}
+
+function routeFailureReason(reason: "cancelled" | "timeout" | "network" | "http" | "malformed"): AutoFailureReason {
+	return reason === "http" ? "router_http" : reason
+}
+
+export interface AutoModelExtensionOptions {
+	/** Require a vision-capable recommendation for context forwarded as image paths. */
+	requiresVision?: boolean
+	/** Record main-process CLI model choices before restoring saved Auto state. */
+	handleCliModelSelection?: boolean
+}
+
+export function createAutoModelExtension(options: AutoModelExtensionOptions = {}): ExtensionFactory {
+	return (pi: ExtensionAPI) => {
+		// Pi clears custom API handlers on /reload, so register with each extension lifecycle.
+		registerAutoApiProvider()
+
+		pi.on("session_start", async (event, ctx) => {
+			const sessionId = ctx.sessionManager.getSessionId()
+			clearAutoRoutingAttempt(sessionId)
+			const entries = ctx.sessionManager.getEntries()
+			const requestedModel =
+				event.reason === "startup" && options.handleCliModelSelection ? getParsedCliArgs().options.model : undefined
+			if (
+				requestedModel &&
+				requestedModel !== MULTI_MODEL_ID &&
+				ctx.model &&
+				(isAutoModel(ctx.model) || sessionSelectsAuto(entries))
+			) {
+				setMultiModelEnabled(sessionId, false)
+				await pi.setModel(ctx.model)
+				if (!isAutoModel(ctx.model)) {
+					clearAutoRoutingState(sessionId)
+					return
+				}
+			}
+			if (!isAutoModel(ctx.model)) {
+				if (!sessionSelectsAuto(entries)) {
+					clearAutoRoutingState(sessionId)
+					return
+				}
+				const autoModel = ctx.modelRegistry.find(AUTO_MODEL_PROVIDER, AUTO_MODEL_ID)
+				if (!autoModel) {
+					clearAutoRoutingState(sessionId)
+					return
+				}
+				await pi.setModel(autoModel)
+			}
+			setMultiModelEnabled(sessionId, false)
+			hydrateAutoRoutingState(sessionId, entries, ctx.modelRegistry)
+		})
+
+		pi.on("input", (event, ctx) => {
+			if (!isAutoModel(ctx.model) || !event.images?.length) return
+			const state = getAutoRoutingState(ctx.sessionManager.getSessionId())
+			if (state.status !== "resolved" || state.model.input.includes("image")) return
+			ctx.ui.notify(
+				`Auto resolved to ${state.model.provider}/${state.model.id}, which does not support images. Select a vision model with /model, or use /strip-images for existing images.`,
+				"warning",
+			)
+			return { action: "handled" }
+		})
+
+		pi.on("before_agent_start", (event, ctx) => {
+			if (!isAutoModel(ctx.model)) return
+			const sessionId = ctx.sessionManager.getSessionId()
+			if (getAutoRoutingState(sessionId).status === "unresolved") {
+				hydrateAutoRoutingState(sessionId, ctx.sessionManager.getEntries(), ctx.modelRegistry)
+			}
+			if (getAutoRoutingState(sessionId).status !== "unresolved") return
+
+			setAutoRoutingState(sessionId, { status: "attempting" })
+
+			const requiresVision =
+				options.requiresVision === true ||
+				Boolean(event.images?.length) ||
+				branchHasImages(ctx.sessionManager.getBranch())
+
+			stageAutoRoutingAttempt(sessionId, async (signal) => {
+				const fail = (reason: AutoFailureReason): Extract<AutoRoutingState, { status: "failed" }> => {
+					setAutoRoutingState(sessionId, { status: "unresolved" })
+					return { status: "failed", reason }
+				}
+
+				const query = await prepareRouterQuery(event.prompt)
+				if (!query.ok) return fail(query.reason)
+
+				let config: RouterConfig | undefined
+				try {
+					config = await getRouterConfig(ctx.modelRegistry)
+				} catch {
+					config = undefined
+				}
+				if (!config) return fail("no_auth")
+
+				const route = await routeQuery(query.query, config, { signal })
+				if (!route.ok) return fail(routeFailureReason(route.reason))
+
+				const resolution = resolveRecommendation(route.recommendation, ctx, requiresVision)
+				if (!resolution.ok) return fail(resolution.reason)
+
+				const state = { status: "resolved", model: resolution.model } satisfies AutoRoutingState
+				setAutoRoutingState(sessionId, state)
+				pi.appendEntry(AUTO_RESOLUTION_ENTRY, resolvedEntry(resolution.model))
+				ctx.ui.notify(`Auto selected ${resolution.model.provider}/${resolution.model.id} for this session`, "info")
+				return state
+			})
+		})
+
+		pi.on("session_shutdown", (_event, ctx) => {
+			const sessionId = ctx.sessionManager.getSessionId()
+			clearAutoRoutingAttempt(sessionId)
+			clearAutoRoutingState(sessionId)
+		})
+	}
+}
+
+const autoModelExtension = createAutoModelExtension({ handleCliModelSelection: true })
+
+export default autoModelExtension

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -85,7 +85,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 			const state = getAutoRoutingState(ctx.sessionManager.getSessionId())
 			if (state.status !== "resolved" || state.model.input.includes("image")) return
 			ctx.ui.notify(
-				`Auto resolved to ${state.model.provider}/${state.model.id}, which does not support images. Select a vision model with /model, or use /strip-images for existing images.`,
+				"Auto cannot process images in this session. Select a vision model with /model, or use /strip-images for existing images.",
 				"warning",
 			)
 			return { action: "handled" }
@@ -132,7 +132,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 				const state = { status: "resolved", model: resolution.model } satisfies AutoRoutingState
 				setAutoRoutingState(sessionId, state)
 				pi.appendEntry(AUTO_RESOLUTION_ENTRY, resolvedEntry(resolution.model))
-				ctx.ui.notify(`Auto selected ${resolution.model.provider}/${resolution.model.id} for this session`, "info")
+				ctx.ui.notify("Auto is ready for this session", "info")
 				return state
 			})
 		})

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -132,7 +132,6 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 				const state = { status: "resolved", model: resolution.model } satisfies AutoRoutingState
 				setAutoRoutingState(sessionId, state)
 				pi.appendEntry(AUTO_RESOLUTION_ENTRY, resolvedEntry(resolution.model))
-				ctx.ui.notify("Auto is ready for this session", "info")
 				return state
 			})
 		})

--- a/src/extensions/router/model-discovery.test.ts
+++ b/src/extensions/router/model-discovery.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { ModelRuntime } from "@earendil-works/pi-coding-agent"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { withExperimentalFeatures } from "../experimental.js"
+import { installAutoModelDiscoveryAdapter } from "./model-discovery.js"
+
+describe("Auto model discovery adapter", () => {
+	let tempDir: string
+	let runtime: ModelRuntime
+
+	beforeAll(async () => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-auto-discovery-"))
+		const modelsPath = join(tempDir, "models.json")
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-dev": {
+						baseUrl: "https://llm.kimchi.dev/openai/v1",
+						apiKey: "test-key",
+						api: "openai-completions",
+						models: [
+							{ id: "concrete", name: "Concrete" },
+							{ id: "auto", name: "Auto (Kimchi Router)", api: "kimchi-auto" },
+						],
+					},
+				},
+			}),
+		)
+		installAutoModelDiscoveryAdapter()
+		runtime = await ModelRuntime.create({ modelsPath, allowModelNetwork: false })
+	})
+
+	afterAll(() => rmSync(tempDir, { recursive: true, force: true }))
+
+	it("keeps Auto restorable but hides it from discovery without the flag", async () => {
+		await withExperimentalFeatures(false, async () => {
+			expect(runtime.getModel("kimchi-dev", "auto")?.id).toBe("auto")
+			const snapshotRefs = runtime.getAvailableSnapshot().map((model) => `${model.provider}/${model.id}`)
+			expect(snapshotRefs).toContain("kimchi-dev/concrete")
+			expect(snapshotRefs).not.toContain("kimchi-dev/auto")
+			const providerRefs = (await runtime.getAvailable("kimchi-dev")).map((model) => `${model.provider}/${model.id}`)
+			expect(providerRefs).toContain("kimchi-dev/concrete")
+			expect(providerRefs).not.toContain("kimchi-dev/auto")
+		})
+	})
+
+	it("exposes exactly kimchi-dev/auto when experimental features are enabled", async () => {
+		await withExperimentalFeatures(true, async () => {
+			expect(runtime.getAvailableSnapshot().map((model) => `${model.provider}/${model.id}`)).toContain(
+				"kimchi-dev/auto",
+			)
+		})
+	})
+})

--- a/src/extensions/router/model-discovery.ts
+++ b/src/extensions/router/model-discovery.ts
@@ -1,0 +1,30 @@
+import type { Model } from "@earendil-works/pi-ai"
+import { ModelRuntime } from "@earendil-works/pi-coding-agent"
+import { isExperimentalFeaturesEnabled } from "../experimental.js"
+import { isAutoModel } from "./constants.js"
+
+let installed = false
+
+function filterAuto<T extends Model<string>>(models: readonly T[]): T[] {
+	return isExperimentalFeaturesEnabled() ? [...models] : models.filter((model) => !isAutoModel(model))
+}
+
+/**
+ * Keep kimchi-dev/auto in Pi's full catalogue so saved sessions and defaults
+ * can restore it, while removing it from discovery surfaces unless the launch
+ * explicitly enables experimental features.
+ */
+export function installAutoModelDiscoveryAdapter(): void {
+	if (installed) return
+	installed = true
+
+	const getAvailable = ModelRuntime.prototype.getAvailable
+	ModelRuntime.prototype.getAvailable = async function (...args) {
+		return filterAuto(await getAvailable.apply(this, args))
+	}
+
+	const getAvailableSnapshot = ModelRuntime.prototype.getAvailableSnapshot
+	ModelRuntime.prototype.getAvailableSnapshot = function () {
+		return filterAuto(getAvailableSnapshot.call(this))
+	}
+}

--- a/src/extensions/router/router-client.test.ts
+++ b/src/extensions/router/router-client.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { routeQuery } from "./router-client.js"
+import type { RouterConfig } from "./router-config.js"
+
+const config: RouterConfig = { endpoint: "https://llm.kimchi.dev/", apiKey: "same-gateway-key" }
+
+function response(body: unknown, ok = true): Response {
+	return { ok, json: async () => body } as Response
+}
+
+describe("routeQuery", () => {
+	beforeEach(() => vi.useFakeTimers())
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	it("parses the best model and supported probability ranking", async () => {
+		const fetchImpl = vi.fn<typeof fetch>(async () =>
+			response({ best_model: "  kimi-k2.5 ", probabilities: { "kimi-k2.5": 0.9, "glm-5.2": 0.6 } }),
+		)
+
+		await expect(routeQuery("explain this", config, { fetchImpl })).resolves.toEqual({
+			ok: true,
+			recommendation: { bestModel: "kimi-k2.5", probabilities: { "kimi-k2.5": 0.9, "glm-5.2": 0.6 } },
+		})
+		expect(fetchImpl).toHaveBeenCalledWith(
+			new URL("https://llm.kimchi.dev/v1/route"),
+			expect.objectContaining({
+				method: "POST",
+				headers: { "Content-Type": "application/json", "X-API-Key": "same-gateway-key" },
+				body: JSON.stringify({ query: "explain this" }),
+			}),
+		)
+	})
+
+	it.each([
+		["HTTP failure", response({}, false), "http"],
+		["missing recommendation", response({ probabilities: {} }), "malformed"],
+		["missing probabilities", response({ best_model: "kimi-k2.5" }), "malformed"],
+		["null response", response(null), "malformed"],
+		["array response", response([{ best_model: "kimi-k2.5" }]), "malformed"],
+		["non-string recommendation", response({ best_model: 42, probabilities: {} }), "malformed"],
+		["empty recommendation", response({ best_model: "  ", probabilities: {} }), "malformed"],
+		[
+			"non-numeric probabilities",
+			response({ best_model: "kimi-k2.5", probabilities: { "kimi-k2.5": "high" } }),
+			"malformed",
+		],
+	] as const)("classifies malformed %s responses", async (_label, result, reason) => {
+		const fetchImpl = vi.fn<typeof fetch>(async () => result)
+		await expect(routeQuery("task", config, { fetchImpl })).resolves.toEqual({ ok: false, reason })
+	})
+
+	it("distinguishes cancellation from timeout", async () => {
+		const hangingFetch = vi.fn<typeof fetch>(
+			async (_input, init) =>
+				new Promise<Response>((_resolve, reject) =>
+					init?.signal?.addEventListener("abort", () => reject(new Error("aborted"))),
+				),
+		)
+		const external = new AbortController()
+		const cancelled = routeQuery("task", config, { fetchImpl: hangingFetch, signal: external.signal })
+		external.abort()
+		await expect(cancelled).resolves.toEqual({ ok: false, reason: "cancelled" })
+
+		const timedOut = routeQuery("task", config, { fetchImpl: hangingFetch })
+		await vi.advanceTimersByTimeAsync(5100)
+		await expect(timedOut).resolves.toEqual({ ok: false, reason: "timeout" })
+	})
+})

--- a/src/extensions/router/router-client.ts
+++ b/src/extensions/router/router-client.ts
@@ -1,0 +1,65 @@
+import { Type } from "typebox"
+import { Value } from "typebox/value"
+import type { RouterConfig } from "./router-config.js"
+
+const RouterResponseSchema = Type.Object(
+	{
+		best_model: Type.String({ pattern: "\\S" }),
+		probabilities: Type.Record(Type.String({ pattern: "\\S" }), Type.Number()),
+	},
+	{ additionalProperties: true },
+)
+
+export interface RouteRecommendation {
+	bestModel: string
+	probabilities: Readonly<Record<string, number>>
+}
+
+export type RouteQueryResult =
+	| { ok: true; recommendation: RouteRecommendation }
+	| { ok: false; reason: "cancelled" | "timeout" | "network" | "http" | "malformed" }
+
+export const ROUTER_TIMEOUT_MS = 5000
+
+export async function routeQuery(
+	query: string,
+	config: RouterConfig,
+	options: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+): Promise<RouteQueryResult> {
+	const controller = new AbortController()
+	let timedOut = false
+	const timeout = setTimeout(() => {
+		timedOut = true
+		controller.abort()
+	}, ROUTER_TIMEOUT_MS)
+	const onExternalAbort = () => controller.abort()
+	if (options.signal?.aborted) controller.abort()
+	else options.signal?.addEventListener("abort", onExternalAbort, { once: true })
+
+	try {
+		const response = await (options.fetchImpl ?? fetch)(new URL("/v1/route", config.endpoint), {
+			method: "POST",
+			headers: { "Content-Type": "application/json", "X-API-Key": config.apiKey },
+			body: JSON.stringify({ query }),
+			signal: controller.signal,
+		})
+		if (!response.ok) return { ok: false, reason: "http" }
+
+		let data: unknown
+		try {
+			data = await response.json()
+		} catch {
+			return { ok: false, reason: "malformed" }
+		}
+		if (!Value.Check(RouterResponseSchema, data)) return { ok: false, reason: "malformed" }
+		const bestModel = data.best_model.trim()
+		return { ok: true, recommendation: { bestModel, probabilities: data.probabilities } }
+	} catch {
+		if (options.signal?.aborted) return { ok: false, reason: "cancelled" }
+		if (timedOut) return { ok: false, reason: "timeout" }
+		return { ok: false, reason: "network" }
+	} finally {
+		clearTimeout(timeout)
+		options.signal?.removeEventListener("abort", onExternalAbort)
+	}
+}

--- a/src/extensions/router/router-config.ts
+++ b/src/extensions/router/router-config.ts
@@ -1,0 +1,20 @@
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { AUTO_MODEL_PROVIDER } from "./constants.js"
+
+export interface RouterConfig {
+	endpoint: string
+	apiKey: string
+}
+
+const DEFAULT_ROUTER_ENDPOINT = "https://llm.kimchi.dev"
+
+export async function getRouterConfig(
+	modelRegistry: Pick<ModelRegistry, "getApiKeyForProvider">,
+): Promise<RouterConfig | undefined> {
+	const apiKey = (await modelRegistry.getApiKeyForProvider(AUTO_MODEL_PROVIDER))?.trim()
+	if (!apiKey) return undefined
+	return {
+		endpoint: process.env.KIMCHI_ROUTER_ENDPOINT?.trim() || DEFAULT_ROUTER_ENDPOINT,
+		apiKey,
+	}
+}

--- a/src/extensions/router/router-query.test.ts
+++ b/src/extensions/router/router-query.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { resetRedactionConfigCache } from "../pii-redaction/config.js"
-import { prepareRouterQuery } from "./router-query.js"
+import { prepareRouterQuery, ROUTER_IMAGE_METADATA } from "./router-query.js"
 
 afterEach(() => {
 	delete process.env.KIMCHI_REDACTION_ENABLED
@@ -12,17 +12,32 @@ describe("prepareRouterQuery", () => {
 		await expect(prepareRouterQuery(" \n ")).resolves.toEqual({ ok: false, reason: "empty_prompt" })
 	})
 
+	it("appends image metadata to the router copy of a text prompt", async () => {
+		await expect(prepareRouterQuery("Explain this screenshot", { containsImages: true })).resolves.toEqual({
+			ok: true,
+			query: `Explain this screenshot\n\n${ROUTER_IMAGE_METADATA}`,
+		})
+	})
+
+	it("uses image metadata as the router query for an image-only prompt", async () => {
+		await expect(prepareRouterQuery("", { containsImages: true })).resolves.toEqual({
+			ok: true,
+			query: ROUTER_IMAGE_METADATA,
+		})
+	})
+
 	it("redacts the router copy without changing the original prompt", async () => {
 		process.env.KIMCHI_REDACTION_ENABLED = "1"
 		resetRedactionConfigCache()
 		const original = "Contact john.doe@example.com about this task"
 
-		const result = await prepareRouterQuery(original)
+		const result = await prepareRouterQuery(original, { containsImages: true })
 
 		expect(result.ok).toBe(true)
 		if (result.ok) {
 			expect(result.query).not.toContain("john.doe@example.com")
 			expect(result.query).toContain("[REDACTED-EMAIL_ADDRESS]")
+			expect(result.query.endsWith(ROUTER_IMAGE_METADATA)).toBe(true)
 		}
 		expect(original).toContain("john.doe@example.com")
 	})

--- a/src/extensions/router/router-query.test.ts
+++ b/src/extensions/router/router-query.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { resetRedactionConfigCache } from "../pii-redaction/config.js"
+import { prepareRouterQuery } from "./router-query.js"
+
+afterEach(() => {
+	delete process.env.KIMCHI_REDACTION_ENABLED
+	resetRedactionConfigCache()
+})
+
+describe("prepareRouterQuery", () => {
+	it("rejects an empty text prompt", async () => {
+		await expect(prepareRouterQuery(" \n ")).resolves.toEqual({ ok: false, reason: "empty_prompt" })
+	})
+
+	it("redacts the router copy without changing the original prompt", async () => {
+		process.env.KIMCHI_REDACTION_ENABLED = "1"
+		resetRedactionConfigCache()
+		const original = "Contact john.doe@example.com about this task"
+
+		const result = await prepareRouterQuery(original)
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.query).not.toContain("john.doe@example.com")
+			expect(result.query).toContain("[REDACTED-EMAIL_ADDRESS]")
+		}
+		expect(original).toContain("john.doe@example.com")
+	})
+
+	it("keeps the full prompt when it exceeds the former router token budget", async () => {
+		process.env.KIMCHI_REDACTION_ENABLED = "0"
+		resetRedactionConfigCache()
+		const original = `BEGIN-${"routertoken ".repeat(2_000)}-END`
+
+		await expect(prepareRouterQuery(original)).resolves.toEqual({ ok: true, query: original })
+	})
+})

--- a/src/extensions/router/router-query.ts
+++ b/src/extensions/router/router-query.ts
@@ -1,0 +1,19 @@
+import { getRedactionConfig } from "../pii-redaction/config.js"
+import { redactTextOrThrow } from "../pii-redaction/redactor.js"
+
+export type PrepareRouterQueryResult =
+	| { ok: true; query: string }
+	| { ok: false; reason: "empty_prompt" | "redaction_failed" }
+
+export async function prepareRouterQuery(text: string): Promise<PrepareRouterQueryResult> {
+	if (!text.trim()) return { ok: false, reason: "empty_prompt" }
+	let redacted = text
+	if (getRedactionConfig().enabled) {
+		try {
+			redacted = await redactTextOrThrow(text)
+		} catch {
+			return { ok: false, reason: "redaction_failed" }
+		}
+	}
+	return { ok: true, query: redacted }
+}

--- a/src/extensions/router/router-query.ts
+++ b/src/extensions/router/router-query.ts
@@ -1,19 +1,30 @@
 import { getRedactionConfig } from "../pii-redaction/config.js"
 import { redactTextOrThrow } from "../pii-redaction/redactor.js"
 
+export const ROUTER_IMAGE_METADATA = "[Routing metadata: the prompt contains images.]"
+
 export type PrepareRouterQueryResult =
 	| { ok: true; query: string }
 	| { ok: false; reason: "empty_prompt" | "redaction_failed" }
 
-export async function prepareRouterQuery(text: string): Promise<PrepareRouterQueryResult> {
-	if (!text.trim()) return { ok: false, reason: "empty_prompt" }
+export async function prepareRouterQuery(
+	text: string,
+	options: { containsImages?: boolean } = {},
+): Promise<PrepareRouterQueryResult> {
+	const containsImages = options.containsImages === true
+	if (!text.trim() && !containsImages) return { ok: false, reason: "empty_prompt" }
 	let redacted = text
-	if (getRedactionConfig().enabled) {
+	if (text.trim() && getRedactionConfig().enabled) {
 		try {
 			redacted = await redactTextOrThrow(text)
 		} catch {
 			return { ok: false, reason: "redaction_failed" }
 		}
 	}
-	return { ok: true, query: redacted }
+	const query = containsImages
+		? redacted.trim()
+			? `${redacted.trimEnd()}\n\n${ROUTER_IMAGE_METADATA}`
+			: ROUTER_IMAGE_METADATA
+		: redacted
+	return { ok: true, query }
 }

--- a/src/extensions/router/selection.test.ts
+++ b/src/extensions/router/selection.test.ts
@@ -1,0 +1,98 @@
+import type { Model } from "@earendil-works/pi-ai"
+import { describe, expect, it } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import { resolveRecommendation } from "./selection.js"
+
+function model(id: string, input: ("text" | "image")[] = ["text"], provider = "kimchi-dev"): Model<string> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16000,
+	}
+}
+
+function context(available: Model<string>[], scopedModels: Model<string>[] = []) {
+	return createContext({
+		modelRegistry: { getAvailable: () => available },
+		scopedModels: scopedModels.map((entry) => ({ model: entry })),
+	})
+}
+
+function recommendation(bestModel: string, probabilities: Record<string, number> = {}) {
+	return { bestModel, probabilities }
+}
+
+describe("resolveRecommendation", () => {
+	it("accepts the router's exact available concrete kimchi-dev model", () => {
+		const target = model("kimi-k2.5", ["text", "image"])
+		expect(resolveRecommendation(recommendation("kimi-k2.5", { "kimi-k2.5": 0.9 }), context([target]), false)).toEqual({
+			ok: true,
+			model: target,
+		})
+	})
+
+	it.each([
+		["an unknown model", "missing", [model("known")]],
+		["Auto itself", "auto", [model("auto")]],
+		["a same-id model from another provider", "shared", [model("shared", ["text"], "other")]],
+	] as const)("rejects %s", (_label, recommendation, available) => {
+		expect(
+			resolveRecommendation({ bestModel: recommendation, probabilities: {} }, context([...available]), false),
+		).toEqual({
+			ok: false,
+			reason: "unavailable_recommendation",
+		})
+	})
+
+	it("uses the highest-ranked remaining vision model when the best model lacks vision", () => {
+		const textOnly = model("text-only")
+		const vision = model("vision", ["text", "image"])
+		expect(
+			resolveRecommendation(
+				recommendation("text-only", { "text-only": 0.9, vision: 0.7 }),
+				context([textOnly, vision]),
+				true,
+			),
+		).toEqual({
+			ok: true,
+			model: vision,
+		})
+	})
+
+	it("uses the highest-ranked remaining scoped model when the best model is outside the active scope", () => {
+		const recommended = model("recommended")
+		const lowerRanked = model("lower-ranked")
+		const highestRankedScoped = model("highest-ranked-scoped")
+		expect(
+			resolveRecommendation(
+				recommendation("recommended", {
+					recommended: 0.9,
+					"lower-ranked": 0.4,
+					"highest-ranked-scoped": 0.7,
+				}),
+				context([recommended, lowerRanked, highestRankedScoped], [lowerRanked, highestRankedScoped]),
+				false,
+			),
+		).toEqual({
+			ok: true,
+			model: highestRankedScoped,
+		})
+	})
+
+	it("stops when no ranked candidate supports required vision", () => {
+		const textOnly = model("text-only")
+		expect(resolveRecommendation(recommendation("text-only", { "text-only": 0.9 }), context([textOnly]), true)).toEqual(
+			{
+				ok: false,
+				reason: "vision_required",
+			},
+		)
+	})
+})

--- a/src/extensions/router/selection.ts
+++ b/src/extensions/router/selection.ts
@@ -1,0 +1,48 @@
+import type { Model } from "@earendil-works/pi-ai"
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { AUTO_MODEL_PROVIDER, isAutoModel } from "./constants.js"
+import type { RouteRecommendation } from "./router-client.js"
+
+export type RecommendationResult =
+	| { ok: true; model: Model<string> }
+	| { ok: false; reason: "unavailable_recommendation" | "vision_required" }
+
+export function resolveRecommendation(
+	recommendation: RouteRecommendation,
+	ctx: Pick<ExtensionContext, "modelRegistry" | "scopedModels">,
+	requiresVision: boolean,
+): RecommendationResult {
+	const available = ctx.modelRegistry.getAvailable()
+	const availableRefs = new Set(available.map((model) => `${model.provider}\0${model.id}`))
+	const candidates = (ctx.scopedModels.length > 0 ? ctx.scopedModels.map((item) => item.model) : available).filter(
+		(model) => availableRefs.has(`${model.provider}\0${model.id}`),
+	)
+	const eligibleById = new Map(
+		candidates
+			.filter((candidate) => candidate.provider === AUTO_MODEL_PROVIDER && !isAutoModel(candidate))
+			.map((candidate) => [candidate.id, candidate] as const),
+	)
+	const rankedModelIds = [
+		recommendation.bestModel,
+		...Object.entries(recommendation.probabilities)
+			.filter(([modelId]) => modelId !== recommendation.bestModel)
+			.sort(([leftId, leftScore], [rightId, rightScore]) => rightScore - leftScore || leftId.localeCompare(rightId))
+			.map(([modelId]) => modelId),
+	]
+
+	let visionRequired = false
+	const seen = new Set<string>()
+	for (const modelId of rankedModelIds) {
+		if (seen.has(modelId)) continue
+		seen.add(modelId)
+		const model = eligibleById.get(modelId)
+		if (!model) continue
+		if (requiresVision && !model.input.includes("image")) {
+			visionRequired = true
+			continue
+		}
+		return { ok: true, model }
+	}
+
+	return { ok: false, reason: visionRequired ? "vision_required" : "unavailable_recommendation" }
+}

--- a/src/extensions/router/state.test.ts
+++ b/src/extensions/router/state.test.ts
@@ -1,0 +1,158 @@
+import type { Model } from "@earendil-works/pi-ai"
+import type { ModelRegistry, SessionEntry } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import {
+	AUTO_RESOLUTION_ENTRY,
+	clearAutoRoutingState,
+	getAutoRoutingState,
+	getEffectiveModel,
+	hydrateAutoRoutingState,
+	resolvedEntry,
+	resolveEffectiveModel,
+	sessionSelectsAuto,
+	setAutoRoutingState,
+} from "./state.js"
+
+const SESSION_ID = "session-1"
+
+function model(id: string): Model<string> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		baseUrl: "https://example.test",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16000,
+	}
+}
+
+function custom(data: unknown): SessionEntry {
+	return {
+		type: "custom",
+		id: crypto.randomUUID(),
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		customType: AUTO_RESOLUTION_ENTRY,
+		data,
+	}
+}
+
+function modelChange(modelId: string): SessionEntry {
+	return {
+		type: "model_change",
+		id: crypto.randomUUID(),
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		provider: "kimchi-dev",
+		modelId,
+	}
+}
+
+function registry(models: Model<string>[]) {
+	return {
+		find: (provider: string, id: string) => models.find((item) => item.provider === provider && item.id === id),
+		getAvailable: () => models,
+	} as Pick<ModelRegistry, "find" | "getAvailable">
+}
+
+afterEach(() => clearAutoRoutingState(SESSION_ID))
+
+describe("effective model resolution", () => {
+	it("returns a concrete context model without reading the session", () => {
+		const getSessionId = vi.fn(() => SESSION_ID)
+		const ctx = createContext({ model: model("concrete"), sessionManager: { getSessionId } })
+
+		expect(getEffectiveModel(ctx)).toBe(ctx.model)
+		expect(getSessionId).not.toHaveBeenCalled()
+	})
+
+	it("resolves Auto from the context's session", () => {
+		const target = model("routed")
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+		const ctx = createContext({
+			model: model("auto"),
+			sessionManager: { getSessionId: () => SESSION_ID },
+		})
+
+		expect(getEffectiveModel(ctx)).toBe(target)
+	})
+
+	it("supports integration boundaries that have a model and session ID but no context", () => {
+		const target = model("routed")
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+
+		expect(resolveEffectiveModel(model("auto"), SESSION_ID)).toBe(target)
+	})
+})
+
+describe("hydrateAutoRoutingState", () => {
+	it("starts unresolved when the session has no successful selection", () => {
+		expect(hydrateAutoRoutingState(SESSION_ID, [], registry([]))).toEqual({ status: "unresolved" })
+	})
+
+	it("restores a successful concrete resolution", () => {
+		const target = model("kimi-k2.5")
+		const state = hydrateAutoRoutingState(SESSION_ID, [custom(resolvedEntry(target))], registry([target]))
+
+		expect(state).toEqual({ status: "resolved", model: target })
+		expect(getAutoRoutingState(SESSION_ID)).toEqual(state)
+	})
+
+	it("ignores legacy attempt entries because transient routing state is not durable", () => {
+		const state = hydrateAutoRoutingState(SESSION_ID, [custom({ version: 1, status: "attempting" })], registry([]))
+		expect(state).toEqual({ status: "unresolved" })
+	})
+
+	it("does not revive a saved target that is no longer available", () => {
+		const state = hydrateAutoRoutingState(
+			SESSION_ID,
+			[custom({ version: 1, status: "resolved", provider: "kimchi-dev", modelId: "gone" })],
+			registry([]),
+		)
+		expect(state).toEqual({ status: "failed", reason: "unavailable_recommendation" })
+	})
+
+	it("ignores legacy failure entries because failures can be retried", () => {
+		const state = hydrateAutoRoutingState(
+			SESSION_ID,
+			[custom({ version: 1, status: "failed", reason: "timeout" })],
+			registry([]),
+		)
+
+		expect(state).toEqual({ status: "unresolved" })
+	})
+})
+
+describe("sessionSelectsAuto", () => {
+	it("treats persisted routing state as an Auto selection", () => {
+		expect(sessionSelectsAuto([custom(resolvedEntry(model("routed")))])).toBe(true)
+	})
+
+	it("ignores corrupted routing entries", () => {
+		expect(sessionSelectsAuto([custom({ version: 1, status: "not-real" })])).toBe(false)
+	})
+
+	it("does not treat legacy attempts or failures as successful Auto selections", () => {
+		expect(
+			sessionSelectsAuto([
+				custom({ version: 1, status: "attempting" }),
+				custom({ version: 1, status: "failed", reason: "timeout" }),
+			]),
+		).toBe(false)
+	})
+
+	it("lets a later concrete model selection override Auto", () => {
+		expect(sessionSelectsAuto([custom(resolvedEntry(model("routed"))), modelChange("override")])).toBe(false)
+	})
+
+	it("recognizes a later explicit switch back to Auto", () => {
+		expect(
+			sessionSelectsAuto([custom(resolvedEntry(model("routed"))), modelChange("override"), modelChange("auto")]),
+		).toBe(true)
+	})
+})

--- a/src/extensions/router/state.ts
+++ b/src/extensions/router/state.ts
@@ -9,6 +9,7 @@ export type AutoFailureReason =
 	| "empty_prompt"
 	| "interrupted"
 	| "malformed"
+	| "model_update_failed"
 	| "network"
 	| "no_auth"
 	| "redaction_failed"

--- a/src/extensions/router/state.ts
+++ b/src/extensions/router/state.ts
@@ -1,0 +1,138 @@
+import type { Model } from "@earendil-works/pi-ai"
+import type { ExtensionContext, ModelRegistry, SessionEntry } from "@earendil-works/pi-coding-agent"
+import { isAutoModel } from "./constants.js"
+
+export const AUTO_RESOLUTION_ENTRY = "kimchi_auto_resolution"
+
+export type AutoFailureReason =
+	| "cancelled"
+	| "empty_prompt"
+	| "interrupted"
+	| "malformed"
+	| "network"
+	| "no_auth"
+	| "redaction_failed"
+	| "router_http"
+	| "timeout"
+	| "unavailable_recommendation"
+	| "vision_required"
+
+export type AutoRoutingState =
+	| { status: "unresolved" }
+	| { status: "attempting" }
+	| { status: "resolved"; model: Model<string> }
+	| { status: "failed"; reason: AutoFailureReason }
+
+type PersistedAutoResolution = { version: 1; status: "resolved"; provider: string; modelId: string }
+
+const stateBySession = new Map<string, AutoRoutingState>()
+
+export function getAutoRoutingState(sessionId: string | undefined): AutoRoutingState {
+	if (!sessionId) return { status: "failed", reason: "interrupted" }
+	return stateBySession.get(sessionId) ?? { status: "unresolved" }
+}
+
+export function setAutoRoutingState(sessionId: string, state: AutoRoutingState): void {
+	stateBySession.set(sessionId, state)
+}
+
+export function clearAutoRoutingState(sessionId: string): void {
+	stateBySession.delete(sessionId)
+}
+
+/**
+ * Pi restores the model recorded on the last assistant message. Auto messages
+ * name their concrete target, so use explicit selection entries and Auto's
+ * persisted state to recover the user-facing model instead.
+ */
+export function sessionSelectsAuto(entries: readonly SessionEntry[]): boolean {
+	let selected = false
+	for (const entry of entries) {
+		if (
+			entry.type === "custom" &&
+			entry.customType === AUTO_RESOLUTION_ENTRY &&
+			isPersistedAutoResolution(entry.data)
+		) {
+			selected = true
+		} else if (entry.type === "model_change") {
+			selected = isAutoModel({ provider: entry.provider, id: entry.modelId })
+		}
+	}
+	return selected
+}
+
+type EffectiveModelContext<TApi extends string> = Pick<ExtensionContext, "sessionManager"> & {
+	model: Model<TApi> | undefined
+}
+
+/**
+ * Returns the concrete model that handles requests for this extension context.
+ *
+ * Extensions should use this instead of reading `ctx.model` when their behavior
+ * depends on model identity or capabilities. After Auto routes a session,
+ * `ctx.model` intentionally remains the user-selected `kimchi-dev/auto` model;
+ * its concrete target is stored separately in that session's routing state.
+ * Accepting the context keeps the selected model paired with its owning session
+ * and avoids accidentally resolving Auto against another session.
+ *
+ * Use {@link resolveEffectiveModel} only at integration boundaries that do not
+ * receive an `ExtensionContext`.
+ */
+export function getEffectiveModel<TApi extends string>(ctx: EffectiveModelContext<TApi>): Model<TApi> | undefined {
+	if (!isAutoModel(ctx.model)) return ctx.model
+	return resolveEffectiveModel(ctx.model, ctx.sessionManager.getSessionId())
+}
+
+/** Low-level Auto resolver for integration boundaries without an extension context. */
+export function resolveEffectiveModel<TApi extends string>(
+	model: Model<TApi> | undefined,
+	sessionId: string,
+): Model<TApi> | undefined {
+	if (!isAutoModel(model)) return model
+	const state = getAutoRoutingState(sessionId)
+	return state.status === "resolved" ? (state.model as Model<TApi>) : model
+}
+
+function isPersistedAutoResolution(data: unknown): data is PersistedAutoResolution {
+	return (
+		data !== null &&
+		typeof data === "object" &&
+		"version" in data &&
+		data.version === 1 &&
+		"status" in data &&
+		data.status === "resolved" &&
+		"provider" in data &&
+		typeof data.provider === "string" &&
+		"modelId" in data &&
+		typeof data.modelId === "string"
+	)
+}
+
+export function hydrateAutoRoutingState(
+	sessionId: string,
+	entries: readonly SessionEntry[],
+	modelRegistry: Pick<ModelRegistry, "find" | "getAvailable">,
+): AutoRoutingState {
+	const entry = entries.findLast(
+		(candidate) =>
+			candidate.type === "custom" &&
+			candidate.customType === AUTO_RESOLUTION_ENTRY &&
+			isPersistedAutoResolution(candidate.data),
+	)
+	const data = entry?.type === "custom" ? entry.data : undefined
+	let state: AutoRoutingState = { status: "unresolved" }
+	if (isPersistedAutoResolution(data)) {
+		const model = modelRegistry.find(data.provider, data.modelId)
+		const available = modelRegistry
+			.getAvailable()
+			.some((candidate) => candidate.provider === data.provider && candidate.id === data.modelId)
+		state =
+			model && available ? { status: "resolved", model } : { status: "failed", reason: "unavailable_recommendation" }
+	}
+	stateBySession.set(sessionId, state)
+	return state
+}
+
+export function resolvedEntry(model: Pick<Model<string>, "provider" | "id">): PersistedAutoResolution {
+	return { version: 1, status: "resolved", provider: model.provider, modelId: model.id }
+}

--- a/src/extensions/router/summarization-model.test.ts
+++ b/src/extensions/router/summarization-model.test.ts
@@ -1,0 +1,50 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { clearAutoRoutingState, setAutoRoutingState } from "./state.js"
+import { installAutoSummarizationModelAdapter } from "./summarization-model.js"
+
+const SESSION_ID = "auto-summary-session"
+
+function model(id: string, api: Api): Model<Api> {
+	return {
+		id,
+		name: id,
+		api,
+		provider: "kimchi-dev",
+		baseUrl: "https://llm.kimchi.dev/openai/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_000,
+	}
+}
+
+afterEach(() => clearAutoRoutingState(SESSION_ID))
+
+describe("Auto summarization model adapter", () => {
+	it("uses the session's resolved concrete model before Pi assigns an isolated summary request id", async () => {
+		const auto = model("auto", "kimchi-auto")
+		const target = model("kimi-k2.5", "openai-completions")
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+		installAutoSummarizationModelAdapter()
+
+		const getAuth = vi.fn(async (requestModel: Model<Api>) => ({ auth: { apiKey: "key" }, model: requestModel }))
+		const session = {
+			agent: { streamFunction: vi.fn() },
+			sessionManager: { getSessionId: () => SESSION_ID },
+			_modelRuntime: { getAuth },
+		} as unknown as AgentSession
+		const resolver = (
+			AgentSession.prototype as unknown as {
+				_getSummarizationRequestAuth(model: Model<Api>): Promise<{ model: Model<Api> }>
+			}
+		)._getSummarizationRequestAuth
+
+		const result = await resolver.call(session, auto)
+
+		expect(getAuth).toHaveBeenCalledWith(target)
+		expect(result.model).toBe(target)
+	})
+})

--- a/src/extensions/router/summarization-model.ts
+++ b/src/extensions/router/summarization-model.ts
@@ -1,0 +1,28 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { resolveEffectiveModel } from "./state.js"
+
+type SummarizationAuthResolver = (this: AgentSession, model: Model<Api>) => Promise<unknown>
+
+interface AgentSessionSummarizationPrototype {
+	_getSummarizationRequestAuth: SummarizationAuthResolver
+}
+
+let installed = false
+
+/**
+ * Pi gives compaction and branch-summary calls isolated request session IDs.
+ * Resolve their request model from the owning AgentSession before that ID is
+ * replaced, so an Auto session summarizes with its saved concrete target.
+ */
+export function installAutoSummarizationModelAdapter(): void {
+	if (installed) return
+	installed = true
+
+	const prototype = AgentSession.prototype as unknown as AgentSessionSummarizationPrototype
+	const getSummarizationRequestAuth = prototype._getSummarizationRequestAuth
+	prototype._getSummarizationRequestAuth = function (model) {
+		const effectiveModel = resolveEffectiveModel(model, this.sessionManager.getSessionId())
+		return getSummarizationRequestAuth.call(this, effectiveModel ?? model)
+	}
+}

--- a/src/extensions/strip-images.test.ts
+++ b/src/extensions/strip-images.test.ts
@@ -19,6 +19,7 @@ const createMockCtx = (overrides: Record<string, unknown> = {}) => ({
 		getAvailable: () => [{ provider: "kimchi-dev", id: "vision-model", input: ["text", "image"] }],
 		getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test-key", headers: {} }),
 	},
+	sessionManager: overrides.sessionManager ?? { getSessionId: () => "strip-images-session" },
 	ui: { notify: mockNotify },
 })
 
@@ -119,6 +120,32 @@ describe("strip-images extension", () => {
 			await handler([], ctx)
 
 			expect(mockNotify).toHaveBeenCalledWith(expect.stringContaining("no API key available"), "error")
+		})
+
+		it("uses a concrete vision model instead of dispatching image analysis through Auto", async () => {
+			vi.mocked(getLatestMessages).mockReturnValue([
+				{ role: "user", content: [{ type: "image", data: "image-data", mimeType: "image/png" }] },
+			] as never)
+			completeMock.mockReturnValue({
+				content: [{ type: "text", text: "description" }],
+				stopReason: "stop",
+			})
+			const ctx = createMockCtx({
+				model: { provider: "kimchi-dev", id: "auto", input: ["text", "image"] },
+				modelRegistry: {
+					getAvailable: () => [
+						{ provider: "kimchi-dev", id: "auto", input: ["text", "image"] },
+						{ provider: "kimchi-dev", id: "vision-model", input: ["text", "image"] },
+					],
+					getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "key", headers: {} }),
+				},
+			})
+			stripImagesExtension(mockPi as never)
+
+			const handler = mockPi.getHandler("strip-images") as (args: string[], ctx: unknown) => Promise<void>
+			await handler([], ctx)
+
+			expect(completeMock.mock.calls[0]?.[0]).toMatchObject({ id: "vision-model" })
 		})
 
 		it("preserves the explicit image-analysis token limit", async () => {

--- a/src/extensions/strip-images.ts
+++ b/src/extensions/strip-images.ts
@@ -9,6 +9,8 @@ import {
 	sessionHasImages,
 	storeImageDescription,
 } from "./model-guard.js"
+import { isAutoModel } from "./router/constants.js"
+import { getEffectiveModel } from "./router/state.js"
 
 const IMAGE_DESCRIPTION_PROMPT = "Describe this image concisely. Include key visual details, text, layout."
 
@@ -44,14 +46,15 @@ function collectImages(messages: ReturnType<typeof getLatestMessages>): Map<stri
  */
 function findVisionModel(ctx: ExtensionContext): Model<Api> | undefined {
 	// Check if current model supports vision
-	if (ctx.model?.input?.includes("image")) {
-		return ctx.model as Model<Api>
+	const currentModel = getEffectiveModel(ctx)
+	if (currentModel?.input.includes("image") && !isAutoModel(currentModel)) {
+		return currentModel
 	}
 
 	// Find first vision-capable model from available models
 	const available = ctx.modelRegistry?.getAvailable() ?? []
 	for (const model of available) {
-		if (model.input?.includes("image")) {
+		if (model.input?.includes("image") && !isAutoModel(model)) {
 			return model as Model<Api>
 		}
 	}

--- a/src/extensions/tags.ts
+++ b/src/extensions/tags.ts
@@ -12,7 +12,7 @@
 
 import { homedir } from "node:os"
 import { resolve } from "node:path"
-import type { Api, Model } from "@earendil-works/pi-ai"
+import type { Model } from "@earendil-works/pi-ai"
 import type {
 	CustomEntry,
 	ExtensionAPI,
@@ -27,6 +27,7 @@ import { Type } from "typebox"
 import { readJson } from "../config/json.js"
 import { readConfigSetting } from "../config/settings.js"
 import type { ThinkingLevel } from "./agents/personas/types.js"
+import { getEffectiveModel } from "./router/state.js"
 import { isStaleCtxError } from "./stale-ctx.js"
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -623,9 +624,9 @@ export default function tagsExtension(pi: ExtensionAPI) {
 		// Tags are a Cast AI-specific API field; skip for other providers.
 		// If a request from a torn-down session reaches us after `/new` (etc.),
 		// any ctx getter throws via assertActive — bail silently in that case.
-		let model: Model<Api> | undefined
+		let model: Model<string> | undefined
 		try {
-			model = ctx.model ?? undefined
+			model = getEffectiveModel(ctx)
 		} catch (err) {
 			if (isStaleCtxError(err)) return
 			throw err

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
+	injectAutoModel,
 	injectExperimentalProvider,
 	isTransientModelsError,
 	ModelsFetchError,
@@ -663,6 +664,19 @@ describe("updateModelsConfig", () => {
 		expect(fetch).not.toHaveBeenCalled()
 	})
 
+	it("does not advertise the virtual Auto model as cached concrete metadata", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ models: [KIMI] }),
+		} as Response)
+		await updateModelsConfig(modelsJsonPath, "test-key")
+		injectAutoModel(modelsJsonPath)
+
+		const result = await updateModelsConfig(modelsJsonPath, "")
+
+		expect(result.models.map((model) => model.slug)).toEqual(["kimi-k2.5"])
+	})
+
 	it("returns empty models without fetching when apiKey is empty and no cache exists", async () => {
 		const result = await updateModelsConfig(modelsJsonPath, "")
 
@@ -811,6 +825,67 @@ describe("updateModelsConfig", () => {
 		const model = result.models.find((m) => m.slug === "old-model")
 		expect(model?.status).toBe("deprecated")
 		expect(model?.replacement).toBe("new-model")
+	})
+})
+
+describe("injectAutoModel", () => {
+	let tempDir: string
+	let modelsJsonPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-auto-model-test-"))
+		modelsJsonPath = join(tempDir, "models.json")
+		writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					"kimchi-dev": {
+						baseUrl: "https://llm.kimchi.dev/openai/v1",
+						api: "openai-completions",
+						models: [
+							{
+								id: "kimi-k2.5",
+								name: "Kimi K2.5",
+								provider: "ai-enabler",
+								reasoning: true,
+								input: ["text", "image"],
+								contextWindow: 262144,
+								maxTokens: 32768,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							},
+						],
+					},
+				},
+			}),
+		)
+	})
+
+	afterEach(() => rmSync(tempDir, { recursive: true, force: true }))
+
+	it("adds exactly kimchi-dev/auto with a model-level API", () => {
+		const providerIds = Object.keys(JSON.parse(readFileSync(modelsJsonPath, "utf-8")).providers)
+		injectAutoModel(modelsJsonPath)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const auto = config.providers["kimchi-dev"].models.find((model: { id: string }) => model.id === "auto")
+
+		expect(auto).toMatchObject({
+			id: "auto",
+			name: "Auto (Kimchi Router)",
+			api: "kimchi-auto",
+			reasoning: true,
+			thinkingLevelMap: { off: "none", max: "max" },
+			input: ["text", "image"],
+		})
+		expect(Object.keys(config.providers)).toEqual(providerIds)
+	})
+
+	it("upserts Auto without duplicates", () => {
+		injectAutoModel(modelsJsonPath)
+		injectAutoModel(modelsJsonPath)
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const autoModels = config.providers["kimchi-dev"].models.filter((model: { id: string }) => model.id === "auto")
+
+		expect(autoModels).toHaveLength(1)
 	})
 })
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import type { ThinkingLevel } from "./extensions/agents/personas/types.js"
+import { AUTO_MODEL_API, AUTO_MODEL_ID, AUTO_MODEL_NAME } from "./extensions/router/constants.js"
 import { getVersion } from "./utils.js"
 
 const KIMCHI_API = "https://llm.kimchi.dev"
@@ -186,6 +187,27 @@ export interface PiModelConfig {
 	headers?: Record<string, string>
 }
 
+function autoModelConfig(models: ModelMetadata[]): PiModelConfig {
+	const rootModels = models.filter((model) => model.provider === "ai-enabler")
+	const contextWindow = Math.min(...rootModels.map((model) => model.limits.context_window), 128_000)
+	const maxTokens = Math.min(...rootModels.map((model) => model.limits.max_output_tokens), 16_384)
+	return {
+		id: AUTO_MODEL_ID,
+		name: AUTO_MODEL_NAME,
+		api: AUTO_MODEL_API,
+		provider: "ai-enabler",
+		// Auto is virtual, but Pi reads this capability to expose the session's
+		// reasoning control. The Auto provider applies that preference only when
+		// the resolved concrete model supports it.
+		reasoning: true,
+		thinkingLevelMap: { off: "none", max: "max" },
+		input: ["text", "image"],
+		contextWindow,
+		maxTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	}
+}
+
 function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// TODO: our LiteLLM gateway does not support `thinking.type.enabled` for Anthropic >Opus 4.6 models
 	// Therefore, we disable it for now. Revisit, once we upgrade our LiteLLM version.
@@ -299,7 +321,7 @@ function readCachedMetadata(modelsJsonPath: string): ModelMetadata[] | undefined
 			if (!name.startsWith("kimchi-dev")) continue
 			const models = (provider as { models?: PiModelConfig[] }).models
 			if (!Array.isArray(models) || models.length === 0) continue
-			result.push(...models.map(modelToMetadata))
+			result.push(...models.filter((model) => model.id !== AUTO_MODEL_ID).map(modelToMetadata))
 		}
 		if (result.length === 0) return undefined
 		return result
@@ -366,6 +388,29 @@ export function injectExperimentalProvider(modelsJsonPath: string, apiKey: strin
 		apiKey,
 	}
 	config.providers = { ...config.providers, "kimchi-experimental": experimental }
+	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
+}
+
+/**
+ * Upsert the virtual kimchi-dev/auto model after the managed provider refresh.
+ * It is always present so saved sessions/defaults remain restorable; the
+ * experimental flag only controls whether Pi exposes it in discovery lists.
+ */
+export function injectAutoModel(modelsJsonPath: string): void {
+	if (!existsSync(modelsJsonPath)) return
+	let config: { providers?: Record<string, { models?: PiModelConfig[] }> }
+	try {
+		config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+	} catch {
+		return
+	}
+	const kimchiDev = config.providers?.["kimchi-dev"]
+	if (!kimchiDev || !Array.isArray(kimchiDev.models)) return
+	const concreteMetadata = kimchiDev.models.filter((model) => model.id !== AUTO_MODEL_ID).map(modelToMetadata)
+	kimchiDev.models = [
+		...kimchiDev.models.filter((model) => model.id !== AUTO_MODEL_ID),
+		autoModelConfig(concreteMetadata),
+	]
 	writeFileSync(modelsJsonPath, JSON.stringify(config, null, "\t"), "utf-8")
 }
 

--- a/tests/e2e/acp/auto-model.test.ts
+++ b/tests/e2e/acp/auto-model.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest"
+import type { AcpFixture } from "./support/acp-fixture.js"
+import { startAcpFixture } from "./support/acp-fixture.js"
+import { prompt } from "./support/scenarios.js"
+
+const MODELS = [
+	{
+		slug: "routed",
+		displayName: "Fake Routed",
+		provider: "ai-enabler",
+		input: ["text"] as const,
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	},
+]
+
+const ROUTED_ROUTER_RESPONSE = { best_model: "routed", probabilities: { routed: 1 } }
+
+describe("ACP Auto model", () => {
+	let fixture: AcpFixture | undefined
+
+	afterEach(async () => {
+		await fixture?.stop()
+	})
+
+	it("keeps a saved Auto model working while hiding it without the experimental flag", async () => {
+		fixture = await startAcpFixture({
+			artifactName: "acp-auto-saved-default",
+			providerId: "kimchi-dev",
+			defaultProvider: "kimchi-dev",
+			defaultModel: "auto",
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			responses: [{ stream: ["ACP Auto works."] }],
+		})
+
+		const session = await fixture.conn.newSession({ cwd: fixture.workDir, mcpServers: [] })
+		expect(session.models?.currentModelId).toBe("kimchi-dev/auto")
+		expect(session.models?.availableModels.map((model) => model.modelId)).not.toContain("kimchi-dev/auto")
+
+		const result = await prompt(fixture, session.sessionId, "Use the saved Auto model")
+		expect(result.stopReason).toBe("end_turn")
+		expect(result.chunks).toContain("ACP Auto works.")
+		expect(fixture.fake.requests.filter((request) => request.url.startsWith("/v1/route"))).toHaveLength(1)
+		const chat = fixture.fake.requests.filter((request) => request.url.startsWith("/openai/v1/chat/completions"))
+		expect(chat).toHaveLength(1)
+		expect(chat[0]?.body).toMatchObject({ model: "routed" })
+	})
+
+	it("advertises Auto when experimental features are enabled", async () => {
+		fixture = await startAcpFixture({
+			artifactName: "acp-auto-visible-with-flag",
+			providerId: "kimchi-dev",
+			defaultProvider: "kimchi-dev",
+			defaultModel: "routed",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			responses: [],
+		})
+
+		const session = await fixture.conn.newSession({ cwd: fixture.workDir, mcpServers: [] })
+		expect(session.models?.availableModels.map((model) => model.modelId)).toContain("kimchi-dev/auto")
+	})
+})

--- a/tests/e2e/acp/support/acp-fixture.ts
+++ b/tests/e2e/acp/support/acp-fixture.ts
@@ -14,8 +14,11 @@ import type { ClientSideConnection } from "@agentclientprotocol/sdk"
 import * as acp from "@agentclientprotocol/sdk"
 import { onTestFailed } from "vitest"
 import {
+	DEFAULT_MODEL,
+	type FakeModel,
 	type FakeOpenAiServer,
 	type FakeResponseScript,
+	resolveModels,
 	startFakeOpenAiServer,
 } from "../../tui/support/fake-openai-server.js"
 
@@ -53,6 +56,12 @@ export interface AcpFixture {
 
 export interface AcpFixtureOptions {
 	responses: FakeResponseScript[]
+	models?: FakeModel[]
+	routerResponses?: unknown[]
+	providerId?: string
+	defaultProvider?: string
+	defaultModel?: string
+	extraArgs?: string[]
 	/**
 	 * Extra capabilities merged on top of the always-present fs baseline.
 	 * Defaults to `{}` (just the fs baseline — matches `verify-acp.mjs`).
@@ -201,8 +210,23 @@ function textOf(update: acp.SessionUpdate): string | undefined {
 }
 
 export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<AcpFixture> {
-	const { artifactName, responses, clientCapabilities, clientMeta, extensionPath } = options
-	const fake = await startFakeOpenAiServer({ responses })
+	const {
+		artifactName,
+		responses,
+		models,
+		routerResponses,
+		providerId = "fake",
+		defaultProvider,
+		defaultModel,
+		extraArgs = [],
+		clientCapabilities,
+		clientMeta,
+		extensionPath,
+	} = options
+	const fake = await startFakeOpenAiServer({ responses, models, routerResponses })
+	const configuredModels = models
+		? resolveModels(models)
+		: [{ ...DEFAULT_MODEL, contextWindow: 64_000, maxTokens: 1024 }]
 	const homeDir = mkdtempSync(join(tmpdir(), "kimchi-acp-home-"))
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-acp-work-"))
 
@@ -282,24 +306,22 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 			JSON.stringify(
 				{
 					providers: {
-						fake: {
+						[providerId]: {
 							baseUrl: `${fake.baseUrl}/openai/v1`,
 							apiKey: "fake",
 							api: "openai-completions",
 							authHeader: true,
 							headers: { "User-Agent": "kimchi/acp-e2e" },
-							models: [
-								{
-									id: "basic",
-									name: "Fake Basic",
-									reasoning: false,
-									input: ["text"],
-									contextWindow: 64_000,
-									maxTokens: 1024,
-									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-									provider: "openai",
-								},
-							],
+							models: configuredModels.map((model) => ({
+								id: model.slug,
+								name: model.displayName,
+								reasoning: model.reasoning,
+								input: model.input,
+								contextWindow: model.contextWindow,
+								maxTokens: model.maxTokens,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								provider: model.provider,
+							})),
 						},
 					},
 				},
@@ -308,13 +330,20 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 			),
 			"utf-8",
 		)
+		if (defaultProvider && defaultModel) {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ defaultProvider, defaultModel }, null, "\t"),
+				"utf-8",
+			)
+		}
 
 		// pi-coding-agent auto-loads `${agentDir}/extensions/*.js` on every session.
 		const extPath = extensionPath ?? TEST_EXTENSION_PATH
 		const extSource = readFileSync(extPath, "utf-8")
 		writeFileSync(join(agentDir, "extensions", "test-ui-extension.js"), extSource, "utf-8")
 
-		proc = spawn(BINARY_PATH, ["--mode", "acp"], {
+		proc = spawn(BINARY_PATH, ["--mode", "acp", ...extraArgs], {
 			stdio: ["pipe", "pipe", "inherit"],
 			env: {
 				...process.env,
@@ -328,6 +357,7 @@ export async function startAcpFixture(options: StartAcpFixtureOptions): Promise<
 				// deterministic.
 				KIMCHI_NO_UPDATE_CHECK: "1",
 				KIMCHI_RTK_AUTO_INSTALL: "0",
+				KIMCHI_ROUTER_ENDPOINT: fake.baseUrl,
 			},
 			cwd: workDir,
 		})

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -1,0 +1,517 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import {
+	fullText,
+	INPUT_TIMEOUT_MS,
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	viewText,
+	waitForText,
+	waitForTurnToSettle,
+} from "./support/assertions.js"
+import {
+	createKimchiFixture,
+	launchKimchi,
+	PROMPT_READY,
+	runKimchiSession,
+	stopKimchi,
+	TUI_TEST_CONFIG,
+} from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const MODELS = [
+	{
+		slug: "routed",
+		displayName: "Fake Routed",
+		provider: "ai-enabler",
+		input: ["text"] as const,
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	},
+]
+
+const MODELS_WITH_OVERRIDE = [
+	...MODELS,
+	{
+		slug: "override",
+		displayName: "Fake Override",
+		provider: "ai-enabler",
+		input: ["text"] as const,
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	},
+]
+
+const ROUTED_ROUTER_RESPONSE = { best_model: "routed", probabilities: { routed: 1 } }
+
+const MODELS_WITH_RANKED_FALLBACK = [
+	...MODELS,
+	{
+		slug: "fallback",
+		displayName: "Fake Ranked Fallback",
+		provider: "ai-enabler",
+		input: ["text"] as const,
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	},
+]
+
+function requestsTo<T extends { url: string }>(fixture: { fake: { requests: T[] } }, path: string): T[] {
+	return fixture.fake.requests.filter((request) => request.url.startsWith(path))
+}
+
+async function waitForRequest(
+	fixture: { fake: { requests: { url: string }[] } },
+	path: string,
+	minimumCount = 1,
+	timeoutMs = INPUT_TIMEOUT_MS,
+): Promise<void> {
+	const startedAt = Date.now()
+	while (Date.now() - startedAt < timeoutMs) {
+		if (requestsTo(fixture, path).length >= minimumCount) return
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	throw new Error(`Timed out waiting for a request to ${path}`)
+}
+
+async function waitForAbortedRequest(
+	fixture: { fake: { requests: { url: string; aborted: boolean }[] } },
+	path: string,
+	timeoutMs = 2_000,
+): Promise<void> {
+	const startedAt = Date.now()
+	while (Date.now() - startedAt < timeoutMs) {
+		if (requestsTo(fixture, path).some((request) => request.aborted)) return
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	throw new Error(`Timed out waiting for the request to ${path} to be aborted`)
+}
+
+function requestModel(body: unknown): string | undefined {
+	return body && typeof body === "object" && "model" in body && typeof body.model === "string" ? body.model : undefined
+}
+
+function agentCall(id: string, model?: string, runInBackground = false) {
+	return {
+		id,
+		function: {
+			name: "Agent",
+			arguments: JSON.stringify({
+				prompt: "Return the words child route complete",
+				description: "verify child routing",
+				subagent_type: "General-Purpose",
+				...(model ? { model } : {}),
+				...(runInBackground ? { run_in_background: true } : {}),
+			}),
+		},
+	}
+}
+
+test("/model autocomplete shows and selects Auto when experimental features are enabled", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-autocomplete-selection",
+			providerId: "kimchi-dev",
+			initialModel: "routed",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			responses: [],
+		},
+		async (_fixture, trace) => {
+			terminal.write("/model")
+			await waitForText(terminal, "/model", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			terminal.submit("")
+			await waitForText(terminal, "Only showing models from configured providers", {
+				timeoutMs: INPUT_TIMEOUT_MS,
+				full: false,
+			})
+			trace.step("model autocomplete open")
+
+			terminal.write("auto")
+			await waitForText(terminal, "Auto (Kimchi Router)", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			expect(viewText(terminal)).toMatch(/→ auto \[kimchi-dev\]/)
+			trace.step("Auto highlighted")
+
+			terminal.submit("")
+			await waitForText(terminal, "Model: auto", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			trace.step("Auto selected")
+		},
+	)
+})
+
+test("Auto routes once and keeps the selected concrete model for the session", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-routes-once",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			responses: [{ stream: ["First routed reply."] }, { stream: ["Second routed reply."] }],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Choose a model for this session")
+			await waitForText(terminal, "First routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("first prompt routed")
+
+			terminal.submit("Keep using it")
+			await waitForText(terminal, "Second routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(2)
+			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed"])
+
+			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8"))
+			expect(settings.defaultProvider).toBe("kimchi-dev")
+			expect(settings.defaultModel).toBe("auto")
+		},
+	)
+})
+
+test("Auto uses the highest-ranked eligible model when the best model is outside the active scope", async ({
+	terminal,
+}) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-ranked-scoped-fallback",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features", "--models", "kimchi-dev/fallback"],
+			models: MODELS_WITH_RANKED_FALLBACK,
+			routerResponses: [{ best_model: "routed", probabilities: { routed: 0.9, fallback: 0.7 } }],
+			responses: [{ stream: ["Ranked fallback reply."] }],
+		},
+		async (fixture) => {
+			terminal.submit("Use the first eligible router-ranked model")
+			await waitForText(terminal, "Ranked fallback reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (fallback)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(1)
+			expect(requestModel(chatRequests[0]?.body)).toBe("fallback")
+		},
+	)
+})
+
+test("Auto stops an unavailable-router prompt and retries when the user submits again", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-router-unavailable",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [undefined, ROUTED_ROUTER_RESPONSE],
+			responses: [{ stream: ["Router retry succeeded."] }],
+		},
+		async (fixture) => {
+			terminal.submit("Try while the router is unavailable")
+			await waitForText(terminal, "Auto is unavailable", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "/model", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			expect(requestsTo(fixture, "/openai/v1/chat/completions")).toHaveLength(0)
+
+			terminal.submit("Try the router again")
+			await waitForText(terminal, "Router retry succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(1)
+			expect(requestModel(chatRequests[0]?.body)).toBe("routed")
+		},
+	)
+})
+
+test("Escape cancels an in-flight router request and the corrected prompt can route", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-router-cancellation",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			responses: [{ stream: ["Corrected prompt succeeded."] }],
+			routerResponses: [ROUTED_ROUTER_RESPONSE, ROUTED_ROUTER_RESPONSE],
+			stallRouterRequestNumber: 1,
+		},
+		async (fixture, trace) => {
+			terminal.submit("Cancel this routing request")
+			await waitForRequest(fixture, "/v1/route")
+			trace.step("router request in flight")
+
+			terminal.keyEscape()
+			await waitForAbortedRequest(fixture, "/v1/route")
+			await waitForText(terminal, PROMPT_READY, { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			trace.step("Escape restored the prompt")
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			expect(requestsTo(fixture, "/openai/v1/chat/completions")).toHaveLength(0)
+
+			terminal.submit("Use this corrected prompt instead")
+			await waitForText(terminal, "Corrected prompt succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(1)
+			expect(requestModel(chatRequests[0]?.body)).toBe("routed")
+		},
+	)
+})
+
+test("Escape cancels an inherited Auto child while it is routing", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-child-router-cancellation",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE, ROUTED_ROUTER_RESPONSE],
+			stallRouterRequestNumber: 2,
+			responses: [{ toolCalls: [agentCall("call_cancelled_auto_child")] }],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Delegate and then let me cancel the child")
+			await waitForRequest(fixture, "/v1/route", 2, STREAM_TIMEOUT_MS)
+			trace.step("child router request in flight")
+
+			terminal.keyEscape()
+			await waitForAbortedRequest(fixture, "/v1/route")
+			await waitForText(terminal, PROMPT_READY, { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			trace.step("Escape restored the parent prompt")
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			expect(requestsTo(fixture, "/openai/v1/chat/completions")).toHaveLength(1)
+		},
+	)
+})
+
+test("a saved Auto default keeps working without the experimental flag", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-saved-default",
+			providerId: "kimchi-dev",
+			initialModel: false,
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			responses: [{ stream: ["Saved Auto still works."] }],
+			seedHome: (homeDir) => {
+				const settingsPath = join(homeDir, ".config", "kimchi", "harness", "settings.json")
+				const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
+				writeFileSync(
+					settingsPath,
+					JSON.stringify({ ...settings, defaultProvider: "kimchi-dev", defaultModel: "auto" }, null, "\t"),
+				)
+			},
+		},
+		async (fixture) => {
+			terminal.submit("Use my saved model")
+			await waitForText(terminal, "Saved Auto still works.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(1)
+			expect(requestModel(chatRequests[0]?.body)).toBe("routed")
+		},
+	)
+})
+
+test("resuming an Auto session reuses its concrete resolution without the flag", async ({ terminal }) => {
+	const exitMarker = "__KIMCHI_AUTO_RESUME_FIRST_SESSION_EXITED__"
+	const fixture = await createKimchiFixture({
+		providerId: "kimchi-dev",
+		initialModel: "auto",
+		models: MODELS,
+		routerResponses: [ROUTED_ROUTER_RESPONSE],
+		responses: [{ stream: ["Initial Auto reply."] }, { stream: ["Resumed Auto reply."] }],
+	})
+
+	try {
+		launchKimchi(terminal, fixture, ["--enable-experimental-features"], fixture.seedEnv, { exitMarker })
+		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+
+		terminal.submit("Resolve Auto now")
+		await waitForText(terminal, "Initial Auto reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+		terminal.submit("/session")
+		await waitForText(terminal, /ID:\s*[0-9a-f-]{36}/, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		const sessionId = fullText(terminal).match(/ID:\s*([0-9a-f-]{36})/)?.[1]
+		expect(sessionId).toBeDefined()
+
+		terminal.submit("/quit")
+		await waitForText(terminal, exitMarker, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+
+		fixture.initialModel = false
+		launchKimchi(terminal, fixture, ["-r", sessionId ?? ""], fixture.seedEnv)
+		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		await waitForText(terminal, "auto (routed)", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		terminal.submit("Continue the same session")
+		await waitForText(terminal, "Resumed Auto reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+		await waitForTurnToSettle(fixture.fake.requests)
+
+		expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+		const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+		expect(chatRequests).toHaveLength(2)
+		expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed"])
+	} finally {
+		await stopKimchi(terminal).catch(() => {})
+		await fixture.stop().catch(() => {})
+	}
+})
+
+test("an explicit concrete CLI model overrides a resumed Auto session", async ({ terminal }) => {
+	const exitMarker = "__KIMCHI_AUTO_OVERRIDE_FIRST_SESSION_EXITED__"
+	const fixture = await createKimchiFixture({
+		providerId: "kimchi-dev",
+		initialModel: "auto",
+		models: MODELS_WITH_OVERRIDE,
+		routerResponses: [ROUTED_ROUTER_RESPONSE],
+		responses: [{ stream: ["Initial routed reply."] }, { stream: ["Explicit override reply."] }],
+	})
+
+	try {
+		launchKimchi(terminal, fixture, ["--enable-experimental-features"], fixture.seedEnv, { exitMarker })
+		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+
+		terminal.submit("Resolve Auto before the resume")
+		await waitForText(terminal, "Initial routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+		terminal.submit("/session")
+		await waitForText(terminal, /ID:\s*[0-9a-f-]{36}/, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		const sessionId = fullText(terminal).match(/ID:\s*([0-9a-f-]{36})/)?.[1]
+		expect(sessionId).toBeDefined()
+
+		terminal.submit("/quit")
+		await waitForText(terminal, exitMarker, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+
+		fixture.initialModel = false
+		launchKimchi(
+			terminal,
+			fixture,
+			["-r", sessionId ?? "", "--provider", "kimchi-dev", "--model", "override"],
+			fixture.seedEnv,
+		)
+		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		terminal.submit("Use the explicit concrete model")
+		await waitForText(terminal, "Explicit override reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+		await waitForTurnToSettle(fixture.fake.requests)
+
+		expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+		const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+		expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "override"])
+		const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8"))
+		expect(settings.defaultProvider).toBe("kimchi-dev")
+		expect(settings.defaultModel).toBe("override")
+	} finally {
+		await stopKimchi(terminal).catch(() => {})
+		await fixture.stop().catch(() => {})
+	}
+})
+
+test("a child that inherits Auto makes one independent routing decision", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-child-routes-independently",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE, ROUTED_ROUTER_RESPONSE],
+			responses: [
+				{ toolCalls: [agentCall("call_auto_child")] },
+				{ stream: ["Parent finished."] },
+				{ stream: ["Child route complete."], forSubagent: true },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("Delegate this check")
+			await waitForText(terminal, "Parent finished.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(3)
+			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed", "routed"])
+		},
+	)
+})
+
+test("a background child follows the same independent Auto routing path", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-background-child-routes-independently",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE, ROUTED_ROUTER_RESPONSE],
+			responses: [
+				{ toolCalls: [agentCall("call_auto_background_child", undefined, true)] },
+				{ stream: ["Parent launched background child."] },
+				{ stream: ["Background child route complete."], forSubagent: true },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("Delegate this in the background")
+			await waitForText(terminal, "Parent launched background child.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, /verify child routing[^\n]*completed/i, { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests.length).toBeGreaterThanOrEqual(3)
+			expect(chatRequests.every((request) => requestModel(request.body) === "routed")).toBe(true)
+		},
+	)
+})
+
+test("an explicitly selected concrete child model bypasses Auto routing", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-explicit-child-bypasses-router",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			responses: [
+				{ toolCalls: [agentCall("call_concrete_child", "kimchi-dev/routed")] },
+				{ stream: ["Parent finished explicit child."] },
+				{ stream: ["Child route complete."], forSubagent: true },
+			],
+		},
+		async (fixture) => {
+			terminal.submit("Delegate with the explicit model")
+			await waitForText(terminal, "Parent finished explicit child.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests).toHaveLength(3)
+			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed", "routed"])
+		},
+	)
+})

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -158,7 +158,8 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 		async (fixture, trace) => {
 			terminal.submit("Choose a model for this session")
 			await waitForText(terminal, "First routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("first prompt routed")
 
@@ -195,7 +196,8 @@ test("Auto uses the highest-ranked eligible model when the best model is outside
 		async (fixture) => {
 			terminal.submit("Use the first eligible router-ranked model")
 			await waitForText(terminal, "Ranked fallback reply.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto (fallback)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toContain("auto (fallback)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
@@ -228,7 +230,8 @@ test("Auto stops an unavailable-router prompt and retries when the user submits 
 
 			terminal.submit("Try the router again")
 			await waitForText(terminal, "Router retry succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
@@ -267,7 +270,8 @@ test("Escape cancels an in-flight router request and the corrected prompt can ro
 
 			terminal.submit("Use this corrected prompt instead")
 			await waitForText(terminal, "Corrected prompt succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto (routed)", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
@@ -365,7 +369,8 @@ test("resuming an Auto session reuses its concrete resolution without the flag",
 		fixture.initialModel = false
 		launchKimchi(terminal, fixture, ["-r", sessionId ?? ""], fixture.seedEnv)
 		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
-		await waitForText(terminal, "auto (routed)", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		expect(viewText(terminal)).not.toContain("auto (routed)")
 		terminal.submit("Continue the same session")
 		await waitForText(terminal, "Resumed Auto reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 		await waitForTurnToSettle(fixture.fake.requests)

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -89,6 +89,21 @@ async function waitForAbortedRequest(
 	throw new Error(`Timed out waiting for the request to ${path} to be aborted`)
 }
 
+async function navigateToSetting(terminal: import("@microsoft/tui-test").Terminal, label: string): Promise<void> {
+	for (let index = 0; index < 30; index += 1) {
+		const cursorLine = viewText(terminal)
+			.split("\n")
+			.find((line) => line.includes("→"))
+		if (cursorLine?.includes(label)) {
+			terminal.submit("")
+			return
+		}
+		terminal.keyDown()
+		await new Promise((resolve) => setTimeout(resolve, 50))
+	}
+	throw new Error(`Could not navigate to setting "${label}"`)
+}
+
 function requestModel(body: unknown): string | undefined {
 	return body && typeof body === "object" && "model" in body && typeof body.model === "string" ? body.model : undefined
 }
@@ -174,6 +189,44 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8"))
 			expect(settings.defaultProvider).toBe("kimchi-dev")
 			expect(settings.defaultModel).toBe("auto")
+		},
+	)
+})
+
+test("Auto exposes only off after routing to a model without reasoning", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-non-reasoning-controls",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			models: MODELS,
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			responses: [{ stream: ["Non-reasoning reply."] }],
+		},
+		async (fixture) => {
+			terminal.submit("Route to the plain model")
+			await waitForText(terminal, "Non-reasoning reply.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+
+			terminal.write("/settings")
+			await waitForText(terminal, "/settings", { timeoutMs: INPUT_TIMEOUT_MS, full: false })
+			terminal.submit("")
+			await waitForText(terminal, "Auto-compact", { timeoutMs: INPUT_TIMEOUT_MS })
+			await navigateToSetting(terminal, "Thinking level")
+			await waitForText(terminal, "Enter to select · Esc to go back", { timeoutMs: INPUT_TIMEOUT_MS })
+
+			terminal.keyDown()
+			terminal.submit("")
+			await waitForText(terminal, "Enter/Space to change · Esc to cancel", { timeoutMs: INPUT_TIMEOUT_MS })
+			const thinkingLine = viewText(terminal)
+				.split("\n")
+				.find((line) => line.includes("Thinking level"))
+			expect(thinkingLine).toMatch(/Thinking level\s+off/)
+
+			terminal.keyEscape()
+			await waitForText(terminal, PROMPT_READY, { timeoutMs: INPUT_TIMEOUT_MS, full: false })
 		},
 	)
 })

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -159,7 +159,6 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 			terminal.submit("Choose a model for this session")
 			await waitForText(terminal, "First routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("first prompt routed")
 
@@ -197,7 +196,6 @@ test("Auto uses the highest-ranked eligible model when the best model is outside
 			terminal.submit("Use the first eligible router-ranked model")
 			await waitForText(terminal, "Ranked fallback reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).not.toContain("auto (fallback)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
@@ -231,7 +229,6 @@ test("Auto stops an unavailable-router prompt and retries when the user submits 
 			terminal.submit("Try the router again")
 			await waitForText(terminal, "Router retry succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
@@ -271,7 +268,6 @@ test("Escape cancels an in-flight router request and the corrected prompt can ro
 			terminal.submit("Use this corrected prompt instead")
 			await waitForText(terminal, "Corrected prompt succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
-			expect(viewText(terminal)).not.toContain("auto (routed)")
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
@@ -370,7 +366,6 @@ test("resuming an Auto session reuses its concrete resolution without the flag",
 		launchKimchi(terminal, fixture, ["-r", sessionId ?? ""], fixture.seedEnv)
 		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
 		await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
-		expect(viewText(terminal)).not.toContain("auto (routed)")
 		terminal.submit("Continue the same session")
 		await waitForText(terminal, "Resumed Auto reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 		await waitForTurnToSettle(fixture.fake.requests)

--- a/tests/e2e/tui/branch-resume.test.ts
+++ b/tests/e2e/tui/branch-resume.test.ts
@@ -11,12 +11,13 @@ import {
 test.use(TUI_TEST_CONFIG)
 
 test("branch creates a named resumable session for -r", async ({ terminal }) => {
+	const exitMarker = "__KIMCHI_BRANCH_FIRST_SESSION_EXITED__"
 	const fixture = await createKimchiFixture({
 		responses: [{ stream: ["Hello", " from", " fake", " Kimchi."] }],
 	})
 
 	try {
-		launchKimchi(terminal, fixture)
+		launchKimchi(terminal, fixture, [], {}, { exitMarker })
 		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
 
 		terminal.submit("hello")
@@ -38,7 +39,7 @@ test("branch creates a named resumable session for -r", async ({ terminal }) => 
 		})
 
 		terminal.submit("/quit")
-		await new Promise((resolve) => setTimeout(resolve, 500))
+		await waitForText(terminal, exitMarker, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
 
 		launchKimchi(terminal, fixture, ["-r", sessionId])
 		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })

--- a/tests/e2e/tui/support/fake-openai-server.ts
+++ b/tests/e2e/tui/support/fake-openai-server.ts
@@ -95,6 +95,10 @@ export interface FakeOpenAiServer {
 interface StartFakeOpenAiServerOptions {
 	models?: FakeModel[]
 	responses: FakeResponseScript[]
+	/** JSON bodies returned by successive `/v1/route` calls. An empty queue returns 503. */
+	routerResponses?: unknown[]
+	/** Keep this one-based router request open until the client disconnects. Used to verify cancellation. */
+	stallRouterRequestNumber?: number
 	creditsResponses?: unknown[]
 	budgetResponses?: unknown[]
 }
@@ -142,6 +146,8 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 	}
 	const creditsQueue = [...(options.creditsResponses ?? [])]
 	const budgetQueue = [...(options.budgetResponses ?? [])]
+	const routerQueue = [...(options.routerResponses ?? [])]
+	let routerRequestCount = 0
 	let lastCreditsResponse: unknown
 	let lastBudgetResponse: unknown
 
@@ -160,9 +166,23 @@ export async function startFakeOpenAiServer(options: StartFakeOpenAiServerOption
 		req.on("aborted", () => {
 			recorded.aborted = true
 		})
+		res.on("close", () => {
+			if (!res.writableEnded) recorded.aborted = true
+		})
 		requests.push(recorded)
 
 		try {
+			if (req.method === "POST" && req.url?.startsWith("/v1/route")) {
+				routerRequestCount += 1
+				const response = routerQueue.shift()
+				if (options.stallRouterRequestNumber === routerRequestCount) {
+					await new Promise<void>((resolve) => res.once("close", resolve))
+					return
+				}
+				writeJson(res, response === undefined ? 503 : 200, response ?? { error: "No scripted router response" })
+				return
+			}
+
 			if (req.method === "GET" && req.url?.startsWith("/v1/models/metadata")) {
 				writeJson(res, 200, {
 					models: models.map((model) => ({

--- a/tests/e2e/tui/support/kimchi-fixture.ts
+++ b/tests/e2e/tui/support/kimchi-fixture.ts
@@ -48,7 +48,14 @@ export interface KimchiFixture {
 	seedResult?: unknown
 	/** Env vars returned by `seedHome`, merged into the launched process env. */
 	seedEnv: Record<string, string>
+	providerId: string
+	initialModel: string | false
 	stop(): Promise<void>
+}
+
+export interface LaunchKimchiOptions {
+	/** Resets the terminal and prints this marker after Kimchi exits, so a test can safely relaunch in the same PTY. */
+	exitMarker?: string
 }
 
 export interface TuiScenarioTrace {
@@ -72,6 +79,13 @@ export interface SeedHomeResult {
 interface CreateKimchiFixtureOptions {
 	models?: FakeModel[]
 	responses: FakeResponseScript[]
+	routerResponses?: unknown[]
+	/** Keep this one-based router request open until cancellation closes the connection. */
+	stallRouterRequestNumber?: number
+	/** Provider id written to models.json and used for the initial CLI selection. */
+	providerId?: string
+	/** Initial CLI model id. Set false to exercise the model saved in settings.json. */
+	initialModel?: string | false
 	creditsResponses?: unknown[]
 	budgetResponses?: unknown[]
 	/** `git init` the work dir so repo-checking flows (e.g. ferment) don't prompt to init one. */
@@ -111,6 +125,8 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 	const ollama = options.ollama ? await startFakeOllamaServer(options.ollama) : undefined
 	const homeDir = mkdtempSync(join(tmpdir(), "kimchi-tui-home-"))
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-tui-work-"))
+	const providerId = options.providerId ?? FAKE_PROVIDER
+	const initialModel = options.initialModel ?? DEFAULT_MODEL.slug
 	// Tear down server + temp dirs if any setup step throws.
 	try {
 		if (options.gitInit) execFileSync("git", ["init", "-q"], { cwd: workDir })
@@ -145,14 +161,17 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 			"utf-8",
 		)
 
-		writeModelsConfig(join(agentDir, "models.json"), fake.baseUrl, options.models)
+		writeModelsConfig(join(agentDir, "models.json"), fake.baseUrl, options.models, providerId)
 
 		const rawSeed = options.seedHome?.(homeDir, workDir)
 		const seedIsResult =
 			rawSeed !== null &&
 			typeof rawSeed === "object" &&
 			("env" in (rawSeed as SeedHomeResult) || "data" in (rawSeed as SeedHomeResult))
-		const seedEnv = seedIsResult ? ((rawSeed as SeedHomeResult).env ?? {}) : {}
+		const seedEnv = {
+			KIMCHI_ROUTER_ENDPOINT: fake.baseUrl,
+			...(seedIsResult ? ((rawSeed as SeedHomeResult).env ?? {}) : {}),
+		}
 		const seedResult = seedIsResult ? (rawSeed as SeedHomeResult).data : rawSeed
 
 		return {
@@ -163,6 +182,8 @@ export async function createKimchiFixture(options: CreateKimchiFixtureOptions): 
 			ollama: ollama ? { baseUrl: ollama.baseUrl, requests: ollama.requests } : undefined,
 			seedResult,
 			seedEnv,
+			providerId,
+			initialModel,
 			async stop() {
 				// Run both server stops even if one throws, so a failing OpenAI
 				// fake doesn't leak an Ollama fake listening on a port.
@@ -190,6 +211,7 @@ export function launchKimchi(
 	fixture: KimchiFixture,
 	extraArgs: string[] = [],
 	extraEnv: Record<string, string> = {},
+	options: LaunchKimchiOptions = {},
 ): void {
 	// KIMCHI_PERMISSIONS=yolo skips every permission check (rules, denylist,
 	// classifier, prompts) so tool calls execute without blocking on the TUI
@@ -198,28 +220,29 @@ export function launchKimchi(
 	// unit tests in src/extensions/permissions/. Tests that deliberately
 	// exercise the prompt UI should override via `extraArgs` (e.g. `--plan`).
 	const envEntries = Object.entries(extraEnv).map(([key, value]) => `${key}=${sh(value)}`)
-	terminal.submit(
-		[
-			`cd ${sh(fixture.workDir)} &&`,
-			"env",
-			`HOME=${sh(fixture.homeDir)}`,
-			`PI_PACKAGE_DIR=${sh(PACKAGE_DIR)}`,
-			"KIMCHI_PERMISSIONS=yolo",
-			// Disable startup network hooks (self-update probe and RTK
-			// auto-install) so the session boots without background HTTP or
-			// synchronous tar/exec work. Keeps the TUI e2e hermetic and its
-			// timing deterministic.
-			"KIMCHI_NO_UPDATE_CHECK=1",
-			"KIMCHI_RTK_AUTO_INSTALL=0",
-			...((fixture.ollama ? [`OLLAMA_HOST=${sh(fixture.ollama.baseUrl)}`] : []) as string[]),
-			...envEntries,
-			"TERM=xterm-256color",
-			sh(BINARY_PATH),
-			`--provider ${FAKE_PROVIDER}`,
-			`--model ${DEFAULT_MODEL.slug}`,
-			...extraArgs,
-		].join(" "),
-	)
+	const command = [
+		`cd ${sh(fixture.workDir)} &&`,
+		"env",
+		`HOME=${sh(fixture.homeDir)}`,
+		`PI_PACKAGE_DIR=${sh(PACKAGE_DIR)}`,
+		"KIMCHI_PERMISSIONS=yolo",
+		// Disable startup network hooks (self-update probe and RTK
+		// auto-install) so the session boots without background HTTP or
+		// synchronous tar/exec work. Keeps the TUI e2e hermetic and its
+		// timing deterministic.
+		"KIMCHI_NO_UPDATE_CHECK=1",
+		"KIMCHI_RTK_AUTO_INSTALL=0",
+		...((fixture.ollama ? [`OLLAMA_HOST=${sh(fixture.ollama.baseUrl)}`] : []) as string[]),
+		...envEntries,
+		"TERM=xterm-256color",
+		sh(BINARY_PATH),
+		...(fixture.initialModel === false
+			? []
+			: [`--provider ${sh(fixture.providerId)}`, `--model ${sh(fixture.initialModel)}`]),
+		...extraArgs,
+	].join(" ")
+	const exitMarker = options.exitMarker ? `; printf '\\033c%s\\n' ${sh(options.exitMarker)}` : ""
+	terminal.submit(`${command}${exitMarker}`)
 }
 
 export async function stopKimchi(terminal: Terminal): Promise<void> {
@@ -314,13 +337,13 @@ export function sh(value: string): string {
 	return `'${value.replaceAll("'", "'\\''")}'`
 }
 
-function writeModelsConfig(path: string, baseUrl: string, models: FakeModel[] | undefined): void {
+function writeModelsConfig(path: string, baseUrl: string, models: FakeModel[] | undefined, providerId: string): void {
 	writeFileSync(
 		path,
 		JSON.stringify(
 			{
 				providers: {
-					[FAKE_PROVIDER]: {
+					[providerId]: {
 						baseUrl: `${baseUrl}/openai/v1`,
 						apiKey: "fake",
 						api: "openai-completions",

--- a/tests/smoke/binary.test.ts
+++ b/tests/smoke/binary.test.ts
@@ -54,6 +54,7 @@ describe("binary smoke tests", () => {
 		expect(result.stdout).toContain("--mode")
 		expect(result.stdout).toContain("--continue")
 		expect(result.stdout).toContain("--resume, -r [id]")
+		expect(result.stdout).toContain("--enable-experimental-features")
 		// Kimchi-only env vars
 		expect(result.stdout).toContain("KIMCHI_API_KEY")
 		// Pi-internal extension management commands and provider-specific env


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Adds an opt-in LLM Router extension that queries the Kimchi router service on the first user prompt of each session (and each subagent) and switches to the recommended Kimchi model before inference begins.

- New extensions/router extension hooks session_start + before_agent_start; resolves the Kimchi credential from the provider registry (KIMCHI_ROUTER_API_KEY is a dev override), respects model scope, provider pinning and vision compatibility, and skips silently on any failure.
- Opt-in via the extensions.router resource toggle (disabled by default; restart required). Resolved credentials avoid a second setup step.
- Threads a launch-time routerEnabled snapshot through agentsExtension -> AgentManager -> runAgent so local child sessions load the router when the parent enabled it at process start.
- e2e TUI coverage for disabled-by-default and enabled-first-prompt flows, plus unit tests for the client, config, and extension.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
