### PR TITLE
fix(acp): drain queued steers before abort on cancel

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -151,6 +151,13 @@ class FakeAgentSession {
 	aborted = false
 	clearQueueCalls = 0
 	clearQueueReturn = { steering: [] as string[], followUp: [] as string[] }
+	// Steering-seam state for the cancel-ordering regression: steer() records
+	// as pending, clearQueue() drops what was never delivered, and `order`
+	// pins the clear-before-abort sequence. `emulatedHistory` receives
+	// whatever an abort's wait lets pi-mono's steering chain deliver.
+	pendingSteers: string[] = []
+	emulatedHistory: string[] = []
+	order: string[] = []
 	model: FakeModel | undefined = {
 		provider: "test",
 		id: "test-model",
@@ -266,11 +273,18 @@ class FakeAgentSession {
 
 	async abort(): Promise<void> {
 		this.aborted = true
+		this.order.push("abort")
 		await this.abortImpl()
+	}
+
+	async steer(text: string, _images?: unknown[]): Promise<void> {
+		this.pendingSteers.push(text)
 	}
 
 	clearQueue(): { steering: string[]; followUp: string[] } {
 		this.clearQueueCalls++
+		this.order.push("clearQueue")
+		this.pendingSteers = []
 		return this.clearQueueReturn
 	}
 
@@ -926,6 +940,45 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		await promptP
 		expect(fake.aborted).toBe(true)
 		expect(fake.clearQueueCalls).toBe(1)
+	})
+
+	// Regression: cancel() must drain the queue BEFORE awaiting the abort.
+	// pi-mono chains queued steering messages into the running prompt —
+	// session.prompt() resolves only after all chained calls — so awaiting
+	// abort() first lets every queued steer self-deliver into history one
+	// reply at a time (observed in dogfooding: steers landing +3.7s/+10.9s
+	// after the abort, each with a full reply). The fake's abortImpl
+	// emulates that chaining by delivering whatever is still pending.
+	it("never delivers queued steers after cancel", async () => {
+		let cancelSeen = false
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			while (!cancelSeen) await delay(5)
+			fake.emit(agentEnd())
+		}
+		fake.abortImpl = async () => {
+			cancelSeen = true
+			// Emulate pi-mono's steering chain: a waiting abort() gives every
+			// still-queued steer time to deliver into the session's history.
+			for (const text of fake.pendingSteers) {
+				fake.emulatedHistory.push(text)
+			}
+		}
+
+		const promptP = agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "t1" }],
+		})
+		await delay(10)
+		await fake.steer("t2")
+		await fake.steer("t3")
+
+		await agent.cancel({ sessionId })
+
+		const result = await promptP
+		expect(result.stopReason).toBe("cancelled")
+		expect(fake.emulatedHistory).toEqual([])
+		expect(fake.order).toEqual(["clearQueue", "abort"])
 	})
 
 	// If session.prompt throws (pre-turn validation, config error, etc.), the

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -942,14 +942,10 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(fake.clearQueueCalls).toBe(1)
 	})
 
-	// Regression: cancel() must drain the queue BEFORE awaiting the abort.
-	// pi-mono chains queued steering messages into the running prompt —
-	// session.prompt() resolves only after all chained calls — so awaiting
-	// abort() first lets every queued steer self-deliver into history one
-	// reply at a time (observed in dogfooding: steers landing +3.7s/+10.9s
-	// after the abort, each with a full reply). The fake's abortImpl
-	// emulates that chaining by delivering whatever is still pending.
-	it("never delivers queued steers after cancel", async () => {
+	// Arms a turn that hangs until abort() runs — emulating a still-running
+	// turn when session/cancel arrives. onAbort runs inside abortImpl after
+	// the hang flag flips, while prompt() is still parked.
+	function armHangingTurn(onAbort?: () => void): void {
 		let cancelSeen = false
 		fake.promptImpl = async () => {
 			fake.emit({ type: "agent_start" })
@@ -958,12 +954,25 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		}
 		fake.abortImpl = async () => {
 			cancelSeen = true
-			// Emulate pi-mono's steering chain: a waiting abort() gives every
-			// still-queued steer time to deliver into the session's history.
+			onAbort?.()
+		}
+	}
+
+	// Regression: cancel() must drain the queue BEFORE awaiting the abort.
+	// pi-mono chains queued steering messages into the running prompt —
+	// session.prompt() resolves only after all chained calls — so awaiting
+	// abort() first lets every queued steer self-deliver into history one
+	// reply at a time (observed in dogfooding: steers landing +3.7s/+10.9s
+	// after the abort, each with a full reply). The fake's abortImpl
+	// emulates that chaining by delivering whatever is still pending.
+	it("never delivers queued steers after cancel", async () => {
+		// Emulate pi-mono's steering chain: a waiting abort() gives every
+		// still-queued steer time to deliver into the session's history.
+		armHangingTurn(() => {
 			for (const text of fake.pendingSteers) {
 				fake.emulatedHistory.push(text)
 			}
-		}
+		})
 
 		const promptP = agent.prompt({
 			sessionId,
@@ -985,15 +994,8 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 	// marked cancelled, and leaving the agent running would burn tokens
 	// until the LLM responds. try/finally guarantees abort runs regardless.
 	it("still aborts when clearQueue throws", async () => {
-		let cancelSeen = false
-		fake.promptImpl = async () => {
-			fake.emit({ type: "agent_start" })
-			while (!cancelSeen) await delay(5)
-			fake.emit(agentEnd())
-		}
-		fake.abortImpl = async () => {
-			cancelSeen = true
-		}
+		armHangingTurn()
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
 		fake.clearQueue = (): { steering: string[]; followUp: string[] } => {
 			throw new Error("clearQueue boom")
 		}
@@ -1010,6 +1012,13 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		const result = await promptP
 		expect(result.stopReason).toBe("cancelled")
 		expect(fake.aborted).toBe(true)
+		// The drain failure is logged, not silently swallowed — a recurring
+		// clearQueue failure must be observable, not re-leak steers quietly.
+		expect(errorSpy).toHaveBeenCalledWith(
+			"kimchi acp: clearQueue() failed during cancel; aborting anyway",
+			expect.any(Error),
+		)
+		errorSpy.mockRestore()
 	})
 
 	// If session.prompt throws (pre-turn validation, config error, etc.), the

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -981,6 +981,37 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 		expect(fake.order).toEqual(["clearQueue", "abort"])
 	})
 
+	// clearQueue() throwing must not skip the abort — the turn is already
+	// marked cancelled, and leaving the agent running would burn tokens
+	// until the LLM responds. try/finally guarantees abort runs regardless.
+	it("still aborts when clearQueue throws", async () => {
+		let cancelSeen = false
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			while (!cancelSeen) await delay(5)
+			fake.emit(agentEnd())
+		}
+		fake.abortImpl = async () => {
+			cancelSeen = true
+		}
+		fake.clearQueue = (): { steering: string[]; followUp: string[] } => {
+			throw new Error("clearQueue boom")
+		}
+
+		const promptP = agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "t1" }],
+		})
+		await delay(10)
+
+		// cancel() must resolve — clearQueue's error is caught so abort still runs.
+		await agent.cancel({ sessionId })
+
+		const result = await promptP
+		expect(result.stopReason).toBe("cancelled")
+		expect(fake.aborted).toBe(true)
+	})
+
 	// If session.prompt throws (pre-turn validation, config error, etc.), the
 	// outer RPC promise must reject — not hang — regardless of whether any
 	// events were emitted before the throw.

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -977,10 +977,15 @@ export class KimchiAcpAgent implements Agent {
 		const entry = this.sessions.get(params.sessionId)
 		if (!entry) return
 		if (entry.turn) entry.turn.cancelled = true
-		await entry.session.abort()
-		// Drain the steer/follow-up queue so queued text doesn't leak into the
-		// next prompt. Mirrors the TUI's Escape → clearAllQueues() behaviour.
+		// Drain the steer/follow-up queue BEFORE awaiting the abort. pi-mono
+		// chains queued steering messages into the running prompt —
+		// session.prompt() resolves only after all chained calls — so awaiting
+		// abort() first lets every still-queued steer self-deliver into history
+		// with a full reply while we wait for idle. clearQueue() is synchronous,
+		// so running it first drops undelivered steers before the chain can
+		// drain them. Mirrors the TUI's Escape → clearAllQueues() behaviour.
 		entry.session.clearQueue()
+		await entry.session.abort()
 	}
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -984,8 +984,19 @@ export class KimchiAcpAgent implements Agent {
 		// with a full reply while we wait for idle. clearQueue() is synchronous,
 		// so running it first drops undelivered steers before the chain can
 		// drain them. Mirrors the TUI's Escape → clearAllQueues() behaviour.
-		entry.session.clearQueue()
-		await entry.session.abort()
+		// Drain before abort (see comment above). Wrap in try/catch/finally so
+		// a clearQueue() failure can never skip the abort — the turn is already
+		// marked cancelled, and leaving the agent running would burn tokens
+		// until the LLM responds. cancel() is a notification (fire-and-forget),
+		// so swallowing the error avoids an unhandled rejection; the worst case
+		// is a partially-drained queue, which is no worse than before the fix.
+		try {
+			entry.session.clearQueue()
+		} catch {
+			// clearQueue failure is non-fatal — abort must still run.
+		} finally {
+			await entry.session.abort()
+		}
 	}
 
 	async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -984,16 +984,20 @@ export class KimchiAcpAgent implements Agent {
 		// with a full reply while we wait for idle. clearQueue() is synchronous,
 		// so running it first drops undelivered steers before the chain can
 		// drain them. Mirrors the TUI's Escape → clearAllQueues() behaviour.
-		// Drain before abort (see comment above). Wrap in try/catch/finally so
-		// a clearQueue() failure can never skip the abort — the turn is already
-		// marked cancelled, and leaving the agent running would burn tokens
-		// until the LLM responds. cancel() is a notification (fire-and-forget),
-		// so swallowing the error avoids an unhandled rejection; the worst case
-		// is a partially-drained queue, which is no worse than before the fix.
+		// The drain is wrapped in try/catch/finally so a clearQueue() failure
+		// can never skip the abort — the turn is already marked cancelled, and
+		// leaving the agent running would burn tokens until the LLM responds.
+		// cancel() is a notification (fire-and-forget), so the error is caught
+		// and logged rather than rethrown as an unhandled rejection; the worst
+		// case is a partially-drained queue, which is no worse than before the
+		// fix.
 		try {
 			entry.session.clearQueue()
-		} catch {
-			// clearQueue failure is non-fatal — abort must still run.
+		} catch (err) {
+			// clearQueue failure is non-fatal — abort must still run. Log so a
+			// recurring drain failure is observable instead of silently leaking
+			// queued steers into history again.
+			console.error("kimchi acp: clearQueue() failed during cancel; aborting anyway", err)
 		} finally {
 			await entry.session.abort()
 		}


### PR DESCRIPTION
## Problem

Aborting a turn via ACP `session/cancel` leaked queued steering messages into session history. `AcpServer.cancel()` called `await session.abort()` before `session.clearQueue()` — but pi-mono chains queued steers into the running prompt (`session.prompt()` resolves only after all chained calls), so while `await abort()` waited for idle, every queued steer self-delivered into history with a full reply. `clearQueue()` then ran on an already-empty queue.

Observed in dogfooding: steers queued mid-turn (t2, t3, t4) each got a full agent reply persisted to the session after the user hit abort, plus a questionnaire that ran ~60s post-abort.

## Fix

Reorder `cancel()` to drain the queue **before** awaiting the abort:

```ts
if (entry.turn) entry.turn.cancelled = true
entry.session.clearQueue()      // sync — drops undelivered steers first
await entry.session.abort()      // chain has nothing left to deliver
```

This mirrors the TUI's Escape → `clearAllQueues()` ordering. `clearQueue()` is synchronous, so it runs before the event loop gives the agent loop a chance to splice the next steer. Steers already delivered before `cancel()` executes stay in history (accepted delivery race — same as TUI).

## Scope

- **`cancel()` only** — `closeSessionRecord()` has the same inverted pattern but is only reachable via `unstable_closeSession`, which no client calls today. Deliberately left untouched.
- Local fix, no upstream pi-mono change.

## Test coverage

New test `"never delivers queued steers after cancel"` in `src/modes/acp/server.test.ts`:
- Extends `FakeAgentSession` with a `steer()` seam, `pendingSteers`, `emulatedHistory`, and an `order` log.
- The fake's `abortImpl` emulates pi-mono's chaining: delivers still-pending steers into history unless `clearQueue()` already ran.
- Asserts: `emulatedHistory` is empty, `order == ["clearQueue", "abort"]`, `stopReason == "cancelled"`.
- **Fails on pre-fix code** (`emulatedHistory = [\"t2\", \"t3\"]`), **passes after fix**.
- Existing `"drains the steer queue when cancel arrives mid-turn"` test untouched (count assertion still valid).

## Verification

- [x] Red→green proof (test fails before fix, passes after)
- [x] Full suite: 217/217 pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean (1 pre-existing unrelated warning)
- [x] Binary built + installed locally for studio dogfood