### PR TITLE
feat(update): interrupt on-launch auto-update with Ctrl+C

### DIFF
--- a/src/http/stream-idle-timeout.test.ts
+++ b/src/http/stream-idle-timeout.test.ts
@@ -210,6 +210,27 @@ describe("wrapFetchWithIdleTimeout", () => {
 			vi.useRealTimers()
 		}
 	})
+
+	it("cancel on an already-errored body resolves instead of leaking the stored error", async () => {
+		// Regression: per the streams spec, reader.cancel() on an already-errored
+		// stream REJECTS with the stored error. Returning that rejection from the
+		// wrapper's cancel() leaked it into the stream machinery — under Bun it
+		// surfaced as an unhandled AbortError when Ctrl+C skipped the on-launch
+		// auto-update download. Pre-fix this test rejects with "stored error".
+		setStreamIdleTimeoutOverride(60_000)
+		const storedError = new Error("stored error")
+		const original = async () =>
+			new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.error(storedError)
+					},
+				}),
+			)
+		const wrapped = wrapFetchWithIdleTimeout(original as never)
+		const res = await wrapped(URL_UNDER_TEST)
+		await expect((res.body as ReadableStream<Uint8Array>).cancel(new Error("user abort"))).resolves.toBeUndefined()
+	})
 })
 
 describe("wrapFetchWithIdleTimeout signal bridging", () => {

--- a/src/http/stream-idle-timeout.ts
+++ b/src/http/stream-idle-timeout.ts
@@ -172,7 +172,13 @@ function wrapBodyWithIdleTimeout(
 		cancel(reason) {
 			abort(reason)
 			onSettled()
-			return reader.cancel(reason)
+			// reader.cancel REJECTS with the stream's stored error when the
+			// source is already errored (streams spec) — e.g. the request just
+			// aborted. Returning that rejection leaks it into the stream
+			// machinery: under Bun it surfaces as an unhandled rejection
+			// (a raw AbortError dumped on the terminal when the user skips
+			// the auto-update download with Ctrl+C).
+			return reader.cancel(reason).catch(() => undefined)
 		},
 	})
 }

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -440,6 +440,27 @@ describe("maybeAutoUpdateOnLaunch — deadline / abort handling", () => {
 		expect(execveSpy).not.toHaveBeenCalled()
 	})
 
+	it("reports the deadline when the caller signal aborts mid-check", async () => {
+		const stderr = makeStderrSpy()
+		const controller = new AbortController()
+		try {
+			mockCheckForUpdate.mockImplementation(async (opts: { signal?: AbortSignal }) => {
+				controller.abort()
+				// The caller-deadline abort of the combined signal rejects the
+				// in-flight check with the signal's reason, like fetch would.
+				throw opts.signal?.reason ?? new Error("aborted")
+			})
+
+			await expect(maybeAutoUpdateOnLaunch({ signal: controller.signal })).resolves.toBeUndefined()
+
+			expect(mockApplyUpdate).not.toHaveBeenCalled()
+			expect(stderr.getLines()).toContain("deadline exceeded after update check; skipping auto-update on this launch")
+			expect(stderr.getLines()).not.toContain("update check failed")
+		} finally {
+			stderr.restore()
+		}
+	})
+
 	it("proceeds with re-exec after applyUpdate completes even if signal aborts mid-install", async () => {
 		const controller = new AbortController()
 		mockCheckForUpdate.mockResolvedValue({
@@ -749,6 +770,7 @@ describe("maybeAutoUpdateOnLaunch — Ctrl+C skip", () => {
 	})
 
 	it("pauses after the skip message so the user can read it before launch continues", async () => {
+		vi.useFakeTimers()
 		const stderr = makeStderrSpy()
 		try {
 			mockCheckForUpdate.mockImplementation(async () => {
@@ -756,11 +778,41 @@ describe("maybeAutoUpdateOnLaunch — Ctrl+C skip", () => {
 				return updateAvailable
 			})
 
-			const started = Date.now()
-			await maybeAutoUpdateOnLaunch()
+			let settled = false
+			const launch = maybeAutoUpdateOnLaunch().then(() => {
+				settled = true
+			})
 
-			expect(Date.now() - started).toBeGreaterThanOrEqual(1_000)
+			// Just before the notice period ends: the notice is on screen but
+			// launch has not continued yet.
+			await vi.advanceTimersByTimeAsync(999)
+			expect(settled).toBe(false)
 			expect(stderr.getLines()).toContain("update skipped by user — launching current version (1.0.0)")
+
+			// The full SKIP_NOTICE_MS pause has elapsed — launch continues.
+			await vi.advanceTimersByTimeAsync(1)
+			await launch
+			expect(settled).toBe(true)
+		} finally {
+			vi.useRealTimers()
+			stderr.restore()
+		}
+	})
+
+	it("reports a genuine check failure even when Ctrl+C fires at the same time", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockImplementation(async () => {
+				process.emit("SIGINT")
+				// A real network failure landing in the same tick as Ctrl+C must
+				// not be misreported as a user skip — its cause is not the abort.
+				throw new Error("getaddrinfo ENOTFOUND github.com")
+			})
+
+			await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+
+			expect(stderr.getLines()).toContain("update check failed: getaddrinfo ENOTFOUND github.com")
+			expect(stderr.getLines()).not.toContain("update skipped by user")
 		} finally {
 			stderr.restore()
 		}
@@ -775,8 +827,9 @@ describe("maybeAutoUpdateOnLaunch — Ctrl+C skip", () => {
 				seenSignal = opts.signal
 				expect(seenSignal?.aborted).toBe(false)
 				process.emit("SIGINT")
-				// Model fetchWithRetry's rejection once the combined signal fires.
-				throw new Error("This operation was aborted")
+				// Model fetchWithRetry's rejection once the combined signal
+				// fires: an AbortError like the one fetch rejects with.
+				throw new DOMException("This operation was aborted", "AbortError")
 			})
 
 			await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()

--- a/src/update/auto-update.test.ts
+++ b/src/update/auto-update.test.ts
@@ -356,7 +356,7 @@ describe("maybeAutoUpdateOnLaunch — happy path", () => {
 
 		await maybeAutoUpdateOnLaunch()
 
-		expect(mockApplyUpdate).toHaveBeenCalledWith({ tag: "v1.1.0" })
+		expect(mockApplyUpdate).toHaveBeenCalledWith({ tag: "v1.1.0", signal: expect.any(AbortSignal) })
 		expect(execveSpy).toHaveBeenCalledTimes(1)
 		// execve(file, args, env): file is process.execPath; args is
 		// [process.execPath, ...userArgs] where userArgs is process.argv.slice(2)
@@ -689,5 +689,153 @@ describe("maybeAutoUpdateOnLaunch — re-exec unavailable fallback", () => {
 		} finally {
 			;(process.stderr.write as unknown) = originalWrite
 		}
+	})
+})
+
+describe("maybeAutoUpdateOnLaunch — Ctrl+C skip", () => {
+	const updateAvailable = {
+		currentVersion: "1.0.0",
+		latestVersion: "1.1.0",
+		tag: "v1.1.0",
+		releaseUrl: "https://example/v1.1.0",
+		hasUpdate: true,
+		cached: false,
+	}
+
+	function makeStderrSpy() {
+		const originalWrite = process.stderr.write.bind(process.stderr)
+		const spy = vi.fn((_chunk: string | Uint8Array, _enc?: unknown, _cb?: unknown) => true)
+		;(process.stderr.write as unknown) = spy
+		return {
+			restore: () => {
+				;(process.stderr.write as unknown) = originalWrite
+			},
+			getLines: () => spy.mock.calls.map((c) => String(c[0])).join(""),
+		}
+	}
+
+	it("prints the skip hint exactly once, even when an update is applied", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockResolvedValue(updateAvailable)
+			mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+			await maybeAutoUpdateOnLaunch()
+
+			const lines = stderr.getLines()
+			expect(lines).toContain("checking for updates — press Ctrl+C to skip and launch the current version")
+			expect((lines.match(/press Ctrl\+C to skip/g) ?? []).length).toBe(1)
+		} finally {
+			stderr.restore()
+		}
+	})
+
+	it("skips the update when SIGINT fires during the check phase", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockImplementation(async () => {
+				process.emit("SIGINT")
+				return updateAvailable
+			})
+
+			await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+
+			expect(mockApplyUpdate).not.toHaveBeenCalled()
+			expect(execveSpy).not.toHaveBeenCalled()
+			expect(stderr.getLines()).toContain("update skipped by user — launching current version (1.0.0)")
+		} finally {
+			stderr.restore()
+		}
+	})
+
+	it("pauses after the skip message so the user can read it before launch continues", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockImplementation(async () => {
+				process.emit("SIGINT")
+				return updateAvailable
+			})
+
+			const started = Date.now()
+			await maybeAutoUpdateOnLaunch()
+
+			expect(Date.now() - started).toBeGreaterThanOrEqual(1_000)
+			expect(stderr.getLines()).toContain("update skipped by user — launching current version (1.0.0)")
+		} finally {
+			stderr.restore()
+		}
+	})
+
+	it("skips the update when SIGINT fires during apply and aborts the in-flight signal", async () => {
+		const stderr = makeStderrSpy()
+		try {
+			mockCheckForUpdate.mockResolvedValue(updateAvailable)
+			let seenSignal: AbortSignal | undefined
+			mockApplyUpdate.mockImplementation(async (opts: { tag: string; signal?: AbortSignal }) => {
+				seenSignal = opts.signal
+				expect(seenSignal?.aborted).toBe(false)
+				process.emit("SIGINT")
+				// Model fetchWithRetry's rejection once the combined signal fires.
+				throw new Error("This operation was aborted")
+			})
+
+			await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+
+			expect(seenSignal).toBeInstanceOf(AbortSignal)
+			expect(seenSignal?.aborted).toBe(true)
+			expect(execveSpy).not.toHaveBeenCalled()
+			expect(stderr.getLines()).toContain("update skipped by user")
+		} finally {
+			stderr.restore()
+		}
+	})
+
+	it("threads an abort signal into checkForUpdate and applyUpdate", async () => {
+		mockCheckForUpdate.mockResolvedValue(updateAvailable)
+		mockApplyUpdate.mockResolvedValue({ from: "v1.1.0", to: "v1.1.0" })
+
+		await maybeAutoUpdateOnLaunch()
+
+		const checkOpts = mockCheckForUpdate.mock.calls[0][0] as { signal?: AbortSignal }
+		const applyOpts = mockApplyUpdate.mock.calls[0][0] as { signal?: AbortSignal }
+		expect(checkOpts.signal).toBeInstanceOf(AbortSignal)
+		expect(applyOpts.signal).toBeInstanceOf(AbortSignal)
+		expect(checkOpts.signal?.aborted).toBe(false)
+	})
+
+	it("still re-execs when apply completed before the SIGINT was observed", async () => {
+		// Mirrors the external-signal semantics: once applyUpdate returns
+		// successfully the install is committed, so we hand off to the new
+		// binary regardless of a late Ctrl+C.
+		mockCheckForUpdate.mockResolvedValue(updateAvailable)
+		mockApplyUpdate.mockImplementation(async () => {
+			process.emit("SIGINT")
+			return { from: "v1.1.0", to: "v1.1.0" }
+		})
+
+		await expect(maybeAutoUpdateOnLaunch()).resolves.toBeUndefined()
+		expect(execveSpy).toHaveBeenCalledOnce()
+	})
+
+	it("leaves no SIGINT listener installed on any exit path", async () => {
+		const baseline = process.listenerCount("SIGINT")
+
+		// Gate-skip path: the listener must never be installed.
+		mockLoadAutoUpdateSetting.mockReturnValue(false)
+		await maybeAutoUpdateOnLaunch()
+		expect(process.listenerCount("SIGINT")).toBe(baseline)
+
+		// No-update path: installed for the check, removed on return.
+		mockLoadAutoUpdateSetting.mockReturnValue(true)
+		await maybeAutoUpdateOnLaunch()
+		expect(process.listenerCount("SIGINT")).toBe(baseline)
+
+		// User-skip path: `.once` is consumed by the emit; cleanup is a no-op.
+		mockCheckForUpdate.mockImplementation(async () => {
+			process.emit("SIGINT")
+			return updateAvailable
+		})
+		await maybeAutoUpdateOnLaunch()
+		expect(process.listenerCount("SIGINT")).toBe(baseline)
 	})
 })

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -67,6 +67,16 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 	})
 }
 
+/** True when `err` is the rejection produced by aborting `signal` — either
+ *  the signal's own reason (what fetch rejects with) or an AbortError-shaped
+ *  error surfaced by a retry/transport layer. Distinguishes a Ctrl+C skip
+ *  from a genuine network/checksum failure that happened to coincide with
+ *  it, so a real failure is never mislabeled as a user skip. */
+function isCausedByAbort(err: unknown, signal: AbortSignal): boolean {
+	if (err === signal.reason) return true
+	return err instanceof Error && err.name === "AbortError"
+}
+
 function warn(message: string): void {
 	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
 }
@@ -309,8 +319,14 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 					AUTO_UPDATE_DEFAULT_TIMEOUT_MS,
 				)
 			} catch (err) {
-				if (sigint.signal.aborted) {
+				if (sigint.signal.aborted && isCausedByAbort(err, sigint.signal)) {
 					await skipByUserNotice()
+					return
+				}
+				// The caller's deadline fired mid-check: not a check failure —
+				// report it the same way as the post-check deadline path.
+				if (opts.signal?.aborted) {
+					warn("deadline exceeded after update check; skipping auto-update on this launch")
 					return
 				}
 				warn(`update check failed: ${(err as Error).message}`)
@@ -335,7 +351,7 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 			try {
 				await raceWithTimeout(applyUpdate({ tag: check.tag, signal }), AUTO_UPDATE_APPLY_TIMEOUT_MS)
 			} catch (err) {
-				if (sigint.signal.aborted) {
+				if (sigint.signal.aborted && isCausedByAbort(err, sigint.signal)) {
 					await skipByUserNotice()
 					return
 				}

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -71,6 +71,24 @@ function warn(message: string): void {
 	process.stderr.write(`${LOG_PREFIX} ${message}\n`)
 }
 
+/** Stderr line when the user interrupts the update with Ctrl+C: name the
+ *  version they're getting so the skip reads as a result, not a failure. */
+function skippedByUserMessage(): string {
+	return `update skipped by user — launching current version (${getVersion()})`
+}
+
+/** Time the Ctrl+C skip notice stays on screen before launch continues — a
+ *  beat for the user to read it before the TUI redraws the terminal. */
+const SKIP_NOTICE_MS = 1_000
+
+/** Print the skip notice, then hold briefly so it is readable before the
+ *  shared terminal is handed to the TUI. The 3-line warn-and-return guard
+ *  lives here rather than at each checkpoint. */
+async function skipByUserNotice(): Promise<void> {
+	warn(skippedByUserMessage())
+	await new Promise((resolve) => setTimeout(resolve, SKIP_NOTICE_MS))
+}
+
 /** Thrown by performReExec when no re-exec primitive is available. Callers
  *  treat this as "binary swapped on disk, but couldn't hand off in-process"
  *  and fall back to a "restart your terminal" message instead of erroring. */
@@ -219,6 +237,9 @@ export interface MaybeAutoUpdateOnLaunchOptions {
  *   - running from source/dev (getVersion() is "dev" or "unknown", or
  *     process.execPath is not the packaged kimchi binary)
  *   - loadAutoUpdateSetting() returns false
+ *   - the user presses Ctrl+C during the check or download (per-launch skip;
+ *     the persisted auto-update setting is untouched, so the next launch
+ *     retries the update)
  *   - checkForUpdate throws or reports no update
  *   - applyUpdate throws (network, checksum, smoke-test failure)
  *   - opts.signal is already aborted (caller's deadline has passed)
@@ -257,63 +278,104 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 		if (!loadAutoUpdateSetting()) return
 		if (opts.signal?.aborted) return
 
-		// Race only the *check* phase against the deadline. Once we commit
-		// to applyUpdate below, we await it fully — a timeout there would
-		// leave the install half-finished with cli.js booting concurrently.
-		let check: Awaited<ReturnType<typeof checkForUpdate>>
+		// Ctrl+C-to-skip: from here until this launch commits to a version,
+		// intercept SIGINT so the first Ctrl+C abandons the update instead of
+		// terminating the process. Installed only after every skip gate above
+		// passed, so launches that never touch the network keep default Ctrl+C
+		// semantics. `.once` means a second Ctrl+C (after the listener has
+		// fired) falls through to the default behavior — terminate. Removed on
+		// every exit path: cli.js must never inherit this listener.
+		const sigint = new AbortController()
+		const onSigint = (): void => sigint.abort()
+		process.once("SIGINT", onSigint)
 		try {
-			check = await raceWithTimeout(
-				checkForUpdate({ currentVersion: getVersion(), skipCache: true, canary: false }),
-				AUTO_UPDATE_DEFAULT_TIMEOUT_MS,
-			)
-		} catch (err) {
-			warn(`update check failed: ${(err as Error).message}`)
-			return
-		}
-		if (opts.signal?.aborted) {
-			warn("deadline exceeded after update check; skipping auto-update on this launch")
-			return
-		}
-		if (!check.hasUpdate) return
+			// The caller's deadline signal and the Ctrl+C controller feed one
+			// combined signal, threaded all the way into fetch: an interrupt
+			// actually cancels the in-flight request (freeing the connection for
+			// the slow-network users this exists for) instead of merely
+			// abandoning the promise while the download loiters in the
+			// background.
+			const signal = opts.signal ? AbortSignal.any([opts.signal, sigint.signal]) : sigint.signal
 
-		// Commit point: from here on we await applyUpdate fully. No external
-		// Promise.race can abandon it mid-swap — the install must complete
-		// before cli.js boots. We do cap with a 30s hard timeout so a hung
-		// network or filesystem doesn't stall startup indefinitely; on
-		// timeout we log a warning and continue on the current version.
-		warn(`applying update ${check.tag} from ${check.releaseUrl || "<no url>"}`)
-		try {
-			await raceWithTimeout(applyUpdate({ tag: check.tag }), AUTO_UPDATE_APPLY_TIMEOUT_MS)
-		} catch (err) {
-			if (err instanceof TimeoutError) {
-				warn(`update apply timed out after ${AUTO_UPDATE_APPLY_TIMEOUT_MS / 1000}s; skipping this launch`)
+			warn("checking for updates — press Ctrl+C to skip and launch the current version")
+
+			// Race only the *check* phase against the deadline. Once we commit
+			// to applyUpdate below, we await it fully — a timeout there would
+			// leave the install half-finished with cli.js booting concurrently.
+			let check: Awaited<ReturnType<typeof checkForUpdate>>
+			try {
+				check = await raceWithTimeout(
+					checkForUpdate({ currentVersion: getVersion(), skipCache: true, canary: false, signal }),
+					AUTO_UPDATE_DEFAULT_TIMEOUT_MS,
+				)
+			} catch (err) {
+				if (sigint.signal.aborted) {
+					await skipByUserNotice()
+					return
+				}
+				warn(`update check failed: ${(err as Error).message}`)
 				return
 			}
-			warn(`update apply failed: ${(err as Error).message}`)
-			return
-		}
+			if (sigint.signal.aborted) {
+				await skipByUserNotice()
+				return
+			}
+			if (opts.signal?.aborted) {
+				warn("deadline exceeded after update check; skipping auto-update on this launch")
+				return
+			}
+			if (!check.hasUpdate) return
 
-		if (process.platform === "win32") {
-			// No re-exec on Windows: the swap is in-place via .old rotation.
-			warn(`Update installed; restart your terminal to use ${check.latestVersion}.`)
-			return
-		}
+			// Commit point: from here on we await applyUpdate fully. No external
+			// Promise.race can abandon it mid-swap — the install must complete
+			// before cli.js boots. We do cap with a 30s hard timeout so a hung
+			// network or filesystem doesn't stall startup indefinitely; on
+			// timeout we log a warning and continue on the current version.
+			warn(`applying update ${check.tag} from ${check.releaseUrl || "<no url>"}`)
+			try {
+				await raceWithTimeout(applyUpdate({ tag: check.tag, signal }), AUTO_UPDATE_APPLY_TIMEOUT_MS)
+			} catch (err) {
+				if (sigint.signal.aborted) {
+					await skipByUserNotice()
+					return
+				}
+				if (err instanceof TimeoutError) {
+					warn(`update apply timed out after ${AUTO_UPDATE_APPLY_TIMEOUT_MS / 1000}s; skipping this launch`)
+					return
+				}
+				warn(`update apply failed: ${(err as Error).message}`)
+				return
+			}
 
-		// Hand off to the freshly-installed binary. We forward only the user
-		// args (process.argv.slice(2)); argv[1] is the launcher's own entry
-		// (a /$bunfs/… virtual path in the compiled binary) and must not be
-		// passed through. performReExec re-prepends process.execPath itself.
-		try {
-			performReExec(process.argv.slice(2), process.env)
-		} catch (err) {
-			if (err instanceof ReExecUnavailableError) {
-				// Update is on disk but we can't swap into it this launch
-				// (no exec primitive). Continue on the current version; the
-				// user's next launch picks up the new binary.
+			if (process.platform === "win32") {
+				// No re-exec on Windows: the swap is in-place via .old rotation.
 				warn(`Update installed; restart your terminal to use ${check.latestVersion}.`)
 				return
 			}
-			throw err
+
+			// Update is on disk and we're handing off: drop the skip handler so
+			// the freshly launched binary (and this process while it waits on
+			// Bun.spawnSync) sees default Ctrl+C semantics again.
+			process.removeListener("SIGINT", onSigint)
+
+			// Hand off to the freshly-installed binary. We forward only the user
+			// args (process.argv.slice(2)); argv[1] is the launcher's own entry
+			// (a /$bunfs/… virtual path in the compiled binary) and must not be
+			// passed through. performReExec re-prepends process.execPath itself.
+			try {
+				performReExec(process.argv.slice(2), process.env)
+			} catch (err) {
+				if (err instanceof ReExecUnavailableError) {
+					// Update is on disk but we can't swap into it this launch
+					// (no exec primitive). Continue on the current version; the
+					// user's next launch picks up the new binary.
+					warn(`Update installed; restart your terminal to use ${check.latestVersion}.`)
+					return
+				}
+				throw err
+			}
+		} finally {
+			process.removeListener("SIGINT", onSigint)
 		}
 	} catch (err) {
 		// Defense in depth — should be unreachable given the inner

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -87,6 +87,11 @@ function skippedByUserMessage(): string {
 	return `update skipped by user — launching current version (${getVersion()})`
 }
 
+/** Stderr line when the caller's deadline aborts the update flow — logged
+ *  from both checkpoints where an aborted opts.signal is observed (mid-check
+ *  catch and post-check), so keep the text in one place. */
+const DEADLINE_EXCEEDED_MESSAGE = "deadline exceeded after update check; skipping auto-update on this launch"
+
 /** Time the Ctrl+C skip notice stays on screen before launch continues — a
  *  beat for the user to read it before the TUI redraws the terminal. */
 const SKIP_NOTICE_MS = 1_000
@@ -326,7 +331,7 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 				// The caller's deadline fired mid-check: not a check failure —
 				// report it the same way as the post-check deadline path.
 				if (opts.signal?.aborted) {
-					warn("deadline exceeded after update check; skipping auto-update on this launch")
+					warn(DEADLINE_EXCEEDED_MESSAGE)
 					return
 				}
 				warn(`update check failed: ${(err as Error).message}`)
@@ -337,7 +342,7 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 				return
 			}
 			if (opts.signal?.aborted) {
-				warn("deadline exceeded after update check; skipping auto-update on this launch")
+				warn(DEADLINE_EXCEEDED_MESSAGE)
 				return
 			}
 			if (!check.hasUpdate) return
@@ -371,7 +376,11 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 
 			// Update is on disk and we're handing off: drop the skip handler so
 			// the freshly launched binary (and this process while it waits on
-			// Bun.spawnSync) sees default Ctrl+C semantics again.
+			// Bun.spawnSync) sees default Ctrl+C semantics again. This removal is
+			// load-bearing — the finally below is NOT sufficient on this path:
+			// process.execve replaces the process image before any finally runs,
+			// and Bun.spawnSync blocks until the child exits, so the skip handler
+			// would outlive the hand-off without this line.
 			process.removeListener("SIGINT", onSigint)
 
 			// Hand off to the freshly-installed binary. We forward only the user

--- a/src/update/auto-update.ts
+++ b/src/update/auto-update.ts
@@ -376,11 +376,11 @@ export async function maybeAutoUpdateOnLaunch(opts: MaybeAutoUpdateOnLaunchOptio
 
 			// Update is on disk and we're handing off: drop the skip handler so
 			// the freshly launched binary (and this process while it waits on
-			// Bun.spawnSync) sees default Ctrl+C semantics again. This removal is
-			// load-bearing — the finally below is NOT sufficient on this path:
-			// process.execve replaces the process image before any finally runs,
-			// and Bun.spawnSync blocks until the child exits, so the skip handler
-			// would outlive the hand-off without this line.
+			// Bun.spawnSync) sees default Ctrl+C semantics again. Do not rely on
+			// the finally below to cover this path: process.execve replaces the
+			// process image before any finally runs, and Bun.spawnSync blocks
+			// until the child exits, so without this explicit removal the skip
+			// handler would outlive the hand-off.
 			process.removeListener("SIGINT", onSigint)
 
 			// Hand off to the freshly-installed binary. We forward only the user

--- a/src/update/github.test.ts
+++ b/src/update/github.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest"
+import { rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it, type MockInstance, vi } from "vitest"
 import { assetName, GitHubClient, type Repo } from "./github.js"
 
 const REPO: Repo = { owner: "castai", name: "kimchi-dev", binary: "kimchi" }
@@ -166,5 +169,63 @@ describe("GitHubClient.fetchChecksum", () => {
 		}) as unknown as typeof fetch
 		const client = new GitHubClient({ fetch: fetchImpl })
 		await expect(client.fetchChecksum(REPO, "v1.0.0")).rejects.toThrow(/checksum not found/)
+	})
+})
+
+describe("GitHubClient abort signal forwarding", () => {
+	it("propagates the constructor signal into fetch calls", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ tag_name: "v1.2.3", html_url: "" }),
+		}) as unknown as typeof fetch
+		const controller = new AbortController()
+		const client = new GitHubClient({ fetch: fetchImpl, signal: controller.signal })
+
+		await client.latestRelease(REPO)
+
+		// fetchWithRetry wraps our signal with its own per-attempt timeout, so
+		// fetch receives a combined signal — the contract we care about is that
+		// aborting the client's signal aborts what fetch actually got.
+		const init = (fetchImpl as unknown as MockInstance).mock.calls[0][1] as RequestInit | undefined
+		expect(init?.signal).toBeInstanceOf(AbortSignal)
+		expect(init?.signal?.aborted).toBe(false)
+		controller.abort()
+		expect(init?.signal?.aborted).toBe(true)
+	})
+})
+
+describe("GitHubClient.downloadArchive abort", () => {
+	it("rejects promptly when the signal aborts mid-download instead of hanging", async () => {
+		// Regression: on Ctrl+C during on-launch auto-update, the pipeline over
+		// the wrapped body never settled under Bun and AbortErrors spammed as
+		// unhandled rejections. Contract: abort always settles the download
+		// with a rejection. (Pre-fix this test dies by vitest timeout.)
+		const body = new ReadableStream<Uint8Array>({
+			async start(controller) {
+				const chunk = new Uint8Array(1024)
+				while (true) {
+					try {
+						controller.enqueue(chunk)
+					} catch {
+						return
+					}
+					await new Promise((r) => setTimeout(r, 5))
+				}
+			},
+		})
+		const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200, body }) as unknown as typeof fetch
+		const controller = new AbortController()
+		const client = new GitHubClient({ fetch: fetchImpl, signal: controller.signal })
+		const dest = join(tmpdir(), `kimchi-dl-abort-${process.pid}.bin`)
+
+		const pending = client.downloadArchive(REPO, "v1.0.0", dest)
+		setTimeout(() => controller.abort(), 25)
+
+		try {
+			await expect(pending).rejects.toThrow()
+		} finally {
+			rmSync(dest, { force: true })
+		}
 	})
 })

--- a/src/update/github.ts
+++ b/src/update/github.ts
@@ -32,6 +32,10 @@ export interface GitHubClientOptions {
 	apiBase?: string
 	downloadBase?: string
 	fetch?: typeof globalThis.fetch
+	/** Aborts every request this client issues (forwarded to fetchWithRetry).
+	 *  Lets a caller — e.g. the on-launch auto-update on Ctrl+C — actually
+	 *  cancel an in-flight download instead of merely abandoning the promise. */
+	signal?: AbortSignal
 }
 
 export const KIMCHI_REPO: Repo = { owner: "getkimchi", name: "kimchi", binary: "kimchi" }
@@ -71,11 +75,13 @@ export class GitHubClient {
 	private readonly apiBase: string
 	private readonly downloadBase: string
 	private readonly fetchImpl: typeof globalThis.fetch
+	private readonly signal: AbortSignal | undefined
 
 	constructor(opts: GitHubClientOptions = {}) {
 		this.apiBase = opts.apiBase ?? DEFAULT_API_BASE
 		this.downloadBase = opts.downloadBase ?? DEFAULT_DOWNLOAD_BASE
 		this.fetchImpl = opts.fetch ?? globalThis.fetch
+		this.signal = opts.signal
 	}
 
 	/** GET /repos/{owner}/{name}/releases/latest. Returns tag + URL. */
@@ -84,7 +90,7 @@ export class GitHubClient {
 		const res = await fetchWithRetry(
 			url,
 			{ headers: { Accept: "application/vnd.github+json" } },
-			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+			{ fetchImpl: this.fetchImpl, signal: this.signal, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
 		)
 		if (!res.ok) {
 			throw new Error(`github API returned ${res.status}`)
@@ -105,7 +111,7 @@ export class GitHubClient {
 		const res = await fetchWithRetry(
 			url,
 			{ headers: { Accept: "application/vnd.github+json" } },
-			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+			{ fetchImpl: this.fetchImpl, signal: this.signal, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
 		)
 		if (res.status === 404) {
 			throw new Error(`release ${tag} not found (404)`)
@@ -129,7 +135,7 @@ export class GitHubClient {
 		const res = await fetchWithRetry(
 			url,
 			{ headers: { Accept: "application/vnd.github+json" } },
-			{ fetchImpl: this.fetchImpl, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
+			{ fetchImpl: this.fetchImpl, signal: this.signal, retry: { maxRetries: THIRD_PARTY_MAX_RETRIES } },
 		)
 		if (!res.ok) {
 			throw new Error(`github API returned ${res.status}`)
@@ -163,6 +169,7 @@ export class GitHubClient {
 		const url = `${this.downloadBase}/${repo.owner}/${repo.name}/releases/download/${tag}/checksums.txt`
 		const res = await fetchWithRetry(url, undefined, {
 			fetchImpl: this.fetchImpl,
+			signal: this.signal,
 			retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
 		})
 		if (!res.ok) {
@@ -184,6 +191,7 @@ export class GitHubClient {
 		const url = `${this.downloadBase}/${repo.owner}/${repo.name}/releases/download/${tag}/${assetName(repo)}`
 		const res = await fetchWithRetry(url, undefined, {
 			fetchImpl: this.fetchImpl,
+			signal: this.signal,
 			timeoutMs: 60_000,
 			retry: { maxRetries: THIRD_PARTY_MAX_RETRIES },
 		})
@@ -194,7 +202,29 @@ export class GitHubClient {
 		// fetch's body is a Web ReadableStream; convert via Readable.fromWeb so we
 		// can pipe it through pipeline() with proper backpressure + cleanup.
 		const source = Readable.fromWeb(res.body as WebReadable<Uint8Array>)
-		await pipeline(source, sink)
+		// On abort, destroy the Node-side stream directly. Pipeline cannot rely
+		// on the web stream's own error terminal here: under Bun,
+		// Readable.fromWeb never settles when a wrapped stream (the idle-timeout
+		// wrapper's) errors while an abort is in flight — observed on Ctrl+C
+		// during auto-update as a hanging launch plus an unhandled AbortError
+		// storm. Node-stream destroy settles pipeline on every runtime; the
+		// underlying request is torn down via fromWeb's cancel/abort chain.
+		const onAbort = () => {
+			source.destroy(this.signal?.reason)
+		}
+		// The signal may have fired during the fetch await above (addEventListener
+		// on an already-aborted signal never calls a new listener) — destroy
+		// immediately in that case so pipeline doesn't wait for body EOF.
+		if (this.signal?.aborted) {
+			onAbort()
+		} else {
+			this.signal?.addEventListener("abort", onAbort, { once: true })
+		}
+		try {
+			await pipeline(source, sink)
+		} finally {
+			this.signal?.removeEventListener("abort", onAbort)
+		}
 	}
 }
 

--- a/src/update/workflow.ts
+++ b/src/update/workflow.ts
@@ -35,6 +35,9 @@ export interface CheckOptions {
 	canary?: boolean
 	/** Resolve an exact release tag (e.g. `v0.0.23-rc.1`) instead of latest or canary. */
 	tag?: string
+	/** Abort signal forwarded to the default GitHubClient (ignored when an
+	 *  explicit `client` is passed). */
+	signal?: AbortSignal
 }
 
 /** Strip the "Canary " title prefix to recover the embedded version string. */
@@ -74,7 +77,7 @@ export function parseCanarySha7(version: string): string | null {
  */
 export async function checkForUpdate(opts: CheckOptions): Promise<CheckResult> {
 	const repo = opts.repo ?? KIMCHI_REPO
-	const client = opts.client ?? new GitHubClient()
+	const client = opts.client ?? new GitHubClient({ signal: opts.signal })
 
 	if (isUpdateCheckDisabled()) {
 		return {
@@ -176,6 +179,11 @@ export interface UpdateOptions {
 	tag: string
 	client?: GitHubClient
 	executablePath?: string
+	/** Abort signal forwarded to the default GitHubClient (ignored when an
+	 *  explicit `client` is passed). On abort the download stops and the temp
+	 *  dirs are cleaned up by the finally blocks below; the install itself
+	 *  (`atomicInstall`) is only reached on a completed download. */
+	signal?: AbortSignal
 }
 
 /**
@@ -194,7 +202,7 @@ export interface UpdateOptions {
  */
 export async function applyUpdate(opts: UpdateOptions): Promise<UpdateResult> {
 	const repo = opts.repo ?? KIMCHI_REPO
-	const client = opts.client ?? new GitHubClient()
+	const client = opts.client ?? new GitHubClient({ signal: opts.signal })
 	const targetPath = opts.executablePath ?? resolveExecutablePath()
 
 	const workDir = mkdtempSync(join(tmpdir(), "kimchi-update-"))


### PR DESCRIPTION
Lets users interrupt the on-launch auto-update. When an update is pending, the harness currently blocks startup on a version check (up to 5s) and then a download + install (up to 30s), with no way to bail out — Ctrl+C during that window kills the process instead of skipping the update.

During the check/apply window a single Ctrl+C now skips the update **for that launch only** and boots the current version:

- The persisted auto-update setting (`auto-update.json`) is untouched — the next launch retries the update.
- A second Ctrl+C keeps its default terminate behavior, and the temporary SIGINT handler is removed before re-exec (proven by a listener-count test covering all exit paths).
- The interrupt is a real cancellation, not promise-abandonment: an `AbortController` is threaded `checkForUpdate`/`applyUpdate` → `GitHubClient` → `fetchWithRetry`, so Ctrl+C tears down the in-flight request/connection (this is the point of the feature for slow-network users). Regression-tested for both the check and apply phases.
- A rejection is reported as a user skip only when the abort actually caused it: a genuine network/checksum failure landing in the same tick as Ctrl+C still logs as a real failure, and the caller's deadline expiring mid-check reports the precise "deadline exceeded" warning instead of a generic check failure.
- The skip notice prints exactly once, with a 1s pause so it's readable before the TUI redraws the terminal.

Two supporting fixes that the interrupt exposed, each with its own regression test:

- `GitHubClient.downloadArchive` now destroys the `Readable.fromWeb` source stream on abort — under Bun, a wrapped stream erroring while an abort is in flight never settles, hanging the launch. Node-stream destroy is the runtime-independent terminal.
- `wrapBodyWithIdleTimeout.cancel()` no longer propagates the streams-spec rejection produced when cancelling an already-errored reader — under Bun that rejection surfaced as an unhandled `AbortError` dump on Ctrl+C.


## Video (pressing Ctrl+C)

https://github.com/user-attachments/assets/3a94fa7b-0b5f-4008-a9c0-669599c596c0


