### PR TITLE
feat(models): route anthropic models through native messages API

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -164,7 +164,7 @@ describe("updateModelsConfig", () => {
 		expect(getSupportedThinkingLevels(model)).toContain("max")
 	})
 
-	it("routes claude-* models from non-anthropic providers through the openai-completions API without compat flags", async () => {
+	it("routes claude-* models from non-anthropic providers through openai-completions with compat flags", async () => {
 		const CLAUDE_ON_AZURE: unknown = {
 			slug: "claude-sonnet-4-6",
 			display_name: "",
@@ -185,7 +185,11 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/azure_ai"]).toBeDefined()
 		expect(config.providers["kimchi-dev/azure_ai"].api).toBe("openai-completions")
 		expect(config.providers["kimchi-dev/azure_ai"].baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
-		expect(config.providers["kimchi-dev/azure_ai"].models[0]).not.toHaveProperty("compat")
+		expect(config.providers["kimchi-dev/azure_ai"].models[0].compat).toEqual({
+			supportsReasoningEffort: false,
+			cacheControlFormat: "anthropic",
+			supportsUsageInStreaming: true,
+		})
 	})
 
 	it("splits ai-enabler models into kimchi-dev and non-ai-enabler models into kimchi-dev/{provider}", async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai"
+import { ANTHROPIC_MODELS } from "@earendil-works/pi-ai/providers/anthropic.models"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
 	injectAutoModel,
@@ -116,7 +117,37 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev/anthropic"]).toBeDefined()
 		expect(config.providers["kimchi-dev/anthropic"].api).toBe("anthropic-messages")
 		expect(config.providers["kimchi-dev/anthropic"].baseUrl).toBe("https://llm.kimchi.dev/anthropic")
-		expect(config.providers["kimchi-dev/anthropic"].models[0]).not.toHaveProperty("compat")
+
+		const model = config.providers["kimchi-dev/anthropic"].models[0]
+		const upstream = ANTHROPIC_MODELS["claude-sonnet-4-6"]
+		expect(model.compat).toEqual(upstream.compat)
+		expect(model.thinkingLevelMap).toEqual(upstream.thinkingLevelMap)
+	})
+
+	it("leaves compat unset for anthropic models not in the upstream catalog", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				models: [
+					{
+						slug: "claude-unknown-9",
+						display_name: "Claude Unknown 9",
+						provider: "anthropic",
+						reasoning: true,
+						input_modalities: ["text", "image"],
+						is_serverless: false,
+						limits: { context_window: 1_000_000, max_output_tokens: 128_000 },
+					},
+				],
+			}),
+		} as Response)
+
+		await updateModelsConfig(modelsJsonPath, "test-key")
+
+		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
+		const model = config.providers["kimchi-dev/anthropic"].models[0]
+		expect(model).not.toHaveProperty("compat")
+		expect(model).not.toHaveProperty("thinkingLevelMap")
 	})
 
 	it("sets X-Provider-Type header at the provider level for sub-providers only", async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -104,7 +104,7 @@ describe("updateModelsConfig", () => {
 		expect(config.providers["kimchi-dev"].models[0].input).toEqual(["text"])
 	})
 
-	it("sets Anthropic compat flags for anthropic models", async () => {
+	it("routes Anthropic models through the native messages API", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [SONNET_46] }),
@@ -114,13 +114,9 @@ describe("updateModelsConfig", () => {
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev/anthropic"]).toBeDefined()
-		expect(config.providers["kimchi-dev/anthropic"].api).toBe("openai-completions")
-		expect(config.providers["kimchi-dev/anthropic"].baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
-		expect(config.providers["kimchi-dev/anthropic"].models[0].compat).toEqual({
-			supportsReasoningEffort: false,
-			cacheControlFormat: "anthropic",
-			supportsUsageInStreaming: true,
-		})
+		expect(config.providers["kimchi-dev/anthropic"].api).toBe("anthropic-messages")
+		expect(config.providers["kimchi-dev/anthropic"].baseUrl).toBe("https://llm.kimchi.dev/anthropic")
+		expect(config.providers["kimchi-dev/anthropic"].models[0]).not.toHaveProperty("compat")
 	})
 
 	it("sets X-Provider-Type header at the provider level for sub-providers only", async () => {
@@ -168,7 +164,7 @@ describe("updateModelsConfig", () => {
 		expect(getSupportedThinkingLevels(model)).toContain("max")
 	})
 
-	it("sets compat for claude-* models regardless of upstream provider (e.g. azure_ai)", async () => {
+	it("routes claude-* models from non-anthropic providers through the openai-completions API without compat flags", async () => {
 		const CLAUDE_ON_AZURE: unknown = {
 			slug: "claude-sonnet-4-6",
 			display_name: "",
@@ -187,11 +183,9 @@ describe("updateModelsConfig", () => {
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
 		expect(config.providers["kimchi-dev/azure_ai"]).toBeDefined()
-		expect(config.providers["kimchi-dev/azure_ai"].models[0].compat).toEqual({
-			supportsReasoningEffort: false,
-			cacheControlFormat: "anthropic",
-			supportsUsageInStreaming: true,
-		})
+		expect(config.providers["kimchi-dev/azure_ai"].api).toBe("openai-completions")
+		expect(config.providers["kimchi-dev/azure_ai"].baseUrl).toBe("https://llm.kimchi.dev/openai/v1")
+		expect(config.providers["kimchi-dev/azure_ai"].models[0]).not.toHaveProperty("compat")
 	})
 
 	it("splits ai-enabler models into kimchi-dev and non-ai-enabler models into kimchi-dev/{provider}", async () => {
@@ -213,9 +207,10 @@ describe("updateModelsConfig", () => {
 		const anthropicIds = config.providers["kimchi-dev/anthropic"].models.map((m: { id: string }) => m.id)
 		expect(anthropicIds).toEqual(["claude-opus-4-6", "claude-sonnet-4-6"])
 
-		// All providers use openai-completions
+		// kimchi-dev stays on openai-completions; anthropic moves to messages
 		expect(config.providers["kimchi-dev"].api).toBe("openai-completions")
-		expect(config.providers["kimchi-dev/anthropic"].api).toBe("openai-completions")
+		expect(config.providers["kimchi-dev/anthropic"].api).toBe("anthropic-messages")
+		expect(config.providers["kimchi-dev/anthropic"].baseUrl).toBe("https://llm.kimchi.dev/anthropic")
 	})
 
 	it("uses correct URL, Authorization header, and timeout", async () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -216,9 +216,16 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// Anthropic models are routed through the native `/v1/messages` API, so no
 	// openai-completions compat flags are needed.
 	//
+	// claude-* models from non-anthropic providers still use openai-completions,
+	// so they keep the openai-completions compat flags.
+	//
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
 	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
 	// disables thinking with `none` and advertises max to Pi's selector.
+	const compat =
+		m.provider !== "anthropic" && m.slug.startsWith("claude-")
+			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
+			: undefined
 	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
 		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
 	return {
@@ -231,6 +238,7 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		// Store upstream provider for telemetry round-trip via models.json
 		provider: m.provider,
+		...(compat && { compat }),
 		...(thinkingLevelMap && { thinkingLevelMap }),
 	}
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -24,6 +24,10 @@ export function chatCompletionsApi(endpoint?: string): string {
 	return `${normalizeKimchiEndpoint(endpoint)}/openai/v1`
 }
 
+export function anthropicMessagesApi(endpoint?: string): string {
+	return `${normalizeKimchiEndpoint(endpoint)}/anthropic`
+}
+
 // HTTP statuses worth retrying: rate limiting and transient gateway/server errors.
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504])
 const MAX_FETCH_ATTEMPTS = 3
@@ -209,20 +213,12 @@ function autoModelConfig(models: ModelMetadata[]): PiModelConfig {
 }
 
 function metadataToModel(m: ModelMetadata): PiModelConfig {
-	// TODO: our LiteLLM gateway does not support `thinking.type.enabled` for Anthropic >Opus 4.6 models
-	// Therefore, we disable it for now. Revisit, once we upgrade our LiteLLM version.
-	//
-	// Claude models routed through openai-completions need:
-	// - cacheControlFormat: "anthropic" so pi injects cache_control markers
-	// - supportsUsageInStreaming: true so stream_options.include_usage is sent
+	// Anthropic models are routed through the native `/v1/messages` API, so no
+	// openai-completions compat flags are needed.
 	//
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
 	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
 	// disables thinking with `none` and advertises max to Pi's selector.
-	const compat =
-		m.provider === "anthropic" || m.slug.startsWith("claude-")
-			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
-			: undefined
 	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
 		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
 	return {
@@ -235,7 +231,6 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		// Store upstream provider for telemetry round-trip via models.json
 		provider: m.provider,
-		...(compat && { compat }),
 		...(thinkingLevelMap && { thinkingLevelMap }),
 	}
 }
@@ -270,10 +265,11 @@ function buildModelsConfig(models: ModelMetadata[], endpoint?: string) {
 
 	for (const [upstreamProvider, group] of byProvider) {
 		const subProviderId = `kimchi-dev/${upstreamProvider}`
+		const isAnthropic = upstreamProvider === "anthropic"
 		providers[subProviderId] = {
-			baseUrl: chatCompletionsApi(endpoint),
+			baseUrl: isAnthropic ? anthropicMessagesApi(endpoint) : chatCompletionsApi(endpoint),
 			apiKey: "$KIMCHI_API_KEY",
-			api: "openai-completions",
+			api: isAnthropic ? "anthropic-messages" : "openai-completions",
 			authHeader: true,
 			headers: providerHeaders(upstreamProvider),
 			models: group.map(metadataToModel),

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,8 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
-import type { ThinkingLevel } from "./extensions/agents/personas/types.js"
+import type { AnthropicMessagesCompat, Model, OpenAICompletionsCompat, ThinkingLevelMap } from "@earendil-works/pi-ai"
+import { ANTHROPIC_MODELS } from "@earendil-works/pi-ai/providers/anthropic.models"
 import { AUTO_MODEL_API, AUTO_MODEL_ID, AUTO_MODEL_NAME } from "./extensions/router/constants.js"
 import { getVersion } from "./utils.js"
+
+// Upstream catalog keyed by exact model id, used to inherit anthropic-messages
+// compat flags (adaptive thinking, strict tools) and effort-level maps.
+const ANTHROPIC_MODELS_BY_ID = ANTHROPIC_MODELS as Record<string, Model<"anthropic-messages">>
 
 const KIMCHI_API = "https://llm.kimchi.dev"
 const FETCH_TIMEOUT_MS = 20000
@@ -176,13 +181,9 @@ export interface PiModelConfig {
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
 	// Persisted so telemetry can resolve the actual upstream provider after cache round-trip.
 	provider: string
-	compat?: {
-		supportsReasoningEffort?: boolean
-		cacheControlFormat?: "anthropic"
-		supportsUsageInStreaming?: boolean
-	}
+	compat?: OpenAICompletionsCompat | AnthropicMessagesCompat
 	/** Maps thinking levels to provider-specific values. `off: "none"` sends `reasoning_effort: "none"`. */
-	thinkingLevelMap?: Partial<Record<ThinkingLevel, string | null>>
+	thinkingLevelMap?: ThinkingLevelMap
 	/** Model-level API type: upstream custom-provider parseModels falls through to this field. */
 	api?: string
 	/** Model-level base URL: upstream custom-provider parseModels falls through to this field. */
@@ -213,8 +214,10 @@ function autoModelConfig(models: ModelMetadata[]): PiModelConfig {
 }
 
 function metadataToModel(m: ModelMetadata): PiModelConfig {
-	// Anthropic models are routed through the native `/v1/messages` API, so no
-	// openai-completions compat flags are needed.
+	// Anthropic models are routed through the native `/v1/messages` API. Inherit
+	// the upstream catalog's compat flags (adaptive thinking, strict tools) and
+	// thinking-level map so Pi picks the correct thinking mode and effort names
+	// per model. Models missing from the catalog get no compat, as before.
 	//
 	// claude-* models from non-anthropic providers still use openai-completions,
 	// so they keep the openai-completions compat flags.
@@ -222,12 +225,13 @@ function metadataToModel(m: ModelMetadata): PiModelConfig {
 	// ai-enabler models don't support chat_template_kwargs, so we rely on the
 	// default `openai` thinkingFormat which sends `reasoning_effort`. The map
 	// disables thinking with `none` and advertises max to Pi's selector.
-	const compat =
-		m.provider !== "anthropic" && m.slug.startsWith("claude-")
+	const upstream = m.provider === "anthropic" ? ANTHROPIC_MODELS_BY_ID[m.slug] : undefined
+	const compat = upstream
+		? upstream.compat
+		: m.provider !== "anthropic" && m.slug.startsWith("claude-")
 			? ({ supportsReasoningEffort: false, cacheControlFormat: "anthropic", supportsUsageInStreaming: true } as const)
 			: undefined
-	const thinkingLevelMap: PiModelConfig["thinkingLevelMap"] =
-		m.provider === "ai-enabler" ? { off: "none", max: "max" } : undefined
+	const thinkingLevelMap = m.provider === "ai-enabler" ? { off: "none", max: "max" } : upstream?.thinkingLevelMap
 	return {
 		id: m.slug,
 		name: m.display_name.trim().length > 0 ? m.display_name : m.slug,


### PR DESCRIPTION
## What
Route gateway-managed Anthropic models in Kimchi's `models.json` through the native Anthropic Messages API (`/anthropic/v1/messages`, `api: "anthropic-messages"`) instead of the OpenAI-compatible chat-completions endpoint, and inherit the upstream Anthropic model catalog's compat flags.

## Why
- The openai-completions path drops `thinking_blocks[].signature`, breaking Claude reasoning continuity on tool turns (see LLM-3076 / Discord thread).
- pi-ai's native `anthropic-messages` provider preserves signatures/thinking blocks end-to-end.
- `provider-composer.js` fully defines each custom-provider model from models.json and does **not** merge with pi-ai's built-in catalog, so dropping `compat` for anthropic models lost `forceAdaptiveThinking` and `thinkingLevelMap`. Restoring them ensures Sonnet 4.6+/5 and Opus 4.7+/5 use adaptive thinking with correct effort levels rather than the deprecated `budget_tokens` mode.

## Changes
- `src/models.ts`:
  - Use `api: "anthropic-messages"` and `baseUrl: https://llm.kimchi.dev/anthropic` for `kimchi-dev/anthropic`.
  - Import `ANTHROPIC_MODELS` from `@earendil-works/pi-ai/providers/anthropic.models` and copy `compat` + `thinkingLevelMap` into each anthropic model entry.
  - Keep openai-completions compat flags for non-anthropic `claude-*` providers (e.g. `azure_ai`).
- `src/models.test.ts`: update expectations and add a regression test for unknown anthropic slugs.

## Validation

### API-level direct curl
| Endpoint | Model | Thinking | Content blocks | Thinking tokens |
|---|---|---|---|---|
| `/anthropic` | Sonnet 4-6 | ON | [thinking, text] | 17 |
| `/anthropic` | Sonnet 4-6 | OFF | [text] | 0 |
| `/anthropic` | Sonnet 5 | ON | [text] | 0* |
| `/openai` | Sonnet 4-6 | ON | [thinking, text] | 8 |
| `/openai` | Sonnet 5 | ON | [text] | 0* |

*Sonnet 5 defaults to `display: "omitted"` at the raw API level, so no visible thinking block is returned even when thinking runs.

### Harness-level (`--mode json`)
| Model | thinking | Master (`openai-completions`) | Branch (`anthropic-messages`) |
|---|---|---|---|
| Sonnet 4-6 | off | reasoning: 0 | reasoning: 0 |
| Sonnet 4-6 | default | reasoning: **0** ❌ | reasoning: **35** ✅ |
| Sonnet 4-6 | max | reasoning: **0** ❌ | reasoning: **49** ✅ |
| Sonnet 5 | off | reasoning: 0 | reasoning: 0 |
| Sonnet 5 | default | reasoning: **0** ❌ | reasoning: **25** ✅ |
| Sonnet 5 | max | reasoning: **0** ❌ | reasoning: **118** ✅ |

### Other checks
- `pnpm run typecheck`: clean
- `vitest run src/models.test.ts`: 55/55 passed
- `pnpm run lint`: only pre-existing unrelated warnings
- End-to-end harness run with `claude-sonnet-5 --thinking max --yolo` executed a bash tool call and returned the result.

