### PR TITLE
fix(router): Sync resolved model's context window onto the Auto session

### DIFF
--- a/src/extensions/model-switch.test.ts
+++ b/src/extensions/model-switch.test.ts
@@ -1,3 +1,4 @@
+import type { Model } from "@earendil-works/pi-ai"
 import type { ExtensionAPI, ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { createContext } from "./__mocks__/context.js"
@@ -12,6 +13,7 @@ import modelSwitchExtension, {
 	withSuppressedModelSelectGuard,
 } from "./model-switch.js"
 import { getMultiModelEnabled, resolveMultiModelEnabled, setMultiModelEnabled } from "./multi-model.js"
+import { clearAutoRoutingState, setAutoRoutingState } from "./router/state.js"
 
 type RegisteredTool = {
 	name: string
@@ -1154,6 +1156,52 @@ describe("modelSwitchExtension", () => {
 				createContext({ tokens: 10_000 }),
 			)
 			expect(setModel).not.toHaveBeenCalled()
+		})
+
+		it("does not revert an Auto switch when the resolved target fits the context", async () => {
+			// Regression (PR #1137 comment): Auto's catalog descriptor reports a 128K
+			// floor, but the routed concrete target is 1M. ~200K of context exceeds the
+			// 128K descriptor yet fits the 1M target, so the guard must validate against
+			// the effective (resolved) window and must NOT revert the Auto switch.
+			const autoDescriptor = {
+				id: "auto",
+				provider: "kimchi-dev",
+				input: ["text", "image"],
+				contextWindow: 128_000,
+			}
+			const resolvedTarget = {
+				id: "nemotron-3-ultra-fp4",
+				provider: "kimchi-dev",
+				input: ["text"],
+				contextWindow: 1_000_000,
+			}
+			clearAutoRoutingState("test-session")
+			setAutoRoutingState("test-session", { status: "resolved", model: { ...resolvedTarget } as Model<string> })
+			try {
+				const { pi, trigger } = createHarnessWithTrigger()
+				modelSwitchExtension(pi)
+				const setModel = pi.setModel as ReturnType<typeof vi.fn>
+				await trigger(
+					"model_select",
+					{
+						type: "model_select",
+						model: autoDescriptor,
+						previousModel: {
+							id: "kimi-k2.6",
+							provider: "kimchi-dev",
+							input: ["text", "image"],
+							contextWindow: 200_000,
+						},
+						source: "set",
+					},
+					createContext({ tokens: 200_000 }),
+				)
+
+				// 200K fits the 1M effective window: no revert, no setModel call.
+				expect(setModel).not.toHaveBeenCalled()
+			} finally {
+				clearAutoRoutingState("test-session")
+			}
 		})
 
 		it("reverts when session has images and target lacks vision", async () => {

--- a/src/extensions/model-switch.ts
+++ b/src/extensions/model-switch.ts
@@ -15,6 +15,7 @@ import { setMultiModelEnabled } from "./multi-model.js"
 import { MODEL_CAPABILITIES } from "./orchestration/model-registry/builtin-models.js"
 import type { ModelTier } from "./orchestration/model-registry/types.js"
 import { getOrchestratorModel, getOrchestratorModelRef } from "./orchestration/model-roles.js"
+import { resolveEffectiveModel } from "./router/state.js"
 
 /** Prevents model_select handler from re-checking what set_model tool already validated. */
 let suppressModelSelectGuard = false
@@ -137,6 +138,11 @@ export default function modelSwitchExtension(
 				}
 			}
 
+			// When switching TO Auto, resolve the effective (routed) concrete model so
+			// the guards validate against the real window/modalities, not Auto's
+			// conservative catalog floor. Keep pi.setModel(target) so Auto stays selected.
+			const effectiveTarget = resolveEffectiveModel(target, sessionId) ?? target
+
 			const usage = ctx.getContextUsage()
 			// getLatestMessages() returns the most recent context from model-guard's
 			// "context" handler. It is updated on every LLM call, so data is fresh
@@ -148,12 +154,12 @@ export default function modelSwitchExtension(
 				console.warn("[model-switch] getLatestMessages() has messages but no timestamp — treating as stale")
 			}
 			const tokens = resolveContextTokens(usage, messages)
-			if (tokens != null && !contextFitsModel(tokens, target.contextWindow)) {
+			if (tokens != null && !contextFitsModel(tokens, effectiveTarget.contextWindow)) {
 				return {
 					content: [
 						{
 							type: "text" as const,
-							text: `Current context (${tokens} tokens) exceeds the target model "${model}" safe context limit (${getSafeContextWindow(target.contextWindow)} of ${target.contextWindow} tokens). Switch rejected to prevent data loss. Use /compact to reduce context size, then retry.`,
+							text: `Current context (${tokens} tokens) exceeds the target model "${model}" safe context limit (${getSafeContextWindow(effectiveTarget.contextWindow)} of ${effectiveTarget.contextWindow} tokens). Switch rejected to prevent data loss. Use /compact to reduce context size, then retry.`,
 						},
 					],
 					details: null,
@@ -161,7 +167,7 @@ export default function modelSwitchExtension(
 			}
 
 			// Vision compatibility guard
-			if (sessionHasImages() && !target.input.includes("image") && ctx.model?.input.includes("image")) {
+			if (sessionHasImages() && !effectiveTarget.input.includes("image") && ctx.model?.input.includes("image")) {
 				return {
 					content: [
 						{
@@ -216,13 +222,14 @@ export default function modelSwitchExtension(
 		if (!event.previousModel) return
 
 		const sessionId = ctx.sessionManager.getSessionId()
+		const effectiveTarget = resolveEffectiveModel(event.model, sessionId) ?? event.model
 		const usage = ctx.getContextUsage?.()
 
 		// Context window guard — block if current tokens exceed target safe context window.
 		// Falls back to local estimate when upstream tokens are null (post-compaction).
 		const messages = getLatestMessages()
 		const tokens = resolveContextTokens(usage, messages)
-		if (tokens != null && !contextFitsModel(tokens, event.model.contextWindow)) {
+		if (tokens != null && !contextFitsModel(tokens, effectiveTarget.contextWindow)) {
 			isRevertingModel = true
 			try {
 				await pi.setModel(event.previousModel)
@@ -230,11 +237,11 @@ export default function modelSwitchExtension(
 				isRevertingModel = false
 			}
 
-			const limit = getSafeContextWindow(event.model.contextWindow)
+			const limit = getSafeContextWindow(effectiveTarget.contextWindow)
 			const excess = tokens - limit
 			if (!ctx.hasUI) {
 				ctx.ui.notify(
-					`Current context (${tokens.toLocaleString()} tokens) exceeds the ${event.model.id} safe context limit (${limit.toLocaleString()} of ${event.model.contextWindow.toLocaleString()} tokens) by ${excess.toLocaleString()} tokens. Start a new session or compact before switching.`,
+					`Current context (${tokens.toLocaleString()} tokens) exceeds the ${event.model.id} safe context limit (${limit.toLocaleString()} of ${effectiveTarget.contextWindow.toLocaleString()} tokens) by ${excess.toLocaleString()} tokens. Start a new session or compact before switching.`,
 					"error",
 				)
 				return
@@ -272,7 +279,11 @@ export default function modelSwitchExtension(
 		}
 
 		// Vision guard — block if session has images but target lacks vision support
-		if (sessionHasImages() && !event.model.input.includes("image") && event.previousModel?.input.includes("image")) {
+		if (
+			sessionHasImages() &&
+			!effectiveTarget.input.includes("image") &&
+			event.previousModel?.input.includes("image")
+		) {
 			isRevertingModel = true
 			await pi.setModel(event.previousModel)
 			isRevertingModel = false

--- a/src/extensions/router/index.test.ts
+++ b/src/extensions/router/index.test.ts
@@ -24,7 +24,12 @@ import {
 const SESSION_ID = "auto-session"
 type ModelSelectEvent = Extract<ExtensionEvent, { type: "model_select" }>
 
-function model(id: string, input: ("text" | "image")[] = ["text"], reasoning = true): Model<string> {
+function model(
+	id: string,
+	input: ("text" | "image")[] = ["text"],
+	reasoning = true,
+	limits: { contextWindow?: number; maxTokens?: number } = {},
+): Model<string> {
 	return {
 		id,
 		name: id,
@@ -34,8 +39,8 @@ function model(id: string, input: ("text" | "image")[] = ["text"], reasoning = t
 		reasoning,
 		input,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 128000,
-		maxTokens: 16000,
+		contextWindow: limits.contextWindow ?? 128000,
+		maxTokens: limits.maxTokens ?? 16000,
 	}
 }
 
@@ -253,6 +258,50 @@ describe("Auto model extension", () => {
 		expect(setModel).toHaveBeenCalledOnce()
 		expect(setModel).toHaveBeenCalledWith(
 			expect.objectContaining({ id: "auto", api: "kimchi-auto", reasoning: false, thinkingLevelMap: undefined }),
+		)
+	})
+
+	it("applies the routed model's context window and max tokens to the Auto session", async () => {
+		const { getHandler, setModel, ctx, target } = harness(
+			model("deepseek-3", ["text"], true, { contextWindow: 1_048_576, maxTokens: 128_000 }),
+		)
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => ({ best_model: target.id, probabilities: { [target.id]: 1 } }),
+			})),
+		)
+		await getHandler<SessionStartEvent>("session_start")({ type: "session_start", reason: "startup" }, ctx)
+
+		await getHandler<BeforeAgentStartEvent>("before_agent_start")(beforeEvent(), ctx)
+		await consumeAutoRoutingAttempt(SESSION_ID)
+
+		expect(setModel).toHaveBeenCalledOnce()
+		expect(setModel).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "auto", api: "kimchi-auto", contextWindow: 1_048_576, maxTokens: 128_000 }),
+		)
+	})
+
+	it("restores Auto with the resolved model's context window on session restore", async () => {
+		const target = model("deepseek-3", ["text"], true, { contextWindow: 1_048_576, maxTokens: 128_000 })
+		const auto = model("auto", ["text", "image"])
+		const extension = createExtensionApi()
+		autoModelExtension(extension.api)
+		const ctx = createContext({
+			model: auto,
+			sessionManager: { getSessionId: () => SESSION_ID, getEntries: () => [] },
+		})
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: target })
+
+		await extension.getHandler<ModelSelectEvent>("model_select")(
+			{ type: "model_select", model: auto, previousModel: target, source: "set" },
+			ctx,
+		)
+
+		expect(extension.setModel).toHaveBeenCalledOnce()
+		expect(extension.setModel).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "auto", api: "kimchi-auto", contextWindow: 1_048_576, maxTokens: 128_000 }),
 		)
 	})
 

--- a/src/extensions/router/index.ts
+++ b/src/extensions/router/index.ts
@@ -34,26 +34,33 @@ function routeFailureReason(reason: "cancelled" | "timeout" | "network" | "http"
 	return reason === "http" ? "router_http" : reason
 }
 
-type ReasoningCapabilities = Pick<Model<Api>, "reasoning" | "thinkingLevelMap">
+type ModelCapabilities = Pick<Model<Api>, "reasoning" | "thinkingLevelMap" | "contextWindow" | "maxTokens">
 
-function hasTargetReasoningCapabilities(autoModel: ReasoningCapabilities, target: ReasoningCapabilities): boolean {
-	return autoModel.reasoning === target.reasoning && autoModel.thinkingLevelMap === target.thinkingLevelMap
+function hasTargetCapabilities(autoModel: ModelCapabilities, target: ModelCapabilities): boolean {
+	return (
+		autoModel.reasoning === target.reasoning &&
+		autoModel.thinkingLevelMap === target.thinkingLevelMap &&
+		autoModel.contextWindow === target.contextWindow &&
+		autoModel.maxTokens === target.maxTokens
+	)
 }
 
-function autoModelForTarget<TApi extends Api>(autoModel: Model<TApi>, target: ReasoningCapabilities): Model<TApi> {
+function autoModelForTarget<TApi extends Api>(autoModel: Model<TApi>, target: ModelCapabilities): Model<TApi> {
 	return {
 		...autoModel,
 		reasoning: target.reasoning,
 		thinkingLevelMap: target.thinkingLevelMap,
+		contextWindow: target.contextWindow,
+		maxTokens: target.maxTokens,
 	}
 }
 
-async function syncAutoReasoningCapabilities<TApi extends Api>(
+async function syncAutoCapabilities<TApi extends Api>(
 	pi: ExtensionAPI,
 	autoModel: Model<TApi>,
-	target: ReasoningCapabilities,
+	target: ModelCapabilities,
 ): Promise<boolean> {
-	if (hasTargetReasoningCapabilities(autoModel, target)) return true
+	if (hasTargetCapabilities(autoModel, target)) return true
 	return pi.setModel(autoModelForTarget(autoModel, target))
 }
 
@@ -107,7 +114,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 			if (
 				!currentModel ||
 				!isAutoModel(currentModel) ||
-				(state.status === "resolved" && !hasTargetReasoningCapabilities(currentModel, state.model))
+				(state.status === "resolved" && !hasTargetCapabilities(currentModel, state.model))
 			) {
 				await pi.setModel(sessionAutoModel)
 			}
@@ -121,7 +128,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 				state = hydrateAutoRoutingState(sessionId, ctx.sessionManager.getEntries(), ctx.modelRegistry)
 			}
 			if (state.status !== "resolved") return
-			await syncAutoReasoningCapabilities(pi, event.model, state.model)
+			await syncAutoCapabilities(pi, event.model, state.model)
 		})
 
 		pi.on("input", (event, ctx) => {
@@ -173,7 +180,7 @@ export function createAutoModelExtension(options: AutoModelExtensionOptions = {}
 
 				const resolution = resolveRecommendation(route.recommendation, ctx, requiresVision)
 				if (!resolution.ok) return fail(resolution.reason)
-				if (!(await syncAutoReasoningCapabilities(pi, autoModel, resolution.model))) {
+				if (!(await syncAutoCapabilities(pi, autoModel, resolution.model))) {
 					return fail("model_update_failed")
 				}
 


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

After the router resolves a concrete model for a session (or subagent delegation), advertise the routed model's contextWindow and maxTokens on the active kimchi-dev/auto model. This makes Pi's context-usage accounting (getContextUsage) reflect the real window (e.g. deepseek ~1M) instead of the fixed pre-routing <=128k floor, so a fresh deepseek turn shows ~4% used rather than ~34%.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
