### PR TITLE
fix(remote-run): provision git credentials on sandbox before clone in remote-run

### DIFF
--- a/src/extensions/agents/manager/agent-manager.test.ts
+++ b/src/extensions/agents/manager/agent-manager.test.ts
@@ -1090,4 +1090,24 @@ describe("AgentManager remote git credential resolution", () => {
 			}),
 		)
 	})
+
+	it("preserves gitDetails but sets gitCredential undefined when resolveGitCredential throws", async () => {
+		mockResolveGitToken.mockRejectedValue(new Error("prompt rejected"))
+		manager = new AgentManager()
+
+		await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		// gitDetails is preserved — the clone plan is not lost
+		expect(mockRunRemoteAgent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(String),
+			expect.objectContaining({
+				gitDetails: expect.objectContaining({ repo: "https://gitlab.com/team/repo.git" }),
+				gitCredential: undefined,
+			}),
+		)
+	})
 })

--- a/src/extensions/agents/manager/agent-manager.test.ts
+++ b/src/extensions/agents/manager/agent-manager.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./agent-runner.js", () => ({
 	runAgent: vi.fn(),
@@ -7,12 +7,48 @@ vi.mock("./agent-runner.js", () => ({
 	MIN_FINALIZE_TOKEN_BUDGET: 256,
 }))
 
+vi.mock("../../../config.js", () => ({
+	loadConfig: vi.fn().mockReturnValue({ apiKey: "test-key" }),
+	readGitToken: vi.fn().mockReturnValue(undefined),
+	writeGitToken: vi.fn(),
+}))
+
+vi.mock("../../../sandbox/cloud/workspaces.js", () => ({
+	listWorkspaces: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock("../../teleport/provisioning/clone-plan.js", () => ({
+	resolveClonePlan: vi.fn(),
+}))
+
+vi.mock("../../teleport/provisioning/paths.js", () => ({
+	repoBasename: vi.fn().mockReturnValue("repo"),
+}))
+
+vi.mock("./remote-agent-runner.js", () => ({
+	runRemoteAgent: vi.fn(),
+}))
+
+vi.mock("../../teleport/ui/git-token-prompt.js", () => ({
+	GitTokenPromptComponent: vi.fn(),
+}))
+
+vi.mock("../../teleport/provisioning/git-token.js", () => ({
+	resolveGitToken: vi.fn(),
+}))
+
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { resolveClonePlan } from "../../teleport/provisioning/clone-plan.js"
+import { resolveGitToken } from "../../teleport/provisioning/git-token.js"
 import { AgentManager, buildAgentOutcome } from "./agent-manager.js"
 import { resumeAgent, runAgent } from "./agent-runner.js"
+import { runRemoteAgent } from "./remote-agent-runner.js"
 
 const mockRunAgent = vi.mocked(runAgent)
 const mockResumeAgent = vi.mocked(resumeAgent)
+const mockResolveClonePlan = vi.mocked(resolveClonePlan)
+const mockResolveGitToken = vi.mocked(resolveGitToken)
+const mockRunRemoteAgent = vi.mocked(runRemoteAgent)
 
 function fakePi(): ExtensionAPI {
 	return {} as ExtensionAPI
@@ -953,5 +989,105 @@ describe("AgentManager detachToBackground", () => {
 
 		// Agent has completed — detach should fail
 		expect(manager.detachToBackground(record.id)).toBe(false)
+	})
+})
+
+describe("AgentManager remote git credential resolution", () => {
+	let manager: AgentManager | undefined
+
+	afterEach(() => {
+		manager?.dispose()
+		manager = undefined
+		vi.clearAllMocks()
+	})
+
+	function fakeRemoteCtx(mode: "tui" | "rpc" = "tui"): ExtensionContext {
+		return {
+			cwd: "/work/myrepo",
+			mode,
+			ui: { custom: vi.fn() },
+		} as unknown as ExtensionContext
+	}
+
+	beforeEach(() => {
+		// Default mocks for remote path
+		mockResolveClonePlan.mockResolvedValue({
+			url: "git@gitlab.com:team/repo.git",
+			httpsUrl: "https://gitlab.com/team/repo.git",
+			branch: "main",
+		})
+		mockResolveGitToken.mockResolvedValue(undefined)
+		mockRunRemoteAgent.mockResolvedValue({
+			responseText: "done",
+			stopReason: "end_turn",
+			remoteSession: {
+				workspaceId: "ws-1",
+				sessionName: "acp-test",
+				wsUrl: "wss://worker.example.com",
+				host: "worker.example.com",
+				cwd: "/home/sandbox/acp-test",
+			},
+		})
+	})
+
+	it("resolves git credential from cached token without prompting", async () => {
+		mockResolveGitToken.mockResolvedValue("glpat-cached-token")
+		manager = new AgentManager()
+
+		const record = await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		expect(record.status).toBe("completed")
+		// resolveGitToken was called with the host extracted from httpsUrl
+		expect(mockResolveGitToken).toHaveBeenCalledWith("gitlab.com", expect.any(Function), expect.any(Function))
+		// gitCredential was forwarded to runRemoteAgent
+		expect(mockRunRemoteAgent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(String),
+			expect.objectContaining({
+				gitCredential: { host: "gitlab.com", token: "glpat-cached-token" },
+			}),
+		)
+	})
+
+	it("passes undefined gitCredential when no token is resolved (non-interactive mode)", async () => {
+		mockResolveGitToken.mockResolvedValue(undefined)
+		manager = new AgentManager()
+
+		await manager.spawnAndWait(fakePi(), fakeRemoteCtx("rpc"), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		// gitCredential should be undefined (no cached token, non-interactive)
+		expect(mockRunRemoteAgent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(String),
+			expect.objectContaining({
+				gitCredential: undefined,
+			}),
+		)
+	})
+
+	it("proceeds without gitDetails when resolveClonePlan throws", async () => {
+		mockResolveClonePlan.mockRejectedValue(new Error("not a git repo"))
+		manager = new AgentManager()
+
+		await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		expect(mockResolveGitToken).not.toHaveBeenCalled()
+		expect(mockRunRemoteAgent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(String),
+			expect.objectContaining({
+				gitDetails: undefined,
+				gitCredential: undefined,
+			}),
+		)
 	})
 })

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -5,8 +5,10 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../../config.js"
 import { listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
-import { resolveClonePlan } from "../../teleport/provisioning/clone-plan.js"
+import { type ClonePlan, resolveClonePlan } from "../../teleport/provisioning/clone-plan.js"
+import { resolveGitToken } from "../../teleport/provisioning/git-token.js"
 import { repoBasename } from "../../teleport/provisioning/paths.js"
+import { GitTokenPromptComponent, type GitTokenPromptResult } from "../../teleport/ui/git-token-prompt.js"
 import type {
 	AgentOutcome,
 	AgentRecord,
@@ -389,6 +391,7 @@ export class AgentManager {
 		// shallow clone of the repo (like /teleport --fast) instead of an empty dir.
 		// If cwd isn't a git repo or has no origin, this is a no-op.
 		let gitDetails: { repo: string; branch?: string; targetDirectory: string; noHistory?: boolean } | undefined
+		let gitCredential: { host: string; token: string } | undefined
 		try {
 			const clonePlan = await resolveClonePlan(ctx.cwd, undefined, { signal: record.abortController?.signal })
 			gitDetails = {
@@ -397,6 +400,7 @@ export class AgentManager {
 				targetDirectory: repoBasename(clonePlan.url),
 				noHistory: true,
 			}
+			gitCredential = await resolveGitCredential(ctx, clonePlan)
 		} catch {
 			// Not a git repo or no origin — proceed without git details.
 			gitDetails = undefined
@@ -417,6 +421,7 @@ export class AgentManager {
 			endpoint: process.env.KIMCHI_REMOTE_ENDPOINT,
 			signal: record.abortController?.signal,
 			gitDetails,
+			gitCredential,
 			localPath: ctx.cwd,
 			workspaceName: dirName,
 			onReady: (acpClient, meta) => {
@@ -850,6 +855,31 @@ export function classifyAgentOutcome(record: Pick<AgentRecord, "status" | "abort
 		return "budget_exhausted"
 	}
 	return "failed"
+}
+
+/**
+ * Resolve a git credential for the sandbox clone. Checks for a cached token
+ * first (config.json), then prompts the user via the same PAT dialog
+ * teleport uses. Returns undefined when no token is available (e.g. user
+ * skipped or non-interactive mode) — the clone proceeds without creds and
+ * will succeed for public repos only.
+ */
+async function resolveGitCredential(
+	ctx: ExtensionContext,
+	clonePlan: ClonePlan,
+): Promise<{ host: string; token: string } | undefined> {
+	const host = new URL(clonePlan.httpsUrl).hostname
+	const prompt: () => Promise<GitTokenPromptResult> =
+		ctx.mode === "tui"
+			? () =>
+					ctx.ui.custom(
+						(tui, theme, _kb, done) => new GitTokenPromptComponent(theme, host, done, () => tui.requestRender()),
+					)
+			: async () => ({ outcome: "skipped" as const })
+	const token = await resolveGitToken(host, prompt, (err) =>
+		console.warn(`[agent-manager] could not save git token: ${err instanceof Error ? err.message : err}`),
+	)
+	return token ? { host, token } : undefined
 }
 
 function buildRemainingWorkGuidance(

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -411,6 +411,7 @@ export class AgentManager {
 		} catch {
 			// Not a git repo or no origin — proceed without git details.
 			gitDetails = undefined
+			gitCredential = undefined
 		}
 
 		// Create the adapter before calling runRemoteAgent so it's available

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -406,6 +406,7 @@ export class AgentManager {
 			try {
 				gitCredential = await resolveGitCredential(ctx, clonePlan)
 			} catch (err) {
+				gitCredential = undefined
 				console.warn(`[agent-manager] git credential resolution failed: ${err instanceof Error ? err.message : err}`)
 			}
 		} catch {

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -400,7 +400,14 @@ export class AgentManager {
 				targetDirectory: repoBasename(clonePlan.url),
 				noHistory: true,
 			}
-			gitCredential = await resolveGitCredential(ctx, clonePlan)
+			// Resolve git credential separately — a failure here (bad URL, prompt
+			// rejection) must not wipe the clone plan. The clone proceeds without
+			// creds; private repos fail, public repos still work.
+			try {
+				gitCredential = await resolveGitCredential(ctx, clonePlan)
+			} catch (err) {
+				console.warn(`[agent-manager] git credential resolution failed: ${err instanceof Error ? err.message : err}`)
+			}
 		} catch {
 			// Not a git repo or no origin — proceed without git details.
 			gitDetails = undefined

--- a/src/extensions/agents/manager/remote-agent-runner.test.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.test.ts
@@ -25,6 +25,10 @@ vi.mock("../../../sandbox/worker/sessions.js", () => ({
 	deleteSession: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock("../../teleport/provisioning/git-provision.js", () => ({
+	provisionGitCredential: vi.fn().mockResolvedValue(undefined),
+}))
+
 vi.mock("../../teleport/provisioning/sync-local-changes.js", () => ({
 	syncLocalChangesAfterClone: vi.fn().mockResolvedValue(undefined),
 }))
@@ -59,6 +63,7 @@ import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
 import { AcpSessionClient, type AcpSessionClientOptions } from "../../../sandbox/worker/acp-client.js"
 import { WorkerClient } from "../../../sandbox/worker/client.js"
 import { createSession, deleteSession } from "../../../sandbox/worker/sessions.js"
+import { provisionGitCredential } from "../../teleport/provisioning/git-provision.js"
 import { syncLocalChangesAfterClone } from "../../teleport/provisioning/sync-local-changes.js"
 import { type RemoteRunOptions, runRemoteAgent } from "./remote-agent-runner.js"
 
@@ -427,6 +432,58 @@ describe("runRemoteAgent", () => {
 		await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ gitDetails }))
 
 		expect(syncLocalChangesAfterClone).not.toHaveBeenCalled()
+	})
+
+	describe("git credential provisioning", () => {
+		beforeEach(() => {
+			vi.mocked(provisionGitCredential).mockResolvedValue(undefined)
+		})
+
+		it("provisions git credential before createSession when gitCredential is provided", async () => {
+			const gitCredential = { host: "gitlab.com", token: "glpat-xyz123" }
+			const gitDetails = {
+				repo: "https://gitlab.com/team/repo.git",
+				branch: "main",
+				targetDirectory: "repo",
+				noHistory: true,
+			}
+			await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ gitDetails, gitCredential }))
+
+			expect(provisionGitCredential).toHaveBeenCalledWith(
+				expect.anything(),
+				{ gitHost: "gitlab.com", gitToken: "glpat-xyz123" },
+				undefined,
+			)
+
+			// provisionGitCredential must be called BEFORE createSession
+			const provisionOrder = vi.mocked(provisionGitCredential).mock.invocationCallOrder[0]
+			const createOrder = vi.mocked(createSession).mock.invocationCallOrder[0]
+			expect(provisionOrder).toBeLessThan(createOrder)
+		})
+
+		it("does not provision git credential when gitCredential is not provided", async () => {
+			await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions())
+
+			expect(provisionGitCredential).not.toHaveBeenCalled()
+		})
+
+		it("does not abort the run when credential provisioning fails", async () => {
+			vi.mocked(provisionGitCredential).mockRejectedValue(new Error("provisioning failed"))
+			const gitCredential = { host: "gitlab.com", token: "bad-token" }
+			const gitDetails = {
+				repo: "https://gitlab.com/team/repo.git",
+				branch: "main",
+				targetDirectory: "repo",
+				noHistory: true,
+			}
+
+			// Should not throw — provisioning failure is non-fatal
+			const result = await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ gitDetails, gitCredential }))
+
+			expect(result.stopReason).toBe("end_turn")
+			// createSession was still called
+			expect(createSession).toHaveBeenCalledOnce()
+		})
 	})
 
 	describe("onReady callback", () => {

--- a/src/extensions/agents/manager/remote-agent-runner.test.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.test.ts
@@ -484,6 +484,18 @@ describe("runRemoteAgent", () => {
 			// createSession was still called
 			expect(createSession).toHaveBeenCalledOnce()
 		})
+
+		it("re-throws AbortError when signal is aborted during provisioning", async () => {
+			const abortErr = new Error("aborted")
+			abortErr.name = "AbortError"
+			vi.mocked(provisionGitCredential).mockRejectedValue(abortErr)
+			const gitCredential = { host: "gitlab.com", token: "tok" }
+
+			await expect(runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ gitCredential }))).rejects.toThrow("aborted")
+
+			// createSession must NOT have been called — abort should stop the run
+			expect(createSession).not.toHaveBeenCalled()
+		})
 	})
 
 	describe("onReady callback", () => {

--- a/src/extensions/agents/manager/remote-agent-runner.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.ts
@@ -16,6 +16,7 @@ import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
 import { type AcpSessionCallbacks, AcpSessionClient } from "../../../sandbox/worker/acp-client.js"
 import { WorkerClient } from "../../../sandbox/worker/client.js"
 import { createSession, deleteSession } from "../../../sandbox/worker/sessions.js"
+import { provisionGitCredential } from "../../teleport/provisioning/git-provision.js"
 import { syncLocalChangesAfterClone } from "../../teleport/provisioning/sync-local-changes.js"
 
 /** Remote session metadata for reconnection/steer/resume/sync. */
@@ -41,6 +42,8 @@ export interface RemoteRunOptions {
 	gitDetails?: { repo: string; branch?: string; targetDirectory: string; noHistory?: boolean }
 	/** Local working directory to diff-sync on top of the clone (when gitDetails is set). */
 	localPath?: string
+	/** Git credential to provision on the sandbox before cloning. */
+	gitCredential?: { host: string; token: string }
 	/** Workspace name passed to authenticateWorkspace (used for matching/reuse). */
 	workspaceName?: string
 	/**
@@ -134,6 +137,26 @@ export async function runRemoteAgent(
 		signal,
 		cwd,
 	})
+
+	// Provision git credentials on the worker BEFORE createSession — the clone
+	// bootstrapper runs synchronously inside createSession and needs the token
+	// available for private repos. Non-fatal: clone may still succeed for public repos.
+	if (options.gitCredential) {
+		try {
+			await provisionGitCredential(
+				client,
+				{
+					gitHost: options.gitCredential.host,
+					gitToken: options.gitCredential.token,
+				},
+				signal,
+			)
+		} catch (err) {
+			console.warn(
+				`[remote-agent-runner] git credential provisioning failed: ${err instanceof Error ? err.message : err}`,
+			)
+		}
+	}
 
 	let stopReason = "end_turn"
 

--- a/src/extensions/agents/manager/remote-agent-runner.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.ts
@@ -152,6 +152,8 @@ export async function runRemoteAgent(
 				signal,
 			)
 		} catch (err) {
+			// Honor abort — don't continue to createSession if the user cancelled.
+			if (err instanceof Error && err.name === "AbortError") throw err
 			console.warn(
 				`[remote-agent-runner] git credential provisioning failed: ${err instanceof Error ? err.message : err}`,
 			)

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -575,7 +575,7 @@ describe("runTeleport", () => {
 			await runTeleport("--workspace 11111111-1111-4111-8111-111111111111 --git-repo https://github.com/me/x.git", ctx)
 
 			expect(progressInstances[0]?.promptGitToken).toHaveBeenCalledWith("github.com")
-			expect(writeGitTokenMock).toHaveBeenCalledWith("github.com", "ghp_new", undefined)
+			expect(writeGitTokenMock).toHaveBeenCalledWith("github.com", "ghp_new")
 			expect(provisionGitCredentialMock).toHaveBeenCalledOnce()
 			expect(provisionGitCredentialMock.mock.calls[0][1]).toMatchObject({
 				gitHost: "github.com",

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -2,13 +2,7 @@ import { existsSync } from "node:fs"
 import { open, readFile, stat } from "node:fs/promises"
 import { platform } from "node:os"
 import { basename, dirname } from "node:path"
-import {
-	readGitToken,
-	readTeleportCompactHintEnabled,
-	readTeleportHelpSeenAt,
-	writeGitToken,
-	writeTeleportHelpSeenAt,
-} from "../../../config.js"
+import { readTeleportCompactHintEnabled, readTeleportHelpSeenAt, writeTeleportHelpSeenAt } from "../../../config.js"
 import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
 import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
@@ -26,6 +20,7 @@ import { type ClonePlan, ClonePlanError, resolveClonePlan } from "../provisionin
 import { SANDBOX_USER } from "../provisioning/constants.js"
 import { sumIncludeListBytes } from "../provisioning/estimate-bytes.js"
 import { provisionGitCredential, provisionGitIdentity } from "../provisioning/git-provision.js"
+import { resolveGitToken as resolveGitTokenShared } from "../provisioning/git-token.js"
 import { buildHandoffNote, copySessionFileAndAddHandoffNote, removeTempDir } from "../provisioning/handoff-note.js"
 import { provisionHarnessConfig } from "../provisioning/harness-config.js"
 import { buildChangedFilesList, buildIncludeList } from "../provisioning/include-list.js"
@@ -504,18 +499,13 @@ async function resolveGitToken(
 	ctx: TeleportContext,
 ): Promise<string | undefined> {
 	if (args.noGitToken || !gitHost) return undefined
-	const cached = readGitToken(gitHost, ctx.configPath)
-	if (cached) return cached
-	const result = await progress.promptGitToken(gitHost)
-	if (result.outcome !== "submitted") return undefined
-	if (result.save) {
-		try {
-			writeGitToken(gitHost, result.token, ctx.configPath)
-		} catch (err) {
+	return resolveGitTokenShared(
+		gitHost,
+		() => progress.promptGitToken(gitHost),
+		(err: unknown) => {
 			warn(ctx, `Could not save git token: ${err instanceof Error ? err.message : String(err)}`)
-		}
-	}
-	return result.token
+		},
+	)
 }
 
 /**

--- a/src/extensions/teleport/provisioning/git-token.ts
+++ b/src/extensions/teleport/provisioning/git-token.ts
@@ -1,0 +1,35 @@
+import { readGitToken, writeGitToken } from "../../../config.js"
+import type { GitTokenPromptResult } from "../ui/git-token-prompt.js"
+
+/**
+ * Resolve a git token: check the cache first, then prompt the user via the
+ * provided prompt function. If the user submits and opts to save, persists
+ * the token for future use.
+ *
+ * Shared between /teleport and remote-run. Each caller provides its own
+ * prompt function (teleport uses its progress overlay; remote-run uses
+ * `ctx.ui.custom` with `GitTokenPromptComponent`).
+ *
+ * Returns the token string, or undefined when the user skipped or no
+ * cached token was found.
+ */
+export async function resolveGitToken(
+	host: string,
+	prompt: () => Promise<GitTokenPromptResult>,
+	onWriteError?: (err: unknown) => void,
+): Promise<string | undefined> {
+	const cached = readGitToken(host)
+	if (cached) return cached
+
+	const result = await prompt()
+	if (result.outcome !== "submitted") return undefined
+
+	if (result.save) {
+		try {
+			writeGitToken(host, result.token)
+		} catch (err) {
+			onWriteError?.(err)
+		}
+	}
+	return result.token
+}


### PR DESCRIPTION
Remote-run (ACP sandbox) never provisioned a git token on the worker before createSession, so private repo clones failed silently — the worker's git-creds-helper logged "error finding git identity", the clone bootstrapper failure was non-fatal, and the session started with an empty directory.

Extract shared resolveGitToken helper (cache check + prompt + save) from teleport, reused by both teleport and remote-run. In remote-run, resolve the token (cached or via the same PAT dialog teleport uses) and call provisionGitCredential on the worker before createSession so the clone bootstrapper has credentials available.

## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

After the fix:
<img width="834" height="257" alt="image" src="https://github.com/user-attachments/assets/6681e0fc-3a34-497e-a2b9-18eab0848196" />


## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
