### PR TITLE
feat: attach pasted image file paths like pasted images

### DIFF
--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -53,8 +53,14 @@ import clipboardImageExtension from "./clipboard-image.js"
 
 type Handlers = Record<string, (...args: unknown[]) => unknown>
 
-function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
-	const terminalInputHandler: { current?: (data: string) => void } = {}
+interface MockTerminalInput {
+	current?: (data: string) => void
+}
+
+function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext & {
+	_mockTerminalInput: MockTerminalInput
+} {
+	const terminalInputHandler: MockTerminalInput = {}
 	return {
 		model: { id: "glm-4", slug: "glm-4", input_modalities: ["text", "image"] as string[] },
 		ui: {
@@ -66,17 +72,24 @@ function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContex
 					terminalInputHandler.current = undefined
 				}
 			},
-			_terminalInput: terminalInputHandler,
 		},
+		_mockTerminalInput: terminalInputHandler,
 		...overrides,
-	} as unknown as ExtensionContext
+	} as unknown as ExtensionContext & { _mockTerminalInput: MockTerminalInput }
 }
 
-function simulatePaste(ctx: ExtensionContext) {
-	const handler = (ctx.ui as unknown as { _terminalInput: { current?: (data: string) => void } })._terminalInput.current
+function simulatePaste(ctx: ExtensionContext & { _mockTerminalInput: MockTerminalInput }) {
+	const handler = ctx._mockTerminalInput.current
 	expect(handler).toBeDefined()
 	if (!handler) throw new Error("expected terminal input handler to be registered")
 	handler("\x1b[200~/dummy.png\x1b[201~")
+}
+
+function simulateTypedInput(ctx: ExtensionContext & { _mockTerminalInput: MockTerminalInput }) {
+	const handler = ctx._mockTerminalInput.current
+	expect(handler).toBeDefined()
+	if (!handler) throw new Error("expected terminal input handler to be registered")
+	handler("typed text")
 }
 
 function makeMockPi(): ExtensionAPI & { _handlers: Handlers } {
@@ -342,6 +355,16 @@ describe("clipboard-image extension", () => {
 
 		it("leaves text untouched when the input is typed, not pasted", () => {
 			const { pi } = startVisionSession()
+			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
+			expect(result).toBeUndefined()
+			expect(mockAddImage).not.toHaveBeenCalled()
+		})
+
+		it("leaves text untouched when input is typed after a paste (sticky flag reset)", () => {
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
+			// Simulate typed keystrokes after the paste — these reset lastInputWasPaste.
+			simulateTypedInput(ctx)
 			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
 			expect(result).toBeUndefined()
 			expect(mockAddImage).not.toHaveBeenCalled()

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -54,11 +54,29 @@ import clipboardImageExtension from "./clipboard-image.js"
 type Handlers = Record<string, (...args: unknown[]) => unknown>
 
 function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
+	const terminalInputHandler: { current?: (data: string) => void } = {}
 	return {
 		model: { id: "glm-4", slug: "glm-4", input_modalities: ["text", "image"] as string[] },
-		ui: { notify: vi.fn(), setStatus: vi.fn() },
+		ui: {
+			notify: vi.fn(),
+			setStatus: vi.fn(),
+			onTerminalInput: (handler: (data: string) => void) => {
+				terminalInputHandler.current = handler
+				return () => {
+					terminalInputHandler.current = undefined
+				}
+			},
+			_terminalInput: terminalInputHandler,
+		},
 		...overrides,
 	} as unknown as ExtensionContext
+}
+
+function simulatePaste(ctx: ExtensionContext) {
+	const handler = (ctx.ui as unknown as { _terminalInput: { current?: (data: string) => void } })._terminalInput.current
+	expect(handler).toBeDefined()
+	if (!handler) throw new Error("expected terminal input handler to be registered")
+	handler("\x1b[200~/dummy.png\x1b[201~")
 }
 
 function makeMockPi(): ExtensionAPI & { _handlers: Handlers } {
@@ -236,12 +254,14 @@ describe("clipboard-image extension", () => {
 		function startVisionSession() {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
-			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
-			return pi
+			const ctx = makeMockCtx()
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, ctx)
+			return { pi, ctx }
 		}
 
-		it("attaches a typed absolute image path with [Image #1] and keeps the text", () => {
-			const pi = startVisionSession()
+		it("attaches a pasted image path with [Image #1] and keeps the text", () => {
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			const result = callInputHandler(pi, { text: `${imgPath} what's this?`, images: [] })
 
 			expect(result).toMatchObject({ action: "transform" })
@@ -254,7 +274,8 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("appends path images after existing attachments and numbers them sequentially", () => {
-			const pi = startVisionSession()
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			const attached: ImageContent = { type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" }
 			const result = callInputHandler(pi, { text: `look ${imgPath}`, images: [attached] })
 
@@ -267,7 +288,8 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("keeps the marker counter advancing across path-attach and paste turns", () => {
-			const pi = startVisionSession()
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			callInputHandler(pi, { text: String(imgPath), images: [] })
 			const result = callInputHandler(pi, {
 				text: "and this",
@@ -277,13 +299,15 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("attaches a path-only message with the marker as prefix", () => {
-			const pi = startVisionSession()
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
 			expect((result as { text: string }).text).toBe(`[Image #1] ${imgPath}`)
 		})
 
 		it("attaches a duplicated path only once", () => {
-			const pi = startVisionSession()
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			const result = callInputHandler(pi, { text: `${imgPath} and ${imgPath}`, images: [] })
 			expect((result as { images: ImageContent[] }).images).toHaveLength(1)
 		})
@@ -291,17 +315,16 @@ describe("clipboard-image extension", () => {
 		it("leaves text untouched when the model cannot read images", () => {
 			const pi = makeMockPi()
 			clipboardImageExtension(pi)
-			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(
-				void 0,
-				makeMockCtx({
-					model: {
-						id: "text-only",
-						slug: "text-only",
-						input_modalities: ["text"],
-					} as unknown as ExtensionContext["model"],
-				}),
-			)
+			const ctx = makeMockCtx({
+				model: {
+					id: "text-only",
+					slug: "text-only",
+					input_modalities: ["text"],
+				} as unknown as ExtensionContext["model"],
+			})
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, ctx)
 			mockGetAvailableModels.mockReturnValue([{ slug: "text-only", input_modalities: ["text"] }])
+			simulatePaste(ctx)
 
 			const result = callInputHandler(pi, { text: `look at ${imgPath}`, images: [] })
 			expect(result).toBeUndefined()
@@ -309,9 +332,17 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("leaves text untouched when the path does not resolve to an image", () => {
-			const pi = startVisionSession()
+			const { pi, ctx } = startVisionSession()
+			simulatePaste(ctx)
 			const missing = join(tmpDir, "missing.png")
 			const result = callInputHandler(pi, { text: `open ${missing}`, images: [] })
+			expect(result).toBeUndefined()
+			expect(mockAddImage).not.toHaveBeenCalled()
+		})
+
+		it("leaves text untouched when the input is typed, not pasted", () => {
+			const { pi } = startVisionSession()
+			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
 			expect(result).toBeUndefined()
 			expect(mockAddImage).not.toHaveBeenCalled()
 		})

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // All mock functions must be vi.hoisted — vi.mock is hoisted and its factory
@@ -212,6 +215,105 @@ describe("clipboard-image extension", () => {
 
 			const calls = mockSetPendingImageIndicator.mock.calls
 			expect(calls[calls.length - 1][0]).toBeNull()
+		})
+	})
+
+	describe("typed image paths", () => {
+		const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+		let tmpDir: string
+		let imgPath: string
+
+		beforeEach(() => {
+			tmpDir = mkdtempSync(join(tmpdir(), "typed-img-ext-"))
+			imgPath = join(tmpDir, "a.png")
+			writeFileSync(imgPath, PNG_BYTES)
+		})
+
+		afterEach(() => {
+			rmSync(tmpDir, { recursive: true, force: true })
+		})
+
+		function startVisionSession() {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, makeMockCtx())
+			return pi
+		}
+
+		it("attaches a typed absolute image path with [Image #1] and keeps the text", () => {
+			const pi = startVisionSession()
+			const result = callInputHandler(pi, { text: `${imgPath} what's this?`, images: [] })
+
+			expect(result).toMatchObject({ action: "transform" })
+			const { text, images } = result as { text: string; images: ImageContent[] }
+			expect(text).toBe(`[Image #1] ${imgPath} what's this?`)
+			expect(images).toHaveLength(1)
+			expect(images[0].mimeType).toBe("image/png")
+			expect(Buffer.from(images[0].data, "base64")).toEqual(PNG_BYTES)
+			expect(mockAddImage).toHaveBeenCalledWith(1, images[0])
+		})
+
+		it("appends path images after existing attachments and numbers them sequentially", () => {
+			const pi = startVisionSession()
+			const attached: ImageContent = { type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" }
+			const result = callInputHandler(pi, { text: `look ${imgPath}`, images: [attached] })
+
+			const { text, images } = result as { text: string; images: ImageContent[] }
+			expect(text).toBe(`[Image #1] [Image #2] look ${imgPath}`)
+			expect(images[0]).toEqual(attached)
+			expect(Buffer.from(images[1].data, "base64")).toEqual(PNG_BYTES)
+			expect(mockAddImage).toHaveBeenNthCalledWith(1, 1, attached)
+			expect(mockAddImage).toHaveBeenNthCalledWith(2, 2, expect.objectContaining({ mimeType: "image/png" }))
+		})
+
+		it("keeps the marker counter advancing across path-attach and paste turns", () => {
+			const pi = startVisionSession()
+			callInputHandler(pi, { text: String(imgPath), images: [] })
+			const result = callInputHandler(pi, {
+				text: "and this",
+				images: [{ type: "image", mimeType: "image/png", data: "aaa" }],
+			})
+			expect((result as { text: string }).text).toContain("[Image #2]")
+		})
+
+		it("attaches a path-only message with the marker as prefix", () => {
+			const pi = startVisionSession()
+			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
+			expect((result as { text: string }).text).toBe(`[Image #1] ${imgPath}`)
+		})
+
+		it("attaches a duplicated path only once", () => {
+			const pi = startVisionSession()
+			const result = callInputHandler(pi, { text: `${imgPath} and ${imgPath}`, images: [] })
+			expect((result as { images: ImageContent[] }).images).toHaveLength(1)
+		})
+
+		it("leaves text untouched when the model cannot read images", () => {
+			const pi = makeMockPi()
+			clipboardImageExtension(pi)
+			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(
+				void 0,
+				makeMockCtx({
+					model: {
+						id: "text-only",
+						slug: "text-only",
+						input_modalities: ["text"],
+					} as unknown as ExtensionContext["model"],
+				}),
+			)
+			mockGetAvailableModels.mockReturnValue([{ slug: "text-only", input_modalities: ["text"] }])
+
+			const result = callInputHandler(pi, { text: `look at ${imgPath}`, images: [] })
+			expect(result).toBeUndefined()
+			expect(mockAddImage).not.toHaveBeenCalled()
+		})
+
+		it("leaves text untouched when the path does not resolve to an image", () => {
+			const pi = startVisionSession()
+			const missing = join(tmpDir, "missing.png")
+			const result = callInputHandler(pi, { text: `open ${missing}`, images: [] })
+			expect(result).toBeUndefined()
+			expect(mockAddImage).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/extensions/clipboard-image.test.ts
+++ b/src/extensions/clipboard-image.test.ts
@@ -53,43 +53,15 @@ import clipboardImageExtension from "./clipboard-image.js"
 
 type Handlers = Record<string, (...args: unknown[]) => unknown>
 
-interface MockTerminalInput {
-	current?: (data: string) => void
-}
-
-function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext & {
-	_mockTerminalInput: MockTerminalInput
-} {
-	const terminalInputHandler: MockTerminalInput = {}
+function makeMockCtx(overrides: Partial<ExtensionContext> = {}): ExtensionContext {
 	return {
 		model: { id: "glm-4", slug: "glm-4", input_modalities: ["text", "image"] as string[] },
 		ui: {
 			notify: vi.fn(),
 			setStatus: vi.fn(),
-			onTerminalInput: (handler: (data: string) => void) => {
-				terminalInputHandler.current = handler
-				return () => {
-					terminalInputHandler.current = undefined
-				}
-			},
 		},
-		_mockTerminalInput: terminalInputHandler,
 		...overrides,
-	} as unknown as ExtensionContext & { _mockTerminalInput: MockTerminalInput }
-}
-
-function simulatePaste(ctx: ExtensionContext & { _mockTerminalInput: MockTerminalInput }) {
-	const handler = ctx._mockTerminalInput.current
-	expect(handler).toBeDefined()
-	if (!handler) throw new Error("expected terminal input handler to be registered")
-	handler("\x1b[200~/dummy.png\x1b[201~")
-}
-
-function simulateTypedInput(ctx: ExtensionContext & { _mockTerminalInput: MockTerminalInput }) {
-	const handler = ctx._mockTerminalInput.current
-	expect(handler).toBeDefined()
-	if (!handler) throw new Error("expected terminal input handler to be registered")
-	handler("typed text")
+	} as unknown as ExtensionContext
 }
 
 function makeMockPi(): ExtensionAPI & { _handlers: Handlers } {
@@ -249,7 +221,7 @@ describe("clipboard-image extension", () => {
 		})
 	})
 
-	describe("typed image paths", () => {
+	describe("image file paths in the prompt", () => {
 		const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47])
 		let tmpDir: string
 		let imgPath: string
@@ -272,9 +244,8 @@ describe("clipboard-image extension", () => {
 			return { pi, ctx }
 		}
 
-		it("attaches a pasted image path with [Image #1] and keeps the text", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+		it("attaches a typed image path with [Image #1] and keeps the text", () => {
+			const { pi } = startVisionSession()
 			const result = callInputHandler(pi, { text: `${imgPath} what's this?`, images: [] })
 
 			expect(result).toMatchObject({ action: "transform" })
@@ -287,8 +258,7 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("appends path images after existing attachments and numbers them sequentially", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+			const { pi } = startVisionSession()
 			const attached: ImageContent = { type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" }
 			const result = callInputHandler(pi, { text: `look ${imgPath}`, images: [attached] })
 
@@ -301,8 +271,7 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("keeps the marker counter advancing across path-attach and paste turns", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+			const { pi } = startVisionSession()
 			callInputHandler(pi, { text: String(imgPath), images: [] })
 			const result = callInputHandler(pi, {
 				text: "and this",
@@ -312,15 +281,13 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("attaches a path-only message with the marker as prefix", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+			const { pi } = startVisionSession()
 			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
 			expect((result as { text: string }).text).toBe(`[Image #1] ${imgPath}`)
 		})
 
 		it("attaches a duplicated path only once", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+			const { pi } = startVisionSession()
 			const result = callInputHandler(pi, { text: `${imgPath} and ${imgPath}`, images: [] })
 			expect((result as { images: ImageContent[] }).images).toHaveLength(1)
 		})
@@ -337,7 +304,6 @@ describe("clipboard-image extension", () => {
 			})
 			;(pi._handlers.session_start as (e: unknown, ctx: ExtensionContext) => void)(void 0, ctx)
 			mockGetAvailableModels.mockReturnValue([{ slug: "text-only", input_modalities: ["text"] }])
-			simulatePaste(ctx)
 
 			const result = callInputHandler(pi, { text: `look at ${imgPath}`, images: [] })
 			expect(result).toBeUndefined()
@@ -345,27 +311,9 @@ describe("clipboard-image extension", () => {
 		})
 
 		it("leaves text untouched when the path does not resolve to an image", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
+			const { pi } = startVisionSession()
 			const missing = join(tmpDir, "missing.png")
 			const result = callInputHandler(pi, { text: `open ${missing}`, images: [] })
-			expect(result).toBeUndefined()
-			expect(mockAddImage).not.toHaveBeenCalled()
-		})
-
-		it("leaves text untouched when the input is typed, not pasted", () => {
-			const { pi } = startVisionSession()
-			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
-			expect(result).toBeUndefined()
-			expect(mockAddImage).not.toHaveBeenCalled()
-		})
-
-		it("leaves text untouched when input is typed after a paste (sticky flag reset)", () => {
-			const { pi, ctx } = startVisionSession()
-			simulatePaste(ctx)
-			// Simulate typed keystrokes after the paste — these reset lastInputWasPaste.
-			simulateTypedInput(ctx)
-			const result = callInputHandler(pi, { text: String(imgPath), images: [] })
 			expect(result).toBeUndefined()
 			expect(mockAddImage).not.toHaveBeenCalled()
 		})

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -34,6 +34,22 @@ function teardownTerminalInput(): void {
 	inBracketedPaste = false
 }
 
+// Strip CSI escape sequences (arrow keys, Home/End, etc.) and carriage returns,
+// then check whether any printable content remains. This distinguishes real
+// typed characters from control keys like Enter (\r) and escape sequences,
+// so that pressing Enter to submit a pasted prompt doesn't clear the paste flag.
+// Built via String.fromCharCode to avoid a control-character literal in the regex.
+const _ESC = String.fromCharCode(0x1b)
+const _CSI_RE = new RegExp(`${_ESC}\\[[0-9;]*[A-Za-z]`, "g")
+function hasTypedContent(data: string): boolean {
+	return (
+		data
+			.replace(_CSI_RE, "")
+			.replace(/[\r\n\t]/g, "")
+			.trim().length > 0
+	)
+}
+
 const CLIPBOARD_POLL_INTERVAL_MS = 1000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
 let clipboardHasImage = false
@@ -266,7 +282,11 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			if (data.includes("\x1b[200~")) {
 				lastInputWasPaste = true
 				inBracketedPaste = !data.includes("\x1b[201~")
-			} else {
+			} else if (hasTypedContent(data)) {
+				// Real keystrokes (letters, digits, punctuation) clear the paste flag
+				// so paste-then-type doesn't wrongly attach image paths. Control keys
+				// like Enter (\r) and escape sequences (arrow keys) are ignored — they
+				// don't represent typed content and must not clobber a just-set flag.
 				lastInputWasPaste = false
 			}
 			return undefined

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -25,6 +25,15 @@ let lastInputWasPaste = false
 let inBracketedPaste = false
 let unsubscribeTerminalInput: (() => void) | null = null
 
+function teardownTerminalInput(): void {
+	if (unsubscribeTerminalInput) {
+		unsubscribeTerminalInput()
+		unsubscribeTerminalInput = null
+	}
+	lastInputWasPaste = false
+	inBracketedPaste = false
+}
+
 const CLIPBOARD_POLL_INTERVAL_MS = 1000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
 let clipboardHasImage = false
@@ -226,17 +235,12 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
-		if (unsubscribeTerminalInput) {
-			unsubscribeTerminalInput()
-			unsubscribeTerminalInput = null
-		}
+		teardownTerminalInput()
 		sessionGeneration++
 		isCheckingFinder = false
 		currentCtx = ctx
 		pendingImages = []
 		imageCounter = 0
-		lastInputWasPaste = false
-		inBracketedPaste = false
 		const sessionDir = ctx.sessionManager?.getSessionDir?.() ?? null
 		const dir = sessionDir ? join(sessionDir, "image-cache") : null
 		setImageCacheDir(dir)
@@ -252,20 +256,21 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		// Watch raw terminal input for bracketed-paste sequences so we can tell
 		// pasted/dropped text apart from typed text. The editor strips these
 		// markers, but they still flow through the raw input listeners.
-		unsubscribeTerminalInput =
-			ctx.ui?.onTerminalInput?.((data) => {
-				if (inBracketedPaste) {
-					if (data.includes("\x1b[201~")) {
-						inBracketedPaste = false
-					}
-					return undefined
-				}
-				if (data.includes("\x1b[200~")) {
-					lastInputWasPaste = true
-					inBracketedPaste = !data.includes("\x1b[201~")
+		unsubscribeTerminalInput = ctx.ui.onTerminalInput((data) => {
+			if (inBracketedPaste) {
+				if (data.includes("\x1b[201~")) {
+					inBracketedPaste = false
 				}
 				return undefined
-			}) ?? null
+			}
+			if (data.includes("\x1b[200~")) {
+				lastInputWasPaste = true
+				inBracketedPaste = !data.includes("\x1b[201~")
+			} else {
+				lastInputWasPaste = false
+			}
+			return undefined
+		})
 	})
 
 	pi.on("session_shutdown", () => {
@@ -273,16 +278,11 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
-		if (unsubscribeTerminalInput) {
-			unsubscribeTerminalInput()
-			unsubscribeTerminalInput = null
-		}
+		teardownTerminalInput()
 		// Increment the generation so any in-flight Finder file-type probe
 		// from the dying session is treated as stale when its callback lands.
 		sessionGeneration++
 		currentCtx = null
-		lastInputWasPaste = false
-		inBracketedPaste = false
 	})
 
 	pi.on("input", (event) => {

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -16,6 +16,14 @@ let currentCtx: ExtensionContext | null = null
 // Per-session running counter of images attached to user turns. Resets on
 // session_start so that a new conversation always begins at #1.
 let imageCounter = 0
+// Tracks whether the current editor content was introduced by a paste (or
+// drag-and-drop, which most terminals deliver as a bracketed paste). Set when
+// we observe a bracketed-paste start sequence in the raw terminal input; the
+// input handler consumes and clears it. This keeps typed image-path mentions
+// from being auto-attached while still giving pasted/dropped paths paste parity.
+let lastInputWasPaste = false
+let inBracketedPaste = false
+let unsubscribeTerminalInput: (() => void) | null = null
 
 const CLIPBOARD_POLL_INTERVAL_MS = 1000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
@@ -218,11 +226,17 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
+		if (unsubscribeTerminalInput) {
+			unsubscribeTerminalInput()
+			unsubscribeTerminalInput = null
+		}
 		sessionGeneration++
 		isCheckingFinder = false
 		currentCtx = ctx
 		pendingImages = []
 		imageCounter = 0
+		lastInputWasPaste = false
+		inBracketedPaste = false
 		const sessionDir = ctx.sessionManager?.getSessionDir?.() ?? null
 		const dir = sessionDir ? join(sessionDir, "image-cache") : null
 		setImageCacheDir(dir)
@@ -230,9 +244,28 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 		updateIndicator()
 		// Linux clipboard detection shells out to wl-paste/xclip, so keep it on-demand.
 		// Polling wl-paste can create transient surfaces that steal focus on Wayland.
-		if (process.platform === "linux") return
-		checkClipboard()
-		clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
+		if (process.platform !== "linux") {
+			checkClipboard()
+			clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
+		}
+
+		// Watch raw terminal input for bracketed-paste sequences so we can tell
+		// pasted/dropped text apart from typed text. The editor strips these
+		// markers, but they still flow through the raw input listeners.
+		unsubscribeTerminalInput =
+			ctx.ui?.onTerminalInput?.((data) => {
+				if (inBracketedPaste) {
+					if (data.includes("\x1b[201~")) {
+						inBracketedPaste = false
+					}
+					return undefined
+				}
+				if (data.includes("\x1b[200~")) {
+					lastInputWasPaste = true
+					inBracketedPaste = !data.includes("\x1b[201~")
+				}
+				return undefined
+			}) ?? null
 	})
 
 	pi.on("session_shutdown", () => {
@@ -240,26 +273,36 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
+		if (unsubscribeTerminalInput) {
+			unsubscribeTerminalInput()
+			unsubscribeTerminalInput = null
+		}
 		// Increment the generation so any in-flight Finder file-type probe
 		// from the dying session is treated as stale when its callback lands.
 		sessionGeneration++
 		currentCtx = null
+		lastInputWasPaste = false
+		inBracketedPaste = false
 	})
 
 	pi.on("input", (event) => {
 		const incoming = event.images ?? []
-		// Typed image paths get paste parity: attach them the same way so the model
-		// receives the image inline instead of depending on the read tool's image
-		// pipeline. Vision-less models keep the text untouched so the read tool
-		// remains the fallback (and errors loudly there). Path images are appended
-		// after pasted/attached ones so existing marker numbering is unchanged.
-		const fromPaths: ImageContent[] = modelSupportsImages(currentCtx?.model)
-			? extractTypedImagePaths(event.text, currentCtx?.cwd ?? process.cwd()).map((match) => ({
-					type: "image" as const,
-					data: Buffer.from(match.image.bytes).toString("base64"),
-					mimeType: match.image.mimeType,
-				}))
-			: []
+		// Typed image paths get paste parity only for pasted or dropped text.
+		// We detect paste/drop by watching for bracketed-paste sequences in the
+		// raw terminal input; this covers Ctrl+V and most drag-and-drop cases.
+		// Vision-less models keep the text untouched so the read tool remains the
+		// fallback (and errors loudly there). Path images are appended after
+		// pasted/attached ones so existing marker numbering is unchanged.
+		const shouldAttachPaths = lastInputWasPaste
+		lastInputWasPaste = false
+		const fromPaths: ImageContent[] =
+			shouldAttachPaths && modelSupportsImages(currentCtx?.model)
+				? extractTypedImagePaths(event.text, currentCtx?.cwd ?? process.cwd()).map((match) => ({
+						type: "image" as const,
+						data: Buffer.from(match.image.bytes).toString("base64"),
+						mimeType: match.image.mimeType,
+					}))
+				: []
 		const totalImages = incoming.length + pendingImages.length + fromPaths.length
 
 		if (totalImages === 0) return

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -7,6 +7,7 @@ import { getNativeClipboard } from "../utils/clipboard-native-harness.js"
 import { readClipboardImage } from "../utils/clipboard-read.js"
 import { addImage, clearAllImages, setImageCacheDir } from "../utils/image-registry.js"
 import { IMAGE_EXT_TO_MIME } from "../utils/image-utils.js"
+import { extractTypedImagePaths } from "../utils/typed-image-paths.js"
 import { isAutoModel } from "./router/constants.js"
 import { setPasteImageHandler, setPendingImageIndicator } from "./ui.js"
 
@@ -247,11 +248,23 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 
 	pi.on("input", (event) => {
 		const incoming = event.images ?? []
-		const totalImages = incoming.length + pendingImages.length
+		// Typed image paths get paste parity: attach them the same way so the model
+		// receives the image inline instead of depending on the read tool's image
+		// pipeline. Vision-less models keep the text untouched so the read tool
+		// remains the fallback (and errors loudly there). Path images are appended
+		// after pasted/attached ones so existing marker numbering is unchanged.
+		const fromPaths: ImageContent[] = modelSupportsImages(currentCtx?.model)
+			? extractTypedImagePaths(event.text, currentCtx?.cwd ?? process.cwd()).map((match) => ({
+					type: "image" as const,
+					data: Buffer.from(match.image.bytes).toString("base64"),
+					mimeType: match.image.mimeType,
+				}))
+			: []
+		const totalImages = incoming.length + pendingImages.length + fromPaths.length
 
 		if (totalImages === 0) return
 
-		const images = [...incoming, ...pendingImages]
+		const images = [...incoming, ...pendingImages, ...fromPaths]
 		pendingImages = []
 		updateIndicator()
 

--- a/src/extensions/clipboard-image.ts
+++ b/src/extensions/clipboard-image.ts
@@ -16,39 +16,6 @@ let currentCtx: ExtensionContext | null = null
 // Per-session running counter of images attached to user turns. Resets on
 // session_start so that a new conversation always begins at #1.
 let imageCounter = 0
-// Tracks whether the current editor content was introduced by a paste (or
-// drag-and-drop, which most terminals deliver as a bracketed paste). Set when
-// we observe a bracketed-paste start sequence in the raw terminal input; the
-// input handler consumes and clears it. This keeps typed image-path mentions
-// from being auto-attached while still giving pasted/dropped paths paste parity.
-let lastInputWasPaste = false
-let inBracketedPaste = false
-let unsubscribeTerminalInput: (() => void) | null = null
-
-function teardownTerminalInput(): void {
-	if (unsubscribeTerminalInput) {
-		unsubscribeTerminalInput()
-		unsubscribeTerminalInput = null
-	}
-	lastInputWasPaste = false
-	inBracketedPaste = false
-}
-
-// Strip CSI escape sequences (arrow keys, Home/End, etc.) and carriage returns,
-// then check whether any printable content remains. This distinguishes real
-// typed characters from control keys like Enter (\r) and escape sequences,
-// so that pressing Enter to submit a pasted prompt doesn't clear the paste flag.
-// Built via String.fromCharCode to avoid a control-character literal in the regex.
-const _ESC = String.fromCharCode(0x1b)
-const _CSI_RE = new RegExp(`${_ESC}\\[[0-9;]*[A-Za-z]`, "g")
-function hasTypedContent(data: string): boolean {
-	return (
-		data
-			.replace(_CSI_RE, "")
-			.replace(/[\r\n\t]/g, "")
-			.trim().length > 0
-	)
-}
 
 const CLIPBOARD_POLL_INTERVAL_MS = 1000
 let clipboardPollId: ReturnType<typeof setInterval> | null = null
@@ -251,7 +218,6 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
-		teardownTerminalInput()
 		sessionGeneration++
 		isCheckingFinder = false
 		currentCtx = ctx
@@ -268,29 +234,6 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			checkClipboard()
 			clipboardPollId = setInterval(checkClipboard, CLIPBOARD_POLL_INTERVAL_MS)
 		}
-
-		// Watch raw terminal input for bracketed-paste sequences so we can tell
-		// pasted/dropped text apart from typed text. The editor strips these
-		// markers, but they still flow through the raw input listeners.
-		unsubscribeTerminalInput = ctx.ui.onTerminalInput((data) => {
-			if (inBracketedPaste) {
-				if (data.includes("\x1b[201~")) {
-					inBracketedPaste = false
-				}
-				return undefined
-			}
-			if (data.includes("\x1b[200~")) {
-				lastInputWasPaste = true
-				inBracketedPaste = !data.includes("\x1b[201~")
-			} else if (hasTypedContent(data)) {
-				// Real keystrokes (letters, digits, punctuation) clear the paste flag
-				// so paste-then-type doesn't wrongly attach image paths. Control keys
-				// like Enter (\r) and escape sequences (arrow keys) are ignored — they
-				// don't represent typed content and must not clobber a just-set flag.
-				lastInputWasPaste = false
-			}
-			return undefined
-		})
 	})
 
 	pi.on("session_shutdown", () => {
@@ -298,7 +241,6 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 			clearInterval(clipboardPollId)
 			clipboardPollId = null
 		}
-		teardownTerminalInput()
 		// Increment the generation so any in-flight Finder file-type probe
 		// from the dying session is treated as stale when its callback lands.
 		sessionGeneration++
@@ -307,22 +249,23 @@ export default function clipboardImageExtension(pi: ExtensionAPI): void {
 
 	pi.on("input", (event) => {
 		const incoming = event.images ?? []
-		// Typed image paths get paste parity only for pasted or dropped text.
-		// We detect paste/drop by watching for bracketed-paste sequences in the
-		// raw terminal input; this covers Ctrl+V and most drag-and-drop cases.
-		// Vision-less models keep the text untouched so the read tool remains the
-		// fallback (and errors loudly there). Path images are appended after
-		// pasted/attached ones so existing marker numbering is unchanged.
-		const shouldAttachPaths = lastInputWasPaste
-		lastInputWasPaste = false
-		const fromPaths: ImageContent[] =
-			shouldAttachPaths && modelSupportsImages(currentCtx?.model)
-				? extractTypedImagePaths(event.text, currentCtx?.cwd ?? process.cwd()).map((match) => ({
-						type: "image" as const,
-						data: Buffer.from(match.image.bytes).toString("base64"),
-						mimeType: match.image.mimeType,
-					}))
-				: []
+		// Local image file paths in the submitted text (typed, pasted, or dropped)
+		// are attached like pasted images. Extraction is intentionally
+		// unconditional: distinguishing paste from typing would require sniffing
+		// raw terminal input, which is unreliable — the UI starts accepting input
+		// before extensions initialize, so early pastes are never observed. The
+		// disk guards keep prose false positives rare (existing file, supported
+		// extension, readable, under the size cap). Vision-less models keep the
+		// text untouched so the read tool remains the fallback (and errors loudly
+		// there). Path images are appended after pasted/attached ones so existing
+		// marker numbering is unchanged.
+		const fromPaths: ImageContent[] = modelSupportsImages(currentCtx?.model)
+			? extractTypedImagePaths(event.text, currentCtx?.cwd ?? process.cwd()).map((match) => ({
+					type: "image" as const,
+					data: Buffer.from(match.image.bytes).toString("base64"),
+					mimeType: match.image.mimeType,
+				}))
+			: []
 		const totalImages = incoming.length + pendingImages.length + fromPaths.length
 
 		if (totalImages === 0) return

--- a/src/utils/typed-image-paths.test.ts
+++ b/src/utils/typed-image-paths.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { extractTypedImagePaths } from "./typed-image-paths.js"
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+
+describe("extractTypedImagePaths", () => {
+	let tmpDir: string
+	let imgPath: string
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "typed-img-"))
+		imgPath = join(tmpDir, "a.png")
+		writeFileSync(imgPath, PNG_BYTES)
+	})
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true })
+		vi.unstubAllEnvs()
+	})
+
+	it("attaches an absolute path", () => {
+		const matches = extractTypedImagePaths(`what is ${imgPath}`, tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].resolvedPath).toBe(imgPath)
+		expect(matches[0].image.mimeType).toBe("image/png")
+		expect(Buffer.from(matches[0].image.bytes)).toEqual(PNG_BYTES)
+	})
+
+	it("expands ~/ paths using HOME", () => {
+		vi.stubEnv("HOME", tmpDir)
+		const matches = extractTypedImagePaths("look at ~/a.png", tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].resolvedPath).toBe(imgPath)
+	})
+
+	it("resolves relative paths against cwd", () => {
+		const matches = extractTypedImagePaths("open a.png please", tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].resolvedPath).toBe(imgPath)
+	})
+
+	it("attaches quoted paths containing spaces", () => {
+		const spacedPath = join(tmpDir, "my cat.jpg")
+		writeFileSync(spacedPath, PNG_BYTES)
+		const matches = extractTypedImagePaths(`"${spacedPath}" what is this?`, tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].resolvedPath).toBe(spacedPath)
+		expect(matches[0].image.mimeType).toBe("image/jpeg")
+	})
+
+	it("attaches single-quoted paths", () => {
+		const spacedPath = join(tmpDir, "my cat.png")
+		writeFileSync(spacedPath, PNG_BYTES)
+		const matches = extractTypedImagePaths(`check '${spacedPath}' now`, tmpDir)
+		expect(matches).toHaveLength(1)
+	})
+
+	it("attaches multiple paths in first-appearance order", () => {
+		const webpPath = join(tmpDir, "b.webp")
+		writeFileSync(webpPath, PNG_BYTES)
+		const matches = extractTypedImagePaths(`${imgPath} and then ${webpPath}`, tmpDir)
+		expect(matches.map((m) => m.resolvedPath)).toEqual([imgPath, webpPath])
+	})
+
+	it("attaches a duplicated path only once", () => {
+		const matches = extractTypedImagePaths(`${imgPath} is the same as ${imgPath}`, tmpDir)
+		expect(matches).toHaveLength(1)
+	})
+
+	it("strips trailing sentence punctuation from bare prose tokens", () => {
+		const matches = extractTypedImagePaths(`is ${imgPath}? really, ${imgPath}.`, tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].resolvedPath).toBe(imgPath)
+	})
+
+	it("strips parentheses wrapping a path in prose", () => {
+		const matches = extractTypedImagePaths(`look (${imgPath}) here`, tmpDir)
+		expect(matches).toHaveLength(1)
+	})
+
+	it("matches uppercase extensions", () => {
+		const upperPath = join(tmpDir, "B.JPG")
+		writeFileSync(upperPath, PNG_BYTES)
+		const matches = extractTypedImagePaths(`open ${upperPath}`, tmpDir)
+		expect(matches).toHaveLength(1)
+		expect(matches[0].image.mimeType).toBe("image/jpeg")
+	})
+
+	it("ignores non-image extensions", () => {
+		const txtPath = join(tmpDir, "notes.txt")
+		writeFileSync(txtPath, "hello")
+		expect(extractTypedImagePaths(`read ${txtPath}`, tmpDir)).toEqual([])
+	})
+
+	it("ignores URLs even when a same-named local file exists", () => {
+		expect(extractTypedImagePaths("see https://example.com/a.png", tmpDir)).toEqual([])
+	})
+
+	it("ignores file:// URIs", () => {
+		expect(extractTypedImagePaths(`see file://${imgPath}`, tmpDir)).toEqual([])
+	})
+
+	it("ignores paths that do not exist", () => {
+		expect(extractTypedImagePaths(`open ${join(tmpDir, "nope.png")}`, tmpDir)).toEqual([])
+	})
+
+	it("ignores directories with image-like names", () => {
+		const dirPath = join(tmpDir, "dir.png")
+		mkdirSync(dirPath)
+		expect(extractTypedImagePaths(`open ${dirPath}`, tmpDir)).toEqual([])
+	})
+
+	it("attaches paths inside inline code spans", () => {
+		const matches = extractTypedImagePaths(`open \`${imgPath}\` please`, tmpDir)
+		expect(matches).toHaveLength(1)
+	})
+
+	it("handles CRLF line endings", () => {
+		const matches = extractTypedImagePaths(`see ${imgPath}\r\nnext line`, tmpDir)
+		expect(matches).toHaveLength(1)
+	})
+
+	it("returns an empty list for text without paths", () => {
+		expect(extractTypedImagePaths("hello world", tmpDir)).toEqual([])
+	})
+})

--- a/src/utils/typed-image-paths.ts
+++ b/src/utils/typed-image-paths.ts
@@ -1,0 +1,90 @@
+import { homedir } from "node:os"
+import { extname, resolve } from "node:path"
+import { IMAGE_EXT_TO_MIME, readImageFileFromDisk } from "./image-utils.js"
+
+/**
+ * Extract image file paths the user typed directly into the prompt editor.
+ *
+ * Pasted images are attached to the user turn by the clipboard-image
+ * extension, but a typed path ("/Users/jose/Downloads/A-Cat.jpg") arrives as
+ * plain text. This module finds those typed paths so the same extension can
+ * attach them as images, giving typed paths paste parity. It is deliberately
+ * conservative: a token only becomes a match when `readImageFileFromDisk`
+ * accepts it (exists, readable, supported extension, within the size cap) —
+ * prose tokens that merely look like paths are silently ignored.
+ */
+
+export interface TypedImagePathMatch {
+	/** Candidate path as written (quotes and prose punctuation stripped). */
+	rawPath: string
+	/** Absolute path after `~` expansion and cwd resolution. */
+	resolvedPath: string
+	/** Guard result from readImageFileFromDisk — the file is read exactly once here. */
+	image: { bytes: Uint8Array; mimeType: string }
+}
+
+// Quoted spans (double, single, backtick) are single tokens so paths with
+// spaces and inline code spans attach; everything else is whitespace-split
+// (\s covers \r, so CRLF line breaks need no special handling).
+const TOKEN_RE = /"([^"\n]+)"|'([^'\n]+)'|`([^`\n]+)`|(\S+)/g
+
+// Prose punctuation clinging to the edges of a typed path in chat text.
+const LEADING_JUNK_RE = /^[([{<'"`]+/
+const TRAILING_JUNK_RE = /[.,;:!?)\]}>'"`]+$/
+
+interface Token {
+	raw: string
+	quoted: boolean
+}
+
+function tokenize(text: string): Token[] {
+	const tokens: Token[] = []
+	for (const m of text.matchAll(TOKEN_RE)) {
+		const quoted = m[1] ?? m[2] ?? m[3]
+		if (quoted !== undefined) tokens.push({ raw: quoted, quoted: true })
+		else if (m[4] !== undefined) tokens.push({ raw: m[4], quoted: false })
+	}
+	return tokens
+}
+
+/**
+ * Reduce a token to a viable local image path candidate, or null. No disk
+ * access here — the regex/extension filters exist only to keep the subsequent
+ * filesystem guard (readImageFileFromDisk) rare and predictable.
+ */
+function toCandidate(token: Token): string | null {
+	const raw = token.quoted ? token.raw.trim() : token.raw.replace(LEADING_JUNK_RE, "").replace(TRAILING_JUNK_RE, "")
+	if (!raw) return null
+	// URLs and file:// URIs are never local attachments.
+	if (raw.includes("://")) return null
+	if (!IMAGE_EXT_TO_MIME[extname(raw).toLowerCase()]) return null
+	return raw
+}
+
+function expandHome(raw: string): string {
+	if (raw === "~") return process.env.HOME || homedir()
+	if (raw.startsWith("~/")) return `${process.env.HOME || homedir()}${raw.slice(1)}`
+	return raw
+}
+
+/**
+ * Scan `text` for typed local image paths. Returns matches in first-appearance
+ * order, deduped by resolved absolute path. Missing/unreadable files are
+ * skipped silently — callers leave the text untouched so the model can still
+ * fall back to the `read` tool, which reports errors loudly.
+ */
+export function extractTypedImagePaths(text: string, cwd: string): TypedImagePathMatch[] {
+	const seen = new Set<string>()
+	const matches: TypedImagePathMatch[] = []
+	for (const token of tokenize(text)) {
+		const raw = toCandidate(token)
+		if (!raw) continue
+		const resolvedPath = resolve(cwd, expandHome(raw))
+		if (seen.has(resolvedPath)) continue
+		const image = readImageFileFromDisk(resolvedPath)
+		if (!image) continue
+		seen.add(resolvedPath)
+		matches.push({ rawPath: raw, resolvedPath, image })
+	}
+	return matches
+}

--- a/tests/e2e/tui/typed-image-path.test.ts
+++ b/tests/e2e/tui/typed-image-path.test.ts
@@ -6,11 +6,13 @@ import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
-// UX consistency: typing an image path must behave like pasting the image —
-// the input transform attaches it, the [Image #N] marker appears in the user
-// message, and the model request carries the binary payload (no read-tool
-// round-trip, which can silently drop the image).
-test("typed image path attaches the image to the user turn", async ({ terminal }) => {
+// UX consistency: pasting an image path (or dragging a file into the terminal)
+// must behave like pasting the image itself — the input transform attaches it,
+// the [Image #N] marker appears in the user message, and the model request
+// carries the binary payload (no read-tool round-trip, which can silently drop
+// the image). Typed paths without a paste are left alone so filename mentions
+// in prose don't auto-attach.
+test("pasted image path attaches the image to the user turn", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
 		{
@@ -33,8 +35,13 @@ test("typed image path attaches the image to the user turn", async ({ terminal }
 			},
 		},
 		async (fixture, trace) => {
-			terminal.submit("cat.png what's this?")
-			trace.step("submitted typed image path prompt")
+			// Simulate a paste (or drag-and-drop) by wrapping the path in the
+			// standard terminal bracketed-paste sequences. The editor strips the
+			// markers, but the extension sees them in the raw terminal input and
+			// treats the submission as pasted.
+			terminal.write("\x1b[200~cat.png\x1b[201~")
+			terminal.submit("")
+			trace.step("submitted pasted image path prompt")
 
 			// User-visible evidence: the attached image's marker prefixes the message.
 			await waitForText(terminal, "[Image #1]")

--- a/tests/e2e/tui/typed-image-path.test.ts
+++ b/tests/e2e/tui/typed-image-path.test.ts
@@ -1,0 +1,51 @@
+import { writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { expect, test } from "@microsoft/tui-test"
+import { waitForText } from "./support/assertions.js"
+import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+// UX consistency: typing an image path must behave like pasting the image —
+// the input transform attaches it, the [Image #N] marker appears in the user
+// message, and the model request carries the binary payload (no read-tool
+// round-trip, which can silently drop the image).
+test("typed image path attaches the image to the user turn", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "typed-image-path",
+			models: [
+				{
+					slug: "vision",
+					displayName: "Fake Vision",
+					provider: "openai",
+					reasoning: false,
+					input: ["text", "image"],
+					contextWindow: 8192,
+					maxTokens: 1024,
+				},
+			],
+			initialModel: "vision",
+			responses: [{ stream: ["I can see your typed image."] }],
+			seedHome: (_homeDir, workDir) => {
+				writeFileSync(join(workDir, "cat.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+			},
+		},
+		async (fixture, trace) => {
+			terminal.submit("cat.png what's this?")
+			trace.step("submitted typed image path prompt")
+
+			// User-visible evidence: the attached image's marker prefixes the message.
+			await waitForText(terminal, "[Image #1]")
+			await waitForText(terminal, "I can see your typed image.")
+			trace.step("image marker and fake reply visible")
+
+			// Behaviour-level evidence: the completion request carried the image.
+			const chatBodies = fixture.fake.requests
+				.filter((request) => request.url.startsWith("/openai/v1/chat/completions"))
+				.map((request) => JSON.stringify(request.body))
+			expect(chatBodies.some((body) => body.includes('"image_url"'))).toBe(true)
+		},
+	)
+})

--- a/tests/e2e/tui/typed-image-path.test.ts
+++ b/tests/e2e/tui/typed-image-path.test.ts
@@ -2,32 +2,33 @@ import { writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { expect, test } from "@microsoft/tui-test"
 import { waitForText } from "./support/assertions.js"
+import type { FakeModel } from "./support/fake-openai-server.js"
 import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
-// UX consistency: pasting an image path (or dragging a file into the terminal)
-// must behave like pasting the image itself — the input transform attaches it,
-// the [Image #N] marker appears in the user message, and the model request
-// carries the binary payload (no read-tool round-trip, which can silently drop
-// the image). Typed paths without a paste are left alone so filename mentions
-// in prose don't auto-attach.
-test("pasted image path attaches the image to the user turn", async ({ terminal }) => {
+const VISION_MODEL: FakeModel = {
+	slug: "vision",
+	displayName: "Fake Vision",
+	provider: "openai",
+	reasoning: false,
+	input: ["text", "image"],
+	contextWindow: 8192,
+	maxTokens: 1024,
+}
+
+// A local image file path typed (or pasted/dropped) into the prompt must behave
+// like pasting the image itself: the input transform attaches the file, the
+// [Image #N] marker appears in the user message, and the model request carries
+// the binary payload (no read-tool round-trip, which can silently drop the
+// image). Prose that names a path which does not resolve to an image file must
+// be left untouched so the read tool stays the loud fallback.
+test("typed image path attaches the image to the user turn", async ({ terminal }) => {
 	await runKimchiSession(
 		terminal,
 		{
 			artifactName: "typed-image-path",
-			models: [
-				{
-					slug: "vision",
-					displayName: "Fake Vision",
-					provider: "openai",
-					reasoning: false,
-					input: ["text", "image"],
-					contextWindow: 8192,
-					maxTokens: 1024,
-				},
-			],
+			models: [VISION_MODEL],
 			initialModel: "vision",
 			responses: [{ stream: ["I can see your typed image."] }],
 			seedHome: (_homeDir, workDir) => {
@@ -35,13 +36,9 @@ test("pasted image path attaches the image to the user turn", async ({ terminal 
 			},
 		},
 		async (fixture, trace) => {
-			// Simulate a paste (or drag-and-drop) by wrapping the path in the
-			// standard terminal bracketed-paste sequences. The editor strips the
-			// markers, but the extension sees them in the raw terminal input and
-			// treats the submission as pasted.
-			terminal.write("\x1b[200~cat.png\x1b[201~")
+			terminal.write("cat.png what's this?")
 			terminal.submit("")
-			trace.step("submitted pasted image path prompt")
+			trace.step("submitted image path prompt")
 
 			// User-visible evidence: the attached image's marker prefixes the message.
 			await waitForText(terminal, "[Image #1]")
@@ -53,6 +50,33 @@ test("pasted image path attaches the image to the user turn", async ({ terminal 
 				.filter((request) => request.url.startsWith("/openai/v1/chat/completions"))
 				.map((request) => JSON.stringify(request.body))
 			expect(chatBodies.some((body) => body.includes('"image_url"'))).toBe(true)
+		},
+	)
+})
+
+test("mentioning a non-existent image path does not attach anything", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "typed-image-path-missing",
+			models: [VISION_MODEL],
+			initialModel: "vision",
+			responses: [{ stream: ["Nothing attached."] }],
+		},
+		async (fixture, trace) => {
+			terminal.write("please open missing.png")
+			terminal.submit("")
+			trace.step("submitted prose mentioning a missing image file")
+
+			await waitForText(terminal, "Nothing attached.")
+			trace.step("fake reply visible")
+
+			// The missing file was skipped: no marker, no image payload in the request.
+			await expect(waitForText(terminal, "[Image #1]", { timeoutMs: 2000 })).rejects.toThrow()
+			const chatBodies = fixture.fake.requests
+				.filter((request) => request.url.startsWith("/openai/v1/chat/completions"))
+				.map((request) => JSON.stringify(request.body))
+			expect(chatBodies.some((body) => body.includes('"image_url"'))).toBe(false)
 		},
 	)
 })


### PR DESCRIPTION
## Summary

Typing, pasting, or dragging a local image file path into the prompt now attaches the image inline just like pasting the image itself: the model receives it as an `ImageContent` block with the standard `[Image #N]` marker.

## Why

Previously, an image path in the prompt arrived as plain text, so the model could only see the image if it chose to call the `read` tool — whose upstream resize pipeline can silently drop the image, leaving the model blind with no surfaced error. Pasting the image itself worked because Kimchi's `input` transform attaches pasted images directly. This change gives image file paths the same parity.

Every candidate token is guarded: supported image extensions only (`.png/.jpg/.jpeg/.gif/.webp`), URLs rejected, the file must exist, be readable and ≤ 50 MB, and attach only happens for vision-capable models. When nothing resolves, the text is left untouched so the `read` tool remains the loud fallback. When an unexpected attach does happen, the `[Image #N]` prefix makes it user-visible.

## What changed

- `src/utils/typed-image-paths.ts` (new) — pure `extractTypedImagePaths(text, cwd)`: quote-aware tokenizer, image-extension filter, URL/`file://` rejection, `~` expansion + cwd resolution, size/type validation, dedup by resolved path preserving first-appearance order.
- `src/extensions/clipboard-image.ts` — the `input` handler converts matching image paths in the submitted prompt (typed, pasted, or dropped) to `ImageContent` whenever the model supports images. Path images append after existing attachments so marker numbering stays consistent. Vision-less models keep plain text as the fallback.
- `src/utils/typed-image-paths.test.ts` (new) — 18 extractor unit tests.
- `src/extensions/clipboard-image.test.ts` — wiring tests for path attach, marker numbering, dedup, vision-less model, and missing-file guard.
- `tests/e2e/tui/typed-image-path.test.ts` — E2E: typed path attaches (marker + `image_url` payload in the request); a non-existent path mentioned in prose attaches nothing.

## Verification

- `pnpm run check` (biome + tsc): clean
- Unit tests: 42 passed
- E2E suite: 3× full runs, all green and deterministic
