### PR TITLE
fix(permissions): skip permission checks for bash_control

### DIFF
--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -1171,6 +1171,36 @@ describe("permissions internal tool classification", () => {
 		expect(bashResult).toBeUndefined()
 		expect(classifyToolCall).not.toHaveBeenCalled()
 	})
+
+	it("allows bash_control in default mode without a prompt (bash was already approved)", async () => {
+		const harness = createPermissionsHarness(["bash", "bash_control"])
+		const ctx = createMockContext([])
+		await harness.fire("session_start", {}, ctx)
+
+		const result = await harness.fire(
+			"tool_call",
+			{ toolName: "bash_control", input: { handle: "h1", action: "continue" } },
+			ctx,
+		)
+
+		expect(result).toBeUndefined()
+		expect(ctx.ui.select).not.toHaveBeenCalled()
+	})
+
+	it("allows bash_control in auto mode without invoking the classifier", async () => {
+		const harness = createPermissionsHarness(["bash", "bash_control"], { auto: true })
+		const ctx = createClassifierContext()
+		await harness.fire("session_start", {}, ctx)
+
+		const result = await harness.fire(
+			"tool_call",
+			{ toolName: "bash_control", input: { handle: "h1", action: "stop" } },
+			ctx,
+		)
+
+		expect(result).toBeUndefined()
+		expect(classifyToolCall).not.toHaveBeenCalled()
+	})
 })
 
 describe("permissions workflow output tool classification", () => {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -27,6 +27,7 @@ import {
 import * as PromptSupplementRegistry from "../../shared/planning/prompt-supplement-registry.js"
 import * as ToolProfileManager from "../../shared/planning/tool-profile-manager.js"
 import { isAgentWorker } from "../agent-worker-context.js"
+import { BASH_CONTROL_TOOL_NAME } from "../bash-background/bash-control-tool.js"
 import { createFerment } from "../ferment/create.js"
 import { emitFermentCreated } from "../ferment/domain-events-emitter.js"
 import { appendRefEntry } from "../ferment/nudge.js"
@@ -158,6 +159,9 @@ const PLAN_MODE_TOOL_SET = new Set<string>(PLAN_MODE_TOOLS)
 // `set_phase` is a kimchi built-in. `agent`/`get_subagent_result`/`steer_subagent`
 // are the agents-extension surface — `agent` is the canonical delegation tool,
 // the other two are read-only/control-plane operations on already-approved spawns.
+// `bash_control` is the control-plane companion of a background `bash` call: the
+// originating command already passed the permission gate (prompt/classifier), so
+// checking its state or stopping it needs no second approval.
 //
 // Names are lowercased because the tool_call handler lowercases event.toolName
 // before comparing (see `const toolName = event.toolName.toLowerCase()` below).
@@ -166,6 +170,7 @@ const BUILTIN_ALLOW_TOOL_NAMES = [
 	"agent",
 	"get_subagent_result",
 	"steer_subagent",
+	BASH_CONTROL_TOOL_NAME,
 	...FERMENT_V2_TOOL_NAMES,
 	...TODO_TOOL_NAMES,
 ]


### PR DESCRIPTION
## Linked issue

No linked issue — small follow-up to the background-bash work (no ticket exists).

## What does this PR do?

`bash_control` only checks the state of, or stops, a background bash process whose originating `bash` command already passed the permission gate (prompt, classifier, or rule). Yet in **default** mode every `bash_control` call raised a redundant approval prompt, and in **auto** mode it burned a classifier round-trip.

This PR auto-approves `bash_control` in the builtin allow-list, alongside the existing control-plane tools (`get_subagent_result`, `steer_subagent` — both "operations on already-approved spawns"). Plan mode still blocks it, and the bash-background gate (which hard-blocks *other* tools while a handle pends) is unaffected.

Changes:
- `src/extensions/permissions/index.ts`: add `BASH_CONTROL_TOOL_NAME` (imported from the bash-background extension, single source of truth) to `BUILTIN_ALLOW_TOOL_NAMES`
- `src/extensions/permissions/index.test.ts`: tests that `bash_control` resolves without a prompt in default mode and without the classifier in auto mode

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`) — permissions (117) + bash-background (85) suites
- [x] Lint passes (`pnpm run check`) — typecheck clean, no new lint warnings
- [ ] Documentation updated if behavior changed