### PR TITLE
feat(acp): support image attachments in _kimchi.dev/steering

### DIFF
--- a/src/modes/acp/ext-methods/steering.test.ts
+++ b/src/modes/acp/ext-methods/steering.test.ts
@@ -1,4 +1,5 @@
 import type { AgentSideConnection, SessionNotification } from "@agentclientprotocol/sdk"
+import type { ImageContent } from "@earendil-works/pi-ai"
 import type { AgentSession, ResourceLoader } from "@earendil-works/pi-coding-agent"
 import { describe, expect, it, vi } from "vitest"
 import { AVAILABLE_EXT_METHODS } from "../capabilities.js"
@@ -22,7 +23,7 @@ class FakeAgentSession {
 		appendCustomEntry: () => "entry-id",
 	}
 	setSessionName = vi.fn()
-	steer = vi.fn(async (_text: string) => {})
+	steer = vi.fn(async (_text: string, _images?: ImageContent[]) => {})
 	clearQueue = vi.fn(() => ({ steering: [] as string[], followUp: [] as string[] }))
 	extensionRunner = { emit: async () => {} }
 	getToolDefinition = vi.fn((_name: string) => undefined)
@@ -115,10 +116,108 @@ describe("KimchiAcpAgent extMethod steering", () => {
 
 		expect(result).toEqual({ status: "injected" })
 		expect(session.steer).toHaveBeenCalledTimes(1)
-		expect(session.steer).toHaveBeenCalledWith("actually, do it differently")
+		expect(session.steer).toHaveBeenCalledWith("actually, do it differently", undefined)
 
 		session.finishTurn()
 		expect(await promptPromise).toEqual({ stopReason: "end_turn" })
+	})
+
+	it("forwards image attachments to session.steer", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+			sessionId: "sess-1",
+			prompt: "this is the screen I meant",
+			attachments: [
+				{ type: "image", data: "aW1hZ2UtYnl0ZXM=", mimeType: "image/png" },
+				{ type: "image", data: "bW9yZS1ieXRlcw==", mimeType: "image/jpeg" },
+			],
+		})
+
+		expect(result).toEqual({ status: "injected" })
+		expect(session.steer).toHaveBeenCalledWith("this is the screen I meant", [
+			{ type: "image", data: "aW1hZ2UtYnl0ZXM=", mimeType: "image/png" },
+			{ type: "image", data: "bW9yZS1ieXRlcw==", mimeType: "image/jpeg" },
+		])
+
+		session.finishTurn()
+		await promptPromise
+	})
+
+	it("treats an empty attachments array the same as no attachments", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		const result = await agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+			sessionId: "sess-1",
+			prompt: "adjust course",
+			attachments: [],
+		})
+
+		expect(result).toEqual({ status: "injected" })
+		expect(session.steer).toHaveBeenCalledWith("adjust course", undefined)
+
+		session.finishTurn()
+		await promptPromise
+	})
+
+	it("rejects malformed attachments with invalidParams", async () => {
+		const session = new FakeAgentSession("sess-1")
+		const agent = makeAgent(session)
+		await agent.initialize({ protocolVersion: 1 })
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+
+		const promptPromise = agent.prompt({
+			sessionId: "sess-1",
+			prompt: [{ type: "text", text: "do work" }],
+		})
+		await Promise.resolve()
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+				sessionId: "sess-1",
+				prompt: "check this",
+				attachments: "not-an-array",
+			}),
+		).rejects.toMatchObject({ code: -32602 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+				sessionId: "sess-1",
+				prompt: "check this",
+				attachments: [{ type: "text", text: "hello" }],
+			}),
+		).rejects.toMatchObject({ code: -32602 })
+
+		await expect(
+			agent.extMethod(AVAILABLE_EXT_METHODS.steering, {
+				sessionId: "sess-1",
+				prompt: "check this",
+				attachments: [{ type: "image", data: 123, mimeType: "image/png" }],
+			}),
+		).rejects.toMatchObject({ code: -32602 })
+
+		expect(session.steer).not.toHaveBeenCalled()
+
+		session.finishTurn()
+		await promptPromise
 	})
 
 	it("returns promptRequired instead of throwing when no turn is in progress", async () => {

--- a/src/modes/acp/ext-methods/steering.ts
+++ b/src/modes/acp/ext-methods/steering.ts
@@ -4,7 +4,9 @@
 // kimchi-native-chat ticket (#06), advertised via _meta["kimchi.dev"].steering.
 
 import { RequestError } from "@agentclientprotocol/sdk"
+import type { ImageContent } from "@earendil-works/pi-ai"
 import type { AgentSession } from "@earendil-works/pi-coding-agent"
+import { extractImages } from "../utils.js"
 
 export type SteeringStatus = "injected" | "promptRequired"
 
@@ -26,6 +28,25 @@ export type SteeringTarget = {
 
 function respond(status: SteeringStatus): SteeringResponse {
 	return { status }
+}
+
+/**
+ * Parse and validate the optional `attachments` param into pi-ai
+ * `ImageContent[]`. Blocks follow the ACP image `ContentBlock` shape
+ * (`{ type: "image", data, mimeType }`); conversion is shared with the
+ * prompt() path via `extractImages`, while this wrapper enforces strict
+ * shapes — a malformed attachment is a caller bug, not content to drop.
+ */
+function parseSteeringImages(attachments: unknown): ImageContent[] {
+	if (attachments == null) return []
+	if (!Array.isArray(attachments)) {
+		throw RequestError.invalidParams(undefined, "attachments must be an array of image blocks")
+	}
+	const images = extractImages(attachments)
+	if (images.length !== attachments.length) {
+		throw RequestError.invalidParams(undefined, "attachments must all be valid image blocks")
+	}
+	return images
 }
 
 /**
@@ -59,6 +80,8 @@ export async function handleSteering(
 		throw RequestError.invalidParams(undefined, "prompt is required and must be a non-empty string")
 	}
 
+	const images = parseSteeringImages(params.attachments)
+
 	const target = getTarget(sessionId)
 	if (!target) {
 		throw RequestError.invalidParams(undefined, `unknown sessionId ${sessionId}`)
@@ -69,7 +92,7 @@ export async function handleSteering(
 	}
 
 	try {
-		await target.session.steer(prompt)
+		await target.session.steer(prompt, images.length > 0 ? images : undefined)
 		return respond("injected")
 	} catch (err) {
 		// Extension commands can't be queued; that's a caller input problem,

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -111,7 +111,7 @@ import {
 import { resetAcpClientInfo, setAcpClientInfo } from "./state.js"
 import { resolveAcpAppendSystemPrompt } from "./system-prompt.js"
 import { buildToolCall, buildToolCallUpdate, describeToolCall, isHiddenToolCall } from "./tool-calls/utils.js"
-import { asString, truncate } from "./utils.js"
+import { asString, extractImages, truncate } from "./utils.js"
 
 /** Auth method ID for Agent Auth (browser-based OAuth). Used in both
  * initialize() declaration and authenticate() validation to avoid typo drift. */
@@ -912,15 +912,7 @@ export class KimchiAcpAgent implements Agent {
 		}
 
 		// Extract image blocks from the prompt only if model supports vision.
-		const images: ImageContent[] = supportsImages
-			? params.prompt
-					.filter((b: ContentBlock): b is ContentBlock & { type: "image" } => b.type === "image")
-					.map((b) => ({
-						type: "image" as const,
-						data: b.data,
-						mimeType: b.mimeType,
-					}))
-			: []
+		const images: ImageContent[] = supportsImages ? extractImages(params.prompt) : []
 		if (!text && images.length === 0) {
 			return { stopReason: "end_turn" }
 		}

--- a/src/modes/acp/utils.ts
+++ b/src/modes/acp/utils.ts
@@ -1,5 +1,22 @@
+import type { ImageContent } from "@earendil-works/pi-ai"
+
 export const asString = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined)
 export const truncate = (s: string, max: number): string => (s.length > max ? `${s.slice(0, max)}…` : s)
+
+/**
+ * Extract pi-ai `ImageContent[]` from ACP-shaped image content blocks
+ * (`{ type: "image", data, mimeType }`). Non-image and malformed blocks are
+ * dropped; callers that need strict validation should check lengths.
+ */
+export function extractImages(blocks: unknown[]): ImageContent[] {
+	return blocks
+		.filter((b): b is { type: "image"; data: string; mimeType: string } => {
+			if (!b || typeof b !== "object") return false
+			const block = b as Record<string, unknown>
+			return block.type === "image" && typeof block.data === "string" && typeof block.mimeType === "string"
+		})
+		.map((b) => ({ type: "image" as const, data: b.data, mimeType: b.mimeType }))
+}
 
 export function requestWithAbort<T>(request: Promise<T>, signal: AbortSignal | undefined): Promise<T | "aborted"> {
 	if (!signal) return request


### PR DESCRIPTION
## Summary

Adds attachment support to the ACP steering extension method (`_kimchi.dev/steering`). Previously the handler only accepted a text `prompt` and called `session.steer(prompt)`, even though pi-mono's `steer(text, images?)` and the RPC mode already support image-bearing steers.

Steering params now accept an optional `attachments` array of ACP image content blocks (`{ type: "image", data, mimeType }`), forwarded as the second argument to `session.steer()`.

## Changes

- **`src/modes/acp/utils.ts`** — new shared `extractImages()` helper converting ACP image `ContentBlock`s to pi-ai `ImageContent[]`, dropping non-image/malformed blocks
- **`src/modes/acp/ext-methods/steering.ts`** — accepts optional `attachments` param; thin `parseSteeringImages()` wrapper reuses `extractImages` but enforces strict shape (any non-image or malformed block → `invalidParams`), then calls `steer(prompt, images)` with `undefined` when empty
- **`src/modes/acp/server.ts`** — `prompt()` now uses the shared `extractImages()` instead of its inline filter→map, so both paths share one implementation
- **`src/modes/acp/ext-methods/steering.test.ts`** — new tests: attachments forwarded to `steer()`; malformed attachments (`not-an-array`, wrong block type, bad `data` type) rejected with `invalidParams` and no `steer()` call

## Design notes

The prompt path drops unsupported blocks with a stderr warning (lenient); the steering handler rejects them with `invalidParams` (strict) — a client explicitly sending bad attachments is a caller bug worth flagging, whereas prompts can legitimately mix text with best-effort extras.

## Verification

- `pnpm vitest run src/modes/acp/ext-methods/steering.test.ts` — 12/12 pass
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (1244 files)