### PR TITLE
fix(lsp): stop respawn storm on failed server start + support TypeScript 7 native server

### DIFF
--- a/src/extensions/__mocks__/extension-api.ts
+++ b/src/extensions/__mocks__/extension-api.ts
@@ -7,6 +7,7 @@ export function createExtensionApi(): {
 	api: ExtensionAPI
 	getHandler<E, R = undefined>(event: string): ExtensionHandler<E, R>
 	getHandlers<E, R = undefined>(event: string): ExtensionHandler<E, R>[]
+	getRegisteredTool(name: string): Parameters<ExtensionAPI["registerTool"]>[0]
 	sendMessage: ReturnType<typeof vi.fn<ExtensionAPI["sendMessage"]>>
 	appendEntry: ReturnType<typeof vi.fn<ExtensionAPI["appendEntry"]>>
 	setModel: ReturnType<typeof vi.fn<ExtensionAPI["setModel"]>>
@@ -46,6 +47,11 @@ export function createExtensionApi(): {
 		},
 		getHandlers<E, R = undefined>(event: string): ExtensionHandler<E, R>[] {
 			return (handlers.get(event) ?? []) as ExtensionHandler<E, R>[]
+		},
+		getRegisteredTool(name: string): Parameters<ExtensionAPI["registerTool"]>[0] {
+			const call = registerTool.mock.calls.find(([tool]) => tool.name === name)
+			if (!call) throw new Error(`Tool ${name} was not registered`)
+			return call[0]
 		},
 		sendMessage,
 		setModel,

--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -15,6 +15,7 @@ vi.mock("./lsp/servers.js", () => ({
 vi.mock("./lsp/client.js", () => ({
 	getOrCreateClient: vi.fn(),
 	ensureFileOpen: vi.fn(),
+	pullDiagnostics: vi.fn(),
 	refreshFile: vi.fn(),
 	sendRequest: vi.fn(),
 	shutdownAll: vi.fn(),
@@ -176,6 +177,16 @@ const FAKE_GO_SERVER = {
 	args: [],
 	extensions: ["go"],
 	installHint: "go install golang.org/x/tools/gopls@latest",
+}
+
+/** TypeScript 7 native server: pull-model diagnostics, no $/progress waits. */
+const FAKE_NATIVE_SERVER = {
+	name: "typescript-native",
+	command: "/project/node_modules/typescript/bin/tsc",
+	args: ["--lsp", "--stdio"],
+	extensions: ["ts", "tsx"],
+	skipProjectLoadWait: true,
+	pullDiagnostics: true,
 }
 
 async function callTool(
@@ -725,6 +736,51 @@ describe("tool_result handler", () => {
 		expect(options).toEqual({ deliverAs: "steer" })
 	})
 
+	it("pulls diagnostics explicitly for pull-model servers (e.g. TypeScript 7 native)", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_NATIVE_SERVER])
+		vi.mocked(serversMod.serverForFile).mockReturnValue(FAKE_NATIVE_SERVER)
+		const diag = {
+			range: { start: { line: 0, character: 6 } },
+			message: "Type 'number' is not assignable",
+			severity: 1,
+		}
+		const pull = clientMod.pullDiagnostics as unknown as ReturnType<typeof vi.fn>
+		pull.mockImplementation(async (client: { diagnostics: Map<string, unknown> }, uri: string) => {
+			client.diagnostics.set(uri, { diagnostics: [diag], version: null })
+			return [diag]
+		})
+		const fakeClient = makeClient()
+		vi.mocked(clientMod.getOrCreateClient).mockResolvedValue(fakeClient as never)
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true })
+
+		await pi.fireToolResult({ toolName: "edit", isError: false, input: { path: "/project/a.ts" } })
+
+		// Pull path: no waiting for a publishDiagnostics notification.
+		expect(clientMod.waitForDiagnostics).not.toHaveBeenCalled()
+		expect(clientMod.pullDiagnostics).toHaveBeenCalledWith(fakeClient, "file:///project/a.ts")
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1)
+		const [message, options] = vi.mocked(pi.sendMessage).mock.calls[0]
+		expect(message.content).toContain("[LSP diagnostics for a.ts]")
+		expect(message.content).toContain("Type 'number' is not assignable")
+		expect(options).toEqual({ deliverAs: "steer" })
+	})
+
+	it("does not send diagnostics when the pull request fails (best-effort)", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_NATIVE_SERVER])
+		vi.mocked(serversMod.serverForFile).mockReturnValue(FAKE_NATIVE_SERVER)
+		vi.mocked(clientMod.pullDiagnostics).mockRejectedValue(new Error("Method not found"))
+		const fakeClient = makeClient()
+		vi.mocked(clientMod.getOrCreateClient).mockResolvedValue(fakeClient as never)
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart({ hasUI: true })
+
+		await pi.fireToolResult({ toolName: "edit", isError: false, input: { path: "/project/a.ts" } })
+		expect(pi.sendMessage).not.toHaveBeenCalled()
+	})
+
 	it("does not send diagnostics when waitForDiagnostics resolves false (timeout/abort)", async () => {
 		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
 		vi.mocked(serversMod.serverForFile).mockReturnValue(FAKE_SERVER)
@@ -839,6 +895,25 @@ describe("lsp_diagnostics", () => {
 		const result = await callTool(pi, "lsp_diagnostics", { file_path: "/project/a.ts", wait_ms: 0 })
 		expect(result.content[0].text).toContain("Type error")
 		expect(result.content[0].text).toContain("error")
+	})
+
+	it("pulls diagnostics for pull-model servers instead of waiting for push", async () => {
+		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_NATIVE_SERVER])
+		vi.mocked(serversMod.serverForFile).mockReturnValue(FAKE_NATIVE_SERVER)
+		const diag = { range: { start: { line: 4, character: 2 } }, message: "Type error", severity: 1 as const }
+		const pull = clientMod.pullDiagnostics as unknown as ReturnType<typeof vi.fn>
+		pull.mockImplementation(async (client: { diagnostics: Map<string, unknown> }, uri: string) => {
+			client.diagnostics.set(uri, { diagnostics: [diag], version: null })
+			return [diag]
+		})
+		const fakeClient = makeClient()
+		vi.mocked(clientMod.getOrCreateClient).mockResolvedValue(fakeClient as never)
+		const pi = makePi()
+		lspExtension(pi)
+		await pi.fireSessionStart()
+		const result = await callTool(pi, "lsp_diagnostics", { file_path: "/project/a.ts", wait_ms: 0 })
+		expect(clientMod.pullDiagnostics).toHaveBeenCalledWith(fakeClient, "file:///project/a.ts")
+		expect(result.content[0].text).toContain("Type error")
 	})
 
 	it("caps wait_ms at 10000", async () => {

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -16,6 +16,7 @@ import { Type } from "typebox"
 import {
 	ensureFileOpen,
 	getOrCreateClient,
+	pullDiagnostics,
 	refreshFile,
 	sendRequest,
 	shutdownAll,
@@ -304,14 +305,26 @@ export default function (pi: ExtensionAPI) {
 				await ensureFileOpen(client, resolved)
 			} else {
 				await refreshFile(client, resolved)
-				// Wait for diagnostics to arrive via the LSP publishDiagnostics
-				// notification, with a deadline fallback. Resolves false on
-				// timeout/abort so we don't block forever on a slow server.
 				const uri = fileToUri(resolved)
-				const gotDiagnostics = await waitForDiagnostics(client, uri, {
-					signal: combinedSignal,
-					timeoutMs: DIAG_WAIT_TIMEOUT_MS,
-				})
+				// Diagnostics arrive via push (publishDiagnostics) on most servers
+				// — wait for the notification with a deadline fallback. Pull-model
+				// servers (e.g. the TypeScript 7 native server) never push, so fetch
+				// explicitly. Both paths are best-effort: timeout/abort/request
+				// failure resolves false and the sync continues.
+				let gotDiagnostics = false
+				if (server.pullDiagnostics) {
+					try {
+						await pullDiagnostics(client, uri)
+						gotDiagnostics = true
+					} catch {
+						gotDiagnostics = false
+					}
+				} else {
+					gotDiagnostics = await waitForDiagnostics(client, uri, {
+						signal: combinedSignal,
+						timeoutMs: DIAG_WAIT_TIMEOUT_MS,
+					})
+				}
 				if (gotDiagnostics) {
 					const entry = client.diagnostics.get(uri)
 					const diags = entry?.diagnostics ?? []
@@ -376,9 +389,20 @@ export default function (pi: ExtensionAPI) {
 			await refreshFile(client, filePath)
 
 			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
-			await new Promise((resolve) => setTimeout(resolve, waitMs))
-
 			const uri = fileToUri(filePath)
+			if (server.pullDiagnostics) {
+				// Pull-model servers (e.g. TypeScript 7 native): fetch instead of
+				// waiting for a push notification that never comes.
+				try {
+					await pullDiagnostics(client, uri)
+				} catch {
+					// Best-effort: fall through and report whatever is cached.
+				}
+			} else {
+				// Push-model servers: give publishDiagnostics time to arrive.
+				await new Promise((resolve) => setTimeout(resolve, waitMs))
+			}
+
 			const entry = client.diagnostics.get(uri)
 			if (!entry || entry.diagnostics.length === 0) {
 				return { content: [{ type: "text", text: "No diagnostics found — file looks clean." }], details: null }

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -104,6 +104,11 @@ export default function (pi: ExtensionAPI) {
 	// fixed between sessions (e.g. by running the package installer), so a new
 	// session retries.
 	let failedClients = new Map<string, FailurePhase>()
+	// The console line is reported once per server per session even when the
+	// failure recurs on different roots (monorepo packages) — the issue's "one
+	// human-readable line per session" — while per-root suppression above
+	// still prevents pointless re-spawns of each distinct root.
+	let reportedFailures = new Set<string>()
 
 	function clientKey(server: ServerConfig, root: string): string {
 		return `${server.command}:${root}`
@@ -137,10 +142,11 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	/** Record a failure once per server+root per session: reflect it in the
-	 *  status bar and log a single one-line message (logging the Error object
-	 *  itself would dump Bun's bundled-source code frame into the TUI). Every
-	 *  failing path — file sync and the lsp_* tool starts — records through
-	 *  here so tool-side failures get the same status visibility. */
+	 *  status bar and log a single one-line message per server (logging the
+	 *  Error object itself would dump Bun's bundled-source code frame into
+	 *  the TUI). Every failing path — file sync and the lsp_* tool starts —
+	 *  records through here so tool-side failures get the same status
+	 *  visibility. */
 	function noteClientFailure(
 		server: ServerConfig,
 		root: string,
@@ -159,7 +165,12 @@ export default function (pi: ExtensionAPI) {
 					: `LSP: ${server.name} ${failureLabel(phase)}`,
 			)
 		}
-		console.error(`LSP file sync failed: ${err instanceof Error ? err.message : String(err)}`)
+		if (reportedFailures.has(server.name)) return
+		reportedFailures.add(server.name)
+		const msg = err instanceof Error ? err.message : String(err)
+		// Say whether the server never started (spawn/initialize failure, e.g.
+		// from an lsp_* tool) or broke mid-session while syncing a file.
+		console.error(phase === "sync" ? `LSP file sync failed: ${msg}` : `LSP: ${server.name} failed to start: ${msg}`)
 	}
 
 	/** Like getOrCreateClient, but skips server+root pairs that already failed
@@ -199,6 +210,7 @@ export default function (pi: ExtensionAPI) {
 		warned = false
 		degradedServers = []
 		failedClients = new Map()
+		reportedFailures = new Set()
 		activeServers = detectServers(cwd)
 
 		// Compute missing candidates independently of active servers. In a mixed
@@ -244,6 +256,7 @@ export default function (pi: ExtensionAPI) {
 		warned = false
 		degradedServers = []
 		failedClients = new Map()
+		reportedFailures = new Set()
 		shutdownAll()
 	})
 
@@ -275,9 +288,14 @@ export default function (pi: ExtensionAPI) {
 		const resolved = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath)
 		const server = serverForFile(resolved, activeServers)
 		if (!server) return
-		// Skip servers that already failed to start this session — re-spawning
-		// once per file op floods the output with the same error.
-		if (hasClientFailed(server, cwd)) return
+		// Resolve the project root the same way the lsp_* tools do (a nested
+		// package in a monorepo is its own root), so the failure cache and the
+		// spawned client are keyed by the same root whichever path sees the
+		// file first.
+		const root = findRoot(resolved, server.name, cwd)
+		// Skip servers that already failed on this root this session —
+		// re-spawning once per file op floods the output with the same error.
+		if (hasClientFailed(server, root)) return
 
 		const effectiveUi = ui ?? ctx.ui
 
@@ -298,7 +316,7 @@ export default function (pi: ExtensionAPI) {
 		// (sendMessage below) rides in the same best-effort sync bucket.
 		let phase: FailurePhase = "start"
 		try {
-			const client = await getOrCreateClient(server, cwd)
+			const client = await getOrCreateClient(server, root)
 			phase = "sync"
 			if (isReadToolResult(event)) {
 				// File was only read, not modified — just ensure LSP has it open
@@ -352,7 +370,7 @@ export default function (pi: ExtensionAPI) {
 			// Non-fatal: LSP sync failure doesn't break the agent. Record the
 			// failure so subsequent file ops skip the dead server, and log one
 			// message (logging the Error object dumps Bun's source code frame).
-			noteClientFailure(server, cwd, err, phase, effectiveUi)
+			noteClientFailure(server, root, err, phase, effectiveUi)
 		} finally {
 			if (pendingRefresh?.abort === refreshController) {
 				pendingRefresh = undefined

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -45,6 +45,12 @@ export function clientCwd(filePath: string, sessionCwd: string): string {
 const LSP_DIAGNOSTICS_CUSTOM_TYPE = "lsp_diagnostics"
 const DIAG_WAIT_TIMEOUT_MS = 2000
 
+/** Why a server+root is disabled for the session: the server never started
+ *  ("start") or it started and then broke mid-session ("sync"). The status
+ *  bar reports each accurately instead of calling everything a start
+ *  failure. */
+type FailurePhase = "start" | "sync"
+
 /** All five LSP tool names. Hidden at session start when detection finds no
  *  language server for the session cwd. */
 export const LSP_TOOL_NAMES = [
@@ -87,15 +93,16 @@ export default function (pi: ExtensionAPI) {
 	// the wait, but we never abort ctx.signal ourselves.
 	let pendingRefresh: { abort: AbortController } | undefined
 
-	// Servers that failed to start (e.g. typescript-language-server with no
-	// resolvable tsserver.js — common in fresh worktrees without node_modules)
-	// are remembered for the rest of the session and never re-spawned: without
+	// Servers that failed (e.g. typescript-language-server with no resolvable
+	// tsserver.js — common in fresh worktrees without node_modules) are
+	// remembered for the rest of the session and never re-spawned: without
 	// environment changes (installing workspace deps) every attempt fails the
 	// same way, and re-spawning on each file op re-prints the same error each
-	// time. Reset on session_start — the failure is often fixed between
-	// sessions (e.g. by running the package installer), so a new session
-	// retries.
-	let failedClients = new Set<string>()
+	// time. A mid-session crash is cached the same way because a dead server
+	// keeps failing identically. Reset on session_start — the failure is often
+	// fixed between sessions (e.g. by running the package installer), so a new
+	// session retries.
+	let failedClients = new Map<string, FailurePhase>()
 
 	function clientKey(server: ServerConfig, root: string): string {
 		return `${server.command}:${root}`
@@ -105,19 +112,52 @@ export default function (pi: ExtensionAPI) {
 		return failedClients.has(clientKey(server, root))
 	}
 
-	/** Record a start failure once per server+root per session: reflect it in
-	 *  the status bar and log a single one-line message. Logging the Error
-	 *  object itself would dump Bun's bundled-source code frame into the TUI. */
+	/** Phase of the recorded failure for this server on any root, if any. */
+	function failedPhaseFor(server: ServerConfig): FailurePhase | undefined {
+		for (const [key, phase] of failedClients) {
+			if (key.startsWith(`${server.command}:`)) return phase
+		}
+		return undefined
+	}
+
+	function failureLabel(phase: FailurePhase): string {
+		return phase === "start" ? "failed to start" : "failed"
+	}
+
+	/** Status line combining healthy and failed servers, so a later successful
+	 *  sync of one server doesn't erase another server's failure indicator in
+	 *  mixed repos (e.g. gopls healthy while typescript failed to start). */
+	function statusText(diagSuffix = ""): string {
+		const parts = activeServers.map((s) => {
+			const phase = failedPhaseFor(s)
+			return phase ? `${s.name} ${failureLabel(phase)}` : s.name
+		})
+		return `LSP: ${parts.join(", ")}${diagSuffix}`
+	}
+
+	/** Record a failure once per server+root per session: reflect it in the
+	 *  status bar and log a single one-line message (logging the Error object
+	 *  itself would dump Bun's bundled-source code frame into the TUI). Every
+	 *  failing path — file sync and the lsp_* tool starts — records through
+	 *  here so tool-side failures get the same status visibility. */
 	function noteClientFailure(
 		server: ServerConfig,
 		root: string,
 		err: unknown,
+		phase: FailurePhase,
 		statusUi: ExtensionUIContext | undefined,
 	): void {
 		const key = clientKey(server, root)
 		if (failedClients.has(key)) return
-		failedClients.add(key)
-		statusUi?.setStatus("lsp", `LSP: ${server.name} failed to start`)
+		failedClients.set(key, phase)
+		if (statusUi) {
+			statusUi.setStatus(
+				"lsp",
+				activeServers.some((s) => s.command === server.command)
+					? statusText()
+					: `LSP: ${server.name} ${failureLabel(phase)}`,
+			)
+		}
 		console.error(`LSP file sync failed: ${err instanceof Error ? err.message : String(err)}`)
 	}
 
@@ -125,15 +165,16 @@ export default function (pi: ExtensionAPI) {
 	 *  this session instead of re-spawning a doomed server. Throws a
 	 *  human-readable error so tool handlers surface something actionable. */
 	async function startClient(server: ServerConfig, root: string): Promise<LspClient> {
-		if (hasClientFailed(server, root)) {
+		const phase = failedClients.get(clientKey(server, root))
+		if (phase) {
 			throw new Error(
-				`LSP server ${server.name} failed to start for this session (see LSP status). Fix the underlying issue and start a new session to retry.`,
+				`LSP server ${server.name} ${failureLabel(phase)} for this session (see LSP status). Fix the underlying issue and start a new session to retry.`,
 			)
 		}
 		try {
 			return await getOrCreateClient(server, root)
 		} catch (err) {
-			failedClients.add(clientKey(server, root))
+			noteClientFailure(server, root, err, "start", ui)
 			throw err
 		}
 	}
@@ -156,7 +197,7 @@ export default function (pi: ExtensionAPI) {
 		ui = ctx.hasUI ? ctx.ui : undefined
 		warned = false
 		degradedServers = []
-		failedClients = new Set()
+		failedClients = new Map()
 		activeServers = detectServers(cwd)
 
 		// Compute missing candidates independently of active servers. In a mixed
@@ -189,7 +230,7 @@ export default function (pi: ExtensionAPI) {
 		for (const server of activeServers) {
 			const markers = server.name === "gopls" ? goMarkers : tsMarkers
 			if (!markers.some((m) => fs.existsSync(path.join(cwd, m)))) continue
-			getOrCreateClient(server, cwd).catch((err) => noteClientFailure(server, cwd, err, ui))
+			getOrCreateClient(server, cwd).catch((err) => noteClientFailure(server, cwd, err, "start", ui))
 		}
 	})
 
@@ -201,7 +242,7 @@ export default function (pi: ExtensionAPI) {
 		}
 		warned = false
 		degradedServers = []
-		failedClients = new Set()
+		failedClients = new Map()
 		shutdownAll()
 	})
 
@@ -249,8 +290,15 @@ export default function (pi: ExtensionAPI) {
 			? AbortSignal.any([ctx.signal, refreshController.signal])
 			: refreshController.signal
 
+		// Distinguish why the sync failed: a server that never started
+		// ("start") vs one that started and then broke while syncing
+		// ("sync") — the status bar says which instead of calling every
+		// failure a start failure. Diagnostics delivery to the agent
+		// (sendMessage below) rides in the same best-effort sync bucket.
+		let phase: FailurePhase = "start"
 		try {
 			const client = await getOrCreateClient(server, cwd)
+			phase = "sync"
 			if (isReadToolResult(event)) {
 				// File was only read, not modified — just ensure LSP has it open
 				await ensureFileOpen(client, resolved)
@@ -281,16 +329,17 @@ export default function (pi: ExtensionAPI) {
 				// Update status bar with total diagnostic count across open files
 				if (effectiveUi) {
 					const totalDiags = [...client.diagnostics.values()].reduce((sum, entry) => sum + entry.diagnostics.length, 0)
-					const names = activeServers.map((s) => s.name).join(", ")
+					// Keep failure indicators for servers that failed this session —
+					// this server's successful sync must not erase them.
 					const diagPart = totalDiags > 0 ? ` (${totalDiags} diag${totalDiags === 1 ? "" : "s"})` : ""
-					effectiveUi.setStatus("lsp", `LSP: ${names}${diagPart}`)
+					effectiveUi.setStatus("lsp", statusText(diagPart))
 				}
 			}
 		} catch (err) {
 			// Non-fatal: LSP sync failure doesn't break the agent. Record the
 			// failure so subsequent file ops skip the dead server, and log one
 			// message (logging the Error object dumps Bun's source code frame).
-			noteClientFailure(server, cwd, err, effectiveUi)
+			noteClientFailure(server, cwd, err, phase, effectiveUi)
 		} finally {
 			if (pendingRefresh?.abort === refreshController) {
 				pendingRefresh = undefined

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -23,7 +23,15 @@ import {
 } from "./lsp/client.js"
 import { applyWorkspaceEdit } from "./lsp/edits.js"
 import { detectMissingCandidates, detectServers, findRoot, serverForFile } from "./lsp/servers.js"
-import type { Hover, Location, LocationLink, TextDocumentEdit, WorkspaceEdit } from "./lsp/types.js"
+import type {
+	Hover,
+	Location,
+	LocationLink,
+	LspClient,
+	ServerConfig,
+	TextDocumentEdit,
+	WorkspaceEdit,
+} from "./lsp/types.js"
 import { fileToUri, formatDiagnostic, uriToFile } from "./lsp/utils.js"
 import { createSystemPromptBlocks } from "./prompt-construction/index.js"
 import { createToolVisibility } from "./prompt-construction/tool-visibility.js"
@@ -79,6 +87,57 @@ export default function (pi: ExtensionAPI) {
 	// the wait, but we never abort ctx.signal ourselves.
 	let pendingRefresh: { abort: AbortController } | undefined
 
+	// Servers that failed to start (e.g. typescript-language-server with no
+	// resolvable tsserver.js — common in fresh worktrees without node_modules)
+	// are remembered for the rest of the session and never re-spawned: without
+	// environment changes (installing workspace deps) every attempt fails the
+	// same way, and re-spawning on each file op re-prints the same error each
+	// time. Reset on session_start — the failure is often fixed between
+	// sessions (e.g. by running the package installer), so a new session
+	// retries.
+	let failedClients = new Set<string>()
+
+	function clientKey(server: ServerConfig, root: string): string {
+		return `${server.command}:${root}`
+	}
+
+	function hasClientFailed(server: ServerConfig, root: string): boolean {
+		return failedClients.has(clientKey(server, root))
+	}
+
+	/** Record a start failure once per server+root per session: reflect it in
+	 *  the status bar and log a single one-line message. Logging the Error
+	 *  object itself would dump Bun's bundled-source code frame into the TUI. */
+	function noteClientFailure(
+		server: ServerConfig,
+		root: string,
+		err: unknown,
+		statusUi: ExtensionUIContext | undefined,
+	): void {
+		const key = clientKey(server, root)
+		if (failedClients.has(key)) return
+		failedClients.add(key)
+		statusUi?.setStatus("lsp", `LSP: ${server.name} failed to start`)
+		console.error(`LSP file sync failed: ${err instanceof Error ? err.message : String(err)}`)
+	}
+
+	/** Like getOrCreateClient, but skips server+root pairs that already failed
+	 *  this session instead of re-spawning a doomed server. Throws a
+	 *  human-readable error so tool handlers surface something actionable. */
+	async function startClient(server: ServerConfig, root: string): Promise<LspClient> {
+		if (hasClientFailed(server, root)) {
+			throw new Error(
+				`LSP server ${server.name} failed to start for this session (see LSP status). Fix the underlying issue and start a new session to retry.`,
+			)
+		}
+		try {
+			return await getOrCreateClient(server, root)
+		} catch (err) {
+			failedClients.add(clientKey(server, root))
+			throw err
+		}
+	}
+
 	function cancelPendingRefresh(): void {
 		if (!pendingRefresh) return
 		pendingRefresh.abort.abort()
@@ -97,6 +156,7 @@ export default function (pi: ExtensionAPI) {
 		ui = ctx.hasUI ? ctx.ui : undefined
 		warned = false
 		degradedServers = []
+		failedClients = new Set()
 		activeServers = detectServers(cwd)
 
 		// Compute missing candidates independently of active servers. In a mixed
@@ -129,7 +189,7 @@ export default function (pi: ExtensionAPI) {
 		for (const server of activeServers) {
 			const markers = server.name === "gopls" ? goMarkers : tsMarkers
 			if (!markers.some((m) => fs.existsSync(path.join(cwd, m)))) continue
-			getOrCreateClient(server, cwd).catch(() => {})
+			getOrCreateClient(server, cwd).catch((err) => noteClientFailure(server, cwd, err, ui))
 		}
 	})
 
@@ -141,6 +201,7 @@ export default function (pi: ExtensionAPI) {
 		}
 		warned = false
 		degradedServers = []
+		failedClients = new Set()
 		shutdownAll()
 	})
 
@@ -172,6 +233,9 @@ export default function (pi: ExtensionAPI) {
 		const resolved = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath)
 		const server = serverForFile(resolved, activeServers)
 		if (!server) return
+		// Skip servers that already failed to start this session — re-spawning
+		// once per file op floods the output with the same error.
+		if (hasClientFailed(server, cwd)) return
 
 		const effectiveUi = ui ?? ctx.ui
 
@@ -223,9 +287,10 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 		} catch (err) {
-			// Non-fatal: LSP sync failure doesn't break the agent, but log it so
-			// production debugging is possible.
-			console.error("LSP file sync failed:", err)
+			// Non-fatal: LSP sync failure doesn't break the agent. Record the
+			// failure so subsequent file ops skip the dead server, and log one
+			// message (logging the Error object dumps Bun's source code frame).
+			noteClientFailure(server, cwd, err, effectiveUi)
 		} finally {
 			if (pendingRefresh?.abort === refreshController) {
 				pendingRefresh = undefined
@@ -258,7 +323,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
+			const client = await startClient(server, findRoot(filePath, server.name, cwd))
 			await refreshFile(client, filePath)
 
 			const waitMs = Math.min(params.wait_ms ?? 2000, 10000)
@@ -297,7 +362,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
+			const client = await startClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/hover", {
@@ -341,7 +406,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
+			const client = await startClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const lspMethod = `textDocument/${params.method ?? "definition"}`
@@ -388,7 +453,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
+			const client = await startClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			const result = (await sendRequest(client, "textDocument/references", {
@@ -432,7 +497,7 @@ export default function (pi: ExtensionAPI) {
 				return { content: [{ type: "text", text: "No LSP server available for this file type." }], details: null }
 			}
 
-			const client = await getOrCreateClient(server, findRoot(filePath, server.name, cwd))
+			const client = await startClient(server, findRoot(filePath, server.name, cwd))
 			await ensureFileOpen(client, filePath)
 
 			// Check if rename is valid at this position

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -146,14 +146,22 @@ export default function (pi: ExtensionAPI) {
 	 *  Error object itself would dump Bun's bundled-source code frame into
 	 *  the TUI). Every failing path — file sync and the lsp_* tool starts —
 	 *  records through here so tool-side failures get the same status
-	 *  visibility. */
+	 *  visibility.
+	 *
+	 *  `sessionFailures` must be the map captured by the session that
+	 *  initiated the async work. A rejection that arrives after
+	 *  session_reset (e.g. a slow eager start from session N) finds the map
+	 *  replaced and is dropped — recording it into the new session's cache
+	 *  would wrongly suppress that server for the rest of the new session. */
 	function noteClientFailure(
 		server: ServerConfig,
 		root: string,
 		err: unknown,
 		phase: FailurePhase,
 		statusUi: ExtensionUIContext | undefined,
+		sessionFailures: Map<string, FailurePhase> = failedClients,
 	): void {
+		if (sessionFailures !== failedClients) return // stale cross-session rejection
 		const key = clientKey(server, root)
 		if (failedClients.has(key)) return
 		failedClients.set(key, phase)
@@ -237,13 +245,16 @@ export default function (pi: ExtensionAPI) {
 			return
 		}
 
-		// Eagerly start servers that have a project marker directly in sessionCwd
+		// Eagerly start servers that have a project marker directly in sessionCwd.
+		// Capture this session's failure map: a rejection that lands after the
+		// next session_start must be dropped, not recorded into the new session.
+		const sessionFailures = failedClients
 		const goMarkers = ["go.mod"]
 		const tsMarkers = ["tsconfig.json", "package.json"]
 		for (const server of activeServers) {
 			const markers = server.name === "gopls" ? goMarkers : tsMarkers
 			if (!markers.some((m) => fs.existsSync(path.join(cwd, m)))) continue
-			getOrCreateClient(server, cwd).catch((err) => noteClientFailure(server, cwd, err, "start", ui))
+			getOrCreateClient(server, cwd).catch((err) => noteClientFailure(server, cwd, err, "start", ui, sessionFailures))
 		}
 	})
 

--- a/src/extensions/lsp/client.ts
+++ b/src/extensions/lsp/client.ts
@@ -2,6 +2,7 @@
 import { resolveTsserverPath } from "./servers.js"
 import type {
 	BunProcess,
+	Diagnostic,
 	DiagnosticWaiter,
 	LspClient,
 	LspJsonRpcNotification,
@@ -302,7 +303,10 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string): Prom
 				workspaceFolders: [{ uri: fileToUri(cwd), name: cwd.split("/").pop() ?? "workspace" }],
 			})
 			await sendNotification(client, "initialized", {})
-			await client.projectLoaded
+			// Servers that never emit $/progress cycles (e.g. the TypeScript 7
+			// native server) never satisfy projectLoaded's token tracking, so
+			// the wait would stall on the fixed timeout at every startup.
+			if (!config.skipProjectLoadWait) await client.projectLoaded
 			return client
 		} catch (err) {
 			clients.delete(key)
@@ -369,6 +373,24 @@ export async function sendNotification(client: LspClient, method: string, params
 	const notification: LspJsonRpcNotification = { jsonrpc: "2.0", method, params }
 	client.lastActivity = Date.now()
 	await writeMessage(client.proc, notification)
+}
+
+/**
+ * Fetch diagnostics via the LSP 3.17 pull model (textDocument/diagnostic)
+ * for servers without publishDiagnostics push support (e.g. the TypeScript 7
+ * native server). Stores the result in client.diagnostics exactly like a
+ * push notification would, so downstream readers don't care which model
+ * served it.
+ */
+export async function pullDiagnostics(client: LspClient, uri: string): Promise<Diagnostic[]> {
+	const result = await sendRequest(client, "textDocument/diagnostic", {
+		textDocument: { uri },
+	})
+	const items = (result as { items?: Diagnostic[] } | null)?.items
+	const diagnostics = Array.isArray(items) ? items : []
+	client.diagnostics.set(uri, { diagnostics, version: client.openFiles.get(uri)?.version ?? null })
+	client.diagnosticsVersion++
+	return diagnostics
 }
 
 // =============================================================================

--- a/src/extensions/lsp/lsp-file-sync.test.ts
+++ b/src/extensions/lsp/lsp-file-sync.test.ts
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("./client.js", () => ({
 	getOrCreateClient: mocks.getOrCreateClient,
 	ensureFileOpen: mocks.ensureFileOpen,
+	pullDiagnostics: vi.fn(async () => []),
 	refreshFile: mocks.refreshFile,
 	waitForDiagnostics: mocks.waitForDiagnostics,
 	sendRequest: vi.fn(),

--- a/src/extensions/lsp/lsp-file-sync.test.ts
+++ b/src/extensions/lsp/lsp-file-sync.test.ts
@@ -17,12 +17,24 @@ const mocks = vi.hoisted(() => {
 		extensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
 		installHint: "npm i -g typescript-language-server typescript",
 	}
+	const goServer = {
+		name: "gopls",
+		command: "gopls",
+		args: [],
+		extensions: ["go"],
+		installHint: "brew install gopls",
+	}
 	return {
 		tsServer,
+		goServer,
 		getOrCreateClient: vi.fn(),
 		ensureFileOpen: vi.fn(async () => {}),
 		refreshFile: vi.fn(async () => {}),
 		waitForDiagnostics: vi.fn(async () => false),
+		detectServers: vi.fn(() => [tsServer]),
+		detectMissingCandidates: vi.fn(() => []),
+		serverForFile: vi.fn((filePath: string) => (filePath.endsWith(".ts") ? tsServer : null)),
+		findRoot: vi.fn((_file: string, _server: string, sessionCwd: string) => sessionCwd),
 	}
 })
 
@@ -36,10 +48,10 @@ vi.mock("./client.js", () => ({
 }))
 
 vi.mock("./servers.js", () => ({
-	detectServers: vi.fn(() => [mocks.tsServer]),
-	detectMissingCandidates: vi.fn(() => []),
-	serverForFile: vi.fn((filePath: string) => (filePath.endsWith(".ts") ? mocks.tsServer : null)),
-	findRoot: vi.fn((_file: string, _server: string, sessionCwd: string) => sessionCwd),
+	detectServers: mocks.detectServers,
+	detectMissingCandidates: mocks.detectMissingCandidates,
+	serverForFile: mocks.serverForFile,
+	findRoot: mocks.findRoot,
 	resolveTsserverPath: vi.fn(() => undefined),
 	findMainRepoRoot: vi.fn(() => undefined),
 }))
@@ -74,11 +86,18 @@ function editToolResult(filePath: string) {
 	return { toolName: "edit", isError: false, input: { path: filePath }, content: [], details: undefined }
 }
 
-type RawHandler = (event: unknown, ctx: unknown) => Promise<unknown>
-
 describe("lsp file sync failure handling", () => {
 	beforeEach(() => {
 		mocks.getOrCreateClient.mockReset().mockRejectedValue(new Error(INIT_FAILURE))
+		mocks.ensureFileOpen.mockReset().mockResolvedValue(undefined)
+		mocks.refreshFile.mockReset().mockResolvedValue(undefined)
+		mocks.waitForDiagnostics.mockReset().mockResolvedValue(false)
+		mocks.detectServers.mockReset().mockReturnValue([mocks.tsServer])
+		mocks.detectMissingCandidates.mockReset().mockReturnValue([])
+		mocks.serverForFile
+			.mockReset()
+			.mockImplementation((filePath: string) => (filePath.endsWith(".ts") ? mocks.tsServer : null))
+		mocks.findRoot.mockReset().mockImplementation((_file: string, _server: string, sessionCwd: string) => sessionCwd)
 	})
 
 	afterEach(() => {
@@ -88,11 +107,11 @@ describe("lsp file sync failure handling", () => {
 	it("logs a single one-line error and stops respawning after a start failure", async () => {
 		const { dir, ext, consoleSpy } = makeSession()
 		const sessionCtx = createContext({ cwd: dir })
-		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
 		// No tsconfig/package.json in dir → no eager server start.
 		expect(mocks.getOrCreateClient).not.toHaveBeenCalled()
 
-		const toolResult = ext.getHandler("tool_result") as RawHandler
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
 		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
 		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
 		await toolResult(editToolResult("bar.ts"), createContext({ cwd: dir }))
@@ -115,12 +134,12 @@ describe("lsp file sync failure handling", () => {
 	it("records an eager session_start failure and skips respawning on later file ops", async () => {
 		const { dir, ext, consoleSpy } = makeSession(["package.json"])
 		const sessionCtx = createContext({ cwd: dir })
-		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
 		// Marker present → eager start attempted and failed (rejection handled async).
 		await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledTimes(1))
 		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
 
-		const toolResult = ext.getHandler("tool_result") as RawHandler
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
 		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
 
 		// No respawn, no repeat log, no file sync attempted.
@@ -132,24 +151,24 @@ describe("lsp file sync failure handling", () => {
 
 	it("retries server startup in a new session", async () => {
 		const { dir, ext, consoleSpy } = makeSession()
-		const toolResult = ext.getHandler("tool_result") as RawHandler
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
 
-		await (ext.getHandler("session_start") as RawHandler)(null, createContext({ cwd: dir }))
+		await ext.getHandler<unknown, unknown>("session_start")(null, createContext({ cwd: dir }))
 		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
 		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
 		expect(consoleSpy).toHaveBeenCalledTimes(1)
 
 		// session_start resets the failure cache — a new session retries once.
-		await (ext.getHandler("session_start") as RawHandler)(null, createContext({ cwd: dir }))
+		await ext.getHandler<unknown, unknown>("session_start")(null, createContext({ cwd: dir }))
 		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
 		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(2)
 		expect(consoleSpy).toHaveBeenCalledTimes(2)
 	})
 
 	it("lsp tools fail with an actionable message instead of respawning", async () => {
-		const { dir, ext } = makeSession()
+		const { dir, ext, consoleSpy } = makeSession()
 		const sessionCtx = createContext({ cwd: dir })
-		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
 
 		const diagnosticTool = ext.getRegisteredTool("lsp_diagnostics")
 		const filePath = path.join(dir, "foo.ts")
@@ -167,7 +186,14 @@ describe("lsp file sync failure handling", () => {
 		).rejects.toThrow(INIT_FAILURE)
 		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
 
-		// Second call short-circuits with the actionable session-scoped message.
+		// The tool-path failure surfaces exactly like a file-sync failure: one
+		// log line and a status-bar indicator (previously it was silent).
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed to start"])
+
+		// Second call short-circuits with the actionable session-scoped message,
+		// without logging or touching the status bar again.
 		await expect(
 			diagnosticTool.execute(
 				"call-2",
@@ -178,5 +204,68 @@ describe("lsp file sync failure handling", () => {
 			),
 		).rejects.toThrow(/failed to start for this session/)
 		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it("marks a mid-session sync failure as 'failed' (not 'failed to start') and stops syncing", async () => {
+		const { dir, ext, consoleSpy } = makeSession()
+		const sessionCtx = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
+
+		// Server starts fine, then dies while syncing the first edit.
+		mocks.getOrCreateClient.mockReset().mockResolvedValue({ diagnostics: new Map() })
+		mocks.refreshFile.mockRejectedValue(new Error("LSP connection closed"))
+
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+
+		// The status bar tells a mid-session crash apart from a start failure.
+		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed"])
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+
+		// Later edits skip the dead server without logging again…
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+
+		// …and tools report the mid-session failure accurately.
+		const diagnosticTool = ext.getRegisteredTool("lsp_diagnostics")
+		await expect(
+			diagnosticTool.execute(
+				"call-1",
+				{ file_path: path.join(dir, "foo.ts") },
+				undefined as never,
+				undefined as never,
+				sessionCtx as never,
+			),
+		).rejects.toThrow(/^LSP server typescript-language-server failed for this session/)
+	})
+
+	it("keeps a failed server's status indicator when a healthy server syncs afterwards", async () => {
+		mocks.detectServers.mockReturnValue([mocks.tsServer, mocks.goServer])
+		mocks.serverForFile.mockImplementation((filePath: string) =>
+			filePath.endsWith(".go") ? mocks.goServer : mocks.tsServer,
+		)
+		mocks.getOrCreateClient.mockImplementation(async (server: { command: string }) => {
+			if (server.command === "gopls") return { diagnostics: new Map() }
+			throw new Error(INIT_FAILURE)
+		})
+
+		const { dir, ext } = makeSession()
+		const sessionCtx = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
+
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
+		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
+
+		// typescript-language-server fails to start; gopls stays healthy.
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed to start, gopls"])
+
+		// A successful gopls sync follows — the failure indicator must survive.
+		await toolResult(editToolResult("main.go"), createContext({ cwd: dir }))
+		expect(mocks.refreshFile).toHaveBeenCalledTimes(1)
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed to start, gopls"])
 	})
 })

--- a/src/extensions/lsp/lsp-file-sync.test.ts
+++ b/src/extensions/lsp/lsp-file-sync.test.ts
@@ -124,12 +124,56 @@ describe("lsp file sync failure handling", () => {
 		expect(consoleSpy).toHaveBeenCalledTimes(1)
 		const logged = consoleSpy.mock.calls[0][0]
 		expect(typeof logged).toBe("string")
-		expect(logged.startsWith("LSP file sync failed: ")).toBe(true)
+		expect(logged.startsWith("LSP: typescript-language-server failed to start: ")).toBe(true)
 		expect(logged.includes(INIT_FAILURE)).toBe(true)
 		expect(logged.includes("\n")).toBe(false)
 		// The status bar reflects the degraded server.
 		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
 		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed to start"])
+	})
+
+	it("logs at most one line per server even when failures recur on different roots (monorepo)", async () => {
+		const { dir, ext, consoleSpy } = makeSession()
+		const sessionCtx = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
+		// Each package in a monorepo resolves to its own root.
+		mocks.findRoot.mockImplementation((file: string) =>
+			file.endsWith("/a/foo.ts") ? `${dir}/packages/a` : `${dir}/packages/b`,
+		)
+
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
+		await toolResult(editToolResult("packages/a/foo.ts"), createContext({ cwd: dir }))
+		await toolResult(editToolResult("packages/b/foo.ts"), createContext({ cwd: dir }))
+		// A repeat of the first root is suppressed without another spawn attempt.
+		await toolResult(editToolResult("packages/a/foo.ts"), createContext({ cwd: dir }))
+
+		// One spawn attempt per distinct root (different roots are genuinely
+		// different server processes), but only one console line for the whole
+		// session — the issue's "one human-readable line per session".
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(2)
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+		const logged = consoleSpy.mock.calls[0][0]
+		expect(logged.startsWith("LSP: typescript-language-server failed to start: ")).toBe(true)
+	})
+
+	it("keeps the 'LSP file sync failed' label for mid-session sync failures", async () => {
+		const { dir, ext, consoleSpy } = makeSession()
+		mocks.getOrCreateClient.mockResolvedValue({ diagnostics: new Map() } as never)
+		mocks.refreshFile.mockRejectedValue(new Error("sync boom"))
+		const sessionCtx = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, sessionCtx)
+
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		await toolResult(editToolResult("bar.ts"), createContext({ cwd: dir }))
+
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+		const logged = consoleSpy.mock.calls[0][0]
+		expect(logged.startsWith("LSP file sync failed: ")).toBe(true)
+		expect(logged).toContain("sync boom")
+		// The status bar reports a mid-session failure, not a start failure.
+		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed"])
 	})
 
 	it("records an eager session_start failure and skips respawning on later file ops", async () => {

--- a/src/extensions/lsp/lsp-file-sync.test.ts
+++ b/src/extensions/lsp/lsp-file-sync.test.ts
@@ -1,0 +1,182 @@
+// Regression tests for the "LSP file sync failed" code-frame dump observed in
+// worktree sessions: a server that fails to start (e.g. typescript-language-server
+// with no resolvable tsserver.js) must be reported once as a one-line message
+// and never re-spawned for the rest of the session.
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import { createExtensionApi } from "../__mocks__/extension-api.js"
+
+const mocks = vi.hoisted(() => {
+	const tsServer = {
+		name: "typescript-language-server",
+		command: "typescript-language-server",
+		args: ["--stdio"],
+		extensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+		installHint: "npm i -g typescript-language-server typescript",
+	}
+	return {
+		tsServer,
+		getOrCreateClient: vi.fn(),
+		ensureFileOpen: vi.fn(async () => {}),
+		refreshFile: vi.fn(async () => {}),
+		waitForDiagnostics: vi.fn(async () => false),
+	}
+})
+
+vi.mock("./client.js", () => ({
+	getOrCreateClient: mocks.getOrCreateClient,
+	ensureFileOpen: mocks.ensureFileOpen,
+	refreshFile: mocks.refreshFile,
+	waitForDiagnostics: mocks.waitForDiagnostics,
+	sendRequest: vi.fn(),
+	shutdownAll: vi.fn(),
+}))
+
+vi.mock("./servers.js", () => ({
+	detectServers: vi.fn(() => [mocks.tsServer]),
+	detectMissingCandidates: vi.fn(() => []),
+	serverForFile: vi.fn((filePath: string) => (filePath.endsWith(".ts") ? mocks.tsServer : null)),
+	findRoot: vi.fn((_file: string, _server: string, sessionCwd: string) => sessionCwd),
+	resolveTsserverPath: vi.fn(() => undefined),
+	findMainRepoRoot: vi.fn(() => undefined),
+}))
+
+vi.mock("../prompt-construction/index.js", () => ({
+	createSystemPromptBlocks: vi.fn(() => ({ register: vi.fn() })),
+}))
+vi.mock("../prompt-construction/tool-visibility.js", () => ({
+	createToolVisibility: vi.fn(() => ({ disable: vi.fn() })),
+}))
+vi.mock("../steer-marker.js", () => ({
+	markHarnessSteer: vi.fn((content: string) => content),
+}))
+
+import lspExtension from "../lsp.js"
+
+const INIT_FAILURE =
+	"LSP error: Request initialize failed with message: Could not find a valid TypeScript installation."
+
+function makeSession(files?: string[]) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kimchi-lsp-fail-"))
+	for (const name of files ?? []) {
+		fs.writeFileSync(path.join(dir, name), "{}\n")
+	}
+	const ext = createExtensionApi()
+	lspExtension(ext.api)
+	const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	return { dir, ext, consoleSpy }
+}
+
+function editToolResult(filePath: string) {
+	return { toolName: "edit", isError: false, input: { path: filePath }, content: [], details: undefined }
+}
+
+type RawHandler = (event: unknown, ctx: unknown) => Promise<unknown>
+
+describe("lsp file sync failure handling", () => {
+	beforeEach(() => {
+		mocks.getOrCreateClient.mockReset().mockRejectedValue(new Error(INIT_FAILURE))
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it("logs a single one-line error and stops respawning after a start failure", async () => {
+		const { dir, ext, consoleSpy } = makeSession()
+		const sessionCtx = createContext({ cwd: dir })
+		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+		// No tsconfig/package.json in dir → no eager server start.
+		expect(mocks.getOrCreateClient).not.toHaveBeenCalled()
+
+		const toolResult = ext.getHandler("tool_result") as RawHandler
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		await toolResult(editToolResult("bar.ts"), createContext({ cwd: dir }))
+
+		// One spawn attempt total; the failure is remembered for the session.
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+		// The failure is logged exactly once, as a plain single-line message —
+		// never as an Error object (Bun would dump the bundled-source code frame).
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+		const logged = consoleSpy.mock.calls[0][0]
+		expect(typeof logged).toBe("string")
+		expect(logged.startsWith("LSP file sync failed: ")).toBe(true)
+		expect(logged.includes(INIT_FAILURE)).toBe(true)
+		expect(logged.includes("\n")).toBe(false)
+		// The status bar reflects the degraded server.
+		const setStatus = sessionCtx.ui.setStatus as ReturnType<typeof vi.fn>
+		expect(setStatus.mock.lastCall).toEqual(["lsp", "LSP: typescript-language-server failed to start"])
+	})
+
+	it("records an eager session_start failure and skips respawning on later file ops", async () => {
+		const { dir, ext, consoleSpy } = makeSession(["package.json"])
+		const sessionCtx = createContext({ cwd: dir })
+		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+		// Marker present → eager start attempted and failed (rejection handled async).
+		await vi.waitFor(() => expect(consoleSpy).toHaveBeenCalledTimes(1))
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+
+		const toolResult = ext.getHandler("tool_result") as RawHandler
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+
+		// No respawn, no repeat log, no file sync attempted.
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+		expect(mocks.ensureFileOpen).not.toHaveBeenCalled()
+		expect(mocks.refreshFile).not.toHaveBeenCalled()
+	})
+
+	it("retries server startup in a new session", async () => {
+		const { dir, ext, consoleSpy } = makeSession()
+		const toolResult = ext.getHandler("tool_result") as RawHandler
+
+		await (ext.getHandler("session_start") as RawHandler)(null, createContext({ cwd: dir }))
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+		expect(consoleSpy).toHaveBeenCalledTimes(1)
+
+		// session_start resets the failure cache — a new session retries once.
+		await (ext.getHandler("session_start") as RawHandler)(null, createContext({ cwd: dir }))
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(2)
+		expect(consoleSpy).toHaveBeenCalledTimes(2)
+	})
+
+	it("lsp tools fail with an actionable message instead of respawning", async () => {
+		const { dir, ext } = makeSession()
+		const sessionCtx = createContext({ cwd: dir })
+		await (ext.getHandler("session_start") as RawHandler)(null, sessionCtx)
+
+		const diagnosticTool = ext.getRegisteredTool("lsp_diagnostics")
+		const filePath = path.join(dir, "foo.ts")
+		const args = [filePath] as const
+
+		// First call propagates the real server error (agent-readable).
+		await expect(
+			diagnosticTool.execute(
+				"call-1",
+				{ file_path: args[0] },
+				undefined as never,
+				undefined as never,
+				sessionCtx as never,
+			),
+		).rejects.toThrow(INIT_FAILURE)
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+
+		// Second call short-circuits with the actionable session-scoped message.
+		await expect(
+			diagnosticTool.execute(
+				"call-2",
+				{ file_path: args[0] },
+				undefined as never,
+				undefined as never,
+				sessionCtx as never,
+			),
+		).rejects.toThrow(/failed to start for this session/)
+		expect(mocks.getOrCreateClient).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/extensions/lsp/lsp-file-sync.test.ts
+++ b/src/extensions/lsp/lsp-file-sync.test.ts
@@ -194,6 +194,46 @@ describe("lsp file sync failure handling", () => {
 		expect(mocks.refreshFile).not.toHaveBeenCalled()
 	})
 
+	it("ignores a stale eager-start rejection arriving after a new session started", async () => {
+		const { dir, ext, consoleSpy } = makeSession(["package.json"])
+		// Session 1's eager start hangs pending; session 2's starts succeed.
+		let rejectEager!: (err: Error) => void
+		mocks.getOrCreateClient.mockImplementationOnce(
+			() =>
+				new Promise((_, reject) => {
+					rejectEager = reject
+				}),
+		)
+		mocks.getOrCreateClient.mockResolvedValue({ diagnostics: new Map() } as never)
+
+		const ctx1 = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, ctx1)
+		expect(rejectEager).toBeDefined() // session-1 eager start still in flight
+
+		const ctx2 = createContext({ cwd: dir })
+		await ext.getHandler<unknown, unknown>("session_start")(null, ctx2)
+
+		// Session 1's eager start finally rejects — after session_start reset
+		// the failure maps. The stale rejection must be dropped, not recorded
+		// into session 2's cache.
+		rejectEager(new Error("stale boom"))
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		// No log line and no failure status from the stale rejection.
+		expect(consoleSpy).not.toHaveBeenCalled()
+		const setStatus2 = ctx2.ui.setStatus as ReturnType<typeof vi.fn>
+		expect(setStatus2.mock.calls.every(([, status]) => typeof status !== "string" || !status.includes("failed"))).toBe(
+			true,
+		)
+
+		// Session 2 is unaffected: a file op still starts and syncs the server
+		// instead of being suppressed by a cached failure it never had.
+		const toolResult = ext.getHandler<unknown, unknown>("tool_result")
+		await toolResult(editToolResult("foo.ts"), createContext({ cwd: dir }))
+		expect(mocks.refreshFile).toHaveBeenCalled()
+		expect(consoleSpy).not.toHaveBeenCalled()
+	})
+
 	it("retries server startup in a new session", async () => {
 		const { dir, ext, consoleSpy } = makeSession()
 		const toolResult = ext.getHandler<unknown, unknown>("tool_result")

--- a/src/extensions/lsp/servers.test.ts
+++ b/src/extensions/lsp/servers.test.ts
@@ -15,7 +15,13 @@ vi.mock("node:child_process", () => ({
 	spawnSync: vi.fn(),
 }))
 
-import { detectMissingCandidates, detectServers, findMainRepoRoot, resolveTsserverPath } from "./servers.js"
+import {
+	detectMissingCandidates,
+	detectServers,
+	findMainRepoRoot,
+	resolveTsNativeServerPath,
+	resolveTsserverPath,
+} from "./servers.js"
 
 const mockExistsSync = vi.mocked(fs.existsSync)
 const mockSpawnSync = vi.mocked(spawnSync)
@@ -223,5 +229,86 @@ describe("resolveTsserverPath", () => {
 		const dotGit = "/cwd/.git"
 		mockExistsSync.mockImplementation((p: unknown) => p === localTsserver || p === dotGit || p === mainTsserver)
 		expect(resolveTsserverPath("/cwd")).toBe(localTsserver)
+	})
+})
+
+describe("resolveTsNativeServerPath", () => {
+	const localNativeBin = "/cwd/node_modules/typescript/bin/tsc"
+	const localTsserverJs = "/cwd/node_modules/typescript/lib/tsserver.js"
+	const mainNativeBin = "/main-repo/node_modules/typescript/bin/tsc"
+
+	beforeEach(() => {
+		mockStatSync.mockReturnValue({ isDirectory: () => false } as unknown as fs.Stats)
+		mockReadFileSync.mockReturnValue("gitdir: /main-repo/.git/worktrees/cwd\n")
+	})
+
+	it("returns own bin/tsc when the package has no tsserver.js (TS7 signature)", () => {
+		mockExistsSync.mockImplementation((p: unknown) => p === localNativeBin)
+		expect(resolveTsNativeServerPath("/cwd")).toBe(localNativeBin)
+	})
+
+	it("returns own bin/tsc even when the main repo has classic TypeScript", () => {
+		const mainTsserverJs = "/main-repo/node_modules/typescript/lib/tsserver.js"
+		mockExistsSync.mockImplementation((p: unknown) => p === localNativeBin || p === mainTsserverJs)
+		expect(resolveTsNativeServerPath("/cwd")).toBe(localNativeBin)
+	})
+
+	it("returns undefined when cwd's own package is classic even if the main repo is native", () => {
+		const dotGit = "/cwd/.git"
+		mockExistsSync.mockImplementation((p: unknown) => p === localTsserverJs || p === dotGit || p === mainNativeBin)
+		expect(resolveTsNativeServerPath("/cwd")).toBeUndefined()
+	})
+
+	it("falls back to the main-repo bin when cwd is a worktree without its own typescript", () => {
+		const dotGit = "/cwd/.git"
+		mockExistsSync.mockImplementation((p: unknown) => p === dotGit || p === mainNativeBin)
+		expect(resolveTsNativeServerPath("/cwd")).toBe(mainNativeBin)
+	})
+
+	it("returns undefined when no resolvable typescript exists anywhere", () => {
+		mockExistsSync.mockReturnValue(false)
+		expect(resolveTsNativeServerPath("/cwd")).toBeUndefined()
+	})
+})
+
+describe("TypeScript 7 native server detection", () => {
+	const nativeBin = "/project/node_modules/typescript/bin/tsc"
+
+	it("activates the native server in a TS7 workspace without typescript-language-server installed", () => {
+		setFiles(["package.json", "node_modules/typescript/bin/tsc"])
+		setBinaries([])
+		const result = detectServers("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0]).toMatchObject({
+			name: "typescript-native",
+			command: nativeBin,
+			args: ["--lsp", "--stdio"],
+			skipProjectLoadWait: true,
+			pullDiagnostics: true,
+		})
+		expect(result[0].extensions).toContain("ts")
+	})
+
+	it("prefers the native server over an installed typescript-language-server in a TS7 workspace", () => {
+		setFiles(["package.json", "node_modules/typescript/bin/tsc"])
+		setBinaries(["typescript-language-server"])
+		const result = detectServers("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("typescript-native")
+	})
+
+	it("keeps typescript-language-server in a classic TS5 workspace", () => {
+		setFiles(["package.json", "node_modules/typescript/lib/tsserver.js"])
+		setBinaries(["typescript-language-server"])
+		const result = detectServers("/project")
+		expect(result).toHaveLength(1)
+		expect(result[0].name).toBe("typescript-language-server")
+	})
+
+	it("does not report TypeScript as missing when the native server is active", () => {
+		setFiles(["package.json", "node_modules/typescript/bin/tsc"])
+		setBinaries([])
+		const result = detectMissingCandidates("/project")
+		expect(result.find((s) => s.name === "typescript-language-server")).toBeUndefined()
 	})
 })

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -6,14 +6,19 @@ import type { ServerConfig } from "./types.js"
 
 const TS_EXTENSIONS = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]
 
+// The classic TypeScript server gets used from several detection branches —
+// reference it by identity instead of repeating the name string (and without
+// a non-null `as` on a SERVERS.find()).
+const TYPESCRIPT_LANGUAGE_SERVER: ServerConfig = {
+	name: "typescript-language-server",
+	command: "typescript-language-server",
+	args: ["--stdio"],
+	extensions: TS_EXTENSIONS,
+	installHint: "npm i -g typescript-language-server typescript",
+}
+
 const SERVERS: ServerConfig[] = [
-	{
-		name: "typescript-language-server",
-		command: "typescript-language-server",
-		args: ["--stdio"],
-		extensions: TS_EXTENSIONS,
-		installHint: "npm i -g typescript-language-server typescript",
-	},
+	TYPESCRIPT_LANGUAGE_SERVER,
 	{
 		name: "gopls",
 		command: "gopls",
@@ -66,7 +71,7 @@ function exists(cmd: string): boolean {
 export function detectServers(cwd: string): ServerConfig[] {
 	const servers: ServerConfig[] = []
 	for (const s of SERVERS) {
-		if (s.name === "typescript-language-server") {
+		if (s === TYPESCRIPT_LANGUAGE_SERVER) {
 			servers.push(...detectTsServers(cwd))
 			continue
 		}
@@ -88,8 +93,7 @@ function detectTsServers(cwd: string): ServerConfig[] {
 	if (!findMarkerUp(cwd, ROOT_MARKERS["typescript-language-server"])) return []
 	const nativePath = resolveTsNativeServerPath(cwd)
 	if (nativePath) return [tsNativeConfig(nativePath)]
-	const tls = SERVERS.find((s) => s.name === "typescript-language-server") as ServerConfig
-	return exists(tls.command) ? [tls] : []
+	return exists(TYPESCRIPT_LANGUAGE_SERVER.command) ? [TYPESCRIPT_LANGUAGE_SERVER] : []
 }
 
 /**
@@ -105,7 +109,7 @@ export function detectMissingCandidates(cwd: string): ServerConfig[] {
 	for (const s of SERVERS) {
 		const markers = ROOT_MARKERS[s.name] ?? []
 		if (!findMarkerUp(cwd, markers)) continue
-		if (s.name === "typescript-language-server") {
+		if (s === TYPESCRIPT_LANGUAGE_SERVER) {
 			// TypeScript is only "missing" when neither the classic server nor
 			// the TypeScript 7 native fallback could be activated.
 			if (detectTsServers(cwd).length === 0) missing.push(s)

--- a/src/extensions/lsp/servers.ts
+++ b/src/extensions/lsp/servers.ts
@@ -4,12 +4,14 @@ import fs from "node:fs"
 import path from "node:path"
 import type { ServerConfig } from "./types.js"
 
+const TS_EXTENSIONS = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]
+
 const SERVERS: ServerConfig[] = [
 	{
 		name: "typescript-language-server",
 		command: "typescript-language-server",
 		args: ["--stdio"],
-		extensions: ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"],
+		extensions: TS_EXTENSIONS,
 		installHint: "npm i -g typescript-language-server typescript",
 	},
 	{
@@ -54,17 +56,40 @@ function exists(cmd: string): boolean {
 }
 
 /**
- * Returns LSP servers whose binary is available on PATH AND whose project
- * marker (go.mod, tsconfig.json, package.json) exists in cwd or a parent
- * directory. This ensures only servers relevant to the current project are
- * activated — e.g. a Go project won't activate typescript-language-server
- * even if it's on PATH.
+ * Returns LSP servers relevant to the current project. Servers are
+ * activated when their binary is on PATH AND their project marker (go.mod,
+ * tsconfig.json, package.json) exists in cwd or a parent directory — e.g. a
+ * Go project won't activate typescript-language-server even if it's on PATH.
+ * TypeScript additionally activates the workspace's own TypeScript 7 native
+ * server when present (no global install needed).
  */
 export function detectServers(cwd: string): ServerConfig[] {
-	return SERVERS.filter((s) => {
+	const servers: ServerConfig[] = []
+	for (const s of SERVERS) {
+		if (s.name === "typescript-language-server") {
+			servers.push(...detectTsServers(cwd))
+			continue
+		}
 		const markers = ROOT_MARKERS[s.name] ?? []
-		return findMarkerUp(cwd, markers) && exists(s.command)
-	})
+		if (findMarkerUp(cwd, markers) && exists(s.command)) servers.push(s)
+	}
+	return servers
+}
+
+/**
+ * Pick the TypeScript server for cwd. A TypeScript 7 workspace gets its own
+ * native server even when typescript-language-server is installed — the
+ * workspace's compiler is the right language-service semantics, and no
+ * global install is needed. Otherwise the classic server is kept whenever
+ * its binary is on PATH; when tsserver is unresolvable the failure then
+ * lands on the clean failed-to-start path rather than going silent.
+ */
+function detectTsServers(cwd: string): ServerConfig[] {
+	if (!findMarkerUp(cwd, ROOT_MARKERS["typescript-language-server"])) return []
+	const nativePath = resolveTsNativeServerPath(cwd)
+	if (nativePath) return [tsNativeConfig(nativePath)]
+	const tls = SERVERS.find((s) => s.name === "typescript-language-server") as ServerConfig
+	return exists(tls.command) ? [tls] : []
 }
 
 /**
@@ -76,11 +101,19 @@ export function detectServers(cwd: string): ServerConfig[] {
  * where the marker lives in a parent are detected.
  */
 export function detectMissingCandidates(cwd: string): ServerConfig[] {
-	return SERVERS.filter((s) => {
+	const missing: ServerConfig[] = []
+	for (const s of SERVERS) {
 		const markers = ROOT_MARKERS[s.name] ?? []
-		const hasMarker = findMarkerUp(cwd, markers)
-		return hasMarker && !exists(s.command)
-	})
+		if (!findMarkerUp(cwd, markers)) continue
+		if (s.name === "typescript-language-server") {
+			// TypeScript is only "missing" when neither the classic server nor
+			// the TypeScript 7 native fallback could be activated.
+			if (detectTsServers(cwd).length === 0) missing.push(s)
+			continue
+		}
+		if (!exists(s.command)) missing.push(s)
+	}
+	return missing
 }
 
 /** Get the server config for a specific file path, or null if no server applies. */
@@ -133,9 +166,54 @@ export function resolveTsserverPath(cwd: string): string | undefined {
 	return undefined
 }
 
+/**
+ * Signature of the TypeScript 7 native package: it ships `bin/tsc` (the
+ * launcher for the native compiler) but no `lib/tsserver.js` — the language
+ * service lives inside the native binary and is exposed as a plain LSP
+ * server via `tsc --lsp --stdio`.
+ */
+function tsNativeBinAt(dir: string): string | undefined {
+	const bin = path.join(dir, "node_modules/typescript/bin/tsc")
+	const tsserver = path.join(dir, "node_modules/typescript/lib/tsserver.js")
+	return fs.existsSync(bin) && !fs.existsSync(tsserver) ? bin : undefined
+}
+
+/**
+ * Resolve the TypeScript 7 native server's tsc launcher for the given cwd.
+ * The workspace's own typescript package decides the flavor: when cwd's own
+ * package is classic (tsserver.js present) the native server is NOT used,
+ * even if the main repo is native — the workspace's compiler semantics win.
+ * Only when cwd has no resolvable typescript package at all does the
+ * main-repo fallback (git worktrees) apply.
+ */
+export function resolveTsNativeServerPath(cwd: string): string | undefined {
+	const ownNative = tsNativeBinAt(cwd)
+	if (ownNative) return ownNative
+	if (fs.existsSync(path.join(cwd, "node_modules/typescript/lib/tsserver.js"))) return undefined
+	const mainRepo = findMainRepoRoot(cwd)
+	if (mainRepo) return tsNativeBinAt(mainRepo)
+	return undefined
+}
+
+/** Build the ServerConfig for a TypeScript 7 native server at tscPath. */
+function tsNativeConfig(tscPath: string): ServerConfig {
+	return {
+		name: "typescript-native",
+		command: tscPath,
+		args: ["--lsp", "--stdio"],
+		extensions: TS_EXTENSIONS,
+		// The native server emits no $/progress startup cycles (so progress
+		// waiting would stall on the fixed timeout), and it has no push
+		// diagnostics — diagnostics are pulled via textDocument/diagnostic.
+		skipProjectLoadWait: true,
+		pullDiagnostics: true,
+	}
+}
+
 const ROOT_MARKERS: Record<string, string[]> = {
 	gopls: ["go.mod"],
 	"typescript-language-server": ["tsconfig.json", "package.json"],
+	"typescript-native": ["tsconfig.json", "package.json"],
 }
 
 /**

--- a/src/extensions/lsp/types.ts
+++ b/src/extensions/lsp/types.ts
@@ -165,4 +165,12 @@ export interface ServerConfig {
 	initOptions?: Record<string, unknown>
 	/** Install command shown in the degraded-state warning when the binary is not on PATH. */
 	installHint?: string
+	/** Server never emits `$/progress` startup cycles, so skip waiting for
+	 *  projectLoaded (otherwise startup stalls on the fixed progress timeout).
+	 *  Used by the TypeScript 7 native server. */
+	skipProjectLoadWait?: boolean
+	/** Server does not push `textDocument/publishDiagnostics`; fetch diagnostics
+	 *  via the LSP 3.17 pull model (`textDocument/diagnostic`) instead. Used by
+	 *  the TypeScript 7 native server. */
+	pullDiagnostics?: boolean
 }


### PR DESCRIPTION
## Linked issue

Closes #1133

## What does this PR do?

### Part 1 — quiet, session-scoped failure handling

When a language server fails to start (e.g. `typescript-language-server` with no resolvable `tsserver.js` — fresh worktrees without `node_modules`, or projects on TypeScript 7 which ships none), the session previously re-spawned the doomed server on **every** file operation and dumped Bun's bundled-source code frame into the TUI each time.

- **Respawn suppression** — `src/extensions/lsp.ts` remembers failed `server+root` pairs for the session (`failedClients`); `tool_result` and the eager `session_start` register failures and skip re-spawn. Reset on `session_start`/`session_shutdown`, so a new session retries (the failure is often fixed between sessions, e.g. by running the package installer). Failures are recorded with a phase (`start` vs mid-session `sync`) so the status bar reports them accurately.
- **Clean error surface** — one line (`LSP file sync failed: <message>`) instead of logging the `Error` object, whose Bun rendering produced the code-frame dump.
- **Status visibility** — the status bar shows `LSP: <server> failed to start`, kept even when other servers sync fine.
- **Tool guard** — all five `lsp_*` tools go through a `startClient` helper that fails fast with an actionable message for known-failed servers instead of re-spawning.

Reproduced with a fixture matrix (main repo vs worktree × with/without resolvable `typescript`, real `typescript-language-server` 6.0.0 + TS 5.9.3 / 7.0.2): red exactly in the no-resolvable-tsserver variants with the same error and stack frame as production, green elsewhere.

### Part 2 — TypeScript 7 native server support

TS7 workspaces turned out to be exactly the environments that fail most often, and no harness-side fallback can fix them the old way: `typescript@7` ships no `lib/tsserver.js` — its language service is a plain LSP server inside the native binary (`tsc --lsp --stdio`), so `typescript-language-server` can never start there. This branch now activates the native server directly:

- **Detection** (`src/extensions/lsp/servers.ts`) — `resolveTsNativeServerPath` recognizes the native package signature (`bin/tsc` present, `lib/tsserver.js` absent). The workspace's own typescript package decides the flavor (a classic TS≤6 package wins even if the worktree's main repo is native); worktrees without their own install fall back to the main repo's bin. In a TS7 workspace the native server is preferred over an installed `typescript-language-server`, and it works with no global install at all.
- **Startup** (`client.ts`) — `skipProjectLoadWait` skips the `projectLoaded` wait for servers that never emit `$/progress` startup cycles (otherwise a fixed 15-second stall on every spawn).
- **Diagnostics** (`client.ts`, `lsp.ts`) — the native server has no `publishDiagnostics` push, so pull-model servers use the LSP 3.17 `textDocument/diagnostic` request in the tool_result sync path and in `lsp_diagnostics`. Push flow unchanged for classic servers.

Verified live against the real TS7 server in an actual TS7 workspace: initialize, didOpen, hover, definition, documentSymbol, and pull diagnostics all work; push diagnostics confirmed absent. Previously these sessions emitted the code-frame dump storm from Part 1; now they get working LSP, and if a server still can't start, the quiet one-line failure plus status entry applies.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`) — 140 LSP tests green including regression tests for the respawn/failure paths (Part 1) and the native-server matrix: signature resolution, flavor precedence, worktree fallback, detection preference order, missing-candidate exclusion, and pull-vs-push sync/tool paths (Part 2). Full suite green except pre-existing environment-dependent failures in `pi-package-lookup` (leaks local `~/.config/kimchi/harness/npm` packages) and `web-fetch` integration (network) — both fail identically without this branch
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed — no docs describe LSP behavior; behavior notes are in the issue and this body
