### PR TITLE
feat(telemetry): send X-Parent-Session-Id header from subagent provider requests

### DIFF
--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -70,6 +70,11 @@ its in-process subagents share the module-level telemetryId). Two caveats:
 subagent's `agent_type` and `reason`, so spawning events can be paired with
 the subagent's own events via `session.parent_id`.
 
+Provider requests issued inside a subagent run also carry an
+`X-Parent-Session-Id` header (same value and gating as `session.parent_id`) so
+the proxy can record the parent session on `chat_completions` rows, mirroring
+how it already records `X-Session-Id` / `X-Turn-Index`.
+
 ## Pre-Session Events
 
 Fired from `pre-session.ts` via `sendPreSessionEvent()`. Sent to the **logs endpoint**.

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -98,6 +98,8 @@ describe("telemetryExtension integration", () => {
 		globalThis.fetch = originalFetch
 		_resetSharedAccumulators()
 		resetAcpClientInfo()
+		Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
+		Reflect.deleteProperty(process.env, "KIMCHI_PARENT_SESSION_ID")
 	})
 
 	it("registers all expected event handlers when enabled", () => {
@@ -317,6 +319,35 @@ describe("telemetryExtension integration", () => {
 		expect(typeof headers["X-Session-Id"]).toBe("string")
 		expect(headers["X-Session-Id"]).toBeTruthy()
 		expect(headers["X-Turn-Index"]).toBe("4")
+	})
+
+	it("before_provider_headers injects X-Parent-Session-Id inside a subagent run", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		process.env.KIMCHI_SUBAGENT = "1"
+		process.env.KIMCHI_PARENT_SESSION_ID = "parent-session-1"
+
+		const event = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(event.headers["X-Parent-Session-Id"]).toBe("parent-session-1")
+	})
+
+	it("before_provider_headers omits X-Parent-Session-Id for main-session requests", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		// KIMCHI_PARENT_SESSION_ID is process-global and set during a subagent
+		// run; main-session requests must not be tagged with it.
+		process.env.KIMCHI_PARENT_SESSION_ID = "parent-session-1"
+
+		const event = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(event.headers["X-Parent-Session-Id"]).toBeUndefined()
 	})
 
 	it("before_provider_headers injects W3C traceparent derived from session id", async () => {

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -750,6 +750,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			// 0 means "before first turn" (sentinel); backend should treat it accordingly.
 			event.headers["X-Turn-Index"] = String(telemetryCtx.turnIndex)
 
+			// Requests issued from inside a subagent run carry the parent session's
+			// pi session id so the proxy can record it on chat_completions rows
+			// (same gating/value as the session.parent_id telemetry attribute).
+			const parentSessionId = telemetryCtx.getParentSessionId()
+			if (parentSessionId) {
+				event.headers["X-Parent-Session-Id"] = parentSessionId
+			}
+
 			// Inject W3C Trace Context (if not already present) derived from
 			// the session id so that downstream distributed tracing spans
 			// join the same trace. Header names are case-insensitive, so

--- a/src/extensions/telemetry/session-context.test.ts
+++ b/src/extensions/telemetry/session-context.test.ts
@@ -507,4 +507,14 @@ describe("SessionContext", () => {
 
 		expect(attrMap["session.parent_id"]).toBe("parent-session-2")
 	})
+
+	it("getParentSessionId returns the env value only inside a subagent run", () => {
+		const ctx = new TelemetryContext(makeConfig())
+		process.env.KIMCHI_SUBAGENT = "1"
+		process.env[PARENT_SESSION_ID_ENV_KEY] = "parent-session-1"
+		expect(ctx.getParentSessionId()).toBe("parent-session-1")
+
+		Reflect.deleteProperty(process.env, "KIMCHI_SUBAGENT")
+		expect(ctx.getParentSessionId()).toBeUndefined()
+	})
 })

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -203,17 +203,22 @@ export class TelemetryContext {
 	}
 
 	/**
-	 * Sessions spawned by this process set KIMCHI_PARENT_SESSION_ID (see the
-	 * Agent runner in extensions/agents) to the spawning session's pi session id
-	 * for the whole subagent run. Events emitted from inside that run — detected
-	 * via the Agent-worker async context — carry it as `session.parent_id` so the
-	 * backend can join subagent events back to their parent session. Events
-	 * emitted outside a subagent run never carry the attribute, even when the env
-	 * var happens to be set (the parent session is not a parent of itself).
+	 * Returns the spawning (parent) session's pi session id when this process is
+	 * inside an Agent-subagent run, undefined otherwise. The Agent runner sets
+	 * KIMCHI_PARENT_SESSION_ID for the whole subagent run; the Agent-worker async
+	 * context (or KIMCHI_SUBAGENT=1) gates the check so parent-session events are
+	 * never attributed a parent.
+	 *
+	 * Used for both the `session.parent_id` telemetry attribute and the
+	 * X-Parent-Session-Id provider header (chat_completions pipeline).
 	 */
-	private getParentSessionAttribute(): TelemetryAttributes | undefined {
+	getParentSessionId(): string | undefined {
 		if (!isAgentWorker()) return undefined
-		const parentSessionId = process.env[PARENT_SESSION_ID_ENV_KEY]
+		return process.env[PARENT_SESSION_ID_ENV_KEY]
+	}
+
+	private getParentSessionAttribute(): TelemetryAttributes | undefined {
+		const parentSessionId = this.getParentSessionId()
 		return parentSessionId ? { "session.parent_id": parentSessionId } : undefined
 	}
 


### PR DESCRIPTION
## Summary

Provider requests issued from inside a subagent run now carry an `X-Parent-Session-Id` header (the spawning session's pi session id), so the proxy can record the parent session on `chat_completions` rows — mirroring how it already records `X-Session-Id` / `X-Turn-Index`.

This closes the chat_completions gap in the parent-session-id feature (#1114): the telemetry **events** already carry `session.parent_id`, but the chat_completions table is sourced from the proxy (not OTLP logs), so the value only reaches the table once the proxy receives it on the request.

## Changes

- `src/extensions/telemetry/session-context.ts` — refactored the parent-id lookup into `TelemetryContext.getParentSessionId()` (same gating as before: `isAgentWorker()` + `KIMCHI_PARENT_SESSION_ID`), shared by the `session.parent_id` attribute and the new header.
- `src/extensions/telemetry/index.ts` — `before_provider_headers` injects `X-Parent-Session-Id` when inside a subagent run.
- Tests: `index.test.ts` (header present in subagent run, absent for main session), `session-context.test.ts` (`getParentSessionId` directly).
- `README.md` — documents the header in the Subagent identification section.

## Verification

- `pnpm exec vitest run src/extensions/telemetry/session-context.test.ts src/extensions/telemetry/index.test.ts` — 79 tests pass (incl. 3 new).
- `pnpm run lint` and `pnpm run typecheck` clean.

## Follow-up (not in this repo)

The proxy that maps `X-Session-Id` → `session_id` must also map `X-Parent-Session-Id` → `parent_session_id` on the ChatCompletionCreated payload. That service is outside kimchi-dev (no `X-*` header reader exists in kubecast's services/); the server-side column + handler mapping are already merged in kubecast.
