### PR TITLE
fix(plans): restore submitted plan visibility

### DIFF
--- a/src/extensions/tool-rendering.test.ts
+++ b/src/extensions/tool-rendering.test.ts
@@ -1,6 +1,6 @@
 import { initTheme, type Theme, ToolExecutionComponent, UserMessageComponent } from "@earendil-works/pi-coding-agent"
-import { Text, visibleWidth } from "@earendil-works/pi-tui"
-import { beforeAll, describe, expect, it } from "vitest"
+import { ProcessTerminal, Text, TuiMainScreen, visibleWidth } from "@earendil-works/pi-tui"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 import { createExtensionApi } from "./__mocks__/extension-api.js"
 import { createToolRenderContext } from "./__mocks__/tool-render-context.js"
 import { FERMENT_V2_TOOL_NAMES } from "./ferment-v2/constants.js"
@@ -217,6 +217,31 @@ describe("hidden tool block rendering", () => {
 		const rendered = component.render(80).map(stripSgr).join("\n")
 		expect(rendered).toContain("Custom Tool")
 		expect(rendered).not.toContain("custom non-Agent renderer")
+	})
+
+	it("keeps complete submitted plans in the transcript before results and after replay or collapse", () => {
+		const plan = `# Cache migration\n\n${Array.from({ length: 80 }, (_, index) => `- Requirement ${index + 1}`).join("\n")}`
+		const args = { plan }
+		const tui = new TuiMainScreen(new ProcessTerminal())
+		vi.spyOn(tui, "requestRender").mockImplementation(() => {})
+		const create = (input: typeof args) =>
+			new ToolExecutionComponent("submit_plan", "tc-plan", input, {}, undefined, tui, "/tmp")
+		const component = create({ plan: "# Draft" })
+		component.updateArgs(args)
+		component.setArgsComplete()
+		for (const current of [component, create(JSON.parse(JSON.stringify(args)))]) {
+			for (const expanded of [false, true, false]) {
+				current.setExpanded(expanded)
+				const rendered = current.render(80).map(stripSgr).join("\n")
+				expect(rendered).toContain("Cache migration")
+				for (let index = 1; index <= 80; index++) expect(rendered).toContain(`Requirement ${index}`)
+			}
+			current.updateResult(
+				{ content: [{ type: "text", text: "Plan submitted for review. Waiting for user decision." }], isError: false },
+				false,
+			)
+			expect(current.render(80).map(stripSgr).join("\n")).toContain("Requirement 80")
+		}
 	})
 })
 

--- a/src/extensions/tool-rendering.ts
+++ b/src/extensions/tool-rendering.ts
@@ -23,6 +23,7 @@ import {
 	createLsTool,
 	createReadTool,
 	createWriteTool,
+	getMarkdownTheme,
 	ToolExecutionComponent,
 	UserMessageComponent,
 } from "@earendil-works/pi-coding-agent"
@@ -34,6 +35,7 @@ import {
 	getImageDimensions,
 	type ImageDimensions,
 	imageFallback,
+	Markdown,
 	Text,
 	truncateToWidth,
 	visibleWidth,
@@ -2819,8 +2821,15 @@ function genericToolLabel(name: string): string {
 	return isMcpToolName(name) ? "MCP" : humanizeToolName(name)
 }
 
-function renderGenericToolCall(name: string, args: unknown, theme: Theme, ctx: ToolRenderContext): Text {
+function renderGenericToolCall(name: string, args: unknown, theme: Theme, ctx: ToolRenderContext): Component {
 	ctx.state._openAiPatchFiles = []
+	if (name === "submit_plan") {
+		// The tool call is persisted and replayed; its plan must remain readable even when tools are collapsed.
+		const transcript = new Container()
+		transcript.addChild(new Text(toolHeader("Submit Plan", "", theme, toolStatusDot(ctx, theme)), 0, 0))
+		transcript.addChild(new Markdown(getStringArg(args, "plan"), 0, 0, getMarkdownTheme()))
+		return transcript
+	}
 	const sp = (path: string) => shortPath(ctx.cwd ?? process.cwd(), path)
 	if (isMcpToolName(name)) {
 		// For MCP calls the summary may already contain ANSI color codes (muted

--- a/tests/e2e/tui/submitted-plan-transcript.test.ts
+++ b/tests/e2e/tui/submitted-plan-transcript.test.ts
@@ -1,0 +1,90 @@
+import { expect, Key, test } from "@microsoft/tui-test"
+import { fullText, viewText, waitForText } from "./support/assertions.js"
+import {
+	createKimchiFixture,
+	createKimchiSessionController,
+	PROMPT_READY,
+	runKimchiSession,
+	TUI_TEST_CONFIG,
+} from "./support/kimchi-fixture.js"
+
+test.use(TUI_TEST_CONFIG)
+
+test("a tool-only submitted plan stays in chat after cancellation and session restart", async ({ terminal }) => {
+	const plan = "# Cache migration\n\n- Preserve the public API.\n- Verify rollback before deployment."
+	const fixture = await createKimchiFixture({
+		responses: [
+			{ stream: [], toolCalls: [{ function: { name: "submit_plan", arguments: JSON.stringify({ plan }) } }] },
+		],
+	})
+	const session = createKimchiSessionController(terminal, fixture, { extraArgs: ["--plan=true", "-c"] })
+	try {
+		await session.start()
+		terminal.submit("Plan a cache migration and wait for approval.")
+		await waitForText(terminal, "Execute the plan", { full: false })
+		const review = viewText(terminal)
+		expect(review).toContain("Cache migration")
+		expect(review).toContain("Preserve the public API.")
+		expect(review).toContain("Verify rollback before deployment.")
+		expect(review.indexOf("Verify rollback before deployment.")).toBeLessThan(review.indexOf("Execute the plan"))
+		terminal.keyPress(Key.Escape)
+		await waitForText(terminal, PROMPT_READY, { full: false })
+		expect(viewText(terminal)).toContain("Verify rollback before deployment.")
+		await session.restart()
+		await waitForText(terminal, "Verify rollback before deployment.", { full: false })
+		expect(viewText(terminal)).toContain("Cache migration")
+		expect(viewText(terminal)).not.toContain("Execute the plan")
+		expect(
+			fixture.fake.requests.filter((request) => request.url.startsWith("/openai/v1/chat/completions")),
+		).toHaveLength(1)
+	} finally {
+		await session.quit().catch(() => {})
+		await fixture.stop()
+	}
+})
+
+test("reworking a plan prints the complete revision and approval keeps it in chat", async ({ terminal }) => {
+	const original = "# Original plan\n\nKeep the existing cache interface."
+	const revised = `# Revised plan\n\n${Array.from({ length: 60 }, (_, index) => `- Revised requirement ${index + 1}.`).join("\n")}`
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "submitted-plan-rework-transcript",
+			extraArgs: ["--plan=true"],
+			responses: [
+				{
+					stream: [],
+					toolCalls: [{ function: { name: "submit_plan", arguments: JSON.stringify({ plan: original }) } }],
+				},
+				{
+					stream: [],
+					toolCalls: [{ function: { name: "submit_plan", arguments: JSON.stringify({ plan: revised }) } }],
+				},
+				{ stream: ["APPROVED_PLAN_EXECUTION_STARTED"] },
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit("Plan a cache migration and wait for approval.")
+			await waitForText(terminal, "Execute the plan", { full: false })
+			expect(viewText(terminal)).toContain("Keep the existing cache interface.")
+			terminal.keyDown()
+			terminal.keyPress(Key.Enter)
+			await waitForText(terminal, PROMPT_READY, { full: false })
+			expect(fullText(terminal)).toContain("Keep the existing cache interface.")
+			trace.step("rework leaves the first submitted plan in the transcript")
+			terminal.submit("Revise the plan to include every verification requirement.")
+			await waitForText(terminal, "Revised requirement 60.", { full: false })
+			await waitForText(terminal, "Execute the plan", { full: false })
+			for (let index = 1; index <= 60; index++) expect(fullText(terminal)).toContain(`Revised requirement ${index}.`)
+			trace.step("the full tool-only revision is printed before the unchanged approval menu")
+			terminal.keyPress(Key.Enter)
+			await waitForText(terminal, "APPROVED_PLAN_EXECUTION_STARTED")
+			expect(fullText(terminal)).toContain("Keep the existing cache interface.")
+			for (let index = 1; index <= 60; index++) expect(fullText(terminal)).toContain(`Revised requirement ${index}.`)
+			expect(
+				fixture.fake.requests.filter((request) => request.url.startsWith("/openai/v1/chat/completions")),
+			).toHaveLength(3)
+			trace.step("approval retained both plans and only started the requested execution turn")
+		},
+	)
+})


### PR DESCRIPTION
## What was wrong
The Plannotator migration moved plans from assistant text into `submit_plan` arguments, which the generic TUI renderer omitted. Users could be asked to approve a plan they could not see.

## Fix
Render the full submitted Markdown in the existing chat transcript, even with tool output collapsed. Reworked plans and session replay remain readable. Keep the existing approval menu and execution routing unchanged; no replacement review screen or extra model turn.

## Validation
Regression failed before the fix. Passed 219 focused unit tests, four TUI workflows (including cancel/restart/replay and full-plan rework/approval), lint/typecheck and binary build. Independent review passed.