### PR TITLE
feat(acp): allow session/load to reattach mid-turn

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -75,6 +75,7 @@ import {
 import { updateModelsConfig } from "../../models.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
+	ACP_REATTACH_MID_TURN_META_KEY,
 	type AcpSessionFactory,
 	type AcpSessionLister,
 	type AcpSessionLoader,
@@ -6004,6 +6005,67 @@ describe("KimchiAcpAgent loadSession", () => {
 			sessionUpdate: "user_message_chunk",
 			content: { type: "text", text: "already here" },
 		})
+	})
+
+	it("allows loadSession to attach while a turn is in progress (client takeover)", async () => {
+		// Reconnect-after-disconnect attaches mid-turn: replay history and let
+		// the in-flight turn keep streaming to the new client.
+		const live = new FakeAgentSession("live-turn")
+		live.branch = [userTextEntry("earlier", "u1", null)]
+		live.promptImpl = () => new Promise<void>(() => {}) // turn never settles
+		const { conn, updates } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(live),
+			sessionLoader: async () => asSession(new FakeAgentSession("unused")),
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+		// Start a turn that never unwinds (mirrors the post-disconnect wedge).
+		void agent.prompt({
+			sessionId: "live-turn",
+			prompt: [{ type: "text", text: "go" }],
+		})
+		// entry.turn is assigned after an await (skill-command parse) inside
+		// prompt() — give it a macrotask so the turn is firmly in progress.
+		await new Promise((r) => setTimeout(r, 0))
+
+		// Previously this rejected with "has a turn in progress; cancel it first".
+		const res = await agent.loadSession({
+			sessionId: "live-turn",
+			cwd: "/tmp",
+			mcpServers: [],
+			_meta: { [ACP_REATTACH_MID_TURN_META_KEY]: true },
+		})
+
+		expect(res.models).toMatchObject({ currentModelId: "test/test-model" })
+		// History was replayed for the attaching client.
+		const replayUpdates = replayOnly(updates)
+		expect(replayUpdates.some((u) => u.update.sessionUpdate === "user_message_chunk")).toBe(true)
+	})
+
+	it("still rejects mid-turn loadSession without the reattach opt-in flag", async () => {
+		// The strict ACP guard stays the default: clients that don't declare
+		// a takeover get the original error and may cancel the turn first.
+		const live = new FakeAgentSession("guarded-turn")
+		live.promptImpl = () => new Promise<void>(() => {}) // turn never settles
+		const { conn } = makeRecordingConn()
+		const agent = new KimchiAcpAgent(conn, {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+			sessionFactory: async () => asSession(live),
+			sessionLoader: async () => asSession(new FakeAgentSession("unused")),
+		})
+		await agent.newSession({ cwd: "/tmp", mcpServers: [] })
+		void agent.prompt({
+			sessionId: "guarded-turn",
+			prompt: [{ type: "text", text: "go" }],
+		})
+		await new Promise((r) => setTimeout(r, 0))
+
+		await expect(agent.loadSession({ sessionId: "guarded-turn", cwd: "/tmp", mcpServers: [] })).rejects.toThrow(
+			"has a turn in progress; cancel it first",
+		)
 	})
 
 	it("returns configOptions in loadSession response", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -733,7 +733,10 @@ export class KimchiAcpAgent implements Agent {
 		if (existing) {
 			// Mid-turn attach is opt-in; clients passing the flag declared the
 			// previous connection dead, so attach and replay instead of rejecting.
-			// Everyone else keeps the strict guard.
+			// Everyone else keeps the strict guard. Turn updates keep flowing over
+			// this process's single stdout pipe — routing them to the currently
+			// attached client is the transport bridge's job (see the
+			// kimchi-sandbox-worker takeover handler).
 			if (existing.turn && params._meta?.[ACP_REATTACH_MID_TURN_META_KEY] !== true) {
 				throw RequestError.invalidRequest(undefined, `session ${sessionId} has a turn in progress; cancel it first`)
 			}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -733,10 +733,7 @@ export class KimchiAcpAgent implements Agent {
 		if (existing) {
 			// Mid-turn attach is opt-in; clients passing the flag declared the
 			// previous connection dead, so attach and replay instead of rejecting.
-			// Everyone else keeps the strict guard. Turn updates keep flowing over
-			// this process's single stdout pipe — routing them to the currently
-			// attached client is the transport bridge's job (see the
-			// kimchi-sandbox-worker takeover handler).
+			// Everyone else keeps the strict guard.
 			if (existing.turn && params._meta?.[ACP_REATTACH_MID_TURN_META_KEY] !== true) {
 				throw RequestError.invalidRequest(undefined, `session ${sessionId} has a turn in progress; cancel it first`)
 			}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -119,6 +119,9 @@ import { asString, extractImages, truncate } from "./utils.js"
  * initialize() declaration and authenticate() validation to avoid typo drift. */
 const KIMCHI_AGENT_AUTH_METHOD_ID = "kimchi-agent"
 
+/** `_meta` key opting `session/load` into mid-turn attach; strict guard stays default. */
+export const ACP_REATTACH_MID_TURN_META_KEY = "kimchi/reattachMidTurn"
+
 /** Resolve --plan/--auto/--yolo CLI flags into a PermissionMode. */
 function resolveCliPermissionMode(): PermissionMode | undefined {
 	const { options } = getParsedCliArgs()
@@ -728,7 +731,10 @@ export class KimchiAcpAgent implements Agent {
 		const sessionId = params.sessionId
 		const existing = this.sessions.get(sessionId)
 		if (existing) {
-			if (existing.turn) {
+			// Mid-turn attach is opt-in; clients passing the flag declared the
+			// previous connection dead, so attach and replay instead of rejecting.
+			// Everyone else keeps the strict guard.
+			if (existing.turn && params._meta?.[ACP_REATTACH_MID_TURN_META_KEY] !== true) {
 				throw RequestError.invalidRequest(undefined, `session ${sessionId} has a turn in progress; cancel it first`)
 			}
 			this.replayTranscript(existing.session)


### PR DESCRIPTION
## Linked issue

Closes #0

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?
TLDR: Introduces a config flag for ACP sessions to allow reattaching to existing ACP session.

Reconnect-after-disconnect previously wedged: the in-flight turn's bookkeeping never unwinds on a dead connection, so session/load rejected with "turn in progress" and the only way back was restarting the task.

- Export ACP_REATTACH_MID_TURN_META_KEY ("kimchi/reattachMidTurn").
- session/load accepts attach while a turn is in progress when the client opts in via _meta: replay the history and let the in-flight turn's remaining updates flow to the new client via the bridge's active connection.
- The strict ACP guard stays the default for clients without the flag (they keep "has a turn in progress; cancel it first").

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
