### PR TITLE
omit max token fields only for kimchi-dev/kimi-k3

### DIFF
--- a/src/extensions/ferment/judge.test.ts
+++ b/src/extensions/ferment/judge.test.ts
@@ -1144,10 +1144,13 @@ describe("judgeApiCall", () => {
 		captureJudgeContext(undefined, undefined, false)
 	})
 
-	it("omits Pi defaults but preserves an explicit Kimchi judge token limit", async () => {
+	it.each([
+		["kimi-k3", true],
+		["judge-x", false],
+	])("preserves an explicit Kimchi judge token limit (strips Pi defaults only for kimi-k3; model=%s)", async (modelId, shouldOmit) => {
 		const model = {
 			provider: "kimchi-dev",
-			id: "judge-x",
+			id: modelId,
 			api: "openai-completions",
 		} as unknown as Model<Api>
 		const registry = {
@@ -1163,9 +1166,9 @@ describe("judgeApiCall", () => {
 		await judgeApiCall("system", "user")
 		await judgeApiCall("system", "user", 100)
 
-		expect(requests[0].onPayload?.({ max_completion_tokens: 100, max_tokens: 100, messages: [] })).toEqual({
-			messages: [],
-		})
+		expect(requests[0].onPayload?.({ max_completion_tokens: 100, max_tokens: 100, messages: [] })).toEqual(
+			shouldOmit ? { messages: [] } : { max_completion_tokens: 100, max_tokens: 100, messages: [] },
+		)
 		expect(requests[1]).toMatchObject({ maxTokens: 100 })
 		expect(requests[1].onPayload).toBeUndefined()
 	})

--- a/src/extensions/ferment/judge.ts
+++ b/src/extensions/ferment/judge.ts
@@ -104,7 +104,7 @@ export async function judgeApiCall(systemPrompt: string, userMsg: string, maxTok
 				headers: auth.headers,
 				signal: AbortSignal.timeout(45_000),
 				...(maxTokens === undefined
-					? { onPayload: (payload: unknown) => omitKimchiMaxTokensFromPayload(payload, model.provider) }
+					? { onPayload: (payload: unknown) => omitKimchiMaxTokensFromPayload(payload, model) }
 					: { maxTokens }),
 			},
 		)

--- a/src/extensions/omit-kimchi-max-tokens.test.ts
+++ b/src/extensions/omit-kimchi-max-tokens.test.ts
@@ -9,8 +9,8 @@ import { createExtensionApi } from "./__mocks__/extension-api.js"
 import omitKimchiMaxTokensExtension, { omitKimchiMaxTokens } from "./omit-kimchi-max-tokens.js"
 
 const KIMI_METADATA = {
-	slug: "kimi-k2.7",
-	display_name: "Kimi K2.7",
+	slug: "kimi-k3",
+	display_name: "Kimi K3",
 	provider: "ai-enabler",
 	reasoning: true,
 	input_modalities: ["text"],
@@ -23,7 +23,7 @@ function openAIStreamResponse(): Response {
 		id: "completion",
 		object: "chat.completion.chunk",
 		created: 0,
-		model: "kimi-k2.7",
+		model: "kimi-k3",
 		choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
 	}
 	return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
@@ -91,15 +91,23 @@ describe("Kimchi managed request invariants", () => {
 		expect(sentPayload).not.toHaveProperty("max_tokens")
 	})
 
-	it.each([
-		"kimchi-dev/anthropic",
-		"kimchi-experimental",
-	])("omits token limits for the managed %s provider", (provider) => {
+	it("omits token limits only for kimchi-dev/kimi-k3", () => {
 		const result = omitKimchiMaxTokens(
 			{ type: "before_provider_request", payload: { max_completion_tokens: 10, max_tokens: 10 } },
-			{ model: { provider } },
+			{ model: { provider: "kimchi-dev", id: "kimi-k3" } },
 		)
 		expect(result).toEqual({})
+	})
+
+	it.each([
+		["other kimchi-dev models", { provider: "kimchi-dev", id: "kimi-k2.7" }],
+		["kimchi-dev sub-providers", { provider: "kimchi-dev/anthropic", id: "kimi-k3" }],
+		["kimchi-experimental", { provider: "kimchi-experimental", id: "kimi-k3" }],
+	])("keeps token limits for %s", (_label, model) => {
+		const payload = { max_completion_tokens: 10, max_tokens: 10 }
+		const result = omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model })
+		expect(result).toBeUndefined()
+		expect(payload).toEqual({ max_completion_tokens: 10, max_tokens: 10 })
 	})
 
 	it("sends Max as reasoning_effort=max", async () => {
@@ -134,9 +142,9 @@ describe("Kimchi managed request invariants", () => {
 
 	it("leaves non-Kimchi provider payloads unchanged", () => {
 		const payload = { max_completion_tokens: 10, messages: [] }
-		expect(omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model: { provider: "openai" } })).toBe(
-			undefined,
-		)
+		expect(
+			omitKimchiMaxTokens({ type: "before_provider_request", payload }, { model: { provider: "openai", id: "gpt-5" } }),
+		).toBe(undefined)
 		expect(payload).toEqual({ max_completion_tokens: 10, messages: [] })
 	})
 })

--- a/src/extensions/omit-kimchi-max-tokens.ts
+++ b/src/extensions/omit-kimchi-max-tokens.ts
@@ -1,27 +1,26 @@
 import type { BeforeProviderRequestEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 
-function isKimchiProvider(provider: string): boolean {
-	return provider === "kimchi-dev" || provider.startsWith("kimchi-dev/") || provider === "kimchi-experimental"
+type ModelRef = Pick<NonNullable<ExtensionContext["model"]>, "id" | "provider">
+
+function shouldOmitMaxTokens(model: ModelRef): boolean {
+	return model.provider === "kimchi-dev" && model.id === "kimi-k3"
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-export function omitKimchiMaxTokensFromPayload(payload: unknown, provider: string): unknown {
-	if (!isKimchiProvider(provider) || !isRecord(payload)) return payload
+export function omitKimchiMaxTokensFromPayload(payload: unknown, model: ModelRef): unknown {
+	if (!shouldOmitMaxTokens(model) || !isRecord(payload)) return payload
 	if (!("max_completion_tokens" in payload) && !("max_tokens" in payload)) return payload
 
 	const { max_completion_tokens: _maxCompletionTokens, max_tokens: _maxTokens, ...rest } = payload
 	return rest
 }
 
-export function omitKimchiMaxTokens(
-	event: BeforeProviderRequestEvent,
-	ctx: { model?: Pick<NonNullable<ExtensionContext["model"]>, "provider"> },
-): unknown {
+export function omitKimchiMaxTokens(event: BeforeProviderRequestEvent, ctx: { model?: ModelRef }): unknown {
 	if (!ctx.model) return
-	const payload = omitKimchiMaxTokensFromPayload(event.payload, ctx.model.provider)
+	const payload = omitKimchiMaxTokensFromPayload(event.payload, ctx.model)
 	return payload === event.payload ? undefined : payload
 }
 

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -68,7 +68,10 @@ describe("classifyToolCall", () => {
 		expect(completeMock).toHaveBeenCalledTimes(1)
 	})
 
-	it("keeps classifier tags while omitting Pi token limits for Kimchi", async () => {
+	it.each([
+		["kimi-k3", true],
+		[CLASSIFIER_PRIMARY_MODEL_ID, false],
+	])("keeps classifier tags and applies the kimi-k3 token-limit rule for %s", async (modelId, shouldOmit) => {
 		let sentPayload: unknown
 		completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
 			const { onPayload } = options as { onPayload: (payload: unknown) => unknown }
@@ -77,12 +80,16 @@ describe("classifyToolCall", () => {
 		})
 
 		await classifyToolCall(
-			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID, "kimchi-dev")]),
+			fakeRegistry([fakeModel(String(modelId), "kimchi-dev")]),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
 		)
 
-		expect(sentPayload).toEqual({ tags: ["source:classifier", "existing"] })
+		expect(sentPayload).toEqual(
+			shouldOmit
+				? { tags: ["source:classifier", "existing"] }
+				: { max_completion_tokens: 100, max_tokens: 100, tags: ["source:classifier", "existing"] },
+		)
 	})
 
 	it("retries up to 3 times on abort before giving up", async () => {

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -68,10 +68,10 @@ describe("classifyToolCall", () => {
 		expect(completeMock).toHaveBeenCalledTimes(1)
 	})
 
-	it.each([
-		["kimi-k3", true],
-		[CLASSIFIER_PRIMARY_MODEL_ID, false],
-	])("keeps classifier tags and applies the kimi-k3 token-limit rule for %s", async (modelId, shouldOmit) => {
+	// classifyToolCall only resolves CLASSIFIER_PRIMARY_MODEL_ID /
+	// CLASSIFIER_FALLBACK_MODEL_ID, so a kimi-k3 can never flow through the
+	// classifier — token limits now pass through untouched.
+	it("keeps classifier tags and token limits for classifier models", async () => {
 		let sentPayload: unknown
 		completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
 			const { onPayload } = options as { onPayload: (payload: unknown) => unknown }
@@ -80,16 +80,16 @@ describe("classifyToolCall", () => {
 		})
 
 		await classifyToolCall(
-			fakeRegistry([fakeModel(String(modelId), "kimchi-dev")]),
+			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID, "kimchi-dev")]),
 			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
 			{ timeoutMs: 5000 },
 		)
 
-		expect(sentPayload).toEqual(
-			shouldOmit
-				? { tags: ["source:classifier", "existing"] }
-				: { max_completion_tokens: 100, max_tokens: 100, tags: ["source:classifier", "existing"] },
-		)
+		expect(sentPayload).toEqual({
+			max_completion_tokens: 100,
+			max_tokens: 100,
+			tags: ["source:classifier", "existing"],
+		})
 	})
 
 	it("retries up to 3 times on abort before giving up", async () => {

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -108,7 +108,7 @@ async function runClassifier(
 						const existing = Array.isArray(p.tags) ? (p.tags as string[]) : []
 						p.tags = [CLASSIFIER_REQUEST_TAG, ...existing]
 					}
-					return omitKimchiMaxTokensFromPayload(payload, model.provider)
+					return omitKimchiMaxTokensFromPayload(payload, model)
 				},
 			},
 		)


### PR DESCRIPTION
The `omit-kimchi-max-tokens` extension previously stripped `max_tokens` and `max_completion_tokens` from the provider payload for **every** managed model (`kimchi-dev/*` and `kimchi-experimental`). Some managed models have meaningful token-limit handling and were being silently downgraded.

This narrows the transform so token-limit fields are removed **only** for the `kimchi-dev` provider's `kimi-k3` model; payloads for all other models pass through unchanged.
