### PR TITLE
Cloud animation for Cloud Agent subagent

### DIFF
--- a/src/extensions/agents/index.ts
+++ b/src/extensions/agents/index.ts
@@ -95,6 +95,7 @@ import {
 	formatMs,
 	formatTokens,
 	formatTurns,
+	getAgentSpinnerFrames,
 	getDisplayName,
 	SPINNER,
 	type Theme,
@@ -163,6 +164,7 @@ interface GetSubagentResultDetails {
 	agentId: string
 	displayName: string
 	description: string
+	subagentType?: string
 	status: string
 	visibility?: AgentVisibility
 	abortReason?: AgentAbortReason
@@ -186,11 +188,13 @@ function formatAgentBodyForDisplay(raw: string): string {
 	return cleaned.replace(/\n{3,}/g, "\n\n").trimEnd()
 }
 
-function getSubagentResultIcon(status: string, theme: Theme): string {
+function getSubagentResultIcon(status: string, theme: Theme, subagentType?: string): string {
 	switch (status) {
 		case "running":
-		case "queued":
-			return theme.fg("accent", SPINNER[0])
+		case "queued": {
+			const frames = subagentType ? getAgentSpinnerFrames(subagentType) : SPINNER
+			return theme.fg("accent", frames[0])
+		}
 		case "error":
 		case "aborted":
 			return theme.fg("error", "✗")
@@ -1320,7 +1324,8 @@ ${AGENT_TOOL_GUIDELINES}`,
 				}
 
 				if (isPartial || details.status === "running") {
-					const frame = SPINNER[details.spinnerFrame ?? 0]
+					const frames = getAgentSpinnerFrames(details.subagentType)
+					const frame = frames[(details.spinnerFrame ?? 0) % frames.length]
 					const s = stats(details)
 					let line = theme.fg("accent", frame) + (s ? ` ${s}` : "")
 					line += `\n${theme.fg("dim", `  ⎿  ${details.activity ?? "thinking..."}`)}  ${theme.fg("muted", "(ctrl+b to run in background)")}`
@@ -1625,7 +1630,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 						durationMs: Date.now() - startedAt,
 						status: "running",
 						activity: describeActivity(fgState.activeTools, fgState.responseText),
-						spinnerFrame: spinnerFrame % SPINNER.length,
+						spinnerFrame: spinnerFrame % getAgentSpinnerFrames(subagentType).length,
 					}
 					onUpdate?.({
 						content: [{ type: "text", text: `${fgState.toolUses} tool uses...` }],
@@ -1927,7 +1932,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 					return parts.map((p) => theme.fg("dim", p)).join(` ${theme.fg("dim", "·")} `)
 				}
 
-				const icon = getSubagentResultIcon(details.status, theme)
+				const icon = getSubagentResultIcon(details.status, theme, details.subagentType)
 
 				const headerName = theme.fg("toolTitle", theme.bold("Get Agent Result"))
 				const headerDesc = details.description ? `  ${theme.fg("muted", details.description)}` : ""
@@ -2022,6 +2027,7 @@ ${AGENT_TOOL_GUIDELINES}`,
 					agentId: record.id,
 					displayName,
 					description: record.description,
+					subagentType: record.type,
 					status: record.status,
 					visibility: record.visibility,
 					abortReason: record.abortReason,

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -13,6 +13,24 @@ const MAX_WIDGET_LINES = 12
 
 export const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
+/**
+ * Cloud Agent animation — a cloud glyph (☁) with a loading arc (◜◝◞◟)
+ * tracing around it, completing in a full circle (◯) before restarting.
+ * Used instead of SPINNER for the Remote-Runner (Cloud Agent) subagent type.
+ */
+export const CLOUD = ["☁◜", "☁◝", "☁◞", "☁◟", "☁◯", "☁◯"]
+
+/** Type identifier for the Cloud Agent (remote sandbox runner via ACP). */
+const CLOUD_AGENT_TYPE = "Remote-Runner"
+
+/**
+ * Returns the animation frames for a given agent type.
+ * Cloud Agent (Remote-Runner) gets the cloud animation; everything else gets the braille spinner.
+ */
+export function getAgentSpinnerFrames(type: string): string[] {
+	return type === CLOUD_AGENT_TYPE ? CLOUD : SPINNER
+}
+
 export const ERROR_STATUSES = new Set(["error", "aborted", "steered", "stopped"])
 
 const TOOL_DISPLAY: Record<string, string> = {
@@ -262,7 +280,6 @@ export class AgentWidget {
 		const truncate = (line: string) => truncateToWidth(line, width)
 		const headingColor = hasActive ? "accent" : "dim"
 		const headingIcon = hasActive ? "●" : "○"
-		const frame = SPINNER[this.widgetFrame % SPINNER.length]
 
 		const finishedLines: string[] = []
 		for (const a of finished) {
@@ -275,6 +292,8 @@ export class AgentWidget {
 		for (const a of running) {
 			const name = getDisplayName(a.type)
 			const elapsed = formatMs(Date.now() - a.startedAt)
+			const frames = getAgentSpinnerFrames(a.type)
+			const frame = frames[this.widgetFrame % frames.length]
 
 			const bg = this.agentActivity.get(a.id)
 			const toolUses = bg?.toolUses ?? a.toolUses


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- No linked issue — this is a UX polish for the experimental Cloud Agent subagent type introduced in #1088. -->

## What does this PR do?

Adds a unique inline animation for the Cloud Agent (`Remote-Runner`) subagent type, replacing the generic braille spinner it shared with all other agents. The Cloud Agent now shows a cloud glyph (`☁`) with a loading arc (`◜◝◞◟`) tracing around it, completing in a full circle before restarting — visually distinguishing remote execution from local agents at a glance.

The animation works across all three TUI rendering surfaces:
- Agent widget (persistent panel above the editor)
- Inline tool-call block (foreground agent progress)
- `get_subagent_result` icon (queued/running status)

Other agent types are unaffected — they continue to use the standard braille spinner.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed