### PR TITLE
feat: add Hermes Agent (NousResearch) integration

### DIFF
--- a/src/commands/hermes.ts
+++ b/src/commands/hermes.ts
@@ -1,0 +1,23 @@
+import "../integrations/hermes.js" // side-effect: register integration
+import { byId } from "../integrations/registry.js"
+import { popScope, prepareTool } from "./_helpers.js"
+
+export async function runHermes(args: string[]): Promise<number> {
+	const scope = popScope(args)
+	const prepped = await prepareTool("hermes", "override")
+	if (!prepped) return 1
+
+	try {
+		const tool = byId("hermes")
+		if (!tool) {
+			console.error("kimchi hermes: integration not registered")
+			return 1
+		}
+		await tool.write(scope, prepped.apiKey, prepped.models)
+		console.log("kimchi hermes: configuration written.")
+		return 0
+	} catch (err) {
+		console.error(`kimchi hermes: ${(err as Error).message}`)
+		return 1
+	}
+}

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -9,6 +9,7 @@ import { runClaude } from "./claude.js"
 import { runConfig } from "./config.js"
 import { runCursor } from "./cursor.js"
 import { runGsd2 } from "./gsd2.js"
+import { runHermes } from "./hermes.js"
 import { runLogin } from "./login.js"
 import { runMcp } from "./mcp.js"
 import { runOpenClaw } from "./openclaw.js"
@@ -28,6 +29,7 @@ export const COMMANDS: CommandDefinition[] = [
 	{ name: "cursor", summary: "Configure Cursor to use Kimchi", run: runCursor },
 	{ name: "openclaw", summary: "Configure OpenClaw to use Kimchi", run: runOpenClaw },
 	{ name: "gsd2", summary: "Install / configure GSD2 with Kimchi", run: runGsd2 },
+	{ name: "hermes", summary: "Configure Hermes to use Kimchi", run: runHermes },
 	{ name: "update", summary: "Check for and install Kimchi/package updates", run: runUpdate },
 	{ name: "config", summary: "Inspect or change kimchi config (e.g. telemetry)", run: runConfig },
 	{ name: "resources", summary: "Enable or disable Kimchi hooks, tools, extensions, and plugins", run: runResources },

--- a/src/commands/setup-tools.ts
+++ b/src/commands/setup-tools.ts
@@ -1,5 +1,6 @@
 // Side-effect imports register each integration. Without these, all()
 // and byId() in the integrations registry return nothing.
+import "../integrations/hermes.js"
 import "../integrations/claude-code.js"
 import "../integrations/cursor.js"
 import "../integrations/gsd2.js"

--- a/src/integrations/hermes.test.ts
+++ b/src/integrations/hermes.test.ts
@@ -1,0 +1,371 @@
+import * as childProcess from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { parse as parseYaml } from "yaml"
+import { TEST_MODELS } from "./__fixtures__/models.js"
+import { findBinary } from "./detect.js"
+import {
+	asObject,
+	buildHermesModelsCatalog,
+	buildHermesProviderBlock,
+	HERMES_CONFIG_PATH,
+	HERMES_VERSION_MIN,
+	HERMES_VERSION_REGEX,
+	mergeFallbacks,
+	mergeModelsCatalog,
+	writeHermesEnv,
+} from "./hermes.js"
+import { byId } from "./registry.js"
+
+vi.mock("./detect.js", async () => {
+	const mockFindBinary = vi.fn().mockReturnValue(undefined)
+	return { findBinary: mockFindBinary }
+})
+
+vi.mock("node:child_process", async () => {
+	const actual = await vi.importActual("node:child_process")
+	return {
+		...actual,
+		execFileSync: vi.fn(),
+		spawnSync: vi.fn(),
+	}
+})
+
+describe("buildHermesProviderBlock", () => {
+	it("uses the kimchi base URL and ${KIMCHI_API_KEY} placeholder", () => {
+		const block = buildHermesProviderBlock(TEST_MODELS) as {
+			baseUrl: string
+			apiKey: string
+			api: string
+			models: unknown[]
+		}
+		expect(block.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(block.apiKey).toBe("${KIMCHI_API_KEY}")
+		expect(block.api).toBe("openai-completions")
+		expect(block.models.length).toBe(TEST_MODELS.length)
+	})
+
+	it("includes per-model id/name/contextWindow/maxTokens", () => {
+		const block = buildHermesProviderBlock(TEST_MODELS) as {
+			models: Array<{ id: string; name: string; contextWindow: number; maxTokens: number }>
+		}
+		const main = block.models.find((m) => m.id === "kimchi/kimi-k2.6")
+		expect(main).toBeDefined()
+		expect(main?.name).toBe("Kimi K2.6")
+		expect(main?.contextWindow).toBe(262_144)
+		expect(main?.maxTokens).toBe(32_768)
+	})
+
+	it("falls back to slug when display_name is empty", () => {
+		const modelsWithEmptyName = [
+			{ ...TEST_MODELS[0], display_name: "" },
+			{ ...TEST_MODELS[1], display_name: "   " },
+		]
+		const block = buildHermesProviderBlock(modelsWithEmptyName) as {
+			models: Array<{ id: string; name: string }>
+		}
+		expect(block.models[0].name).toBe(modelsWithEmptyName[0].slug)
+		expect(block.models[1].name).toBe(modelsWithEmptyName[1].slug)
+	})
+})
+
+describe("buildHermesModelsCatalog", () => {
+	it("maps each model id to its display alias", () => {
+		const catalog = buildHermesModelsCatalog(TEST_MODELS)
+		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "Kimi K2.6" })
+		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "Kimi K2.5" })
+		expect(catalog["kimchi/nemotron-3-ultra-fp4"]).toEqual({ alias: "Nemotron 3 Ultra FP4" })
+		expect(catalog["kimchi/minimax-m2.7"]).toEqual({ alias: "MiniMax M2.7" })
+	})
+
+	it("falls back to slug when display_name is empty", () => {
+		const modelsWithEmptyName = [
+			{ ...TEST_MODELS[0], display_name: "" },
+			{ ...TEST_MODELS[1], display_name: "   " },
+		]
+		const catalog = buildHermesModelsCatalog(modelsWithEmptyName)
+		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "kimi-k2.6" })
+		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "kimi-k2.5" })
+	})
+})
+
+describe("writeHermesEnv", () => {
+	let tmp: string
+	let prevHome: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-hermes-test-"))
+		prevHome = process.env.HOME
+		process.env.HOME = tmp
+	})
+
+	afterEach(() => {
+		if (prevHome === undefined) process.env.HOME = undefined
+		else process.env.HOME = prevHome
+		rmSync(tmp, { recursive: true, force: true })
+	})
+
+	it("creates the .env file with the API key when none exists", () => {
+		mkdirSync(join(tmp, ".hermes"), { recursive: true })
+		writeHermesEnv("test-key-123")
+		expect(readFileSync(join(tmp, ".hermes", ".env"), "utf-8")).toBe("KIMCHI_API_KEY=test-key-123\n")
+	})
+
+	it("creates the parent directory if missing", () => {
+		writeHermesEnv("fresh")
+		expect(readFileSync(join(tmp, ".hermes", ".env"), "utf-8")).toBe("KIMCHI_API_KEY=fresh\n")
+	})
+
+	it("replaces an existing KIMCHI_API_KEY line in place, preserving other entries", () => {
+		mkdirSync(join(tmp, ".hermes"), { recursive: true })
+		writeFileSync(join(tmp, ".hermes", ".env"), "OTHER_VAR=keep-me\nKIMCHI_API_KEY=old-key\nALSO=keep\n", "utf-8")
+		writeHermesEnv("new-key")
+		expect(readFileSync(join(tmp, ".hermes", ".env"), "utf-8")).toBe(
+			"OTHER_VAR=keep-me\nKIMCHI_API_KEY=new-key\nALSO=keep\n",
+		)
+	})
+
+	it("appends KIMCHI_API_KEY when the file exists but doesn't have one yet", () => {
+		mkdirSync(join(tmp, ".hermes"), { recursive: true })
+		writeFileSync(join(tmp, ".hermes", ".env"), "OTHER=foo\n", "utf-8")
+		writeHermesEnv("appended")
+		expect(readFileSync(join(tmp, ".hermes", ".env"), "utf-8")).toBe("OTHER=foo\nKIMCHI_API_KEY=appended\n")
+	})
+})
+
+describe("hermes tool registration", () => {
+	it("registers itself with install metadata for the wizard", () => {
+		const tool = byId("hermes")
+		expect(tool).toBeDefined()
+		expect(tool?.installUrl).toBe("https://hermes-agent.nousresearch.com/install.sh")
+		expect(tool?.installArgs).toEqual(["--no-prompt", "--no-onboard"])
+		expect(tool?.configPath).toBe(HERMES_CONFIG_PATH)
+	})
+	it("write() rejects an empty API key", async () => {
+		const tool = byId("hermes")
+		await expect(tool?.write("global", "", TEST_MODELS)).rejects.toThrow(/API key/)
+	})
+})
+
+describe("asObject", () => {
+	it("returns the object when passed a plain object", () => {
+		expect(asObject({ foo: "bar" })).toEqual({ foo: "bar" })
+	})
+	it("returns {} for null", () => {
+		expect(asObject(null)).toEqual({})
+	})
+	it("returns {} for arrays", () => {
+		expect(asObject([1, 2, 3])).toEqual({})
+	})
+	it("returns {} for primitives", () => {
+		expect(asObject("string")).toEqual({})
+		expect(asObject(42)).toEqual({})
+		expect(asObject(true)).toEqual({})
+	})
+	it("returns {} for undefined", () => {
+		expect(asObject(undefined)).toEqual({})
+	})
+})
+
+describe("mergeFallbacks", () => {
+	it("appends new fallbacks to an existing array", () => {
+		expect(mergeFallbacks(["a", "b"], ["c", "d"])).toEqual(["a", "b", "c", "d"])
+	})
+	it("dedupes entries across existing and new", () => {
+		expect(mergeFallbacks(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"])
+	})
+	it("treats non-array existing as empty", () => {
+		expect(mergeFallbacks(null, ["a"])).toEqual(["a"])
+		expect(mergeFallbacks("string", ["a"])).toEqual(["a"])
+		expect(mergeFallbacks({ foo: "bar" }, ["a"])).toEqual(["a"])
+	})
+	it("returns only new fallbacks when existing is undefined", () => {
+		expect(mergeFallbacks(undefined, ["a", "b"])).toEqual(["a", "b"])
+	})
+})
+
+describe("mergeModelsCatalog", () => {
+	it("merges catalog entries into existing object", () => {
+		expect(mergeModelsCatalog({ existing: true }, { newKey: "value" })).toEqual({
+			existing: true,
+			newKey: "value",
+		})
+	})
+	it("new catalog entries take precedence over existing keys", () => {
+		expect(mergeModelsCatalog({ same: "old" }, { same: "new" })).toEqual({ same: "new" })
+	})
+	it("treats non-object existing as empty", () => {
+		expect(mergeModelsCatalog(null, { a: 1 })).toEqual({ a: 1 })
+		expect(mergeModelsCatalog([1, 2], { a: 1 })).toEqual({ a: 1 })
+		expect(mergeModelsCatalog("string", { a: 1 })).toEqual({ a: 1 })
+	})
+})
+
+describe("hermes version constants", () => {
+	it("exposes the minimum supported Hermes version", () => {
+		expect(HERMES_VERSION_MIN).toBe("2026.1.0")
+	})
+	it("exposes a regex that matches `hermes --version` output", () => {
+		const match = "Hermes 2026.1.2".match(HERMES_VERSION_REGEX)
+		expect(match?.[1]).toBe("2026.1.2")
+		expect(HERMES_VERSION_REGEX.test("hermes 2026.1.0")).toBe(false)
+	})
+})
+
+describe("writeHermesDirect integration", () => {
+	let tmp: string
+	let prevHome: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-hermes-direct-"))
+		prevHome = process.env.HOME
+		process.env.HOME = tmp
+		vi.mocked(findBinary).mockReturnValue(undefined)
+	})
+
+	afterEach(() => {
+		if (prevHome === undefined) process.env.HOME = undefined
+		else process.env.HOME = prevHome
+		rmSync(tmp, { recursive: true, force: true })
+		vi.mocked(findBinary).mockClear()
+	})
+
+	it("writes valid YAML that preserves existing user config keys like temperature and fallbacks", async () => {
+		const configDir = join(tmp, ".hermes")
+		mkdirSync(configDir, { recursive: true })
+		const existing = `agents:
+  defaults:
+    model:
+      temperature: 0.7
+      fallbacks:
+        - other/model
+    models:
+      other/model:
+        alias: Other
+`
+		writeFileSync(join(configDir, "config.yaml"), existing, "utf-8")
+
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const written = parseYaml(readFileSync(join(configDir, "config.yaml"), "utf-8")) as Record<string, unknown>
+		const agents = (written.agents as Record<string, unknown>).defaults as Record<string, unknown>
+		const model = agents.model as Record<string, unknown>
+
+		expect(model.temperature).toBe(0.7)
+		const fallbacks = model.fallbacks as string[]
+		expect(fallbacks).toContain("other/model")
+		expect(fallbacks).toContain("kimchi/nemotron-3-ultra-fp4")
+		expect(fallbacks).toContain("kimchi/minimax-m2.7")
+
+		const models = agents.models as Record<string, unknown>
+		expect(models["other/model"]).toEqual({ alias: "Other" })
+		expect(models["kimchi/kimi-k2.6"]).toBeDefined()
+
+		const providers = ((written.models as Record<string, unknown>).providers as Record<string, unknown>)
+			.kimchi as Record<string, unknown>
+		expect(providers).toBeDefined()
+		expect(providers.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(providers.apiKey).toBe("${KIMCHI_API_KEY}")
+		expect(providers.api).toBe("openai-completions")
+	})
+
+	it("creates a fresh config.yaml when none exists", async () => {
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const configPath = join(tmp, ".hermes", "config.yaml")
+		const written = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown>
+		const agents = (written.agents as Record<string, unknown>).defaults as Record<string, unknown>
+		const model = agents.model as Record<string, unknown>
+		expect(typeof model.primary).toBe("string")
+		expect((model.primary as string).startsWith("kimchi/")).toBe(true)
+
+		const envContent = readFileSync(join(tmp, ".hermes", ".env"), "utf-8")
+		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")
+	})
+})
+
+describe("writeHermesViaCLI integration", () => {
+	let tmp: string
+	let prevHome: string | undefined
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "kimchi-hermes-cli-"))
+		prevHome = process.env.HOME
+		process.env.HOME = tmp
+		vi.mocked(findBinary).mockReturnValue("/usr/bin/hermes")
+		vi.mocked(childProcess.execFileSync).mockReturnValue("not running")
+		vi.mocked(childProcess.spawnSync).mockImplementation((_cmd: unknown, args: unknown) => {
+			const cmdArgs = args as string[]
+			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.model.fallbacks") {
+				return { status: 0, stdout: JSON.stringify(["existing/model"]), stderr: "" } as ReturnType<
+					typeof childProcess.spawnSync
+				>
+			}
+			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.models") {
+				return { status: 0, stdout: JSON.stringify({ "other/model": { alias: "Other" } }), stderr: "" } as ReturnType<
+					typeof childProcess.spawnSync
+				>
+			}
+			return { status: 0, stdout: "", stderr: "" } as ReturnType<typeof childProcess.spawnSync>
+		})
+	})
+
+	afterEach(() => {
+		if (prevHome === undefined) process.env.HOME = undefined
+		else process.env.HOME = prevHome
+		rmSync(tmp, { recursive: true, force: true })
+		vi.mocked(findBinary).mockClear()
+		vi.mocked(childProcess.execFileSync).mockClear()
+		vi.mocked(childProcess.spawnSync).mockClear()
+	})
+
+	it("preserves existing fallbacks and other keys via CLI merge", async () => {
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const calls = vi.mocked(childProcess.spawnSync).mock.calls
+		const fallbackSetCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.model.fallbacks"
+		})
+		expect(fallbackSetCall).toBeDefined()
+		const mergedFallbacks = JSON.parse((fallbackSetCall?.[1] as string[])[3])
+		expect(mergedFallbacks).toContain("existing/model")
+		expect(mergedFallbacks).toContain("kimchi/nemotron-3-ultra-fp4")
+
+		const modelsSetCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.models"
+		})
+		expect(modelsSetCall).toBeDefined()
+		const mergedModels = JSON.parse((modelsSetCall?.[1] as string[])[3]) as Record<string, unknown>
+		expect(mergedModels["other/model"]).toEqual({ alias: "Other" })
+		expect(mergedModels["kimchi/kimi-k2.6"]).toBeDefined()
+		expect(mergedModels["kimchi/nemotron-3-ultra-fp4"]).toBeDefined()
+
+		const envContent = readFileSync(join(tmp, ".hermes", ".env"), "utf-8")
+		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")
+	})
+
+	it("runs hermes gateway restart when the gateway is already running", async () => {
+		vi.mocked(childProcess.execFileSync).mockReturnValue("gateway: running\n")
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const calls = vi.mocked(childProcess.spawnSync).mock.calls
+		const restartCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return args && args[0] === "gateway" && args[1] === "restart"
+		})
+		expect(restartCall).toBeDefined()
+		const onboardCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return args && args[0] === "onboard"
+		})
+		expect(onboardCall).toBeUndefined()
+	})
+})

--- a/src/integrations/hermes.test.ts
+++ b/src/integrations/hermes.test.ts
@@ -8,8 +8,8 @@ import { TEST_MODELS } from "./__fixtures__/models.js"
 import { findBinary } from "./detect.js"
 import {
 	asObject,
-	buildHermesModelsCatalog,
-	buildHermesProviderBlock,
+	buildHermesFallbackProviders,
+	buildHermesModelConfig,
 	HERMES_CONFIG_PATH,
 	HERMES_VERSION_MIN,
 	HERMES_VERSION_REGEX,
@@ -28,66 +28,82 @@ vi.mock("node:child_process", async () => {
 	const actual = await vi.importActual("node:child_process")
 	return {
 		...actual,
-		execFileSync: vi.fn(),
 		spawnSync: vi.fn(),
 	}
 })
 
-describe("buildHermesProviderBlock", () => {
-	it("uses the kimchi base URL and ${KIMCHI_API_KEY} placeholder", () => {
-		const block = buildHermesProviderBlock(TEST_MODELS) as {
-			baseUrl: string
-			apiKey: string
-			api: string
-			models: unknown[]
+describe("buildHermesModelConfig", () => {
+	it("uses the custom provider, kimchi base URL and ${KIMCHI_API_KEY} placeholder", () => {
+		const config = buildHermesModelConfig(TEST_MODELS) as {
+			provider: string
+			base_url: string
+			api_key: string
+			default: string
 		}
-		expect(block.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
-		expect(block.apiKey).toBe("${KIMCHI_API_KEY}")
-		expect(block.api).toBe("openai-completions")
-		expect(block.models.length).toBe(TEST_MODELS.length)
+		expect(config.provider).toBe("custom")
+		expect(config.base_url).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(config.api_key).toBe("${KIMCHI_API_KEY}")
+		expect(config.default).toBe("kimchi/kimi-k2.6")
 	})
 
-	it("includes per-model id/name/contextWindow/maxTokens", () => {
-		const block = buildHermesProviderBlock(TEST_MODELS) as {
-			models: Array<{ id: string; name: string; contextWindow: number; maxTokens: number }>
-		}
-		const main = block.models.find((m) => m.id === "kimchi/kimi-k2.6")
-		expect(main).toBeDefined()
-		expect(main?.name).toBe("Kimi K2.6")
-		expect(main?.contextWindow).toBe(262_144)
-		expect(main?.maxTokens).toBe(32_768)
+	it("throws when given an empty model list", () => {
+		expect(() => buildHermesModelConfig([])).toThrow(/No models/)
 	})
 
-	it("falls back to slug when display_name is empty", () => {
-		const modelsWithEmptyName = [
-			{ ...TEST_MODELS[0], display_name: "" },
-			{ ...TEST_MODELS[1], display_name: "   " },
-		]
-		const block = buildHermesProviderBlock(modelsWithEmptyName) as {
-			models: Array<{ id: string; name: string }>
+	it("falls back to the first model when the main role cannot be resolved", () => {
+		const onlyTextModel = {
+			...TEST_MODELS[0],
+			slug: "lonely-text-model",
+			input_modalities: ["text"] as Array<"text" | "image">,
 		}
-		expect(block.models[0].name).toBe(modelsWithEmptyName[0].slug)
-		expect(block.models[1].name).toBe(modelsWithEmptyName[1].slug)
+		// Build a list where every model is text-only and not vision-capable;
+		// resolveModelRole still picks the first serverless model.
+		const config = buildHermesModelConfig([onlyTextModel]) as { default: string }
+		expect(config.default.startsWith("kimchi/")).toBe(true)
 	})
 })
 
-describe("buildHermesModelsCatalog", () => {
-	it("maps each model id to its display alias", () => {
-		const catalog = buildHermesModelsCatalog(TEST_MODELS)
-		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "Kimi K2.6" })
-		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "Kimi K2.5" })
-		expect(catalog["kimchi/nemotron-3-ultra-fp4"]).toEqual({ alias: "Nemotron 3 Ultra FP4" })
-		expect(catalog["kimchi/minimax-m2.7"]).toEqual({ alias: "MiniMax M2.7" })
+describe("buildHermesFallbackProviders", () => {
+	it("emits one entry per non-main fallback role using key_env", () => {
+		const fallbacks = buildHermesFallbackProviders(TEST_MODELS)
+		expect(fallbacks).toEqual([
+			{
+				provider: "custom",
+				model: "kimchi/nemotron-3-ultra-fp4",
+				base_url: "https://llm.kimchi.dev/openai/v1",
+				key_env: "KIMCHI_API_KEY",
+			},
+			{
+				provider: "custom",
+				model: "kimchi/minimax-m2.7",
+				base_url: "https://llm.kimchi.dev/openai/v1",
+				key_env: "KIMCHI_API_KEY",
+			},
+		])
 	})
 
-	it("falls back to slug when display_name is empty", () => {
-		const modelsWithEmptyName = [
-			{ ...TEST_MODELS[0], display_name: "" },
-			{ ...TEST_MODELS[1], display_name: "   " },
+	it("never uses api_key (uses key_env so Hermes reads ~/.hermes/.env at runtime)", () => {
+		const fallbacks = buildHermesFallbackProviders(TEST_MODELS) as Array<Record<string, unknown>>
+		for (const entry of fallbacks) {
+			expect(entry.api_key).toBeUndefined()
+			expect(entry.key_env).toBe("KIMCHI_API_KEY")
+		}
+	})
+
+	it("dedupes when coding and sub resolve to the same model", () => {
+		// Only one non-main serverless model — both `coding` and `sub`
+		// roles resolve to it, so the list must dedupe.
+		const modelsWithDuplicates: typeof TEST_MODELS = [
+			TEST_MODELS[0], // kimi-k2.6 (main, vision-capable serverless)
+			TEST_MODELS[2], // nemotron-3-ultra-fp4 (only non-main serverless)
 		]
-		const catalog = buildHermesModelsCatalog(modelsWithEmptyName)
-		expect(catalog["kimchi/kimi-k2.6"]).toEqual({ alias: "kimi-k2.6" })
-		expect(catalog["kimchi/kimi-k2.5"]).toEqual({ alias: "kimi-k2.5" })
+		const fallbacks = buildHermesFallbackProviders(modelsWithDuplicates) as Array<{ model: string }>
+		const models = fallbacks.map((f) => f.model)
+		expect(models).toEqual(["kimchi/nemotron-3-ultra-fp4"])
+	})
+
+	it("throws when given an empty model list", () => {
+		expect(() => buildHermesFallbackProviders([])).toThrow(/No models/)
 	})
 })
 
@@ -140,7 +156,7 @@ describe("hermes tool registration", () => {
 		const tool = byId("hermes")
 		expect(tool).toBeDefined()
 		expect(tool?.installUrl).toBe("https://hermes-agent.nousresearch.com/install.sh")
-		expect(tool?.installArgs).toEqual(["--no-prompt", "--no-onboard"])
+		expect(tool?.installArgs).toEqual(["--skip-setup", "--non-interactive", "--skip-browser", "--no-skills"])
 		expect(tool?.configPath).toBe(HERMES_CONFIG_PATH)
 	})
 	it("write() rejects an empty API key", async () => {
@@ -232,7 +248,31 @@ describe("writeHermesDirect integration", () => {
 		vi.mocked(findBinary).mockClear()
 	})
 
-	it("writes valid YAML that preserves existing user config keys like temperature and fallbacks", async () => {
+	it("writes a config.yaml with the model + fallback_providers shape Hermes recognises", async () => {
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const written = parseYaml(readFileSync(join(tmp, ".hermes", "config.yaml"), "utf-8")) as Record<string, unknown>
+		const model = written.model as Record<string, unknown>
+		expect(model.provider).toBe("custom")
+		expect(model.base_url).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(model.api_key).toBe("${KIMCHI_API_KEY}")
+		expect(model.default).toBe("kimchi/kimi-k2.6")
+
+		const fallbacks = written.fallback_providers as Array<Record<string, unknown>>
+		expect(Array.isArray(fallbacks)).toBe(true)
+		expect(fallbacks.length).toBeGreaterThan(0)
+		const models = fallbacks.map((f) => f.model as string)
+		expect(models).toContain("kimchi/nemotron-3-ultra-fp4")
+		expect(models).toContain("kimchi/minimax-m2.7")
+		for (const entry of fallbacks) {
+			expect(entry.provider).toBe("custom")
+			expect(entry.key_env).toBe("KIMCHI_API_KEY")
+			expect(entry.api_key).toBeUndefined()
+		}
+	})
+
+	it("preserves unrelated existing user config keys when merging", async () => {
 		const configDir = join(tmp, ".hermes")
 		mkdirSync(configDir, { recursive: true })
 		const existing = `agents:
@@ -244,6 +284,7 @@ describe("writeHermesDirect integration", () => {
     models:
       other/model:
         alias: Other
+custom_user_key: keep-me
 `
 		writeFileSync(join(configDir, "config.yaml"), existing, "utf-8")
 
@@ -251,25 +292,17 @@ describe("writeHermesDirect integration", () => {
 		await tool?.write("global", "test-key-123", TEST_MODELS)
 
 		const written = parseYaml(readFileSync(join(configDir, "config.yaml"), "utf-8")) as Record<string, unknown>
+		// The new top-level model/fallback_providers keys must be present.
+		expect((written.model as Record<string, unknown>).default).toBe("kimchi/kimi-k2.6")
+		expect(Array.isArray(written.fallback_providers)).toBe(true)
+		// Unrelated user keys must survive untouched.
+		expect(written.custom_user_key).toBe("keep-me")
 		const agents = (written.agents as Record<string, unknown>).defaults as Record<string, unknown>
-		const model = agents.model as Record<string, unknown>
-
-		expect(model.temperature).toBe(0.7)
-		const fallbacks = model.fallbacks as string[]
-		expect(fallbacks).toContain("other/model")
-		expect(fallbacks).toContain("kimchi/nemotron-3-ultra-fp4")
-		expect(fallbacks).toContain("kimchi/minimax-m2.7")
-
-		const models = agents.models as Record<string, unknown>
-		expect(models["other/model"]).toEqual({ alias: "Other" })
-		expect(models["kimchi/kimi-k2.6"]).toBeDefined()
-
-		const providers = ((written.models as Record<string, unknown>).providers as Record<string, unknown>)
-			.kimchi as Record<string, unknown>
-		expect(providers).toBeDefined()
-		expect(providers.baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
-		expect(providers.apiKey).toBe("${KIMCHI_API_KEY}")
-		expect(providers.api).toBe("openai-completions")
+		const userModel = agents.model as Record<string, unknown>
+		expect(userModel.temperature).toBe(0.7)
+		expect(userModel.fallbacks).toEqual(["other/model"])
+		const userCatalog = agents.models as Record<string, unknown>
+		expect(userCatalog["other/model"]).toEqual({ alias: "Other" })
 	})
 
 	it("creates a fresh config.yaml when none exists", async () => {
@@ -278,10 +311,10 @@ describe("writeHermesDirect integration", () => {
 
 		const configPath = join(tmp, ".hermes", "config.yaml")
 		const written = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown>
-		const agents = (written.agents as Record<string, unknown>).defaults as Record<string, unknown>
-		const model = agents.model as Record<string, unknown>
-		expect(typeof model.primary).toBe("string")
-		expect((model.primary as string).startsWith("kimchi/")).toBe(true)
+		const model = written.model as Record<string, unknown>
+		expect(model.provider).toBe("custom")
+		expect(typeof model.default).toBe("string")
+		expect((model.default as string).startsWith("kimchi/")).toBe(true)
 
 		const envContent = readFileSync(join(tmp, ".hermes", ".env"), "utf-8")
 		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")
@@ -297,21 +330,9 @@ describe("writeHermesViaCLI integration", () => {
 		prevHome = process.env.HOME
 		process.env.HOME = tmp
 		vi.mocked(findBinary).mockReturnValue("/usr/bin/hermes")
-		vi.mocked(childProcess.execFileSync).mockReturnValue("not running")
-		vi.mocked(childProcess.spawnSync).mockImplementation((_cmd: unknown, args: unknown) => {
-			const cmdArgs = args as string[]
-			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.model.fallbacks") {
-				return { status: 0, stdout: JSON.stringify(["existing/model"]), stderr: "" } as ReturnType<
-					typeof childProcess.spawnSync
-				>
-			}
-			if (cmdArgs[0] === "config" && cmdArgs[1] === "get" && cmdArgs[2] === "agents.defaults.models") {
-				return { status: 0, stdout: JSON.stringify({ "other/model": { alias: "Other" } }), stderr: "" } as ReturnType<
-					typeof childProcess.spawnSync
-				>
-			}
-			return { status: 0, stdout: "", stderr: "" } as ReturnType<typeof childProcess.spawnSync>
-		})
+		vi.mocked(childProcess.spawnSync).mockReturnValue({ status: 0, stdout: "", stderr: "" } as ReturnType<
+			typeof childProcess.spawnSync
+		>)
 	})
 
 	afterEach(() => {
@@ -319,40 +340,49 @@ describe("writeHermesViaCLI integration", () => {
 		else process.env.HOME = prevHome
 		rmSync(tmp, { recursive: true, force: true })
 		vi.mocked(findBinary).mockClear()
-		vi.mocked(childProcess.execFileSync).mockClear()
 		vi.mocked(childProcess.spawnSync).mockClear()
 	})
 
-	it("preserves existing fallbacks and other keys via CLI merge", async () => {
+	it("calls hermes config set for each model.* key and fallback_providers", async () => {
 		const tool = byId("hermes")
 		await tool?.write("global", "test-key-123", TEST_MODELS)
 
 		const calls = vi.mocked(childProcess.spawnSync).mock.calls
-		const fallbackSetCall = calls.find((c) => {
-			const args = c[1] as string[] | undefined
-			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.model.fallbacks"
-		})
-		expect(fallbackSetCall).toBeDefined()
-		const mergedFallbacks = JSON.parse((fallbackSetCall?.[1] as string[])[3])
-		expect(mergedFallbacks).toContain("existing/model")
-		expect(mergedFallbacks).toContain("kimchi/nemotron-3-ultra-fp4")
+		const configSet = (path: string) =>
+			calls.find((c) => {
+				const args = c[1] as string[] | undefined
+				return args && args[0] === "config" && args[1] === "set" && args[2] === path
+			})
 
-		const modelsSetCall = calls.find((c) => {
-			const args = c[1] as string[] | undefined
-			return args && args[0] === "config" && args[1] === "set" && args[2] === "agents.defaults.models"
-		})
-		expect(modelsSetCall).toBeDefined()
-		const mergedModels = JSON.parse((modelsSetCall?.[1] as string[])[3]) as Record<string, unknown>
-		expect(mergedModels["other/model"]).toEqual({ alias: "Other" })
-		expect(mergedModels["kimchi/kimi-k2.6"]).toBeDefined()
-		expect(mergedModels["kimchi/nemotron-3-ultra-fp4"]).toBeDefined()
+		expect(configSet("model.provider")?.[1]).toEqual(["config", "set", "model.provider", "custom"])
+		expect(configSet("model.base_url")?.[1]).toEqual([
+			"config",
+			"set",
+			"model.base_url",
+			"https://llm.kimchi.dev/openai/v1",
+		])
+		expect(configSet("model.api_key")?.[1]).toEqual(["config", "set", "model.api_key", "${KIMCHI_API_KEY}"])
+		expect(configSet("model.default")?.[1]).toEqual(["config", "set", "model.default", "kimchi/kimi-k2.6"])
+
+		const fallbackSetCall = configSet("fallback_providers")
+		expect(fallbackSetCall).toBeDefined()
+		const fallbackPayload = JSON.parse((fallbackSetCall?.[1] as string[])[3]) as Array<Record<string, unknown>>
+		expect(Array.isArray(fallbackPayload)).toBe(true)
+		expect(fallbackPayload.length).toBeGreaterThan(0)
+		const models = fallbackPayload.map((f) => f.model as string)
+		expect(models).toContain("kimchi/nemotron-3-ultra-fp4")
+		expect(models).toContain("kimchi/minimax-m2.7")
+		for (const entry of fallbackPayload) {
+			expect(entry.provider).toBe("custom")
+			expect(entry.key_env).toBe("KIMCHI_API_KEY")
+			expect(entry.api_key).toBeUndefined()
+		}
 
 		const envContent = readFileSync(join(tmp, ".hermes", ".env"), "utf-8")
 		expect(envContent).toBe("KIMCHI_API_KEY=test-key-123\n")
 	})
 
-	it("runs hermes gateway restart when the gateway is already running", async () => {
-		vi.mocked(childProcess.execFileSync).mockReturnValue("gateway: running\n")
+	it("does not restart or onboard the Hermes gateway", async () => {
 		const tool = byId("hermes")
 		await tool?.write("global", "test-key-123", TEST_MODELS)
 
@@ -361,11 +391,31 @@ describe("writeHermesViaCLI integration", () => {
 			const args = c[1] as string[] | undefined
 			return args && args[0] === "gateway" && args[1] === "restart"
 		})
-		expect(restartCall).toBeDefined()
+		expect(restartCall).toBeUndefined()
 		const onboardCall = calls.find((c) => {
 			const args = c[1] as string[] | undefined
 			return args && args[0] === "onboard"
 		})
 		expect(onboardCall).toBeUndefined()
+	})
+
+	it("does not write to the legacy models.providers / agents.defaults paths", async () => {
+		const tool = byId("hermes")
+		await tool?.write("global", "test-key-123", TEST_MODELS)
+
+		const calls = vi.mocked(childProcess.spawnSync).mock.calls
+		const legacyCall = calls.find((c) => {
+			const args = c[1] as string[] | undefined
+			return (
+				args &&
+				args[0] === "config" &&
+				args[1] === "set" &&
+				(args[2] === "models.providers.kimchi" ||
+					args[2] === "agents.defaults.model.primary" ||
+					args[2] === "agents.defaults.model.fallbacks" ||
+					args[2] === "agents.defaults.models")
+			)
+		})
+		expect(legacyCall).toBeUndefined()
 	})
 })

--- a/src/integrations/hermes.ts
+++ b/src/integrations/hermes.ts
@@ -1,0 +1,285 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml"
+import { writeFileAtomic } from "../config/json.js"
+import type { ConfigScope } from "../config/scope.js"
+import { resolveScopePath } from "../config/scope.js"
+import type { ModelMetadata } from "../models.js"
+import { API_KEY_ENV, BASE_URL, PROVIDER_NAME } from "./constants.js"
+import { findBinary } from "./detect.js"
+import { type ModelRole, resolveAllModelRoles } from "./models.js"
+import { register } from "./registry.js"
+
+export const HERMES_CONFIG_PATH = "~/.hermes/config.yaml"
+export const HERMES_ENV_PATH = "~/.hermes/.env"
+
+/** Minimum Hermes version we know the config layout works against. Exported for tests and version gating. */
+export const HERMES_VERSION_MIN = "2026.1.0"
+
+/** Matches `hermes --version` output: "Hermes 2026.1.2". Exported for tests and version gating. */
+export const HERMES_VERSION_REGEX = /Hermes\s+(\d{4}\.\d+\.\d+)/
+
+/**
+ * Build the Hermes provider block — the JSON dropped at
+ * `models.providers.kimchi`. Same shape whether we write it via the CLI
+ * batch flag or directly into ~/.hermes/config.yaml. Pure so we can
+ * snapshot-test it without exec or fs.
+ *
+ * `apiKey` deliberately points at `${KIMCHI_API_KEY}` rather than the raw
+ * key so the YAML can be checked into version control without leaking
+ * credentials; the daemon resolves the env var from ~/.hermes/.env at
+ * launch time.
+ *
+ * @param models - Live `ModelMetadata[]` fetched from the API.
+ */
+export function buildHermesProviderBlock(models: readonly ModelMetadata[]): Record<string, unknown> {
+	return {
+		baseUrl: BASE_URL,
+		apiKey: `\${${API_KEY_ENV}}`,
+		api: "openai-completions",
+		models: models.map((m) => ({
+			id: `${PROVIDER_NAME}/${m.slug}`,
+			name: (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug,
+			reasoning: m.reasoning,
+			input: m.input_modalities,
+			contextWindow: m.limits.context_window,
+			maxTokens: m.limits.max_output_tokens,
+		})),
+	}
+}
+
+/** Map of `<provider>/<slug>` → `{ alias: displayName }` for agents.defaults.models. */
+export function buildHermesModelsCatalog(models: readonly ModelMetadata[]): Record<string, unknown> {
+	const out: Record<string, unknown> = {}
+	for (const m of models) {
+		const alias = (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug
+		out[`${PROVIDER_NAME}/${m.slug}`] = { alias }
+	}
+	return out
+}
+
+/** Detection: ~/.hermes/ dir present OR `hermes` on PATH. */
+export function detectHermes(): boolean {
+	const dir = join(homedir(), ".hermes")
+	if (existsSync(dir)) return true
+	return findBinary("hermes") !== undefined
+}
+
+/**
+ * Write `KIMCHI_API_KEY=<key>` into ~/.hermes/.env, replacing any prior
+ * line for the same key. The .env file feeds the Hermes daemon, which
+ * interpolates `${KIMCHI_API_KEY}` from config.yaml at runtime.
+ */
+export function writeHermesEnv(apiKey: string): void {
+	// The .env file feeds the Hermes daemon, which always reads from
+	// ~/.hermes/.env regardless of the config scope.
+	const envPath = resolveScopePath("global", HERMES_ENV_PATH)
+	let content = ""
+	try {
+		content = readFileSync(envPath, "utf-8")
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+	}
+
+	const newLine = `${API_KEY_ENV}=${apiKey}`
+	const lines = content === "" ? [] : content.split("\n")
+	// Drop a trailing empty line so we don't double up on the newline when
+	// we re-join below.
+	if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop()
+
+	let found = false
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].startsWith(`${API_KEY_ENV}=`)) {
+			lines[i] = newLine
+			found = true
+			break
+		}
+	}
+	if (!found) lines.push(newLine)
+
+	writeFileAtomic(envPath, `${lines.join("\n")}\n`)
+}
+
+function isHermesGatewayRunning(execFile: typeof execFileSync = execFileSync): boolean {
+	try {
+		const out = execFile("hermes", ["gateway", "status"], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] })
+		return out.includes("running")
+	} catch {
+		return false
+	}
+}
+
+function runHermesCmd(args: string[]): void {
+	const result = spawnSync("hermes", args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] })
+	if (result.status !== 0) {
+		const detail = (result.stderr || result.stdout || "").trim()
+		throw new Error(`hermes ${args.slice(0, 2).join(" ")} failed: ${detail || `exit ${result.status}`}`)
+	}
+}
+
+/** Configure Hermes via the `hermes config set` CLI (preferred when binary is present). */
+async function writeHermesViaCLI(apiKey: string, models: readonly ModelMetadata[]): Promise<void> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
+	const providerBlock = buildHermesProviderBlock(models)
+	const modelsCatalog = buildHermesModelsCatalog(models)
+
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
+	const primary = resolved.main ? `${PROVIDER_NAME}/${resolved.main.slug}` : `${PROVIDER_NAME}/${models[0].slug}`
+	const fallbacks = ([resolved.coding, resolved.sub] as Array<ModelMetadata | undefined>)
+		.filter((m): m is ModelMetadata => m !== undefined)
+		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
+
+	runHermesCmd(["config", "set", "models.providers.kimchi", JSON.stringify(providerBlock)])
+	runHermesCmd(["config", "set", "agents.defaults.model.primary", primary])
+	// Merge fields that may conflict with existing user config.
+	runHermesMerge("agents.defaults.model.fallbacks", (existing) => mergeFallbacks(existing, fallbacks))
+	runHermesMerge("agents.defaults.models", (existing) => mergeModelsCatalog(existing, modelsCatalog))
+
+	writeHermesEnv(apiKey)
+
+	if (isHermesGatewayRunning()) {
+		// Pick up the new config without prompting the user to restart.
+		runHermesCmd(["gateway", "restart"])
+	} else {
+		// Fresh install — run `hermes onboard` to scaffold the workspace and
+		// install the daemon. --auth-choice skip: we already configured the
+		// kimchi provider; choosing custom-api-key would create a duplicate
+		// provider that overrides our settings.
+		runHermesCmd([
+			"onboard",
+			"--non-interactive",
+			"--accept-risk",
+			"--auth-choice",
+			"skip",
+			"--install-daemon",
+			"--skip-channels",
+			"--skip-skills",
+			"--skip-search",
+			"--skip-ui",
+		])
+	}
+}
+
+/** Configure Hermes by writing YAML directly when no CLI is available. */
+async function writeHermesDirect(scope: ConfigScope, apiKey: string, models: readonly ModelMetadata[]): Promise<void> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
+	const path = resolveScopePath(scope, HERMES_CONFIG_PATH)
+	let existing: Record<string, unknown> = {}
+	try {
+		const raw = readFileSync(path, "utf-8")
+		const trimmed = raw.trim()
+		if (trimmed !== "") {
+			const parsed = parseYaml(trimmed)
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				existing = parsed as Record<string, unknown>
+			}
+		}
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+	}
+
+	const modelsRoot = asObject(existing.models)
+	const providers = asObject(modelsRoot.providers)
+	providers[PROVIDER_NAME] = buildHermesProviderBlock(models)
+	modelsRoot.providers = providers
+	existing.models = modelsRoot
+
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
+	const mainSlug = resolved.main?.slug ?? models[0].slug
+	const fallbacks = ([resolved.coding, resolved.sub] as Array<ModelMetadata | undefined>)
+		.filter((m): m is ModelMetadata => m !== undefined)
+		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
+
+	const agents = asObject(existing.agents)
+	const defaults = asObject(agents.defaults)
+	// Merge into model config to preserve existing keys like temperature, max_tokens.
+	const modelMap = asObject(defaults.model)
+	modelMap.primary = `${PROVIDER_NAME}/${mainSlug}`
+	modelMap.fallbacks = mergeFallbacks(modelMap.fallbacks, fallbacks)
+	defaults.model = modelMap
+
+	defaults.models = mergeModelsCatalog(defaults.models, buildHermesModelsCatalog(models))
+	agents.defaults = defaults
+	existing.agents = agents
+
+	writeFileAtomic(path, stringifyYaml(existing))
+	writeHermesEnv(apiKey)
+}
+
+async function writeHermes(
+	scope: ConfigScope,
+	apiKey: string,
+	models: readonly ModelMetadata[],
+	_options?: { telemetryEnabled?: boolean },
+): Promise<void> {
+	if (!apiKey) {
+		throw new Error("API key not configured")
+	}
+	if (!models || models.length === 0) {
+		throw new Error("No models available — is the API key valid?")
+	}
+	// CLI route preferred when the binary is on PATH — Hermes uses YAML
+	// internally and the CLI's setter is the only path that round-trips
+	// cleanly through its parser. Fall back to direct YAML write only when
+	// there's no hermes binary to ask.
+	if (findBinary("hermes")) {
+		await writeHermesViaCLI(apiKey, models)
+	} else {
+		await writeHermesDirect(scope, apiKey, models)
+	}
+}
+
+/** Read a config value via `hermes config get --json`; returns `null` if the path is missing or unreadable. */
+function openHermesConfigGet(path: string): unknown | null {
+	try {
+		const result = spawnSync("hermes", ["config", "get", path, "--json"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+		if (result.status !== 0) return null
+		const raw = (result.stdout ?? "").trim()
+		if (!raw) return null
+		return JSON.parse(raw)
+	} catch {
+		return null
+	}
+}
+
+/** Narrow an unknown value to a plain object, defaulting to `{}` for any other type. */
+export function asObject(v: unknown): Record<string, unknown> {
+	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
+}
+
+/** Merge fallbacks with an existing array, deduping entries. */
+export function mergeFallbacks(existing: unknown, fallbacks: string[]): string[] {
+	const current = Array.isArray(existing) ? (existing as string[]) : []
+	return [...new Set([...current, ...fallbacks])]
+}
+
+/** Merge models catalog with an existing object, with new entries taking precedence. */
+export function mergeModelsCatalog(existing: unknown, catalog: Record<string, unknown>): Record<string, unknown> {
+	return { ...asObject(existing), ...catalog }
+}
+
+/** Read existing value, merge it, and write back. */
+function runHermesMerge(path: string, merger: (existing: unknown) => unknown): void {
+	const existing = openHermesConfigGet(path)
+	const merged = merger(existing)
+	runHermesCmd(["config", "set", path, JSON.stringify(merged)])
+}
+
+register({
+	id: "hermes",
+	name: "Hermes",
+	description: "AI agent framework",
+	configPath: HERMES_CONFIG_PATH,
+	binaryName: "hermes",
+	installUrl: "https://hermes-agent.nousresearch.com/install.sh",
+	installArgs: ["--no-prompt", "--no-onboard"],
+	isInstalled: detectHermes,
+	write: writeHermes,
+})

--- a/src/integrations/hermes.ts
+++ b/src/integrations/hermes.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from "node:child_process"
+import { spawnSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -22,42 +22,64 @@ export const HERMES_VERSION_MIN = "2026.1.0"
 export const HERMES_VERSION_REGEX = /Hermes\s+(\d{4}\.\d+\.\d+)/
 
 /**
- * Build the Hermes provider block — the JSON dropped at
- * `models.providers.kimchi`. Same shape whether we write it via the CLI
- * batch flag or directly into ~/.hermes/config.yaml. Pure so we can
- * snapshot-test it without exec or fs.
+ * Build the top-level `model` block Hermes uses to pick an active inference
+ * provider. Same shape whether we write it via the CLI batch flag or
+ * directly into ~/.hermes/config.yaml. Pure so we can snapshot-test it
+ * without exec or fs.
  *
  * `apiKey` deliberately points at `${KIMCHI_API_KEY}` rather than the raw
  * key so the YAML can be checked into version control without leaking
  * credentials; the daemon resolves the env var from ~/.hermes/.env at
  * launch time.
  *
+ * `default` uses the `<provider>/<slug>` convention Hermes expects when
+ * `provider: "custom"`.
+ *
  * @param models - Live `ModelMetadata[]` fetched from the API.
  */
-export function buildHermesProviderBlock(models: readonly ModelMetadata[]): Record<string, unknown> {
+export function buildHermesModelConfig(models: readonly ModelMetadata[]): Record<string, unknown> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
+	const resolved = resolveAllModelRoles(models, ["main"] as readonly ModelRole[])
+	const mainSlug = resolved.main?.slug ?? models[0].slug
+
 	return {
-		baseUrl: BASE_URL,
-		apiKey: `\${${API_KEY_ENV}}`,
-		api: "openai-completions",
-		models: models.map((m) => ({
-			id: `${PROVIDER_NAME}/${m.slug}`,
-			name: (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug,
-			reasoning: m.reasoning,
-			input: m.input_modalities,
-			contextWindow: m.limits.context_window,
-			maxTokens: m.limits.max_output_tokens,
-		})),
+		provider: "custom",
+		base_url: BASE_URL,
+		api_key: `\${${API_KEY_ENV}}`,
+		default: `${PROVIDER_NAME}/${mainSlug}`,
 	}
 }
 
-/** Map of `<provider>/<slug>` → `{ alias: displayName }` for agents.defaults.models. */
-export function buildHermesModelsCatalog(models: readonly ModelMetadata[]): Record<string, unknown> {
-	const out: Record<string, unknown> = {}
-	for (const m of models) {
-		const alias = (m.display_name ?? "").trim().length > 0 ? m.display_name : m.slug
-		out[`${PROVIDER_NAME}/${m.slug}`] = { alias }
+/**
+ * Build the `fallback_providers` list Hermes uses when the primary model
+ * can't be reached. Each entry uses `key_env` (not `api_key`) so Hermes
+ * reads the credential from ~/.hermes/.env at runtime. Falls back through
+ * the `coding` and `sub` role slots; entries are deduped.
+ *
+ * @param models - Live `ModelMetadata[]` fetched from the API.
+ */
+export function buildHermesFallbackProviders(models: readonly ModelMetadata[]): Array<Record<string, unknown>> {
+	if (models.length === 0) throw new Error("No models available — is the API key valid?")
+
+	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
+	const mainSlug = resolved.main?.slug
+	const slugs = ([resolved.coding, resolved.sub] as Array<ModelMetadata | undefined>)
+		.filter((m): m is ModelMetadata => m !== undefined)
+		.map((m) => m.slug)
+		.filter((slug) => slug !== mainSlug)
+
+	const deduped: string[] = []
+	for (const slug of slugs) {
+		if (!deduped.includes(slug)) deduped.push(slug)
 	}
-	return out
+
+	return deduped.map((slug) => ({
+		provider: "custom",
+		model: `${PROVIDER_NAME}/${slug}`,
+		base_url: BASE_URL,
+		key_env: API_KEY_ENV,
+	}))
 }
 
 /** Detection: ~/.hermes/ dir present OR `hermes` on PATH. */
@@ -102,15 +124,6 @@ export function writeHermesEnv(apiKey: string): void {
 	writeFileAtomic(envPath, `${lines.join("\n")}\n`)
 }
 
-function isHermesGatewayRunning(execFile: typeof execFileSync = execFileSync): boolean {
-	try {
-		const out = execFile("hermes", ["gateway", "status"], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] })
-		return out.includes("running")
-	} catch {
-		return false
-	}
-}
-
 function runHermesCmd(args: string[]): void {
 	const result = spawnSync("hermes", args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] })
 	if (result.status !== 0) {
@@ -123,44 +136,24 @@ function runHermesCmd(args: string[]): void {
 async function writeHermesViaCLI(apiKey: string, models: readonly ModelMetadata[]): Promise<void> {
 	if (models.length === 0) throw new Error("No models available — is the API key valid?")
 
-	const providerBlock = buildHermesProviderBlock(models)
-	const modelsCatalog = buildHermesModelsCatalog(models)
+	const modelConfig = buildHermesModelConfig(models)
+	const fallbackProviders = buildHermesFallbackProviders(models)
 
-	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
-	const primary = resolved.main ? `${PROVIDER_NAME}/${resolved.main.slug}` : `${PROVIDER_NAME}/${models[0].slug}`
-	const fallbacks = ([resolved.coding, resolved.sub] as Array<ModelMetadata | undefined>)
-		.filter((m): m is ModelMetadata => m !== undefined)
-		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
-
-	runHermesCmd(["config", "set", "models.providers.kimchi", JSON.stringify(providerBlock)])
-	runHermesCmd(["config", "set", "agents.defaults.model.primary", primary])
-	// Merge fields that may conflict with existing user config.
-	runHermesMerge("agents.defaults.model.fallbacks", (existing) => mergeFallbacks(existing, fallbacks))
-	runHermesMerge("agents.defaults.models", (existing) => mergeModelsCatalog(existing, modelsCatalog))
+	// Set each model.* key individually — `hermes config set model <json>`
+	// stringifies the whole object under `model.default` instead of expanding
+	// nested keys, so we use dot-path setters.
+	runHermesCmd(["config", "set", "model.provider", String(modelConfig.provider)])
+	runHermesCmd(["config", "set", "model.base_url", String(modelConfig.base_url)])
+	runHermesCmd(["config", "set", "model.api_key", String(modelConfig.api_key)])
+	runHermesCmd(["config", "set", "model.default", String(modelConfig.default)])
+	runHermesCmd(["config", "set", "fallback_providers", JSON.stringify(fallbackProviders)])
 
 	writeHermesEnv(apiKey)
-
-	if (isHermesGatewayRunning()) {
-		// Pick up the new config without prompting the user to restart.
-		runHermesCmd(["gateway", "restart"])
-	} else {
-		// Fresh install — run `hermes onboard` to scaffold the workspace and
-		// install the daemon. --auth-choice skip: we already configured the
-		// kimchi provider; choosing custom-api-key would create a duplicate
-		// provider that overrides our settings.
-		runHermesCmd([
-			"onboard",
-			"--non-interactive",
-			"--accept-risk",
-			"--auth-choice",
-			"skip",
-			"--install-daemon",
-			"--skip-channels",
-			"--skip-skills",
-			"--skip-search",
-			"--skip-ui",
-		])
-	}
+	// We intentionally do not restart a running Hermes gateway here. In
+	// container/headless environments `hermes gateway restart` can hang or
+	// restart the process under the current shell, blocking setup-tools.
+	// The provider/model config is persisted to ~/.hermes/config.yaml and
+	// will be picked up the next time the user starts Hermes.
 }
 
 /** Configure Hermes by writing YAML directly when no CLI is available. */
@@ -182,29 +175,8 @@ async function writeHermesDirect(scope: ConfigScope, apiKey: string, models: rea
 		if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
 	}
 
-	const modelsRoot = asObject(existing.models)
-	const providers = asObject(modelsRoot.providers)
-	providers[PROVIDER_NAME] = buildHermesProviderBlock(models)
-	modelsRoot.providers = providers
-	existing.models = modelsRoot
-
-	const resolved = resolveAllModelRoles(models, ["main", "coding", "sub"] as readonly ModelRole[])
-	const mainSlug = resolved.main?.slug ?? models[0].slug
-	const fallbacks = ([resolved.coding, resolved.sub] as Array<ModelMetadata | undefined>)
-		.filter((m): m is ModelMetadata => m !== undefined)
-		.map((m) => `${PROVIDER_NAME}/${m.slug}`)
-
-	const agents = asObject(existing.agents)
-	const defaults = asObject(agents.defaults)
-	// Merge into model config to preserve existing keys like temperature, max_tokens.
-	const modelMap = asObject(defaults.model)
-	modelMap.primary = `${PROVIDER_NAME}/${mainSlug}`
-	modelMap.fallbacks = mergeFallbacks(modelMap.fallbacks, fallbacks)
-	defaults.model = modelMap
-
-	defaults.models = mergeModelsCatalog(defaults.models, buildHermesModelsCatalog(models))
-	agents.defaults = defaults
-	existing.agents = agents
+	existing.model = buildHermesModelConfig(models)
+	existing.fallback_providers = buildHermesFallbackProviders(models)
 
 	writeFileAtomic(path, stringifyYaml(existing))
 	writeHermesEnv(apiKey)
@@ -233,22 +205,6 @@ async function writeHermes(
 	}
 }
 
-/** Read a config value via `hermes config get --json`; returns `null` if the path is missing or unreadable. */
-function openHermesConfigGet(path: string): unknown | null {
-	try {
-		const result = spawnSync("hermes", ["config", "get", path, "--json"], {
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "pipe"],
-		})
-		if (result.status !== 0) return null
-		const raw = (result.stdout ?? "").trim()
-		if (!raw) return null
-		return JSON.parse(raw)
-	} catch {
-		return null
-	}
-}
-
 /** Narrow an unknown value to a plain object, defaulting to `{}` for any other type. */
 export function asObject(v: unknown): Record<string, unknown> {
 	return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {}
@@ -265,13 +221,6 @@ export function mergeModelsCatalog(existing: unknown, catalog: Record<string, un
 	return { ...asObject(existing), ...catalog }
 }
 
-/** Read existing value, merge it, and write back. */
-function runHermesMerge(path: string, merger: (existing: unknown) => unknown): void {
-	const existing = openHermesConfigGet(path)
-	const merged = merger(existing)
-	runHermesCmd(["config", "set", path, JSON.stringify(merged)])
-}
-
 register({
 	id: "hermes",
 	name: "Hermes",
@@ -279,7 +228,7 @@ register({
 	configPath: HERMES_CONFIG_PATH,
 	binaryName: "hermes",
 	installUrl: "https://hermes-agent.nousresearch.com/install.sh",
-	installArgs: ["--no-prompt", "--no-onboard"],
+	installArgs: ["--skip-setup", "--non-interactive", "--skip-browser", "--no-skills"],
 	isInstalled: detectHermes,
 	write: writeHermes,
 })

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -1,7 +1,7 @@
 import type { ConfigScope } from "../config/scope.js"
 import type { ModelMetadata } from "../models.js"
 
-export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2"
+export type ToolId = "opencode" | "claudecode" | "cursor" | "openclaw" | "gsd2" | "hermes"
 
 /**
  * A configurable third-party tool that kimchi can point at the kimchi LLM

--- a/src/setup-wizard/index.ts
+++ b/src/setup-wizard/index.ts
@@ -1,6 +1,7 @@
 // Side-effect imports register each integration. Import order doesn't matter
 // — the registry is a Map keyed by ToolId — but the imports themselves do,
 // otherwise byId() returns undefined for an unimported tool.
+import "../integrations/hermes.js"
 import "../integrations/claude-code.js"
 import "../integrations/cursor.js"
 import "../integrations/gsd2.js"


### PR DESCRIPTION
# feat: add Hermes Agent (NousResearch) integration

Re-introduces the Hermes Agent integration attempted in PR #454, with the fixes required to pass CI and work against the real Hermes CLI.

## What changed since PR #454
- **Preserved `ToolDefinition` interface** — the original PR deleted it and only extended `ToolId`, which broke `tsc` for every other integration.
- **Fixed installer flags** — Hermes's install script does not support `--no-prompt` / `--no-onboard`. Uses supported flags: `--skip-setup --non-interactive --skip-browser --no-skills`.
- **Correct Hermes config shape** — Hermes recognizes an active inference provider under the top-level `model:` block (`provider: custom`, `base_url`, `api_key`, `default`), not under `models.providers`. The integration writes that block plus a `fallback_providers` chain.
- **No daemon commands during setup** — removed `hermes onboard --install-daemon` and `hermes gateway restart`, both of which hang in container/headless environments.
- **Wired everywhere** — Hermes is registered as a `ToolId`, imported in the setup wizard and `setup-tools`, and exposed as `kimchi hermes`.

## Files changed
- `src/integrations/hermes.ts` — Hermes integration
- `src/integrations/hermes.test.ts` — unit tests
- `src/integrations/types.ts` — added `"hermes"` to `ToolId`
- `src/setup-wizard/index.ts` — imported Hermes integration
- `src/commands/setup-tools.ts` — imported Hermes integration
- `src/commands/hermes.ts` — new `kimchi hermes` subcommand
- `src/commands/registry.ts` — registered `kimchi hermes`

## Verification
- `pnpm run check` — lint + typecheck clean
- `pnpm vitest run src/integrations/hermes.test.ts` — 33/33 passing
- `node scripts/build-binary.js --target linux-arm64` — builds Linux ARM64 binary
