### PR TITLE
feat(telemetry): add session.parent_id to subagent telemetry events

### DIFF
--- a/src/extensions/curator/index.ts
+++ b/src/extensions/curator/index.ts
@@ -1,7 +1,7 @@
 import { watch } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { ExtensionAPI, MessageRenderer } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, MessageRenderer } from "@earendil-works/pi-coding-agent"
 import { Container, Text } from "@earendil-works/pi-tui"
 import { isSubagent } from "../prompt-construction/prompt-enrichment.js"
 import { getEffectiveModel } from "../router/state.js"
@@ -78,7 +78,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 
 	debugLog(`curator registered: threshold=${SESSION_REVIEW_THRESHOLD} skillsDir=${skillsDir}`)
 
-	pi.on("agent_end", (event) => {
+	pi.on("agent_end", (event, ctx) => {
 		const turnCount = event.messages.filter((m) => (m as { role: string }).role === "assistant").length
 		debugLog(
 			`agent_end fired: turnCount=${turnCount} threshold=${SESSION_REVIEW_THRESHOLD} providerModel=${JSON.stringify(providerModel)}`,
@@ -97,6 +97,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 			model: providerModel.model,
 			skillsDir,
 			messages: event.messages,
+			parentSessionId: ctx.sessionManager.getSessionId(),
 		})
 
 		// Watch skillsDir for .usage.json changes and notify when new agent_created skills appear.
@@ -148,7 +149,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 		cleanup.unref()
 	})
 
-	pi.on("session_start", async () => {
+	pi.on("session_start", async (_event, ctx) => {
 		const now = new Date()
 
 		try {
@@ -188,6 +189,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 						skillsDir,
 						manager,
 						background: true,
+						parentSessionId: ctx.sessionManager.getSessionId(),
 					})
 				} catch {
 					// Swallow — never block session startup
@@ -221,7 +223,13 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 		} as never,
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		execute: (async (_toolCallId: string, params: { action: "run" | "status" }) => {
+		execute: (async (
+			_toolCallId: string,
+			params: { action: "run" | "status" },
+			_signal: AbortSignal | undefined,
+			_onUpdate: unknown,
+			ctx: ExtensionContext,
+		) => {
 			if (params.action === "status") {
 				const state = await loadState(statePath)
 				return {
@@ -267,6 +275,7 @@ export default function curatorExtension(pi: ExtensionAPI, options?: CuratorExte
 					skillsDir,
 					manager,
 					background: false,
+					parentSessionId: ctx.sessionManager.getSessionId(),
 				})
 
 				const text = summary

--- a/src/extensions/curator/review.test.ts
+++ b/src/extensions/curator/review.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest"
-import { buildCuratorPrompt, parseCuratorOutput } from "./review.js"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { spawnKimchiSubprocess } from "../../utils/spawn-kimchi-subprocess.js"
+import { buildCuratorPrompt, parseCuratorOutput, spawnSessionReview } from "./review.js"
+
+vi.mock("../../utils/spawn-kimchi-subprocess.js", () => ({
+	spawnKimchiSubprocess: vi.fn(() => ({ unref: () => {}, on: () => {} })),
+}))
 
 describe("buildCuratorPrompt", () => {
 	it("includes candidate skill names in prompt", () => {
@@ -78,5 +83,45 @@ prunings: []
 		const result = parseCuratorOutput(text)
 		expect(result?.consolidations).toHaveLength(0)
 		expect(result?.prunings).toHaveLength(0)
+	})
+
+	describe("spawnSessionReview", () => {
+		beforeEach(() => {
+			vi.mocked(spawnKimchiSubprocess).mockClear()
+		})
+
+		const minimalMessages = [{ role: "user", content: "hello" }]
+
+		it("forwards parentSessionId into the review subprocess env", () => {
+			spawnSessionReview({
+				provider: "openai",
+				model: "gpt-4o",
+				skillsDir: "/tmp/skills",
+				messages: minimalMessages,
+				parentSessionId: "parent-session-1",
+			})
+
+			expect(spawnKimchiSubprocess).toHaveBeenCalledTimes(1)
+			const { env } = vi.mocked(spawnKimchiSubprocess).mock.calls[0][0]
+			expect(env).toMatchObject({
+				KIMCHI_SUBAGENT: "1",
+				KIMCHI_SESSION_REVIEW: "1",
+				KIMCHI_PARENT_SESSION_ID: "parent-session-1",
+			})
+		})
+
+		it("omits KIMCHI_PARENT_SESSION_ID from the env when no parent session is available", () => {
+			spawnSessionReview({
+				provider: "openai",
+				model: "gpt-4o",
+				skillsDir: "/tmp/skills",
+				messages: minimalMessages,
+			})
+
+			expect(spawnKimchiSubprocess).toHaveBeenCalledTimes(1)
+			const { env } = vi.mocked(spawnKimchiSubprocess).mock.calls[0][0]
+			expect(Object.hasOwn(env ?? {}, "KIMCHI_PARENT_SESSION_ID")).toBe(false)
+			expect(env?.KIMCHI_SUBAGENT).toBe("1")
+		})
 	})
 })

--- a/src/extensions/curator/review.ts
+++ b/src/extensions/curator/review.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { convertToLlm } from "@earendil-works/pi-coding-agent"
 import { parse as parseYaml } from "yaml"
 import { spawnKimchiSubprocess } from "../../utils/spawn-kimchi-subprocess.js"
+import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import type { SkillManager } from "../skills-manager/skill-manager.js"
 import { agentCreatedReport } from "../skills-manager/usage.js"
 import { loadState, saveState } from "./state.js"
@@ -119,6 +120,8 @@ export interface RunCuratorReviewOptions {
 	skillsDir: string
 	manager: SkillManager
 	background?: boolean
+	/** Spawning session's pi session id — forwarded to the review subprocess env. */
+	parentSessionId?: string
 }
 
 function collectExtensionArgs(): string[] {
@@ -167,7 +170,12 @@ function spawnReviewAgent(
 	provider: string,
 	model: string,
 	prompt: string,
-	opts?: { detached?: boolean; stdout?: "pipe" | "ignore" | number; stderr?: "pipe" | "ignore" | number },
+	opts?: {
+		detached?: boolean
+		stdout?: "pipe" | "ignore" | number
+		stderr?: "pipe" | "ignore" | number
+		parentSessionId?: string
+	},
 ) {
 	const args = buildReviewAgentArgs(provider, model, prompt)
 	debugLog(`spawning review agent with args: ${args.slice(0, 6).join(" ")} ...`)
@@ -176,7 +184,11 @@ function spawnReviewAgent(
 		stdout: opts?.stdout,
 		stderr: opts?.stderr,
 		detached: opts?.detached,
-		env: { KIMCHI_SUBAGENT: "1", KIMCHI_SESSION_REVIEW: "1" },
+		env: {
+			KIMCHI_SUBAGENT: "1",
+			KIMCHI_SESSION_REVIEW: "1",
+			...(opts?.parentSessionId ? { [PARENT_SESSION_ID_ENV_KEY]: opts.parentSessionId } : {}),
+		},
 	})
 }
 
@@ -188,9 +200,9 @@ function spawnReviewAgent(
 const REVIEW_TIMEOUT_MS = 30 * 60 * 1000
 const REVIEW_INACTIVITY_TIMEOUT_MS = 3 * 60 * 1000
 
-function runReviewAgent(provider: string, model: string, prompt: string): Promise<string> {
+function runReviewAgent(provider: string, model: string, prompt: string, parentSessionId?: string): Promise<string> {
 	return new Promise((resolvePromise, reject) => {
-		const proc = spawnReviewAgent(provider, model, prompt)
+		const proc = spawnReviewAgent(provider, model, prompt, { parentSessionId })
 		let output = ""
 		let stderr = ""
 		let buffer = ""
@@ -287,7 +299,11 @@ export async function runCuratorReview(opts: RunCuratorReviewOptions): Promise<C
 	}
 
 	if (background) {
-		const proc = spawnReviewAgent(provider, model, prompt, { detached: true, stderr: "ignore" })
+		const proc = spawnReviewAgent(provider, model, prompt, {
+			detached: true,
+			stderr: "ignore",
+			parentSessionId: opts.parentSessionId,
+		})
 		proc.unref()
 		let output = ""
 		let buffer = ""
@@ -308,7 +324,7 @@ export async function runCuratorReview(opts: RunCuratorReviewOptions): Promise<C
 	}
 
 	try {
-		const output = await runReviewAgent(provider, model, prompt)
+		const output = await runReviewAgent(provider, model, prompt, opts.parentSessionId)
 		return finalize(output)
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err)
@@ -392,6 +408,8 @@ export interface RunSessionReviewOptions {
 	skillsDir: string
 	// biome-ignore lint/suspicious/noExplicitAny: messages type not exported from pi-coding-agent
 	messages: any[]
+	/** Spawning session's pi session id — forwarded to the review subprocess env. */
+	parentSessionId?: string
 }
 
 export function debugLog(msg: string): void {
@@ -401,8 +419,7 @@ export function debugLog(msg: string): void {
 }
 
 export function spawnSessionReview(opts: RunSessionReviewOptions): void {
-	const { provider, model, messages } = opts
-
+	const { provider, model, messages, parentSessionId } = opts
 	debugLog(`spawnSessionReview called: provider=${provider} model=${model} messages=${messages.length}`)
 
 	const transcript = serializeTranscript(messages)
@@ -423,7 +440,12 @@ export function spawnSessionReview(opts: RunSessionReviewOptions): void {
 		stdoutOption = logFd
 	}
 
-	const proc = spawnReviewAgent(provider, model, prompt, { detached: true, stdout: stdoutOption, stderr: "ignore" })
+	const proc = spawnReviewAgent(provider, model, prompt, {
+		detached: true,
+		stdout: stdoutOption,
+		stderr: "ignore",
+		parentSessionId,
+	})
 
 	if (logFd !== undefined) {
 		closeSync(logFd)

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -30,7 +30,7 @@ Every in-session payload includes:
 
 | Attribute | Value |
 |-----------|-------|
-| `session.id` | Shared root UUID across all agents in the process |
+| `session.id` | Per-process telemetry session id — shared by the main agent and in-process subagents, so events roll up under one backend session; not a per-agent id, and out-of-process agents (remote, session-review subprocesses) have their own |
 | `session.parent_id` | Spawning (parent) session's pi session id — present only on events emitted from inside a subagent run |
 | `client` | `"pi"` |
 | `source` | Where the event originated (e.g. `"cli"`) |

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -31,6 +31,7 @@ Every in-session payload includes:
 | Attribute | Value |
 |-----------|-------|
 | `session.id` | Shared root UUID across all agents in the process |
+| `session.parent_id` | Spawning (parent) session's pi session id — present only on events emitted from inside a subagent run |
 | `client` | `"pi"` |
 | `source` | Where the event originated (e.g. `"cli"`) |
 | `mode` | `"coding"` or `"ferment"` |

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -38,6 +38,38 @@ Every in-session payload includes:
 
 Pre-session payloads use the **device ID** (from PostHog) as `session.id`.
 
+### Subagent identification
+
+`session.parent_id` is the marker for events raised inside a subagent run. It
+is emitted only when the process is inside an Agent-subagent execution
+(`isAgentWorker()` — the Agent-worker async context, or `KIMCHI_SUBAGENT=1`)
+*and* the runner has recorded the spawning session (`KIMCHI_PARENT_SESSION_ID`,
+set for the whole subagent run by `withParentSessionEnv` in
+`extensions/agents/manager/agent-runner.ts`). Its value is the **parent**
+session's pi session id; the emitting session's own id is `pi_session_id`.
+Combine the two to reconstruct the spawn tree:
+
+| Attribute | Main agent event | In-process subagent event |
+|-----------|------------------|---------------------------|
+| `session.id` | process telemetryId `T` | `T` (shared — same process) |
+| `pi_session_id` | parent session id `P` | subagent session id `S` |
+| `session.parent_id` | *(absent)* | `P` |
+
+An event with `session.parent_id != ""` whose `session.id` equals the
+parent's is from an **in-process** subagent (same process — the main agent and
+its in-process subagents share the module-level telemetryId). Two caveats:
+
+- The **curator session-review subprocess** also sets `KIMCHI_SUBAGENT=1` and
+  `KIMCHI_PARENT_SESSION_ID`, so its events carry `session.parent_id` too. It
+  is a separate process, so it is distinguished by its own `session.id`
+  (different from the parent's telemetryId).
+- **Remote sandbox agents** never receive the env var, so their events carry
+  no `session.parent_id`.
+
+`subagent.spawned` (raised by the *parent*) additionally declares the
+subagent's `agent_type` and `reason`, so spawning events can be paired with
+the subagent's own events via `session.parent_id`.
+
 ## Pre-Session Events
 
 Fired from `pre-session.ts` via `sendPreSessionEvent()`. Sent to the **logs endpoint**.

--- a/src/extensions/telemetry/session-context.test.ts
+++ b/src/extensions/telemetry/session-context.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { TelemetryConfig } from "../../config.js"
 import * as osMetadata from "../../utils/os-metadata.js"
+import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import { _resetSharedAccumulators, TelemetryContext } from "./session-context.js"
 
 vi.mock("../../api/me.js", () => ({
@@ -38,6 +39,10 @@ describe("SessionContext", () => {
 		globalThis.fetch = originalFetch
 		_resetSharedAccumulators()
 		vi.restoreAllMocks()
+		// session.parent_id simulation env — never leak the subagent worker flag
+		// or the parent session id into sibling tests.
+		Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
+		Reflect.deleteProperty(process.env, PARENT_SESSION_ID_ENV_KEY)
 	})
 
 	it("emit appends source and session_type to every event", async () => {
@@ -429,5 +434,77 @@ describe("SessionContext", () => {
 			),
 		)
 		expect(attrMap["user.account_uuid"]).toBe("user-uuid-123")
+	})
+
+	it("emit adds session.parent_id when running inside a subagent", async () => {
+		const { getActiveFerment } = await import("../ferment/index.js")
+		vi.mocked(getActiveFerment).mockReturnValue(undefined)
+		process.env.KIMCHI_SUBAGENT = "1"
+		process.env[PARENT_SESSION_ID_ENV_KEY] = "parent-session-1"
+
+		const ctx = new TelemetryContext(makeConfig())
+		ctx.emit("test.event", { custom: "value" })
+		ctx.flushLogBuffer()
+
+		await Promise.allSettled([...ctx.inFlight])
+
+		expect(globalThis.fetch).toHaveBeenCalledOnce()
+		const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+		const body = JSON.parse(options.body)
+		const attrMap = Object.fromEntries(
+			body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes.map(
+				(a: { key: string; value: { stringValue: string } }) => [a.key, a.value.stringValue],
+			),
+		)
+
+		expect(attrMap["session.parent_id"]).toBe("parent-session-1")
+	})
+
+	it("emit omits session.parent_id for non-subagent events even when the env var is set", async () => {
+		const { getActiveFerment } = await import("../ferment/index.js")
+		vi.mocked(getActiveFerment).mockReturnValue(undefined)
+		// KIMCHI_PARENT_SESSION_ID is process-global and set during a subagent run.
+		// Events emitted OUTSIDE a subagent run must not be tagged with it — the
+		// parent session is not a parent of itself.
+		process.env[PARENT_SESSION_ID_ENV_KEY] = "parent-session-1"
+
+		const ctx = new TelemetryContext(makeConfig())
+		ctx.emit("test.event", { custom: "value" })
+		ctx.flushLogBuffer()
+
+		await Promise.allSettled([...ctx.inFlight])
+
+		expect(globalThis.fetch).toHaveBeenCalledOnce()
+		const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+		const body = JSON.parse(options.body)
+		const attrMap = Object.fromEntries(
+			body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes.map(
+				(a: { key: string; value: { stringValue: string } }) => [a.key, a.value.stringValue],
+			),
+		)
+
+		expect(attrMap["session.parent_id"]).toBeUndefined()
+	})
+
+	it("emitWithIds adds session.parent_id when running inside a subagent", async () => {
+		process.env.KIMCHI_SUBAGENT = "1"
+		process.env[PARENT_SESSION_ID_ENV_KEY] = "parent-session-2"
+
+		const ctx = new TelemetryContext(makeConfig())
+		ctx.emitWithIds("ferment.started", { ferment_id: "ferment-1" })
+		ctx.flushLogBuffer()
+
+		await Promise.allSettled([...ctx.inFlight])
+
+		expect(globalThis.fetch).toHaveBeenCalledOnce()
+		const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+		const body = JSON.parse(options.body)
+		const attrMap = Object.fromEntries(
+			body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes.map(
+				(a: { key: string; value: { stringValue: string } }) => [a.key, a.value.stringValue],
+			),
+		)
+
+		expect(attrMap["session.parent_id"]).toBe("parent-session-2")
 	})
 })

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -5,6 +5,8 @@ import type { TelemetryConfig } from "../../config.js"
 import { IS_ACP_MODE } from "../../modes/acp/state.js"
 import { getOsMetadata } from "../../utils/os-metadata.js"
 import { getVersion } from "../../utils.js"
+import { isAgentWorker } from "../agent-worker-context.js"
+import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import { getActiveFerment } from "../ferment/index.js"
 import { type CumulativeState, collectMetrics, createCumulativeState } from "./accumulator.js"
 import { getAcpAttributes, getPiSessionAttributes } from "./handlers/utils.js"
@@ -155,6 +157,7 @@ export class TelemetryContext {
 		ctx?: ExtensionContext,
 	): void {
 		const { session_type, source, ...commonAttrs } = this.getCommonAttributes(ctx)
+		const parentAttr = this.getParentSessionAttribute()
 		const merged: TelemetryAttributes = {
 			source,
 			session_type,
@@ -162,6 +165,7 @@ export class TelemetryContext {
 			...attrs,
 			"user.account_uuid": this.userId ?? "",
 			...commonAttrs,
+			...(parentAttr ?? {}),
 		}
 		this.enqueueLogRecord(buildLogRecord(this.telemetryId, eventName, toAttrs(merged)))
 	}
@@ -169,6 +173,7 @@ export class TelemetryContext {
 	emit(eventName: string, attrs?: TelemetryAttributes, ctx?: ExtensionContext): void {
 		const ferment = getActiveFerment()
 		const { session_type, source, ...commonAttrs } = this.getCommonAttributes(ctx)
+		const parentAttr = this.getParentSessionAttribute()
 
 		// Detect and emit session.type_changed when the type transitions
 		if (this.lastSessionType !== undefined && session_type !== this.lastSessionType) {
@@ -178,6 +183,7 @@ export class TelemetryContext {
 				source,
 				ferment_id: ferment?.id ?? "",
 				"telemetry.cli_version": getVersion(),
+				...(parentAttr ?? {}),
 			})
 			this.logBuffer.push(buildLogRecord(this.telemetryId, "session.type_changed", changeAttrs))
 		}
@@ -191,8 +197,24 @@ export class TelemetryContext {
 			ferment_id: ferment?.id ?? "",
 			"user.account_uuid": this.userId ?? "",
 			...commonAttrs,
+			...(parentAttr ?? {}),
 		}
 		this.enqueueLogRecord(buildLogRecord(this.telemetryId, eventName, toAttrs(merged)))
+	}
+
+	/**
+	 * Sessions spawned by this process set KIMCHI_PARENT_SESSION_ID (see the
+	 * Agent runner in extensions/agents) to the spawning session's pi session id
+	 * for the whole subagent run. Events emitted from inside that run — detected
+	 * via the Agent-worker async context — carry it as `session.parent_id` so the
+	 * backend can join subagent events back to their parent session. Events
+	 * emitted outside a subagent run never carry the attribute, even when the env
+	 * var happens to be set (the parent session is not a parent of itself).
+	 */
+	private getParentSessionAttribute(): TelemetryAttributes | undefined {
+		if (!isAgentWorker()) return undefined
+		const parentSessionId = process.env[PARENT_SESSION_ID_ENV_KEY]
+		return parentSessionId ? { "session.parent_id": parentSessionId } : undefined
 	}
 
 	private getCommonAttributes(


### PR DESCRIPTION
## Summary

Adds `session.parent_id` to OTEL telemetry events raised in subagents so the telemetry backend can join a subagent's events back to its parent (spawning) session.

- **In-process Agent subagents** (`Agent` tool, ferment step/grader agents): every in-session telemetry event emitted from inside a subagent run now carries `session.parent_id` = the spawning session's pi session id (the value of `KIMCHI_PARENT_SESSION_ID`, which the Agent runner already sets for the whole subagent run). The attribute is added at emit time in `TelemetryContext`, gated on the Agent-worker async context (`isAgentWorker()`), so parent-session events (`subagent.spawned`, `ferment.completed` after a subagent ends) never carry it.
- **Curator review subprocesses** (session review on `agent_end`, background curator on `session_start`, and the `curator` tool): the caller session id is forwarded into the subprocess env as `KIMCHI_PARENT_SESSION_ID`, so events in the review session are linked to the originating session too.

Value semantics: `session.parent_id` holds the **pi session id** of the immediate parent (spawning) session. The process-shared telemetry `session.id` is identical across main + subagents, so it cannot serve as a parent id.

## Changes

- `src/extensions/telemetry/session-context.ts` — new `getParentSessionAttribute()` helper wired into `emit()`, `emitWithIds()`, and the `session.type_changed` side-event.
- `src/extensions/telemetry/session-context.test.ts` — 3 new tests (subagent positive, non-subagent negative, `emitWithIds`).
- `src/extensions/telemetry/README.md` — documents the `session.parent_id` common attribute.
- `src/extensions/curator/review.ts` + `index.ts` — `parentSessionId` threaded from the three spawn call sites into the review subprocess env.
- `src/extensions/curator/review.test.ts` — 2 new tests (env contains / omits `KIMCHI_PARENT_SESSION_ID`).

## Verification

- `pnpm run lint` and `pnpm run typecheck` clean.
- Full `pnpm run test`: 9143 passed, 14 skipped. The one failure (`src/modes/acp/server.test.ts` — "declares image: true when cached models include vision models") is **pre-existing and unrelated** — it fails identically on `master` with these changes stashed.
