### PR TITLE
fix: grep tool no longer counts "No matches found" as 1 match

### DIFF
--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -204,6 +204,41 @@ describe("hidden tool block rendering", () => {
 	})
 })
 
+describe("grep result rendering", () => {
+	let mockApi: ReturnType<typeof createExtensionApi>
+	beforeAll(() => {
+		mockApi = createExtensionApi()
+		toolRenderingExtension(mockApi.api)
+	})
+
+	function grepRenderResult(result: unknown, options: { expanded?: boolean } = {}) {
+		// biome-ignore lint/suspicious/noExplicitAny: registerTool is a vi mock in the shared double
+		const grepDef = ((mockApi.api as any).registerTool as any).mock.calls
+			.map((call: unknown[]) => call[0])
+			.find((def: { name?: string }) => def?.name === "grep")
+		expect(grepDef, "grep tool definition registered").toBeDefined()
+		const invoke = (expanded: boolean) =>
+			grepDef.renderResult(result, { expanded, isPartial: false }, plainTheme, createToolRenderContext())
+		// renderResult returns a Text component; render it and strip SGR + branch glyphs for a plain string.
+		const rendered = invoke(options.expanded ?? false).render(120)
+		return rendered.map((line: string) => stripSgr(line)).join("\n")
+	}
+
+	it("reports no matches when ripgrep returns the empty sentinel", () => {
+		const text = grepRenderResult({ content: [{ type: "text", text: "No matches found" }], details: undefined })
+		expect(text).toContain("no matches")
+		expect(text).not.toContain("1 matches")
+	})
+
+	it("still counts real match lines", () => {
+		const text = grepRenderResult({
+			content: [{ type: "text", text: "src/a.ts:12: const x = 1\nsrc/b.ts:3: const y = 2" }],
+			details: undefined,
+		})
+		expect(text).toContain("2 matches")
+	})
+})
+
 describe("elapsed time helpers", () => {
 	it("returns 0 when no timestamps exist", () => {
 		expect(getToolElapsedMs({ state: {} } as ToolRenderContext)).toBe(0)

--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -6,6 +6,7 @@ import { createToolRenderContext } from "./__mocks__/tool-render-context.js"
 import toolRenderingExtension, {
 	createErrorTruncatingResultRenderer,
 	formatToolTimer,
+	GREP_NO_MATCHES_SENTINEL,
 	getToolElapsedMs,
 	isMcpToolName,
 	mcpCallLabelAndSummary,
@@ -225,7 +226,7 @@ describe("grep result rendering", () => {
 	}
 
 	it("reports no matches when ripgrep returns the empty sentinel", () => {
-		const text = grepRenderResult({ content: [{ type: "text", text: "No matches found" }], details: undefined })
+		const text = grepRenderResult({ content: [{ type: "text", text: GREP_NO_MATCHES_SENTINEL }], details: undefined })
 		expect(text).toContain("no matches")
 		expect(text).not.toContain("1 matches")
 	})
@@ -236,6 +237,17 @@ describe("grep result rendering", () => {
 			details: undefined,
 		})
 		expect(text).toContain("2 matches")
+	})
+
+	it("counts a real match whose text equals the sentinel string", () => {
+		// A genuine match line always carries a `path:line:` prefix, so even if its text is
+		// "No matches found" it must be counted — not treated as the zero-match sentinel.
+		const text = grepRenderResult({
+			content: [{ type: "text", text: `src/a.ts:7: ${GREP_NO_MATCHES_SENTINEL}` }],
+			details: undefined,
+		})
+		expect(text).toContain("1 matches")
+		expect(text).not.toContain("no matches")
 	})
 })
 

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -430,6 +430,12 @@ function formatWorkedDuration(ms: number): string {
  * framework's `getRenderContext` method aliases them via
  * `state: this.rendererState`.
  */
+/**
+ * Sentinel string that pi's grep tool returns as the sole content line when ripgrep
+ * finds nothing. Used to distinguish a genuine zero-match result from match output.
+ */
+export const GREP_NO_MATCHES_SENTINEL = "No matches found"
+
 export function getToolElapsedMs(ctx: ToolRenderContext): number {
 	const startedAt = ctx?.state?._executionStartedAt
 	if (!startedAt) return 0
@@ -4260,13 +4266,14 @@ export default function (pi: ExtensionAPI) {
 			}
 			clearBlinkTimer(ctx)
 			const details = result.details as GrepToolDetails | undefined
-			// Pi's grep tool emits the literal "No matches found" sentinel as a single text line when
-			// ripgrep finds nothing. Filter it out so it isn't miscounted as one match. Real match lines
-			// always carry a `path:line:` prefix, so this can't swallow genuine results.
-			const matches = (result.content[0]?.type === "text" ? result.content[0].text : "")
-				.split("\n")
-				.map((line) => line.trim())
-				.filter((line) => line.length > 0 && line !== "No matches found")
+			const rawText = result.content[0]?.type === "text" ? result.content[0].text : ""
+			// Pi's grep tool emits the GREP_NO_MATCHES_SENTINEL string as the sole content line
+			// when ripgrep finds nothing. Detect it at the content level so it isn't miscounted
+			// as one match — a per-line filter would risk swallowing a genuine match whose text
+			// happens to equal the sentinel.
+			if (rawText.trim() === GREP_NO_MATCHES_SENTINEL)
+				return makeText(ctx.lastComponent, withBranch(theme.fg("muted", "no matches"), theme))
+			const matches = rawText.split("\n").filter((line) => line.trim().length > 0)
 			if (matches.length === 0) return makeText(ctx.lastComponent, withBranch(theme.fg("muted", "no matches"), theme))
 			let text = theme.fg("muted", `${matches.length} matches`)
 			if (details?.truncation?.truncated) text += theme.fg("warning", " (truncated)")

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -4260,9 +4260,13 @@ export default function (pi: ExtensionAPI) {
 			}
 			clearBlinkTimer(ctx)
 			const details = result.details as GrepToolDetails | undefined
+			// Pi's grep tool emits the literal "No matches found" sentinel as a single text line when
+			// ripgrep finds nothing. Filter it out so it isn't miscounted as one match. Real match lines
+			// always carry a `path:line:` prefix, so this can't swallow genuine results.
 			const matches = (result.content[0]?.type === "text" ? result.content[0].text : "")
 				.split("\n")
-				.filter((line) => line.trim().length > 0)
+				.map((line) => line.trim())
+				.filter((line) => line.length > 0 && line !== "No matches found")
 			if (matches.length === 0) return makeText(ctx.lastComponent, withBranch(theme.fg("muted", "no matches"), theme))
 			let text = theme.fg("muted", `${matches.length} matches`)
 			if (details?.truncation?.truncated) text += theme.fg("warning", " (truncated)")


### PR DESCRIPTION
## What does this PR do?

When ripgrep finds nothing, pi's grep tool (upstream) returns the literal sentinel `"No matches found"` as a single text line instead of empty content. Kimchi's grep `renderResult` in `src/extensions/tool-rendering.ts` counted every non-empty line as a "match", so the sentinel was miscounted and displayed as `1 matches` — contradicting the "No matches found" text underneath.

This PR filters the sentinel out before counting. Real match lines always carry a `path:line:` prefix, so the exact-string filter cannot swallow genuine results. A zero-match result now correctly renders `no matches`.

### Investigation summary

- Root cause is in Kimchi's rendering layer, not upstream. No patch needed — the sentinel is a legitimate upstream response.
- Added regression tests in `src/extensions/tool-rendering.test.ts`:
  - a no-match sentinel renders `no matches`, never `1 matches`
  - a two-line result still renders `2 matches`
