### PR TITLE
fix(multi-model): allow selecting Auto model for roles when experimental features are enabled

### DIFF
--- a/src/extensions/orchestration/model-roles-command.ts
+++ b/src/extensions/orchestration/model-roles-command.ts
@@ -10,10 +10,12 @@ import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-wor
 import type { Component } from "@earendil-works/pi-tui"
 import { Key, matchesKey, type TUI, wrapTextWithAnsi } from "@earendil-works/pi-tui"
 import { getAvailableModels } from "../../startup-context.js"
+import { isExperimentalFeaturesEnabled } from "../experimental.js"
 import { setProcessOrchestratorRef } from "../kimchi-process.js"
 import { withSuppressedModelSelectGuard } from "../model-switch.js"
 import { getMultiModelEnabled } from "../multi-model.js"
 import { createQuestionForm, type Question, type QuestionFormResult, YES_NO_OPTIONS } from "../questionnaire/index.js"
+import { AUTO_MODEL_REF } from "../router/constants.js"
 import {
 	deleteModelMetadata,
 	getModelMetadata,
@@ -323,7 +325,10 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 			const roles = { ...getModelRoles() }
 
 			const apiModels = getAvailableModels()
-			const availableModelRefs = apiModels.map((m) => `kimchi-dev/${m.slug}`)
+			const availableModelRefs = [...new Set(apiModels.map((m) => `kimchi-dev/${m.slug}`))]
+			if (isExperimentalFeaturesEnabled() && !availableModelRefs.includes(AUTO_MODEL_REF)) {
+				availableModelRefs.push(AUTO_MODEL_REF)
+			}
 
 			for (const key of ROLE_KEYS) {
 				for (const ref of normalizeRoleModels(roles[key])) {
@@ -332,6 +337,7 @@ export function registerModelRolesCommand(pi: ExtensionAPI): void {
 					}
 				}
 			}
+			availableModelRefs.sort()
 
 			const showMainMenu = async (): Promise<void> => {
 				const roleOptions = ROLE_KEYS.map((key) => formatRoleSummaryBlock(key, roles[key]))

--- a/tests/e2e/tui/multi-model-command.test.ts
+++ b/tests/e2e/tui/multi-model-command.test.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
 import { INPUT_TIMEOUT_MS, viewText, waitForText } from "./support/assertions.js"
 import { PROMPT_READY, runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
@@ -353,8 +355,9 @@ test("/multi-model toggle-select cursor resets to row 0 on Escape + re-open", as
 			await waitForText(terminal, "toggle models", { timeoutMs: INPUT_TIMEOUT_MS })
 			trace.step("toggle-select first open")
 
-			// Move cursor down to row 1 (with TWO_MODELS that's the second
-			// and last model — no wrap yet). Confirm we're not on row 0.
+			// Move cursor down to row 1 and confirm we're no longer on row 0.
+			// Saved default-role models also appear in this sorted list, so the
+			// exact model occupying row 1 is deliberately not part of this test.
 			terminal.keyDown()
 			await new Promise((resolve) => setTimeout(resolve, 100))
 			const firstOpenView = viewText(terminal)
@@ -362,7 +365,7 @@ test("/multi-model toggle-select cursor resets to row 0 on Escape + re-open", as
 				.split("\n")
 				.find((line) => /^> \[/.test(line))
 				?.match(/kimchi-dev\/(\S+)/)?.[1]
-			expect(firstCursorModel).toBe("heavy")
+			expect(firstCursorModel).not.toBe("basic")
 			trace.step(`cursor on row 1 (${firstCursorModel}) after first open`)
 
 			// Escape cancels back to main menu.
@@ -565,7 +568,100 @@ test("/multi-model orchestrator picker omits the Enter custom model... option", 
 
 			const view = viewText(terminal)
 			expect(view).not.toContain("Enter custom model")
+			expect(view).not.toContain("kimchi-dev/auto")
 			trace.step("no Enter custom model... option visible")
+
+			terminal.keyEscape()
+			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
+		},
+	)
+})
+
+test("/multi-model offers Auto when experimental features are enabled", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "multi-model-experimental-auto",
+			extraArgs: ["--enable-experimental-features"],
+			// Deliberately reverse the API order so this scenario also verifies sorting.
+			models: [TWO_MODELS[1], TWO_MODELS[0]],
+			responses: [],
+		},
+		async (_fixture, trace) => {
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("main menu open")
+
+			// Orchestrator is the first role, so Enter opens its single-model picker.
+			terminal.submit("")
+			await waitForText(terminal, "delegates work", { timeoutMs: INPUT_TIMEOUT_MS })
+			await waitForText(terminal, "kimchi-dev/auto", { timeoutMs: INPUT_TIMEOUT_MS })
+			const view = viewText(terminal)
+			expect(view).toContain("kimchi-dev/auto")
+			expect(view.match(/kimchi-dev\/basic/g)).toHaveLength(1)
+			expect(view.match(/kimchi-dev\/heavy/g)).toHaveLength(1)
+			expect(view.indexOf("kimchi-dev/auto")).toBeLessThan(view.indexOf("kimchi-dev/basic"))
+			expect(view.indexOf("kimchi-dev/basic")).toBeLessThan(view.indexOf("kimchi-dev/heavy"))
+			trace.step("Auto and unique concrete models visible in sorted order")
+
+			terminal.keyEscape()
+			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
+		},
+	)
+})
+
+test("/multi-model restores every role configured as Auto", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "multi-model-all-roles-auto",
+			models: [...TWO_MODELS],
+			responses: [],
+			seedHome(homeDir) {
+				const auto = "kimchi-dev/auto"
+				writeFileSync(
+					join(homeDir, ".config", "kimchi", "harness", "settings.json"),
+					JSON.stringify(
+						{
+							hideThinkingBlock: true,
+							statusLine: { pinned: [] },
+							modelRoles: {
+								orchestrator: auto,
+								planner: auto,
+								builder: auto,
+								reviewer: auto,
+								explorer: auto,
+								researcher: auto,
+								judge: auto,
+								compactor: auto,
+							},
+						},
+						null,
+						"\t",
+					),
+					"utf-8",
+				)
+			},
+		},
+		async (_fixture, trace) => {
+			terminal.write("/multi-model")
+			await waitForText(terminal, "/multi-model", { timeoutMs: INPUT_TIMEOUT_MS })
+			terminal.submit("")
+			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("main menu open with saved Auto roles")
+
+			const view = viewText(terminal)
+			for (const label of ["Orchestrator", "Planner", "Builder", "Reviewer", "Explorer", "Researcher", "Judge"]) {
+				expect(view).toMatch(new RegExp(`${label}:\\s+kimchi-dev/auto`))
+			}
+			trace.step("all surfaced roles restored as Auto")
+
+			await navigateMenuTo(terminal, trace, "Builder")
+			await waitForText(terminal, "toggle models", { timeoutMs: INPUT_TIMEOUT_MS })
+			expect(viewText(terminal)).toMatch(/\[x\]\s+kimchi-dev\/auto/)
+			trace.step("Auto is retained and checked without the experimental flag")
 
 			terminal.keyEscape()
 			await waitForText(terminal, "Model Roles", { timeoutMs: INPUT_TIMEOUT_MS })


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The /multi-model picker built its model list only from concrete API models, so the router's virtual kimchi-dev/auto model could never be assigned to a role, and roles already saved as Auto were not shown correctly.

Append AUTO_MODEL_REF when experimental features are enabled, dedupe the available-model list, and sort it so role pickers render in a deterministic order regardless of API response ordering.

Cover the behavior with TUI tests: Auto offered and sorted when the flag is on, saved all-Auto roles restored and kept checked when it is off, and Auto excluded from the picker without the flag.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
