### PR TITLE
feat(router): forward telemetry correlation headers on Auto router requests

### DIFF
--- a/src/extensions/router/api-provider.test.ts
+++ b/src/extensions/router/api-provider.test.ts
@@ -12,7 +12,7 @@ import {
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { clearAutoRoutingAttempt, registerAutoApiProvider, stageAutoRoutingAttempt } from "./api-provider.js"
 import { AUTO_MODEL_API } from "./constants.js"
-import { clearAutoRoutingState, getAutoRoutingState, setAutoRoutingState } from "./state.js"
+import { type AutoRoutingState, clearAutoRoutingState, getAutoRoutingState, setAutoRoutingState } from "./state.js"
 
 const SESSION_ID = "provider-test-session"
 const TARGET_API = "kimchi-auto-test-target"
@@ -93,6 +93,25 @@ describe("Auto model API provider", () => {
 		)
 	})
 
+	it("passes assembled provider headers to the staged routing attempt", async () => {
+		const auto = model("auto", AUTO_MODEL_API)
+		const target = model("concrete", TARGET_API)
+		const headers = {
+			"X-Session-Id": "process-session",
+			"X-Conversation-Id": "agent-session",
+			"X-Parent-Session-Id": "parent-session",
+		}
+		const attempt = vi.fn(async () => ({ status: "resolved", model: target }) satisfies AutoRoutingState)
+		setAutoRoutingState(SESSION_ID, { status: "attempting" })
+		stageAutoRoutingAttempt(SESSION_ID, attempt)
+
+		const provider = getApiProvider(AUTO_MODEL_API)
+		if (!provider) throw new Error("Auto API provider was not registered")
+		await provider.streamSimple(auto, { messages: [] }, { sessionId: SESSION_ID, headers }).result()
+
+		expect(attempt).toHaveBeenCalledWith({ signal: undefined, headers })
+	})
+
 	it("does not forward the UI-selected reasoning option to a model that cannot use it", async () => {
 		const auto = model("auto", AUTO_MODEL_API)
 		const target = model("concrete", TARGET_API, false)
@@ -155,7 +174,7 @@ describe("Auto model API provider", () => {
 		const auto = model("auto", AUTO_MODEL_API)
 		const controller = new AbortController()
 		const attempt = vi.fn(
-			(signal: AbortSignal | undefined) =>
+			({ signal }: { signal?: AbortSignal }) =>
 				new Promise<{ status: "failed"; reason: "cancelled" }>((resolve) => {
 					expect(signal).toBe(controller.signal)
 					signal?.addEventListener("abort", () => resolve({ status: "failed", reason: "cancelled" }), {

--- a/src/extensions/router/api-provider.ts
+++ b/src/extensions/router/api-provider.ts
@@ -5,6 +5,7 @@ import {
 	type Context,
 	createAssistantMessageEventStream,
 	type Model,
+	type ProviderHeaders,
 	type ProviderStreamOptions,
 	registerApiProvider,
 	type SimpleStreamOptions,
@@ -18,14 +19,16 @@ import { type AutoFailureReason, type AutoRoutingState, getAutoRoutingState, set
 const SOURCE_ID = "kimchi-auto-model"
 
 type AutoRoutingAttemptResult = Extract<AutoRoutingState, { status: "resolved" | "failed" }>
-type AutoRoutingAttempt = (signal: AbortSignal | undefined) => Promise<AutoRoutingAttemptResult>
+type AutoRoutingRequestOptions = Pick<StreamOptions, "signal" | "headers">
+type AutoRoutingAttempt = (options: AutoRoutingRequestOptions) => Promise<AutoRoutingAttemptResult>
 
 /**
  * One pending router attempt per Pi session ID. Keying attempts by session ID
  * keeps main-agent and subagent routing isolated. The extension stages the
  * attempt before Pi starts the provider request; the Auto provider then consumes
- * it once with that request's cancellation signal. Attempts remain in memory and
- * are never written to the session log—only successful model selections persist.
+ * it once with that request's cancellation signal and assembled headers. Attempts
+ * remain in memory and are never written to the session log—only successful model
+ * selections persist.
  */
 const routingAttempts = new Map<string, AutoRoutingAttempt>()
 
@@ -42,12 +45,12 @@ export function clearAutoRoutingAttempt(sessionId: string): void {
 /** Claim a staged attempt before running it so concurrent provider calls cannot route twice. */
 export async function consumeAutoRoutingAttempt(
 	sessionId: string,
-	signal?: AbortSignal,
+	options: AutoRoutingRequestOptions = {},
 ): Promise<AutoRoutingAttemptResult | undefined> {
 	const attempt = routingAttempts.get(sessionId)
 	if (!attempt) return undefined
 	routingAttempts.delete(sessionId)
-	return attempt(signal)
+	return attempt(options)
 }
 
 function contextHasImages(context: Context): boolean {
@@ -123,11 +126,12 @@ async function resolvedTarget(
 	context: Context,
 	sessionId: string | undefined,
 	signal: AbortSignal | undefined,
+	headers: ProviderHeaders | undefined,
 ): Promise<Model<Api> | AutoFailureReason> {
 	let state = getAutoRoutingState(sessionId)
 	if (state.status === "attempting" && sessionId) {
 		try {
-			const result = await consumeAutoRoutingAttempt(sessionId, signal)
+			const result = await consumeAutoRoutingAttempt(sessionId, { signal, headers })
 			if (!result) {
 				setAutoRoutingState(sessionId, { status: "unresolved" })
 				return "interrupted"
@@ -163,7 +167,7 @@ function routeAndStream<T extends StreamOptions>(
 	void (async () => {
 		let source: AssistantMessageEventStream
 		try {
-			const target = await resolvedTarget(context, options?.sessionId, options?.signal)
+			const target = await resolvedTarget(context, options?.sessionId, options?.signal, options?.headers)
 			source =
 				typeof target === "string"
 					? errorStream(model, target)

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -379,7 +379,7 @@ describe("Auto model extension", () => {
 		const routePrompt = getHandler<BeforeAgentStartEvent>("before_agent_start")
 		await routePrompt(beforeEvent(), ctx)
 		const controller = new AbortController()
-		const attempt = consumeAutoRoutingAttempt(SESSION_ID, controller.signal)
+		const attempt = consumeAutoRoutingAttempt(SESSION_ID, { signal: controller.signal })
 		controller.abort()
 		await expect(attempt).resolves.toEqual({ status: "failed", reason: "cancelled" })
 		expect(getAutoRoutingState(SESSION_ID)).toEqual({ status: "unresolved" })

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -151,7 +151,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 				Boolean(event.images?.length) ||
 				branchHasImages(ctx.sessionManager.getBranch())
 
-			stageAutoRoutingAttempt(sessionId, async (signal) => {
+			stageAutoRoutingAttempt(sessionId, async ({ signal, headers }) => {
 				const fail = (reason: AutoFailureReason): Extract<AutoRoutingState, { status: "failed" }> => {
 					setAutoRoutingState(sessionId, { status: "unresolved" })
 					return { status: "failed", reason }
@@ -168,7 +168,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 				}
 				if (!config) return fail("no_auth")
 
-				const route = await routeQuery(query.query, config, { signal })
+				const route = await routeQuery(query.query, config, { signal, headers })
 				if (!route.ok) return fail(routeFailureReason(route.reason))
 
 				const resolution = resolveRecommendation(route.recommendation, ctx, requiresVision)

--- a/src/extensions/router/router-client.test.ts
+++ b/src/extensions/router/router-client.test.ts
@@ -34,6 +34,40 @@ describe("routeQuery", () => {
 		)
 	})
 
+	it("forwards only telemetry correlation headers", async () => {
+		const fetchImpl = vi.fn<typeof fetch>(async () =>
+			response({ best_model: "kimi-k2.5", probabilities: { "kimi-k2.5": 1 } }),
+		)
+
+		await routeQuery("explain this", config, {
+			fetchImpl,
+			headers: {
+				"x-session-id": "process-session",
+				"X-Conversation-Id": "agent-session",
+				"X-Turn-Index": "3",
+				"X-Parent-Session-Id": "parent-session",
+				traceparent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+				Authorization: "Bearer provider-secret",
+				"X-API-Key": "provider-override",
+			},
+		})
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			new URL("https://llm.kimchi.dev/v1/route"),
+			expect.objectContaining({
+				headers: {
+					"X-Session-Id": "process-session",
+					"X-Conversation-Id": "agent-session",
+					"X-Turn-Index": "3",
+					"X-Parent-Session-Id": "parent-session",
+					traceparent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+					"Content-Type": "application/json",
+					"X-API-Key": "same-gateway-key",
+				},
+			}),
+		)
+	})
+
 	it.each([
 		["HTTP failure", response({}, false), "http"],
 		["missing recommendation", response({ probabilities: {} }), "malformed"],

--- a/src/extensions/router/router-client.ts
+++ b/src/extensions/router/router-client.ts
@@ -1,5 +1,7 @@
+import type { StreamOptions } from "@earendil-works/pi-ai"
 import { Type } from "typebox"
 import { Value } from "typebox/value"
+import { selectTelemetryProviderHeaders } from "../telemetry/provider-headers.js"
 import type { RouterConfig } from "./router-config.js"
 
 const RouterResponseSchema = Type.Object(
@@ -21,10 +23,12 @@ export type RouteQueryResult =
 
 export const ROUTER_TIMEOUT_MS = 5000
 
+type RouteQueryOptions = Pick<StreamOptions, "signal" | "headers"> & { fetchImpl?: typeof fetch }
+
 export async function routeQuery(
 	query: string,
 	config: RouterConfig,
-	options: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+	options: RouteQueryOptions = {},
 ): Promise<RouteQueryResult> {
 	const controller = new AbortController()
 	let timedOut = false
@@ -39,7 +43,11 @@ export async function routeQuery(
 	try {
 		const response = await (options.fetchImpl ?? fetch)(new URL("/v1/route", config.endpoint), {
 			method: "POST",
-			headers: { "Content-Type": "application/json", "X-API-Key": config.apiKey },
+			headers: {
+				...selectTelemetryProviderHeaders(options.headers),
+				"Content-Type": "application/json",
+				"X-API-Key": config.apiKey,
+			},
 			body: JSON.stringify({ query }),
 			signal: controller.signal,
 		})

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -73,7 +73,9 @@ the subagent's own events via `session.parent_id`.
 Provider requests issued inside a subagent run also carry an
 `X-Parent-Session-Id` header (same value and gating as `session.parent_id`) so
 the proxy can record the parent session on `chat_completions` rows, mirroring
-how it already records `X-Session-Id` / `X-Turn-Index`.
+how it already records `X-Session-Id` / `X-Turn-Index`. When Auto routing is
+active, its `/v1/route` request receives the same telemetry correlation headers
+as the concrete model request; unrelated provider headers are not forwarded.
 
 ## Pre-Session Events
 

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -40,6 +40,7 @@ import {
 } from "./handlers/session.js"
 import { handleToolExecutionEnd, handleToolExecutionStart } from "./handlers/tools.js"
 import { handleWorkflowEvent } from "./handlers/workflows.js"
+import { TELEMETRY_PROVIDER_HEADER_NAMES } from "./provider-headers.js"
 import { type TelemetryAttributes, TelemetryContext } from "./session-context.js"
 import { startSettingsChangeWatcher } from "./settings-change-emitter.js"
 import {
@@ -745,17 +746,17 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			}
 		})
 		pi.on("before_provider_headers", (event) => {
-			event.headers["X-Session-Id"] = telemetryCtx.telemetryId
-			event.headers["X-Conversation-Id"] = conversationId
+			event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.sessionId] = telemetryCtx.telemetryId
+			event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.conversationId] = conversationId
 			// 0 means "before first turn" (sentinel); backend should treat it accordingly.
-			event.headers["X-Turn-Index"] = String(telemetryCtx.turnIndex)
+			event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.turnIndex] = String(telemetryCtx.turnIndex)
 
 			// Requests issued from inside a subagent run carry the parent session's
 			// pi session id so the proxy can record it on chat_completions rows
 			// (same gating/value as the session.parent_id telemetry attribute).
 			const parentSessionId = telemetryCtx.getParentSessionId()
 			if (parentSessionId) {
-				event.headers["X-Parent-Session-Id"] = parentSessionId
+				event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.parentSessionId] = parentSessionId
 			}
 
 			// Inject W3C Trace Context (if not already present) derived from
@@ -766,12 +767,14 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			//   session id: 85a2d4f5-9f9f-49fb-890e-522a10e4a1e8
 			//   trace id:   85a2d4f59f9f49fb890e522a10e4a1e8
 			//   span id:    <new random 16-hex value per request>
-			const hasTraceparent = Object.keys(event.headers).some((name) => name.toLowerCase() === "traceparent")
+			const hasTraceparent = Object.keys(event.headers).some(
+				(name) => name.toLowerCase() === TELEMETRY_PROVIDER_HEADER_NAMES.traceparent,
+			)
 			if (!hasTraceparent) {
 				const traceId = telemetryCtx.telemetryId.replace(/-/g, "").toLowerCase()
 				if (traceId.length === 32) {
 					const spanId = randomBytes(8).toString("hex")
-					event.headers.traceparent = `00-${traceId}-${spanId}-01`
+					event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.traceparent] = `00-${traceId}-${spanId}-01`
 				}
 			}
 		})

--- a/src/extensions/telemetry/provider-headers.ts
+++ b/src/extensions/telemetry/provider-headers.ts
@@ -1,0 +1,24 @@
+import type { ProviderHeaders } from "@earendil-works/pi-ai"
+
+export const TELEMETRY_PROVIDER_HEADER_NAMES = {
+	sessionId: "X-Session-Id",
+	conversationId: "X-Conversation-Id",
+	turnIndex: "X-Turn-Index",
+	parentSessionId: "X-Parent-Session-Id",
+	traceparent: "traceparent",
+} as const
+
+const CANONICAL_HEADER_NAMES = new Map(
+	Object.values(TELEMETRY_PROVIDER_HEADER_NAMES).map((name) => [name.toLowerCase(), name]),
+)
+
+/** Copy only Kimchi's telemetry correlation headers from an assembled provider request. */
+export function selectTelemetryProviderHeaders(headers: ProviderHeaders | undefined): Record<string, string> {
+	const selected: Record<string, string> = {}
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		if (value === null) continue
+		const canonicalName = CANONICAL_HEADER_NAMES.get(name.toLowerCase())
+		if (canonicalName) selected[canonicalName] = value
+	}
+	return selected
+}

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -181,10 +181,16 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 			await waitForText(terminal, "Second routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 
-			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
+			const routerRequests = requestsTo(fixture, "/v1/route")
+			expect(routerRequests).toHaveLength(1)
 			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
 			expect(chatRequests).toHaveLength(2)
 			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed"])
+			expect(routerRequests[0]?.headers["x-session-id"]).toBe(chatRequests[0]?.headers["x-session-id"])
+			expect(routerRequests[0]?.headers["x-conversation-id"]).toBe(chatRequests[0]?.headers["x-conversation-id"])
+			expect(routerRequests[0]?.headers["x-turn-index"]).toBe(chatRequests[0]?.headers["x-turn-index"])
+			expect(routerRequests[0]?.headers.traceparent).toBe(chatRequests[0]?.headers.traceparent)
+			expect(routerRequests[0]?.headers["x-parent-session-id"]).toBeUndefined()
 
 			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8"))
 			expect(settings.defaultProvider).toBe("kimchi-dev")
@@ -502,10 +508,22 @@ test("a child that inherits Auto makes one independent routing decision", async 
 			await waitForText(terminal, "Parent finished.", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 
-			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
+			const routerRequests = requestsTo(fixture, "/v1/route")
+			expect(routerRequests).toHaveLength(2)
 			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
 			expect(chatRequests).toHaveLength(3)
 			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed", "routed"])
+
+			const parentRouterRequest = routerRequests.find((request) => !request.headers["x-parent-session-id"])
+			const childRouterRequest = routerRequests.find((request) => request.headers["x-parent-session-id"])
+			const childChatRequest = chatRequests.find((request) => request.headers["x-parent-session-id"])
+			expect(childRouterRequest?.headers["x-session-id"]).toBe(parentRouterRequest?.headers["x-session-id"])
+			expect(childRouterRequest?.headers["x-conversation-id"]).not.toBe(
+				parentRouterRequest?.headers["x-conversation-id"],
+			)
+			expect(childRouterRequest?.headers["x-session-id"]).toBe(childChatRequest?.headers["x-session-id"])
+			expect(childRouterRequest?.headers["x-conversation-id"]).toBe(childChatRequest?.headers["x-conversation-id"])
+			expect(childRouterRequest?.headers["x-parent-session-id"]).toBe(childChatRequest?.headers["x-parent-session-id"])
 		},
 	)
 })


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

The Auto model's POST /v1/route call now carries the same correlation headers as the chat-completions request it precedes: X-Session-Id, X-Conversation-Id, X-Turn-Index, traceparent, and X-Parent-Session-Id inside subagent runs.

Rather than duplicating telemetry's ID state, the staged routing attempt receives the provider headers pi already assembled for the kimchi-auto request (populated by the telemetry extension's before_provider_headers hook) and forwards only the telemetry subset: provider credentials like Authorization/X-API-Key are never sent to the router, and the router's own X-API-Key cannot be overridden.

Header names now live in one place (telemetry/provider-headers.ts) so the injector and the router can't drift apart.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
