### PR TITLE
fix: restore context-overflow recovery after error sanitization

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,7 +160,7 @@ import { runSetupWizard } from "./setup-wizard.js"
 import { setAvailableModels } from "./startup-context.js"
 import { probeTerminalBackground } from "./terminal-bg-probe.js"
 import { installInlineCompactPatch } from "./upstream-inline-compact-patch.js"
-import { installInfrastructureRetryPatch } from "./upstream-retry-patch.js"
+import { installCompactionRecoveryPatch, installInfrastructureRetryPatch } from "./upstream-retry-patch.js"
 import {
 	postProcessHtmlExport,
 	postProcessJsonlExport,
@@ -171,6 +171,7 @@ import { captureSessionStart } from "./utils/session-metadata-store.js"
 import { getVersion } from "./utils.js"
 
 installInfrastructureRetryPatch()
+installCompactionRecoveryPatch()
 installInlineCompactPatch()
 installPiNativeCompatibilityShim()
 // Wrap InteractiveMode.prototype.showError so retried provider errors are

--- a/src/extensions/error-preservation.test.ts
+++ b/src/extensions/error-preservation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getRawErrorMessage, preserveRawErrorMessage } from "./error-preservation.js"
+import { getRawErrorMessage, hasPreservedRawErrorMessage, preserveRawErrorMessage } from "./error-preservation.js"
 
 describe("preserveRawErrorMessage", () => {
 	it("preserves the original errorMessage before mutation", () => {
@@ -50,5 +50,22 @@ describe("preserveRawErrorMessage", () => {
 		const message = { errorMessage: "original" }
 		message.errorMessage = "mutated"
 		expect(getRawErrorMessage(message)).toBe("mutated")
+	})
+})
+
+describe("hasPreservedRawErrorMessage", () => {
+	it("returns true only when preservation actually happened", () => {
+		const message = { errorMessage: "raw error" }
+		expect(hasPreservedRawErrorMessage(message)).toBe(false)
+		preserveRawErrorMessage(message)
+		expect(hasPreservedRawErrorMessage(message)).toBe(true)
+	})
+
+	it("returns false when errorMessage was absent (nothing to preserve)", () => {
+		expect(hasPreservedRawErrorMessage({})).toBe(false)
+	})
+
+	it("returns false when errorMessage was empty (nothing preserved)", () => {
+		expect(hasPreservedRawErrorMessage({ errorMessage: "" })).toBe(false)
 	})
 })

--- a/src/extensions/error-preservation.ts
+++ b/src/extensions/error-preservation.ts
@@ -44,3 +44,14 @@ export function getRawErrorMessage(message: ErrorMessageHolder): string | undefi
 	const preserved = (message as Record<symbol, unknown>)[RAW_ERROR_SYMBOL]
 	return (typeof preserved === "string" ? preserved : undefined) ?? message.errorMessage
 }
+
+/**
+ * True when a raw error was preserved on the message (in-process symbol),
+ * as opposed to `getRawErrorMessage` falling back to the current display
+ * `errorMessage`. Callers that must distinguish "unity preserved raw"
+ * from "fallback" (e.g. compaction recovery, where a fallback must not win
+ * over a stale audit entry) gate on this.
+ */
+export function hasPreservedRawErrorMessage(message: ErrorMessageHolder): boolean {
+	return RAW_ERROR_SYMBOL in message
+}

--- a/src/extensions/error-preservation.ts
+++ b/src/extensions/error-preservation.ts
@@ -48,7 +48,7 @@ export function getRawErrorMessage(message: ErrorMessageHolder): string | undefi
 /**
  * True when a raw error was preserved on the message (in-process symbol),
  * as opposed to `getRawErrorMessage` falling back to the current display
- * `errorMessage`. Callers that must distinguish "unity preserved raw"
+ * `errorMessage`. Callers that must distinguish "a preserved raw"
  * from "fallback" (e.g. compaction recovery, where a fallback must not win
  * over a stale audit entry) gate on this.
  */

--- a/src/extensions/interactive-error-surface.test.ts
+++ b/src/extensions/interactive-error-surface.test.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getRawErrorMessage } from "./error-preservation.js"
 import {
 	__getPendingProviderError,
 	__resetInteractiveErrorSurfaceState,
@@ -116,6 +117,27 @@ describe("interactiveErrorSurfaceExtension (pending-state tracking)", () => {
 		emitMessageEnd(message)
 		expect(message.errorMessage).toContain("The request could not be completed (bad request)")
 		expect(message.errorMessage).not.toContain("BadRequestError")
+	})
+
+	// Non-retryable errors get sanitized for display but the raw error must be
+	// recoverable: upstream's `_checkCompaction` → `isContextOverflow` looks for
+	// provider-specific overflow phrases the sanitized label does not contain.
+	// This is the regression test for over-context sessions never auto-compacting.
+	it("preserves the raw errorMessage when sanitizing non-retryable errors", () => {
+		const { emitMessageEnd } = createHarness()
+		const raw = `{"error":{"type":"invalid_request_error","message":"The input (313972 tokens) is longer than the model's context length (262144 tokens).","retryable":false,"code":"400"}}`
+		const message = { role: "assistant", stopReason: "error", errorMessage: raw }
+		emitMessageEnd(message)
+		expect(message.errorMessage).toContain("The request could not be completed (context window exceeded)")
+		expect(getRawErrorMessage(message)).toBe(raw)
+	})
+
+	it("preserves the raw errorMessage for retryable errors too (no double-preserve)", () => {
+		const { emitMessageEnd } = createHarness()
+		const message = { role: "assistant", stopReason: "error", errorMessage: VLLM_RAW }
+		emitMessageEnd(message)
+		expect(message.errorMessage).toBe("Retrying…")
+		expect(getRawErrorMessage(message)).toBe(VLLM_RAW)
 	})
 
 	it("clears pending state on a successful assistant message_end", () => {

--- a/src/extensions/interactive-error-surface.ts
+++ b/src/extensions/interactive-error-surface.ts
@@ -131,6 +131,12 @@ export default function interactiveErrorSurfaceExtension(pi: ExtensionAPI): void
 			// suppressed by interceptShowError if it reaches showError.
 			message.errorMessage = RETRYING_PLACEHOLDER
 		} else {
+			// Preserve the raw error BEFORE sanitizing so upstream's compaction
+			// recovery (`_checkCompaction` → `isContextOverflow`, which matches
+			// provider-specific overflow patterns) can still classify it after
+			// the display text is replaced. Without this the raw `"context window
+			// exceeded"` text is lost and overflow recovery silently never fires.
+			preserveRawErrorMessage(message)
 			// Non-retryable: sanitize in place. No pending state is created —
 			// the error is fully handled here and agent_end must not re-render.
 			message.errorMessage = formatSanitizedErrorMessage(message.errorMessage, "interactive", {

--- a/src/upstream-compaction-recovery.test.ts
+++ b/src/upstream-compaction-recovery.test.ts
@@ -275,6 +275,45 @@ describe("resume path: raw error recovered from session audit entries", () => {
 		expect(captured[0].errorMessage).toBe(RAW_OVERFLOW)
 	})
 
+	it("prefers the preserved raw over a stale audit entry even when raw === display text", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		// A stale audit entry from an EARLIER error is on the branch. It belongs
+		// to a different message and must never be substituted here.
+		const staleOverflow =
+			'{"error":{"type":"invalid_request_error","message":"The input (999999 tokens) is longer than the model\'s context length (262144 tokens).","retryable":false,"code":"400"}}'
+		const branch = [
+			{
+				type: "custom",
+				customType: "kimchi_error_classification",
+				data: { rawMessage: staleOverflow, reason: "context_window_exceeded", retryable: false },
+			},
+		]
+		const session = { sessionManager: { getBranch: () => branch } }
+
+		// Raw was preserved, then sanitization turned out to be a no-op, so
+		// display text === preserved raw. The in-process raw must win.
+		const nonOverflow = "429 Too Many Requests"
+		const msg: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: nonOverflow,
+		}
+		preserveRawErrorMessage(msg)
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		// Identity pass-through: NOT a copy carrying the stale overflow raw.
+		expect(captured).toHaveLength(1)
+		expect(captured[0]).toBe(msg)
+		expect(captured[0].errorMessage).toBe(nonOverflow)
+	})
+
 	it("passes the raw, sanitized message through unchanged when no raw is recoverable anywhere", async () => {
 		const original = vi.fn<CheckCompaction>(async () => false)
 		const cls = createPatchedClass(original)

--- a/src/upstream-compaction-recovery.test.ts
+++ b/src/upstream-compaction-recovery.test.ts
@@ -1,0 +1,288 @@
+import { AgentSession } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { getRawErrorMessage, preserveRawErrorMessage } from "./extensions/error-preservation.js"
+import { installCompactionRecoveryPatch } from "./upstream-retry-patch.js"
+
+/**
+ * Raw moonshot-style over-limit error as returned by the gateway (and as
+ * matched by pi-ai's OVERFLOW_PATTERNS "input (N tokens) is longer than").
+ */
+const RAW_OVERFLOW =
+	'{"error":{"type":"invalid_request_error","message":"The input (313972 tokens) is longer than the model\'s context length (262144 tokens).","retryable":false,"code":"400"}}'
+
+/** Sanitized display text the interactive-error-surface writes over the raw error. */
+const SANITIZED_OVERFLOW = "The request could not be completed (context window exceeded). Please retry your request."
+
+type CheckCompaction = (message: Record<string, unknown>, skipAbortedCheck?: boolean) => Promise<boolean>
+
+type FakeSessionPrototype = {
+	_checkCompaction?: CheckCompaction
+	_kimchiCompactionRecoveryPatch?: boolean
+}
+
+function createPatchedClass(original: CheckCompaction): { prototype: FakeSessionPrototype } {
+	const sessionClass = { prototype: { _checkCompaction: original } as FakeSessionPrototype }
+	installCompactionRecoveryPatch(sessionClass as never)
+	return sessionClass
+}
+
+/** Nontrivial unwrap so tests avoid biome-forbidden non-null assertions. */
+function patchedCheckCompaction(cls: { prototype: FakeSessionPrototype }): CheckCompaction {
+	const fn = cls.prototype._checkCompaction
+	if (!fn) throw new Error("expected _checkCompaction to be installed")
+	return fn
+}
+
+describe("installCompactionRecoveryPatch", () => {
+	it("upstream still exposes the _checkCompaction hook the patch wraps", () => {
+		// The patch wraps a private upstream method. If upstream renames or removes
+		// it, this must fail loudly instead of silently disabling recovery.
+		const proto = (AgentSession as unknown as { prototype: Record<string, unknown> }).prototype
+		expect(typeof proto._checkCompaction).toBe("function")
+	})
+
+	it("passes through untouched when the message has no errorMessage (no string → identity call)", async () => {
+		const original = vi.fn<CheckCompaction>(async () => false)
+		const cls = createPatchedClass(original)
+		const msg = { role: "assistant", stopReason: "stop" }
+
+		await patchedCheckCompaction(cls)(msg, false)
+
+		expect(original).toHaveBeenCalledTimes(1)
+		expect(original.mock.calls[0][0]).toBe(msg)
+		expect(original.mock.calls[0][1]).toBe(false)
+	})
+
+	it("wraps once (re-installing does not double-wrap)", () => {
+		const original = vi.fn<CheckCompaction>(async () => false)
+		const sessionClass = { prototype: { _checkCompaction: original } as FakeSessionPrototype }
+		installCompactionRecoveryPatch(sessionClass as never)
+		const wrapped = sessionClass.prototype._checkCompaction
+		installCompactionRecoveryPatch(sessionClass as never)
+		expect(sessionClass.prototype._checkCompaction).toBe(wrapped)
+	})
+
+	it("installing when the hook is missing is a safe no-op", () => {
+		const empty = { prototype: {} as FakeSessionPrototype }
+		expect(() => installCompactionRecoveryPatch(empty as never)).not.toThrow()
+		expect(empty.prototype._checkCompaction).toBeUndefined()
+	})
+
+	it("restores the preserved raw error on a fresh copy before calling (display text untouched)", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		const message: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: "kimchi-dev",
+			model: "kimi-k2.7",
+		}
+		// Simulate interactive-error-surface sanitizing the message.
+		preserveRawErrorMessage(message)
+		message.errorMessage = SANITIZED_OVERFLOW
+
+		await patchedCheckCompaction(cls)(message)
+
+		expect(captured).toHaveLength(1)
+		expect(captured[0].errorMessage).toBe(RAW_OVERFLOW)
+		// The visible message keeps its sanitized display text.
+		expect(message.errorMessage).toBe(SANITIZED_OVERFLOW)
+		// The copy does not alias the original message.
+		expect(captured[0]).not.toBe(message)
+	})
+
+	it("does not change the call when the message already carries the raw error (no sanitize happened)", async () => {
+		const original = vi.fn<CheckCompaction>(async () => false)
+		const cls = createPatchedClass(original)
+		const msg = { role: "assistant", stopReason: "error", errorMessage: RAW_OVERFLOW }
+
+		// In production _checkCompaction is always called as session._checkCompaction(msg),
+		// so `this` is the session. Bind a minimal stub with no sessionManager →
+		// branch scan returns [] → no raw found → identity pass-through.
+		await patchedCheckCompaction(cls).call({ sessionManager: undefined } as never, msg)
+
+		expect(original.mock.calls[0][0]).toBe(msg)
+	})
+})
+
+describe("end-to-end overflow recovery through the real upstream method", () => {
+	/**
+	 * Drives the REAL AgentSession.prototype._checkCompaction through the
+	 * installed patch against a hand-rolled session — the closest unit-level
+	 * simulation of `_handlePostAgentRun` we can build without pi-mono's full
+	 * agent runnable. Asserts the compact-and-retry branch fires exactly when
+	 * the raw overflow is visible, and skips it when only the sanitized text is.
+	 */
+	function buildRealishSession(opts: {
+		compactionCalls: Array<{ reason: string; willRetry: boolean }>
+		agentMessages: Array<Record<string, unknown>>
+	}) {
+		const { compactionCalls, agentMessages } = opts
+		return {
+			settingsManager: {
+				getCompactionSettings: () => ({ enabled: true }),
+			},
+			model: {
+				provider: "kimchi-dev",
+				id: "kimi-k2.7",
+				contextWindow: 262_144,
+				maxTokens: 131_072,
+			},
+			sessionManager: {
+				getBranch: () => [],
+				getSessionFile: () => "/tmp/fake.jsonl",
+			},
+			agent: { state: { messages: agentMessages } },
+			_overflowRecoveryAttempted: false,
+			_runAutoCompaction: vi.fn(async (reason: string, willRetry: boolean) => {
+				compactionCalls.push({ reason, willRetry })
+				return true
+			}),
+			_emit: vi.fn(),
+		}
+	}
+
+	function realCheckCompaction(session: unknown, message: Record<string, unknown>): Promise<boolean> {
+		const proto = AgentSession.prototype as unknown as Record<string, CheckCompaction>
+		return proto._checkCompaction.call(session, message)
+	}
+
+	it("skips overflow recovery when only the sanitized text is visible (regression witness)", async () => {
+		const compactionCalls: Array<{ reason: string; willRetry: boolean }> = []
+		const agentMessages = [
+			{ role: "user", content: [{ type: "text", text: "hi" }] },
+			{
+				role: "assistant",
+				stopReason: "error",
+				errorMessage: SANITIZED_OVERFLOW,
+				content: [],
+				timestamp: Date.now(),
+			},
+		]
+		const session = buildRealishSession({ compactionCalls, agentMessages })
+
+		const ran = await realCheckCompaction(session, agentMessages[1])
+
+		expect(ran).toBe(false)
+		expect(compactionCalls).toHaveLength(0)
+	})
+
+	it("fires overflow compact-and-retry when the raw error is preserved (the fix)", async () => {
+		const compactionCalls: Array<{ reason: string; willRetry: boolean }> = []
+		const failingMessage: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: "kimchi-dev",
+			model: "kimi-k2.7",
+			content: [],
+			timestamp: Date.now(),
+		}
+		preserveRawErrorMessage(failingMessage)
+		failingMessage.errorMessage = SANITIZED_OVERFLOW
+
+		const agentMessages = [{ role: "user", content: [{ type: "text", text: "hi" }] }, failingMessage]
+		const session = buildRealishSession({ compactionCalls, agentMessages })
+
+		// Install on the REAL AgentSession class to prove the patched path flows,
+		// then put the exact original back so later tests in this process see
+		// unpatched upstream behavior.
+		const proto = AgentSession.prototype as unknown as Record<string, CheckCompaction | undefined>
+		const originalBeforeInstall = proto._checkCompaction
+		installCompactionRecoveryPatch()
+		let ran = false
+		try {
+			const patched = proto._checkCompaction
+			if (!patched) throw new Error("expected _checkCompaction to be installed")
+			ran = await patched.call(session, failingMessage)
+		} finally {
+			proto._checkCompaction = originalBeforeInstall
+		}
+		expect(ran).toBe(true)
+
+		expect(compactionCalls).toHaveLength(1)
+		expect(compactionCalls[0]).toEqual({ reason: "overflow", willRetry: true })
+		// The failed message is removed from agent state before the retry.
+		// (Upstream reassigns agent.state.messages = messages.slice(0, -1), so
+		// assert on the session's current array, not the old reference.)
+		const current = (session as { agent: { state: { messages: unknown[] } } }).agent.state.messages
+		expect(current).toHaveLength(1)
+		expect((current[0] as { role?: string }).role).toBe("user")
+	})
+})
+
+describe("resume path: raw error recovered from session audit entries", () => {
+	it("finds the most recent rawMessage from kimchi_error_classification audit entries when the symbol is gone", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		const branch = [
+			{ type: "message", message: { role: "user" } },
+			{
+				type: "custom",
+				customType: "kimchi_error_classification",
+				data: { rawMessage: RAW_OVERFLOW, reason: "context_window_exceeded", retryable: false },
+			},
+			{ type: "message", message: { role: "assistant", errorMessage: SANITIZED_OVERFLOW } },
+		]
+		const session = { sessionManager: { getBranch: () => branch } }
+		const msg = { role: "assistant", stopReason: "error", errorMessage: SANITIZED_OVERFLOW }
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		expect(captured[0].errorMessage).toBe(RAW_OVERFLOW)
+	})
+
+	it("prefers the in-process preserved raw over the audit entry", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		const branch = [
+			{
+				type: "custom",
+				customType: "kimchi_error_classification",
+				data: { rawMessage: "earlier raw error", reason: "context_window_exceeded" },
+			},
+		]
+		const session = { sessionManager: { getBranch: () => branch } }
+
+		// Faithful production flow: raw present → preserve → sanitize in place.
+		const faithful: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+		}
+		preserveRawErrorMessage(faithful)
+		faithful.errorMessage = SANITIZED_OVERFLOW
+
+		await patchedCheckCompaction(cls).call(session as never, faithful)
+
+		expect(getRawErrorMessage(faithful)).toBe(RAW_OVERFLOW)
+		expect(captured[0].errorMessage).toBe(RAW_OVERFLOW)
+	})
+
+	it("passes the raw, sanitized message through unchanged when no raw is recoverable anywhere", async () => {
+		const original = vi.fn<CheckCompaction>(async () => false)
+		const cls = createPatchedClass(original)
+		const session = { sessionManager: { getBranch: () => [] } }
+		const msg = { role: "assistant", stopReason: "error", errorMessage: SANITIZED_OVERFLOW }
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		expect(original.mock.calls[0][0]).toBe(msg)
+	})
+})

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -269,7 +269,7 @@ export function installCompactionRecoveryPatch(
 		// Restore the raw provider error for the classification, leaving the
 		// display text untouched. A shared copy (not the session message) is
 		// passed through so nothing downstream observes the swap.
-		if (typeof message?.errorMessage === "string") {
+		if (typeof message.errorMessage === "string") {
 			const raw = rawErrorForCompactionRecovery(message, this)
 			if (raw && raw !== message.errorMessage) {
 				return original.call(this, { ...message, errorMessage: raw }, skipAbortedCheck)

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,16 +1,30 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import { getRawErrorMessage } from "./extensions/error-preservation.js"
+import { GATEWAY_CLASSIFICATION_AUDIT_TYPE } from "./infrastructure-error.js"
 import { classifyLLMGatewayError, parseRateLimitRetryAt } from "./llm-gateway-error.js"
 
 type RetryableMessage = Partial<Pick<AssistantMessage, "stopReason" | "errorMessage">>
 type RetryableClassifier = (message: RetryableMessage) => boolean
 type RetryPreparer = (message: RetryableMessage) => Promise<boolean>
+/** Message shape upstream `_checkCompaction` consumes; spread-copied when restored. */
+type CompactionCheckMessage = RetryableMessage & Record<string, unknown>
+type CompactionChecker = (message: CompactionCheckMessage, skipAbortedCheck?: boolean) => Promise<boolean>
+type SessionBranchEntry = {
+	type?: string
+	customType?: string
+	data?: { rawMessage?: unknown }
+}
+type BranchBackedSession = {
+	sessionManager?: { getBranch?: () => SessionBranchEntry[] }
+}
 type PatchableAgentSession = {
 	prototype: {
 		_isRetryableError?: RetryableClassifier
 		_prepareRetry?: RetryPreparer
+		_checkCompaction?: CompactionChecker
 		_kimchiInfrastructureRetryPatch?: boolean
+		_kimchiCompactionRecoveryPatch?: boolean
 	}
 }
 
@@ -183,6 +197,85 @@ type RetryingSession = {
 	_retryAttempt: number
 	_retryAbortController?: AbortController
 	_emit: (event: Record<string, unknown>) => void
+}
+
+// --- Overflow-compaction recovery error restoration ---
+//
+// The interactive-error-surface extension sanitizes message.errorMessage on
+// every classified provider error so provider internals never reach the UI.
+// Upstream's compaction recovery (`AgentSession._checkCompaction`, invoked
+// from `_handlePostAgentRun` / prompt()) runs AFTER that mutation and matches
+// provider-specific overflow regexes (pi-ai `isContextOverflow`) against
+// `assistantMessage.errorMessage`. The sanitized label ("The request could
+// not be completed (context window exceeded)…") matches none of them, so an
+// over-limit request terminated the session instead of triggering upstream's
+// single compact-and-retry.
+//
+// This patch wraps `_checkCompaction` to restore the raw provider error for
+// the duration of the check. Display text stays sanitized — only the internal
+// overflow classifier sees the raw error, on a throwaway copy of the message.
+
+/**
+ * Raw overflow error for a message, when recoverable. Preference order:
+ * 1. the in-process preserved raw message (written before sanitization by
+ *    interactive-error-surface via error-preservation),
+ * 2. the most recent gateway classification audit entry on the session branch
+ *    (covers resumed sessions, where the in-memory symbol is gone).
+ */
+function rawErrorForCompactionRecovery(
+	message: CompactionCheckMessage,
+	session: BranchBackedSession,
+): string | undefined {
+	const preserved = getRawErrorMessage(message)
+	if (preserved && preserved !== message.errorMessage) return preserved
+
+	const branch = session.sessionManager?.getBranch?.() ?? []
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i]
+		if (entry.type === "custom" && entry.customType === GATEWAY_CLASSIFICATION_AUDIT_TYPE) {
+			const raw = entry.data?.rawMessage
+			if (typeof raw === "string" && raw.length > 0) return raw
+		}
+	}
+	return undefined
+}
+
+/**
+ * Companion to {@link installInfrastructureRetryPatch}: teaches upstream's
+ * `_checkCompaction` to classify overflow from the preserved raw provider
+ * error rather than the sanitized display text.
+ *
+ * The wrap is a pure delegation — classification, the one-attempt-per-turn
+ * `_overflowRecoveryAttempted` gate, the dropped failed message, and
+ * `_runAutoCompaction("overflow", willRetry)` all stay upstream-owned, so
+ * behavior changes only for messages whose display text hid the raw error.
+ */
+export function installCompactionRecoveryPatch(
+	sessionClass: Pick<PatchableAgentSession, "prototype"> = AgentSession as unknown as PatchableAgentSession,
+): void {
+	const proto = sessionClass.prototype
+	if (proto._kimchiCompactionRecoveryPatch) return
+	const original = proto._checkCompaction
+	if (!original) return
+
+	proto._checkCompaction = async function patchedCheckCompaction(
+		this: BranchBackedSession,
+		message: CompactionCheckMessage,
+		skipAbortedCheck?: boolean,
+	): Promise<boolean> {
+		// Restore the raw provider error for the classification, leaving the
+		// display text untouched. A shared copy (not the session message) is
+		// passed through so nothing downstream observes the swap.
+		if (typeof message?.errorMessage === "string") {
+			const raw = rawErrorForCompactionRecovery(message, this)
+			if (raw && raw !== message.errorMessage) {
+				return original.call(this, { ...message, errorMessage: raw }, skipAbortedCheck)
+			}
+		}
+		return original.call(this, message, skipAbortedCheck)
+	}
+
+	proto._kimchiCompactionRecoveryPatch = true
 }
 
 function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
-import { getRawErrorMessage } from "./extensions/error-preservation.js"
+import { getRawErrorMessage, hasPreservedRawErrorMessage } from "./extensions/error-preservation.js"
 import { GATEWAY_CLASSIFICATION_AUDIT_TYPE } from "./infrastructure-error.js"
 import { classifyLLMGatewayError, parseRateLimitRetryAt } from "./llm-gateway-error.js"
 
@@ -226,8 +226,11 @@ function rawErrorForCompactionRecovery(
 	message: CompactionCheckMessage,
 	session: BranchBackedSession,
 ): string | undefined {
-	const preserved = getRawErrorMessage(message)
-	if (preserved && preserved !== message.errorMessage) return preserved
+	// Prefer the in-process preserved raw unconditionally: even when it equals
+	// the display text (sanitization no-op), a branch audit entry belongs to an
+	// EARLIER message and would inject a stale raw error here. The caller
+	// already passes the message through unchanged when raw === errorMessage.
+	if (hasPreservedRawErrorMessage(message)) return getRawErrorMessage(message)
 
 	const branch = session.sessionManager?.getBranch?.() ?? []
 	for (let i = branch.length - 1; i >= 0; i--) {

--- a/tests/e2e/tui/context-overflow-recovery.test.ts
+++ b/tests/e2e/tui/context-overflow-recovery.test.ts
@@ -1,0 +1,147 @@
+/**
+ * E2E TUI test: context-window overflow recovery.
+ *
+ * When a request fails with a 400 context-length error, the error sanitizer
+ * used to destroy the raw overflow text before upstream's `_checkCompaction`
+ * could classify it. The session then wedged: every subsequent turn sent the
+ * same oversized context and got the same 400.
+ *
+ * This test simulates that path end-to-end:
+ *   1. Prime a session with several long prompts (large enough that upstream's
+ *      compaction algorithm, which estimates from message content, has a
+ *      summarizable prefix).
+ *   2. Submit a follow-up that the gateway rejects with a context-length 400.
+ *   3. Assert the session auto-compacts and retries instead of wedging.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import {
+	STARTUP_TIMEOUT_MS,
+	STREAM_TIMEOUT_MS,
+	viewText,
+	waitForText,
+	waitForTurnToSettle,
+} from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+const LARGE_CONTEXT_MODEL = {
+	slug: "basic",
+	displayName: "Fake Basic",
+	// Large window so proactive threshold compaction (90%) never fires during priming.
+	contextWindow: 100_000,
+	maxTokens: 4096,
+}
+
+const OVERFLOW_ERROR_BODY = {
+	error: {
+		message: "BadRequestError: The input (104857 tokens) is longer than the model's context length (1048576 tokens).",
+		type: "invalid_request_error",
+		code: 400,
+	},
+}
+
+/**
+ * Generate a long prompt so the chars÷4 token estimate pushes the session over
+ * keepRecentTokens. The compaction algorithm estimates tokens from message
+ * content, not from fake usage numbers.
+ */
+function largePrompt(base: string, tokens: number): string {
+	const chunk = "one two three four five six seven eight nine ten "
+	const repeats = Math.ceil((tokens * 4) / chunk.length)
+	return `${base}: ${chunk.repeat(repeats)}`
+}
+
+function seedCompactionSettings(homeDir: string, _workDir: string) {
+	const settingsPath = join(homeDir, ".config", "kimchi", "harness", "settings.json")
+	const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
+	// Lower keepRecentTokens so a small number of long prompts creates a
+	// summarizable prefix without needing tens of thousands of characters.
+	settings.compaction = { keepRecentTokens: 1_000 }
+	writeFileSync(settingsPath, JSON.stringify(settings, null, "\t"), "utf-8")
+	return {}
+}
+
+test("context-window 400 is sanitized, auto-compacts, and recovers instead of wedging", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "context-overflow-auto-compaction-recovery",
+			gitInit: true,
+			models: [LARGE_CONTEXT_MODEL],
+			seedHome: seedCompactionSettings,
+			responses: [
+				// Prime enough history that compaction has something to summarize.
+				{ stream: ["Ack 1."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				{ stream: ["Ack 2."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				{ stream: ["Ack 3."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				// The overflow 400.
+				{
+					status: 400,
+					body: OVERFLOW_ERROR_BODY,
+				},
+				// Compaction summary request.
+				{
+					stream: ["Summary", " of", " prior", " context."],
+					usage: { prompt_tokens: 100, completion_tokens: 4 },
+				},
+				// Retry after compaction.
+				{
+					stream: ["Recovered", " after", " compaction."],
+					usage: { prompt_tokens: 1000, completion_tokens: 3 },
+				},
+			],
+		},
+		async (fixture, trace) => {
+			await waitForText(terminal, "ask anything or type / for commands", { timeoutMs: STARTUP_TIMEOUT_MS })
+			trace.step("ready prompt visible")
+
+			terminal.submit(largePrompt("First prompt", 500))
+			await waitForText(terminal, "Ack 1.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("turn 1 complete")
+
+			terminal.submit(largePrompt("Second prompt", 500))
+			await waitForText(terminal, "Ack 2.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("turn 2 complete")
+
+			terminal.submit(largePrompt("Third prompt", 500))
+			await waitForText(terminal, "Ack 3.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("turn 3 complete")
+
+			terminal.submit("Continue the task")
+			trace.step("submitted follow-up that will overflow")
+
+			// Wait for the recovered response. This proves the session did not
+			// wedge on the 400: _checkCompaction classified the raw overflow,
+			// _runAutoCompaction compacted, and the retry completed.
+			await waitForText(terminal, "Recovered after compaction.", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("recovered response visible — overflow recovery worked")
+
+			const chatRequests = fixture.fake.requests.filter((req) => req.url.startsWith("/openai/v1/chat/completions"))
+			expect(chatRequests.length).toBeGreaterThanOrEqual(6)
+			trace.step(`${chatRequests.length} chat requests recorded`)
+
+			// The 5th chat request (0-indexed: 4) should be the compaction summary.
+			const compactionReq = chatRequests[4]?.body as Record<string, unknown>
+			const compactionMessages = JSON.stringify(compactionReq.messages ?? compactionReq)
+			expect(compactionMessages).toContain("context summarization assistant")
+			trace.step("compaction request present")
+
+			// The 6th chat request (0-indexed: 5) should be the retry after compaction.
+			const retryReq = chatRequests[5]?.body as Record<string, unknown>
+			expect(retryReq).toBeDefined()
+			trace.step("retry request present")
+
+			// The raw provider error must not leak to the terminal.
+			expect(viewText(terminal)).not.toContain("longer than the model")
+			expect(viewText(terminal)).not.toContain("104857 tokens")
+			trace.step("raw overflow error sanitized")
+		},
+	)
+})


### PR DESCRIPTION
## Problem

Re-enabling `max_output_tokens` for the 6 non-K3 models (branch `omit-max-tokens-kimi-k3-only`) activates pi-ai's `clampMaxTokensToContext`. When the chars÷4 estimate exceeds the context window, this clamps `maxTokens=1` → `out=1, stop=length` → upstream fires a nudge continuation → that continuation resends the full context without truncation (stale usage estimate said it fit) → **hard 400 context-length error**.

This exposed a latent bug: the error sanitizer in `interactive-error-surface.ts` runs *before* upstream's `_checkCompaction` and replaces the raw provider error with a sanitized label. Upstream's `isContextOverflow` then can't match the overflow pattern → reactive compact-and-retry never fires → the errored message stays in the session → every subsequent turn sends the same oversized context → same 400 → **session is permanently wedged**. Resuming with `--continue` doesn't help; the raw error only lived in memory and is gone on disk.

The sanitization gap existed before this branch — re-enabling `max_tokens` just creates the path that reliably triggers it.

## Fix

**1. Preserve the raw error before sanitizing** (`interactive-error-surface.ts`)
- Call `preserveRawErrorMessage(message)` in the non-retryable branch (already done for retryable errors). The raw provider text is stored as a non-enumerable symbol on the message.

**2. Restore the raw error for classification only** (`upstream-retry-patch.ts`)
- New `installCompactionRecoveryPatch` wraps `AgentSession.prototype._checkCompaction` to swap the raw error back in on a throwaway copy (`{ ...message, errorMessage: raw }`) before the overflow classifier runs. Display text stays sanitized; nothing downstream observes the swap.
- Raw-error lookup order:
  1. **In-process symbol** (`hasPreservedRawErrorMessage` → `getRawErrorMessage`) — covers the failing turn itself.
  2. **Resume fallback**: scan `sessionManager.getBranch()` for the most recent `kimchi_error_classification` audit entry with a `rawMessage` — covers `--continue` where the symbol is gone.
- Upstream then runs its own Case-1 overflow branch: `isContextOverflow` matches the raw text, `_overflowRecoveryAttempted` allows one compact-and-retry per turn, `_runAutoCompaction("overflow", willRetry)` fires, session recovers.

**3. Register the patch** (`cli.ts`)
- `installCompactionRecoveryPatch()` called alongside the existing `installInfrastructureRetryPatch()`.

## What this does NOT change

- Sanitization behavior (display text stays sanitized — only the internal classifier sees the raw error)
- `clampMaxTokensToContext` or pi-mono's offline estimate (pinned upstream)
- `model-guard` truncation or `resolveContextTokens` staleness
- Retry policy (`context_window_exceeded` stays non-retryable; compaction is the recovery, not retries)
- One compact-and-retry per turn (upstream `_overflowRecoveryAttempted` gate — no infinite loops)

## Test coverage

- **12 tests** in `src/upstream-compaction-recovery.test.ts`: wrap-once idempotency, no-op on missing hook, raw restore on fresh copy (no aliasing), end-to-end through real `AgentSession.prototype._checkCompaction`, resume fallback via audit entries, stale-audit-entry guard (equality case).
- **2 tests** in `src/extensions/interactive-error-surface.test.ts`: raw preservation for non-retryable + retryable errors.
- **3 tests** in `src/extensions/error-preservation.test.ts`: `hasPreservedRawErrorMessage` accessor behavior.
- 42/42 pass across touched suites. `typecheck` + `lint` clean. Full-suite failures (25) are pre-existing on clean master (permissions/ACP/web-fetch — env-dependent, unrelated).

## E2E verification (prod, rebuilt binary)

- **Resumed wedged session** (real 400 in history): `--continue` triggers overflow compaction, writes `compaction` entry to session JSONL, replies `RECOVERED`, exit 0.
- **Fresh over-limit run** (kimi-k2.7): 3-turn sequence with oversized prompts, all exit 0.
- **kimi-k3** (merge target): 3-turn over-limit run, all exit 0.

Co-Authored-By: Kimchi <noreply@kimchi.dev>