### PR TITLE
feat(status-line): show selected model next to Auto

### DIFF
--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { StatusLineElementId } from "../config/status-line-config.js"
 import * as AGENTS from "../extensions/agents/index.js"
 import { setBillingStatusForTest } from "../extensions/billing/status.js"
+import { setExperimentalFeaturesEnabled } from "../extensions/experimental.js"
 import * as FERMENT from "../extensions/ferment/index.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
 import { clearAutoRoutingState, setAutoRoutingState } from "../extensions/router/state.js"
@@ -315,6 +316,17 @@ describe("compact-form builders", () => {
 			const seg = buildModelAbbrev(compactCtx, false, "claude-opus-4-7")
 			expect(seg.text).toBe("claude-opus-4-7 → ctrl+p")
 			expect(seg.raw).toEqual({ kind: "model", multiModel: false, modelId: "claude-opus-4-7" })
+		})
+
+		it("keeps the routed model next to auto in the compact form", () => {
+			const seg = buildModelAbbrev(compactCtx, false, "auto", "kimi-k2.6")
+			expect(seg.text).toBe("auto (kimi-k2.6) → ctrl+p")
+			expect(seg.raw).toEqual({
+				kind: "model",
+				multiModel: false,
+				modelId: "auto",
+				routedModelId: "kimi-k2.6",
+			})
 		})
 	})
 
@@ -849,6 +861,7 @@ describe("status line pinning", () => {
 
 	afterEach(() => {
 		clearAutoRoutingState("test-session")
+		setExperimentalFeaturesEnabled(false)
 		vi.restoreAllMocks()
 		restorePlatform()
 		pinnedElements = []
@@ -870,6 +883,59 @@ describe("status line pinning", () => {
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
 		expect(visible).toContain("auto → ctrl+p")
+	})
+
+	it("shows the routed model next to Auto when experimental features are enabled and routing resolved", () => {
+		setExperimentalFeaturesEnabled(true)
+		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+
+		expect(visible).toContain("auto (kimi-k2.6) → ctrl+p")
+	})
+
+	it("shows plain Auto even with experimental features enabled before routing resolves", () => {
+		setExperimentalFeaturesEnabled(true)
+
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+
+		expect(visible).toContain("auto → ctrl+p")
+	})
+
+	it("reverts to plain Auto after routing state is cleared (e.g. /new)", () => {
+		setExperimentalFeaturesEnabled(true)
+		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+
+		// Before /new — routed model is shown
+		const beforeClear = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+		expect(beforeClear).toContain("auto (kimi-k2.6) → ctrl+p")
+
+		// /new clears the routing state for the session
+		clearAutoRoutingState("test-session")
+
+		// After /new — label reverts to plain Auto
+		const afterClear = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+		expect(afterClear).toContain("auto → ctrl+p")
+		expect(afterClear).not.toContain("kimi-k2.6")
+	})
+
+	it("keeps the multi-model label unchanged when the active model is Auto", () => {
+		setExperimentalFeaturesEnabled(true)
+		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
+		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
+
+		expect(visible).toContain("multi-model (auto) → ctrl+p")
+	})
+
+	it("keeps the routed suffix through compaction at narrow width", () => {
+		setExperimentalFeaturesEnabled(true)
+		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+
+		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(40)[0])
+
+		expect(visible).toContain("auto (kimi-k2.6)")
 	})
 
 	it("pinned usage shows '↑0 ↓0' when no tokens are present", () => {

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -883,12 +883,6 @@ describe("status line pinning", () => {
 		expect(visible).toContain("auto (kimi-k2.6) → ctrl+p")
 	})
 
-	it("shows plain Auto before routing resolves", () => {
-		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
-
-		expect(visible).toContain("auto → ctrl+p")
-	})
-
 	it("reverts to plain Auto after routing state is cleared (e.g. /new)", () => {
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { StatusLineElementId } from "../config/status-line-config.js"
 import * as AGENTS from "../extensions/agents/index.js"
 import { setBillingStatusForTest } from "../extensions/billing/status.js"
-import { setExperimentalFeaturesEnabled } from "../extensions/experimental.js"
 import * as FERMENT from "../extensions/ferment/index.js"
 import * as MULTI_MODEL from "../extensions/multi-model.js"
 import { clearAutoRoutingState, setAutoRoutingState } from "../extensions/router/state.js"
@@ -861,7 +860,6 @@ describe("status line pinning", () => {
 
 	afterEach(() => {
 		clearAutoRoutingState("test-session")
-		setExperimentalFeaturesEnabled(false)
 		vi.restoreAllMocks()
 		restorePlatform()
 		pinnedElements = []
@@ -871,22 +869,13 @@ describe("status line pinning", () => {
 		return new StatusLine(createMockContext(opts), theme, createMockStatusLineData())
 	}
 
-	it("shows Auto without a suffix after routing", () => {
-		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
-
-		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
-
-		expect(visible).toContain("auto → ctrl+p")
-	})
-
 	it("shows only Auto before routing resolves", () => {
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
 		expect(visible).toContain("auto → ctrl+p")
 	})
 
-	it("shows the routed model next to Auto when experimental features are enabled and routing resolved", () => {
-		setExperimentalFeaturesEnabled(true)
+	it("shows the routed model next to Auto when routing resolved", () => {
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
@@ -894,16 +883,13 @@ describe("status line pinning", () => {
 		expect(visible).toContain("auto (kimi-k2.6) → ctrl+p")
 	})
 
-	it("shows plain Auto even with experimental features enabled before routing resolves", () => {
-		setExperimentalFeaturesEnabled(true)
-
+	it("shows plain Auto before routing resolves", () => {
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(200)[0])
 
 		expect(visible).toContain("auto → ctrl+p")
 	})
 
 	it("reverts to plain Auto after routing state is cleared (e.g. /new)", () => {
-		setExperimentalFeaturesEnabled(true)
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
 		// Before /new — routed model is shown
@@ -920,7 +906,6 @@ describe("status line pinning", () => {
 	})
 
 	it("keeps the multi-model label unchanged when the active model is Auto", () => {
-		setExperimentalFeaturesEnabled(true)
 		vi.spyOn(MULTI_MODEL, "getMultiModelEnabled").mockReturnValue(true)
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
@@ -930,7 +915,6 @@ describe("status line pinning", () => {
 	})
 
 	it("keeps the routed suffix through compaction at narrow width", () => {
-		setExperimentalFeaturesEnabled(true)
 		setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
 
 		const visible = stripAnsi(makeStatusLine({ modelId: "auto" }).render(40)[0])

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -10,11 +10,14 @@ import { readStatusLineConfig } from "../config/status-line-config.js"
 import { getActiveAgentCount } from "../extensions/agents/index.js"
 import { getBillingStatusLine } from "../extensions/billing/status.js"
 import { formatBudgetStatusLine, formatCreditsStatusLine } from "../extensions/billing/status-line-format.js"
+import { isExperimentalFeaturesEnabled } from "../extensions/experimental.js"
 import { getActiveFerment, getFermentContinuationPolicy } from "../extensions/ferment/index.js"
 import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-line.js"
 import { formatCount } from "../extensions/format.js"
 import { getMultiModelEnabled } from "../extensions/multi-model.js"
 import { getPermissionMode } from "../extensions/permissions/mode-controller.js"
+import { AUTO_MODEL_ID, isAutoModel } from "../extensions/router/constants.js"
+import { getEffectiveModel } from "../extensions/router/state.js"
 import { getActiveTags, getCurrentPhase, parseTag } from "../extensions/tags.js"
 
 /** Stable identifier used by compaction steps to find segments. */
@@ -43,7 +46,7 @@ export type SegmentId =
  *  and the segment's tail is identical in both forms anyway. */
 type SegmentRaw =
 	| { kind: "context"; percent: number; pctColor?: "error" | "warning" }
-	| { kind: "model"; multiModel: boolean; modelId: string }
+	| { kind: "model"; multiModel: boolean; modelId: string; routedModelId?: string }
 	| { kind: "phase"; phase: string }
 	| { kind: "budget"; percentage: string }
 	| { kind: "ferment"; prefix: string; prefixWidth: number }
@@ -203,14 +206,19 @@ export function buildContextCompact(ctx: CompactionContext, percent: number, pct
 }
 
 /** Compact form for model: abbreviates "multi-model (kimi-k2.6)" to "m-m (kimi-k2.6)". */
-export function buildModelAbbrev(ctx: CompactionContext, multiModel: boolean, modelId: string): Segment {
-	const label = multiModel ? `m-m (${modelId})` : modelId
+export function buildModelAbbrev(
+	ctx: CompactionContext,
+	multiModel: boolean,
+	modelId: string,
+	routedModelId?: string,
+): Segment {
+	const label = multiModel ? `m-m (${modelId})` : routedModelId ? `auto (${routedModelId})` : modelId
 	const text = `${ctx.accent(label)} ${ctx.dim("→ ctrl+p")}`
 	return {
 		id: "model",
 		text,
 		width: visibleWidth(text),
-		raw: { kind: "model", multiModel, modelId },
+		raw: { kind: "model", multiModel, modelId, ...(routedModelId ? { routedModelId } : {}) },
 	}
 }
 
@@ -290,7 +298,9 @@ const STEPS: CompactionStep[] = [
 	{
 		name: "abbrev-model-label",
 		apply: (segs, ctx) =>
-			recompactSegment(segs, "model", "model", (raw) => buildModelAbbrev(ctx, raw.multiModel, raw.modelId)),
+			recompactSegment(segs, "model", "model", (raw) =>
+				buildModelAbbrev(ctx, raw.multiModel, raw.modelId, raw.routedModelId),
+			),
 	},
 	{
 		name: "drop-shortcut-hints",
@@ -428,9 +438,25 @@ function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
 	const multiModel = getMultiModelEnabled(ctx.sessionManager)
 	const selectedModelId = ctx.model?.id ?? "n/a"
 	const modelId = selectedModelId
-	const label = multiModel ? `multi-model (${modelId})` : modelId
+	const routedModelId = resolveRoutedModelId(ctx)
+	const label = multiModel ? `multi-model (${modelId})` : routedModelId ? `auto (${routedModelId})` : modelId
 	const text = `${accentText(theme, label)} ${dimText(theme, "→ ctrl+p")}`
-	return { id: "model", text, width: visibleWidth(text), raw: { kind: "model", multiModel, modelId } }
+	return {
+		id: "model",
+		text,
+		width: visibleWidth(text),
+		raw: { kind: "model", multiModel, modelId, ...(routedModelId ? { routedModelId } : {}) },
+	}
+}
+
+/** Concrete model id chosen by the Auto router, shown next to the `auto` label
+ *  in single-model mode. `undefined` before routing resolves (or when the flag
+ *  is off / the model isn't Auto / multi-model mode), keeping the plain `auto` label. */
+function resolveRoutedModelId(ctx: ExtensionContext): string | undefined {
+	if (!isExperimentalFeaturesEnabled()) return undefined
+	if (!isAutoModel(ctx.model)) return undefined
+	const effective = getEffectiveModel(ctx)
+	return effective && effective.id !== AUTO_MODEL_ID ? effective.id : undefined
 }
 
 function buildThinkingSegment(ctx: ExtensionContext, theme: Theme, pinned: boolean): Segment | null {

--- a/src/components/status-line.ts
+++ b/src/components/status-line.ts
@@ -10,7 +10,6 @@ import { readStatusLineConfig } from "../config/status-line-config.js"
 import { getActiveAgentCount } from "../extensions/agents/index.js"
 import { getBillingStatusLine } from "../extensions/billing/status.js"
 import { formatBudgetStatusLine, formatCreditsStatusLine } from "../extensions/billing/status-line-format.js"
-import { isExperimentalFeaturesEnabled } from "../extensions/experimental.js"
 import { getActiveFerment, getFermentContinuationPolicy } from "../extensions/ferment/index.js"
 import { formatFermentStatusLineDisplay } from "../extensions/ferment/status-line.js"
 import { formatCount } from "../extensions/format.js"
@@ -450,10 +449,9 @@ function buildModelSegment(ctx: ExtensionContext, theme: Theme): Segment {
 }
 
 /** Concrete model id chosen by the Auto router, shown next to the `auto` label
- *  in single-model mode. `undefined` before routing resolves (or when the flag
- *  is off / the model isn't Auto / multi-model mode), keeping the plain `auto` label. */
+ *  in single-model mode. `undefined` before routing resolves (or when the
+ *  model isn't Auto / multi-model mode), keeping the plain `auto` label. */
 function resolveRoutedModelId(ctx: ExtensionContext): string | undefined {
-	if (!isExperimentalFeaturesEnabled()) return undefined
 	if (!isAutoModel(ctx.model)) return undefined
 	const effective = getEffectiveModel(ctx)
 	return effective && effective.id !== AUTO_MODEL_ID ? effective.id : undefined

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -173,7 +173,7 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 		async (fixture, trace) => {
 			terminal.submit("Choose a model for this session")
 			await waitForText(terminal, "First routed reply.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed) → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 			trace.step("first prompt routed")
 
@@ -254,7 +254,7 @@ test("Auto uses the highest-ranked eligible model when the best model is outside
 		async (fixture) => {
 			terminal.submit("Use the first eligible router-ranked model")
 			await waitForText(terminal, "Ranked fallback reply.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (fallback) → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(1)
@@ -287,7 +287,7 @@ test("Auto stops an unavailable-router prompt and retries when the user submits 
 
 			terminal.submit("Try the router again")
 			await waitForText(terminal, "Router retry succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed) → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)
@@ -326,7 +326,7 @@ test("Escape cancels an in-flight router request and the corrected prompt can ro
 
 			terminal.submit("Use this corrected prompt instead")
 			await waitForText(terminal, "Corrected prompt succeeded.", { timeoutMs: STREAM_TIMEOUT_MS })
-			await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed) → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
 			await waitForTurnToSettle(fixture.fake.requests)
 
 			expect(requestsTo(fixture, "/v1/route")).toHaveLength(2)

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -424,7 +424,7 @@ test("resuming an Auto session reuses its concrete resolution without the flag",
 		fixture.initialModel = false
 		launchKimchi(terminal, fixture, ["-r", sessionId ?? ""], fixture.seedEnv)
 		await waitForText(terminal, PROMPT_READY, { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
-		await waitForText(terminal, "auto → ctrl+p", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
+		await waitForText(terminal, "auto (routed) → ctrl+p", { timeoutMs: STARTUP_TIMEOUT_MS, full: false })
 		terminal.submit("Continue the same session")
 		await waitForText(terminal, "Resumed Auto reply.", { timeoutMs: STREAM_TIMEOUT_MS })
 		await waitForTurnToSettle(fixture.fake.requests)


### PR DESCRIPTION
Shows the routed model id next to `auto` in the status line when Auto routing resolves (e.g. `auto (kimi-k2.6)`). Reverts to plain `auto` on `/new` when routing state is cleared.

- Only shows when experimental features are enabled and model is Auto
- Multi-model label takes precedence
- Survives narrow-width compaction


https://github.com/user-attachments/assets/57fc202c-e7b6-43df-b619-ddab80b0b39a