### PR TITLE
fix(ui): don't crash on 1-2 col terminals in questionnaire and assistant-prefix

### DIFF
--- a/src/components/main-screen-narrow.test.ts
+++ b/src/components/main-screen-narrow.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Narrow-terminal width-invariant fuzz for the remaining main-screen
+ * components: user messages, assistant Markdown, and thinking steps.
+ * pi-tui's doRender hard-crashes on the first over-wide line, so any
+ * failure here is a production crash at tiny terminal widths.
+ */
+import { getMarkdownTheme, initTheme, UserMessageComponent } from "@earendil-works/pi-coding-agent"
+import { Markdown, visibleWidth } from "@earendil-works/pi-tui"
+import { beforeAll, describe, expect, it } from "vitest"
+import { deriveThinkingSteps } from "../extensions/thinking-steps/parse.js"
+import { renderThinkingStepsLines } from "../extensions/thinking-steps/render.js"
+import type { ThinkingSourceBlock, ThinkingThemeLike } from "../extensions/thinking-steps/types.js"
+
+const LONG_TEXT = `This is a long user message that spans multiple semantic chunks and keeps going ${"\u2014 ".repeat(60)}end`
+
+const MARKDOWN_DOC = [
+	"# Heading that is fairly long so it wraps",
+	"",
+	"Some paragraph with a sentence that is long enough to require wrapping at any sane width.",
+	"",
+	"```ts",
+	'const aVeryLongIdentifierName = computeSomething("argument one", "argument two", "argument three")',
+	"```",
+	"",
+	"| column one | column two |",
+	"| --- | --- |",
+	"| some quite long cell content | another long cell |",
+].join("\n")
+
+const thinkingTheme: ThinkingThemeLike = {
+	fg: (_color, text) => text,
+	bold: (text) => text,
+}
+
+function thinkingBlocks(): ThinkingSourceBlock[] {
+	return [
+		{ contentIndex: 0, text: `step one ${"details ".repeat(40)}\nstep two ${"more ".repeat(40)}`, redacted: false },
+	]
+}
+
+describe("main-screen narrow-terminal width invariant", () => {
+	beforeAll(() => {
+		initTheme("default")
+	})
+
+	it("UserMessageComponent fits widths 1-12", () => {
+		const component = new UserMessageComponent(LONG_TEXT)
+		for (let width = 1; width <= 12; width++) {
+			for (const line of component.render(width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+			}
+		}
+	})
+
+	it("assistant Markdown (headings, code, tables) fits widths 1-12", () => {
+		const md = new Markdown(MARKDOWN_DOC, 0, 0, getMarkdownTheme())
+		for (let width = 1; width <= 12; width++) {
+			for (const line of md.render(width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+			}
+		}
+	})
+
+	for (const mode of ["collapsed", "expanded"] as const) {
+		it(`thinking steps (${mode}) fit widths 1-12`, () => {
+			const blocks = thinkingBlocks()
+			for (let width = 1; width <= 12; width++) {
+				const lines = renderThinkingStepsLines(thinkingTheme, width, {
+					mode,
+					blocks,
+					steps: deriveThinkingSteps(blocks),
+					activeStepId: undefined,
+					isActive: mode === "collapsed",
+					nowMs: 1000,
+				})
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			}
+		})
+	}
+})

--- a/src/components/status-line.test.ts
+++ b/src/components/status-line.test.ts
@@ -1293,3 +1293,38 @@ describe("StatusLineScript", () => {
 		expect(sls.render(80)).toEqual(["one"])
 	})
 })
+
+describe("StatusLine narrow-terminal width invariant", () => {
+	// The status line renders on the main screen, where pi-tui's doRender
+	// hard-crashes on any line wider than the terminal. Sweep widths 1-12
+	// with every segment family active — permissions/model/context, usage,
+	// agents, billing, router — and assert the invariant.
+	afterEach(() => {
+		vi.restoreAllMocks()
+		setBillingStatusForTest(undefined)
+	})
+
+	it("never emits a line wider than the requested width at widths 1-12", () => {
+		const theme = createMockTheme()
+		withPinned(["agents", "credits", "budget"], () => {
+			vi.spyOn(AGENTS, "getActiveAgentCount").mockReturnValue(3)
+			setTestBilling()
+			setAutoRoutingState("test-session", { status: "resolved", model: concreteModel("kimi-k2.6") })
+			const ctx = createMockContext({
+				percent: 87,
+				modelId: "auto",
+				assistantMessages: [
+					{ input: 1200, output: 340 },
+					{ input: 800, output: 200 },
+				],
+			})
+			const sl = new StatusLine(ctx, theme, createMockStatusLineData())
+			for (let width = 1; width <= 12; width++) {
+				const lines = sl.render(width)
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			}
+		})
+	})
+})

--- a/src/extensions/assistant-prefix.test.ts
+++ b/src/extensions/assistant-prefix.test.ts
@@ -1,0 +1,61 @@
+import { getMarkdownTheme } from "@earendil-works/pi-coding-agent"
+import { visibleWidth } from "@earendil-works/pi-tui"
+import { describe, expect, it } from "vitest"
+import { DottedParagraph } from "./assistant-prefix.js"
+
+// Strip ANSI escape codes for content assertions.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: test-only helper
+const ANSI_RE = /\x1b\[[0-9;]*m/g
+function stripAnsi(s: string): string {
+	return s.replace(ANSI_RE, "")
+}
+
+function makeParagraph(text = "hello world"): DottedParagraph {
+	return new DottedParagraph(text, getMarkdownTheme())
+}
+
+describe("DottedParagraph render", () => {
+	it("prefixes the first visible line with a dot and indents the rest", () => {
+		const p = makeParagraph()
+		// Many lines so Markdown wraps at width 40 (inner width 37).
+		const lines = p.render(40).map(stripAnsi)
+		expect(lines.some((line) => line.startsWith(" ● "))).toBe(true)
+		for (const line of lines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(40)
+		}
+	})
+
+	describe("narrow terminals", () => {
+		// Regression: at width <= 2 the narrow-width guard returned a fixed
+		// 3-cell " ● " line. DottedParagraph replaces Markdown children inside
+		// AssistantMessageComponent (main screen), where pi-tui hard-crashes
+		// on any line wider than the terminal.
+		for (const width of [1, 2, 3]) {
+			it(`stays within width ${width}`, () => {
+				const p = makeParagraph()
+				const lines = p.render(width)
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			})
+
+			it(`stays within width ${width} on the cached path too`, () => {
+				const p = makeParagraph()
+				p.render(width)
+				const lines = p.render(width) // cache hit
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			})
+		}
+
+		it("never exceeds the requested width across a resize sweep", () => {
+			const p = makeParagraph("a reasonably long paragraph that wraps onto several lines when narrow")
+			for (let width = 1; width <= 12; width++) {
+				for (const line of p.render(width)) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			}
+		})
+	})
+})

--- a/src/extensions/assistant-prefix.ts
+++ b/src/extensions/assistant-prefix.ts
@@ -2,11 +2,12 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { AssistantMessageComponent } from "@earendil-works/pi-coding-agent"
 import type { MarkdownTheme } from "@earendil-works/pi-tui"
 import { Markdown, visibleWidth } from "@earendil-works/pi-tui"
+import { truncateLinesToWidth } from "../truncate-lines.js"
 
 const PATCH_SYMBOL = Symbol("kimchi:dotted-paragraph")
 
 /** Wraps a Markdown block with a ` ● ` prefix on the first visible line, `   ` on the rest. */
-class DottedParagraph {
+export class DottedParagraph {
 	private md: Markdown
 	private cachedWidth?: number
 	private cachedLines?: string[]
@@ -24,9 +25,11 @@ class DottedParagraph {
 	render(width: number): string[] {
 		if (this.cachedLines && this.cachedWidth === width) return this.cachedLines
 		const PREFIX_W = 3
+		// At width <= PREFIX_W there is no room for prefix + content; emit a
+		// bare dot marker instead (truncated to width by the guard below).
 		if (width <= PREFIX_W) {
 			this.cachedWidth = width
-			this.cachedLines = [" ● "]
+			this.cachedLines = truncateLinesToWidth([" ● "], width)
 			return this.cachedLines
 		}
 		const lines = this.md.render(width - PREFIX_W)
@@ -39,8 +42,10 @@ class DottedParagraph {
 			return `   ${line}`
 		})
 		this.cachedWidth = width
-		this.cachedLines = rendered
-		return rendered
+		// This component renders on the main screen, where pi-tui crashes on
+		// over-wide lines; hard-truncate the final output as a last defense.
+		this.cachedLines = truncateLinesToWidth(rendered, width)
+		return this.cachedLines
 	}
 }
 

--- a/src/extensions/questionnaire/questionnaire-form.test.ts
+++ b/src/extensions/questionnaire/questionnaire-form.test.ts
@@ -1,0 +1,91 @@
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import { type TUI, visibleWidth } from "@earendil-works/pi-tui"
+import { describe, expect, it, vi } from "vitest"
+import { createQuestionForm } from "./questionnaire-form.js"
+import type { Question } from "./questionnaire-reducer.js"
+
+// Minimal stubs that satisfy what the questionnaire form and the upstream
+// Editor actually touch during render. Anything not listed here is unused by
+// the render path; the casts keep the typechecker honest.
+
+function makeTui(cols = 80): TUI {
+	return {
+		requestRender: vi.fn(),
+		terminal: { rows: 40, cols },
+	} as unknown as TUI
+}
+
+function makeTheme(): Theme {
+	return {
+		fg: (_color: string, s: string) => s,
+		bg: (_color: string, s: string) => s,
+		bold: (s: string) => s,
+	} as unknown as Theme
+}
+
+const TEXT_QUESTION: Question = {
+	id: "q1",
+	label: "Name",
+	prompt: "What is your name?",
+	type: "text",
+	options: [],
+	allowOther: false,
+	required: true,
+}
+
+const SINGLE_QUESTION: Question = {
+	id: "q1",
+	label: "Choice",
+	prompt: "Pick one",
+	type: "single",
+	options: [
+		{ id: "a", label: "Option A" },
+		{ id: "b", label: "Option B" },
+	],
+	allowOther: false,
+	required: true,
+}
+
+function makeForm(questions: Question[]) {
+	const tui = makeTui()
+	const done = vi.fn()
+	const form = createQuestionForm(tui, makeTheme(), questions, { title: "Test" }, done)
+	return { form, tui, done }
+}
+
+describe("createQuestionForm render", () => {
+	it("renders a title, prompt, and options at a normal width", () => {
+		const { form } = makeForm([SINGLE_QUESTION])
+		const lines = form.render(60)
+		const text = lines.join("\n")
+		expect(text).toContain("Test")
+		expect(text).toContain("Pick one")
+		expect(text).toContain("Option A")
+	})
+
+	describe("narrow terminals", () => {
+		// Regression: at width <= 2 the upstream Editor received
+		// `width - 2 < 0` and threw RangeError on "─".repeat(-1), crashing the
+		// whole TUI on extremely small terminals (uncaughtException).
+		for (const width of [1, 2, 3]) {
+			it(`does not throw and stays within width ${width} in text input mode`, () => {
+				const { form } = makeForm([TEXT_QUESTION])
+				// Typing a printable char on a text question switches the form
+				// into editor input mode — the path that previously crashed.
+				form.handleInput?.("a")
+				const lines = form.render(width)
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			})
+
+			it(`does not throw and stays within width ${width} in options mode`, () => {
+				const { form } = makeForm([SINGLE_QUESTION])
+				const lines = form.render(width)
+				for (const line of lines) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			})
+		}
+	})
+})

--- a/src/extensions/questionnaire/questionnaire-form.ts
+++ b/src/extensions/questionnaire/questionnaire-form.ts
@@ -14,6 +14,7 @@
 import { getSelectListTheme, type Theme } from "@earendil-works/pi-coding-agent"
 import type { Component } from "@earendil-works/pi-tui"
 import { Editor, Key, type KeyId, matchesKey, type TUI, wrapTextWithAnsi } from "@earendil-works/pi-tui"
+import { truncateLinesToWidth } from "../../truncate-lines.js"
 import {
 	type Answer,
 	allRequiredAnswered,
@@ -235,7 +236,10 @@ export function createQuestionForm(
 			if (opts.length > 0) renderOptions()
 			lines.push("")
 			add(theme.fg("muted", " Your answer:"))
-			for (const line of editor.render(width - 2)) add(` ${line}`)
+			// Upstream Editor crashes on negative widths ("─".repeat(-1)) at
+			// terminal widths <= 2; clamp to a minimum of 1 (same pattern as
+			// src/components/editor.ts).
+			for (const line of editor.render(Math.max(1, width - 2))) add(` ${line}`)
 			lines.push("")
 			add(theme.fg("dim", " Enter to submit • Shift+Enter for newline • Esc to cancel"))
 		} else if (isSubmitTab(state)) {
@@ -298,9 +302,12 @@ export function createQuestionForm(
 		}
 		add(theme.fg("accent", "─".repeat(width)))
 
-		cachedLines = lines
+		// pi-tui crashes if a component emits a line wider than the terminal;
+		// hard-truncate the final output as the last line of defense.
+		const out = truncateLinesToWidth(lines, width)
+		cachedLines = out
 		cachedWidth = width
-		return lines
+		return out
 	}
 
 	return {

--- a/src/extensions/tool-rendering-narrow.test.ts
+++ b/src/extensions/tool-rendering-narrow.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Narrow-terminal width-invariant fuzz for tool execution rendering.
+ *
+ * Renders the real ToolExecutionComponent for every built-in tool the
+ * tool-rendering extension overrides — collapsed and expanded, call and
+ * result phases — at widths 1..12 and asserts every emitted line fits the
+ * terminal. pi-tui's doRender hard-crashes on the first over-wide line, so
+ * any failure here is a production crash.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent"
+import { initTheme, ToolExecutionComponent } from "@earendil-works/pi-coding-agent"
+import { type TUI, visibleWidth } from "@earendil-works/pi-tui"
+import { beforeAll, describe, expect, it } from "vitest"
+import { createExtensionApi } from "./__mocks__/extension-api.js"
+import toolRenderingExtension, { ToolText, toolHeader } from "./tool-rendering.js"
+
+const plainTheme = {
+	fg: (_name: string, value: string) => value,
+	bold: (value: string) => value,
+} as unknown as Theme
+
+const fakeTui = { requestRender: () => {} } as unknown as TUI
+
+function makeComponent(
+	toolName: string,
+	args: Record<string, unknown>,
+	resultText: string | undefined,
+	expanded: boolean,
+): ToolExecutionComponent {
+	const component = new ToolExecutionComponent(
+		toolName,
+		`tc-${toolName}-${expanded}`,
+		args,
+		{},
+		undefined,
+		fakeTui,
+		"/tmp",
+	)
+	if (resultText !== undefined) {
+		component.markExecutionStarted()
+		component.updateResult({ content: [{ type: "text", text: resultText }], isError: false }, false)
+	}
+	component.setExpanded(expanded)
+	return component
+}
+
+const LONG_OUTPUT = Array.from(
+	{ length: 40 },
+	(_, i) => `output line ${i} with some decently long content to force wrapping behavior`,
+).join("\n")
+
+const DIFF_EDIT_ARGS = {
+	path: "/Users/someone/reps/project/src/file.ts",
+	oldText: "const alpha = 1\nconst beta = 2\nconst gamma = 3",
+	newText: "const alpha = 10\nconst beta = 2\nconst gamma = 30\nconst delta = 4",
+}
+
+const CASES: Array<{ name: string; args: Record<string, unknown>; result?: string }> = [
+	{ name: "bash", args: { command: "pnpm run test -- --reporter=verbose" }, result: LONG_OUTPUT },
+	{ name: "bash", args: { command: "pnpm run test" } },
+	{ name: "read", args: { path: "/Users/someone/reps/project/src/file.ts" }, result: LONG_OUTPUT },
+	{ name: "read", args: { path: "/Users/someone/reps/project/src/file.ts" } },
+	{ name: "edit", args: DIFF_EDIT_ARGS, result: "Edit applied" },
+	{ name: "edit", args: DIFF_EDIT_ARGS },
+	{
+		name: "write",
+		args: { path: "/Users/someone/reps/project/src/new-file.ts", content: LONG_OUTPUT },
+		result: "Written",
+	},
+	{ name: "grep", args: { pattern: "wrapMarkedLine", path: "/Users/someone/reps/project" }, result: LONG_OUTPUT },
+	{ name: "find", args: { pattern: "*.ts", path: "/Users/someone/reps/project" }, result: LONG_OUTPUT },
+	{
+		name: "list",
+		args: { path: "/Users/someone/reps/project/src/extensions/" },
+		result: Array.from({ length: 20 }, (_, i) => `entry-${i}.ts`).join("\n"),
+	},
+	{ name: "unknown_tool", args: { foo: "bar" }, result: LONG_OUTPUT },
+]
+
+describe("tool execution narrow-terminal width invariant", () => {
+	beforeAll(() => {
+		initTheme("default")
+		toolRenderingExtension(createExtensionApi().api)
+	})
+
+	// ToolText fuzz: headers with a WRAP_MARK-tagged long summary — the shape
+	// that caused the (9 > 2) doRender crash (` ● Edit /Users/...`). This is
+	// the direct contract the end-to-end cases above cannot reliably reach,
+	// because whether a header carries a marked summary depends on each
+	// tool's arg-shape heuristics.
+	const CRASH_HEADERS = [
+		// Exact shape from the reported pi-crash.log (leading space included).
+		` ${toolHeader("Edit", "/Users/vytautaspetrikas/reps/very/long/path/file.ts", plainTheme, "● ")}`,
+		toolHeader("Read", "/Users/someone/reps/project/src/deeply/nested/file.ts", plainTheme, "● "),
+		toolHeader("Bash", "pnpm run test -- --reporter=verbose --runInBand --watchAll", plainTheme, "◎ "),
+		toolHeader("Grep", "wrapMarkedLineWithSomeVeryLongPattern", plainTheme, "✗ ", "12.0s"),
+	]
+
+	it("ToolText never emits a line wider than the requested width", () => {
+		for (const header of CRASH_HEADERS) {
+			const component = new ToolText(header)
+			for (let width = 1; width <= 12; width++) {
+				for (const line of component.render(width)) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+				}
+			}
+		}
+	})
+
+	it("ToolText respects the width on cached re-renders across resizes", () => {
+		const component = new ToolText(CRASH_HEADERS[0])
+		for (const width of [80, 2, 1, 30, 80]) {
+			component.invalidate()
+			for (const line of component.render(width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+			}
+		}
+	})
+
+	for (const c of CASES) {
+		for (const expanded of [false, true]) {
+			it(`${c.name}${c.result ? " (result)" : " (call)"}${expanded ? " expanded" : " collapsed"} fits widths 1-12`, async () => {
+				const component = makeComponent(c.name, c.args, c.result, expanded)
+				// Some result renderers (edit diffs) resolve syntax highlighting async.
+				await new Promise((resolve) => setTimeout(resolve, 50))
+				for (let width = 1; width <= 12; width++) {
+					const lines = component.render(width)
+					for (const line of lines) {
+						expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+					}
+				}
+			})
+		}
+	}
+})

--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -16,6 +16,7 @@ import toolRenderingExtension, {
 	summarizeOpenAiToolCall,
 	type ToolRenderContext,
 	toolHeader,
+	wrapMarkedLine,
 } from "./tool-rendering.js"
 
 const OSC133_A = "\x1b]133;A\x07"
@@ -260,6 +261,36 @@ describe("toolHeader", () => {
 		const headerWithout = toolHeader("Read", "src/foo.ts", plainTheme, "○ ")
 		expect(headerWithout).not.toContain("1.5s")
 		expect(headerWith).toContain("1.5s")
+	})
+})
+
+describe("wrapMarkedLine", () => {
+	// Regression (pi-crash.log, terminal width 2): the collapsed header of an
+	// Edit tool call (` ● Edit <mark>/Users/...`) has a marked prefix wider
+	// than the terminal. wrapMarkedLine emitted `${prefix}${body-chunk}` lines
+	// of width prefixWidth + 1 = 9 regardless of the requested width, and
+	// pi-tui's doRender hard-crashed: "Rendered line N exceeds terminal
+	// width (9 > 2)".
+	const crashHeader = toolHeader("Edit", "/Users/vytautas/reps/some-project/file.ts", plainTheme, " ● ")
+
+	it("never emits a line wider than the requested width at narrow sizes", () => {
+		for (let width = 1; width <= 12; width++) {
+			for (const line of wrapMarkedLine(crashHeader, width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width)
+			}
+		}
+	})
+
+	it("falls back to plain wrapping when the prefix fills the width", () => {
+		const lines = wrapMarkedLine(crashHeader, 2)
+		expect(lines.length).toBeGreaterThan(1)
+		// The full header text still shows, one fragment at a time.
+		expect(stripSgr(lines.join("")).replace(/\s/g, "")).toContain("/Users/vytautas")
+	})
+
+	it("keeps marked-prefix wrapping when the width fits", () => {
+		const lines = wrapMarkedLine(crashHeader, 40)
+		expect(stripSgr(lines[0]).startsWith(" ● Edit /")).toBe(true)
 	})
 })
 

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -1065,12 +1065,17 @@ function markedContinuationPrefix(prefix: string): string {
 	return " ".repeat(visibleWidth(prefix))
 }
 
-function wrapMarkedLine(line: string, width: number): string[] {
+export function wrapMarkedLine(line: string, width: number): string[] {
 	const markerIndex = line.indexOf(WRAP_MARK)
 	if (markerIndex === -1) return wrapTextWithAnsi(line, width)
 	const prefix = line.slice(0, markerIndex)
 	const body = line.slice(markerIndex + WRAP_MARK.length)
 	const prefixWidth = visibleWidth(prefix)
+	// When the prefix alone fills (or exceeds) the width, marked wrapping
+	// cannot hold the invariant — every line would start with the
+	// already-over-wide prefix. Fall back to plain wrapping, which still
+	// shows the full header text one fragment at a time.
+	if (prefixWidth >= width) return wrapTextWithAnsi(line, width)
 	const bodyWidth = Math.max(1, width - prefixWidth)
 	const wrapped = wrapTextWithAnsi(body, bodyWidth)
 	const continuation = markedContinuationPrefix(prefix)
@@ -1112,7 +1117,11 @@ class ToolText extends Text {
 		}
 		const contentWidth = Math.max(1, width)
 		const lines = this.value.replace(/\t/g, "   ").split("\n")
-		const rendered = lines.flatMap((line) => wrapMarkedLine(line, contentWidth)).map((line) => padToWidth(line, width))
+		// ToolText renders on the main screen, where pi-tui hard-crashes on any
+		// line wider than the terminal; hard-truncate before padding.
+		const rendered = lines
+			.flatMap((line) => wrapMarkedLine(line, contentWidth))
+			.map((line) => padToWidth(truncateToWidth(line, width), width))
 		this.toolCachedValue = this.value
 		this.toolCachedWidth = width
 		this.toolCachedLines = rendered

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -1082,7 +1082,7 @@ export function wrapMarkedLine(line: string, width: number): string[] {
 	return wrapped.map((part, index) => (index === 0 ? `${prefix}${part}` : `${continuation}${part}`))
 }
 
-class ToolText extends Text {
+export class ToolText extends Text {
 	private value = ""
 	private toolCachedValue?: string
 	private toolCachedWidth?: number


### PR DESCRIPTION
## What does this PR do?

Fixes two latent hard-crash sites on extremely narrow terminals (1–2 columns), in the same family as #1080 (6595fbe).

**1. Questionnaire form → upstream `Editor` `RangeError` (the reported crash)**

`questionnaire-form.ts` renders the free-text input with `editor.render(width - 2)` unclamped. pi-tui's overlay layout guarantees width ≥ 1, so at width 1 the upstream `Editor.render` receives `-1` and throws:

```
RangeError: String.prototype.repeat argument must be greater than or equal to 0 and not be Infinity
    at result.push(horizontal.repeat(width))   # "─" top-border repeat in pi-tui's editor.js
```

This is the `pi exiting due to uncaughtException` incident. Trigger: questionnaire tool / ferment `ask_user` UI in text input mode on a 1-col terminal (or a resize to a 1-col split while the overlay is open).

**2. `assistant-prefix` `DottedParagraph` over-wide line**

The narrow-width guard (`width <= 3`) returned a fixed 3-cell `" ● "` line regardless of width. `DottedParagraph` replaces `Markdown` children inside `AssistantMessageComponent` on the **main screen**, where pi-tui's `doRender` hard-crashes on any line wider than the terminal. Crash window: width 1–2.

**3. Tool call headers (`wrapMarkedLine`) — the `(9 > 2)` `doRender` crash**

Reported via `pi-crash.log`: `Rendered line exceeds terminal width (9 > 2)`. The offending line was the collapsed header of an Edit tool call (` ● Edit /Users/...`). `toolHeader` inserts a `WRAP_MARK` before the path summary, and `wrapMarkedLine` composes `${prefix}${body-chunk}` lines where the prefix (` ● Edit `) is 8 cells. At terminal widths below the prefix width every line was emitted at `prefixWidth + 1 = 9` cells regardless of the requested width — and `ToolText.render` overrides `Text.render`, so the pi-tui patch's `Text` truncation never applied to it. Pi-tui hard-crashes on the main screen.

The first two are latent defects, not regressions. A repo-wide audit of every custom `render(width)` (28 components) found no other unguarded sites: main-screen components (status line, logo, thinking steps) already truncate; everything under `ui.custom` is composited with pi-tui's built-in defensive overlay truncation; the fixes from 6595fbe cover the rest.

## Fix

Same approach as 6595fbe / a795ee96 — `Math.max(1, width - X)` clamp + final `truncateLinesToWidth`:

- `questionnaire-form.ts`: clamp the editor width to ≥ 1; truncate the cached render output.
- `assistant-prefix.ts`: truncate the narrow-branch fallback line and the normal-path output; export `DottedParagraph` for tests.
- `tool-rendering.ts`: `wrapMarkedLine` falls back to plain `wrapTextWithAnsi` when the marked prefix alone fills the width; `ToolText.render` hard-truncates wrapped lines to width before padding. `wrapMarkedLine` exported for tests.

## Tests

- New `questionnaire-form.test.ts` (7 tests) — width 1–3 invariants in both text-input and options modes. Fails pre-fix at width 1 (`render(-1)` → `RangeError`).
- New `assistant-prefix.test.ts` (8 tests) — width 1–3 invariants (fresh + cache-hit) and a 1–12 resize sweep. Fails pre-fix exactly at widths 1–2.
- 3 new `wrapMarkedLine` tests in `tool-rendering.test.ts` with a header shaped exactly like the offending crash-log line: width 1–12 invariant (produces 9-wide lines pre-fix), fallback behavior, and unchanged wide-width behavior.

## Width-invariant fuzz suites (audit hardening)

Inspection-only audits missed the compose bug above, so the PR adds empirical fuzz suites that render the real components at widths 1–12 and assert pi-tui's `doRender` contract (`visibleWidth(line) <= width`) — a failure here is a production hard crash:

- `tool-rendering-narrow.test.ts` (24 tests): direct `ToolText` fuzz with `WRAP_MARK`-tagged headers shaped like the reported crash line (verified sensitive: fails against the pre-fix code), a resize/cache-invalidation sweep, and end-to-end `ToolExecutionComponent` rendering for bash/read/edit/write/grep/find/list/unknown tools (call + result, collapsed + expanded) at widths 1–12.
- `status-line.test.ts`: width 1–12 invariant with agents/credits/budget pinned, routing resolved, usage active.
- `main-screen-narrow.test.ts` (4 tests): `UserMessageComponent`, assistant `Markdown` (headings/code/tables), thinking steps (collapsed + expanded).

The fuzz found **no additional violations** beyond the three fixed here.

- 1275 related tests pass; typecheck and lint clean.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
