### PR TITLE
fix(mcp-adapter): list lazy servers in proxy tool description

### DIFF
--- a/src/extensions/mcp-adapter/README.md
+++ b/src/extensions/mcp-adapter/README.md
@@ -304,6 +304,7 @@ If `settings.autoAuth` is `true`, `mcp({ connect: ... })`, `mcp({ tool: ... })`,
 
 - One `mcp` tool in context (~200 tokens) instead of hundreds
 - Servers are lazy by default — they connect on first tool call, not at startup
+- Lazy servers (configured but not yet connected) appear in the `mcp` tool description with a `(lazy)` marker, e.g. `Servers: my-server (5 tools), lazy-server (lazy)`. The agent knows these servers exist and can connect on demand via `mcp({ connect: "lazy-server" })` to discover their tools
 - Tool metadata is cached to disk so search/list/describe work without live connections
 - Idle servers disconnect after 10 minutes (configurable), reconnect automatically on next use
 - npx-based servers resolve to direct binary paths, skipping the ~143 MB npm parent process

--- a/src/extensions/mcp-adapter/direct-tools.test.ts
+++ b/src/extensions/mcp-adapter/direct-tools.test.ts
@@ -91,5 +91,25 @@ describe("buildProxyDescription", () => {
 
 			expect(desc).not.toContain("Servers:")
 		})
+
+		it("does not label cached-but-empty servers as lazy", () => {
+			const config = makeConfig({
+				"empty-cached": { command: "npx", args: ["-y", "empty"] },
+				"lazy-server": { command: "npx", args: ["-y", "lazy"] },
+			})
+			const cache = makeCache({
+				"empty-cached": {
+					configHash: "abc",
+					tools: [],
+					resources: [],
+					cachedAt: Date.now(),
+				},
+			})
+
+			const desc = buildProxyDescription(config, cache, [])
+
+			expect(desc).not.toContain("empty-cached")
+			expect(desc).toContain("lazy-server (lazy)")
+		})
 	})
 })

--- a/src/extensions/mcp-adapter/direct-tools.test.ts
+++ b/src/extensions/mcp-adapter/direct-tools.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import { buildProxyDescription } from "./direct-tools.js"
+import type { MetadataCache } from "./metadata-cache.js"
+import type { McpConfig } from "./types.js"
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeConfig(servers: Record<string, unknown>): McpConfig {
+	return { mcpServers: servers as McpConfig["mcpServers"] }
+}
+
+function makeCache(servers: Record<string, unknown>): MetadataCache {
+	return { version: 1, servers: servers as MetadataCache["servers"] }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("buildProxyDescription", () => {
+	describe("lazy server visibility", () => {
+		it("lists lazy servers (no cached metadata) with (lazy) marker", () => {
+			const config = makeConfig({
+				"eager-server": { command: "npx", args: ["-y", "some-server"] },
+				"lazy-server": { command: "npx", args: ["-y", "lazy-server"] },
+			})
+			const cache = makeCache({
+				"eager-server": {
+					configHash: "abc",
+					tools: [{ name: "do_thing", description: "Does a thing" }],
+					resources: [],
+					cachedAt: Date.now(),
+				},
+			})
+
+			const desc = buildProxyDescription(config, cache, [])
+
+			expect(desc).toContain("eager-server (1 tools)")
+			expect(desc).toContain("lazy-server (lazy)")
+			expect(desc).toContain("Servers:")
+		})
+
+		it("lists multiple lazy servers", () => {
+			const config = makeConfig({
+				"lazy-a": { command: "npx", args: ["-y", "a"] },
+				"lazy-b": { url: "https://example.com/mcp" },
+			})
+			const cache = makeCache({})
+
+			const desc = buildProxyDescription(config, cache, [])
+
+			expect(desc).toContain("lazy-a (lazy)")
+			expect(desc).toContain("lazy-b (lazy)")
+		})
+	})
+
+	describe("eager-only behaviour unchanged", () => {
+		it("lists only cached servers when no lazy servers configured", () => {
+			const config = makeConfig({
+				"server-a": { command: "npx", args: ["-y", "a"] },
+				"server-b": { command: "npx", args: ["-y", "b"] },
+			})
+			const cache = makeCache({
+				"server-a": {
+					configHash: "abc",
+					tools: [{ name: "tool_a", description: "Tool A" }],
+					resources: [],
+					cachedAt: Date.now(),
+				},
+				"server-b": {
+					configHash: "def",
+					tools: [
+						{ name: "tool_b1", description: "Tool B1" },
+						{ name: "tool_b2", description: "Tool B2" },
+					],
+					resources: [],
+					cachedAt: Date.now(),
+				},
+			})
+
+			const desc = buildProxyDescription(config, cache, [])
+
+			expect(desc).toContain("server-a (1 tools)")
+			expect(desc).toContain("server-b (2 tools)")
+			expect(desc).not.toContain("(lazy)")
+		})
+
+		it("produces no Servers line when no servers configured", () => {
+			const config = makeConfig({})
+			const cache = makeCache({})
+
+			const desc = buildProxyDescription(config, cache, [])
+
+			expect(desc).not.toContain("Servers:")
+		})
+	})
+})

--- a/src/extensions/mcp-adapter/direct-tools.ts
+++ b/src/extensions/mcp-adapter/direct-tools.ts
@@ -207,7 +207,9 @@ export function buildProxyDescription(
 				: 0
 		const totalItems = toolCount + resourceCount
 		if (totalItems === 0) {
-			serverSummaries.push(`${serverName} (lazy)`)
+			if (!entry) {
+				serverSummaries.push(`${serverName} (lazy)`)
+			}
 			continue
 		}
 		const directCount = directByServer.get(serverName) ?? 0

--- a/src/extensions/mcp-adapter/direct-tools.ts
+++ b/src/extensions/mcp-adapter/direct-tools.ts
@@ -206,7 +206,10 @@ export function buildProxyDescription(
 					}).length
 				: 0
 		const totalItems = toolCount + resourceCount
-		if (totalItems === 0) continue
+		if (totalItems === 0) {
+			serverSummaries.push(`${serverName} (lazy)`)
+			continue
+		}
 		const directCount = directByServer.get(serverName) ?? 0
 		const proxyCount = totalItems - directCount
 		if (proxyCount > 0) {


### PR DESCRIPTION
## Problem

Before:
<img width="667" height="435" alt="image" src="https://github.com/user-attachments/assets/234b5954-bf7f-41f2-968b-421c4a93e0c0" />


After:
<img width="558" height="438" alt="image" src="https://github.com/user-attachments/assets/3d6b323f-f3e1-4337-beba-dbb0bbe542c2" />




Context:
Lazy MCP servers (configured but not yet connected) were silently skipped when injecting mcp description into contet, making them invisible to the agent. i.e. the agent did not know what MCPs are configured and not yet loaded.

## Solution

Modified `buildProxyDescription()` in `src/extensions/mcp-adapter/direct-tools.ts` to list lazy servers with a `(lazy)` marker in the `Servers:` line instead of skipping them:

```
Servers: mcp-atlassian (63 tools), castai (lazy)
```

The agent can then connect on demand via `mcp({ connect: "castai" })` to discover and use their tools.

## Verification

- `pnpm run check` passes (biome lint + tsc type check, 0 errors)
- New test file passes 4/4
- Full test suite: 8993 passed, 5 pre-existing failures (confirmed on clean master, unrelated to this change)

Co-Authored-By: Kimchi <noreply@kimchi.dev>