### PR TITLE
fix(permissions): make classifier fallback resilient

### DIFF
--- a/src/extensions/__mocks__/model-registry.ts
+++ b/src/extensions/__mocks__/model-registry.ts
@@ -1,0 +1,30 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { vi } from "vitest"
+
+export function createModel(id: string, provider = "kimchi-dev"): Model<Api> {
+	return {
+		id,
+		provider,
+		name: id,
+		api: "openai-completions",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 10000,
+		maxTokens: 1000,
+	}
+}
+
+export function createModelRegistry(models: Model<Api>[] = []) {
+	return {
+		find: vi.fn((provider: string, id: string) => models.find((m) => m.provider === provider && m.id === id)),
+		getAvailable: vi.fn(() => models),
+		getApiKeyAndHeaders: vi.fn<ModelRegistry["getApiKeyAndHeaders"]>().mockResolvedValue({
+			ok: true,
+			apiKey: "test-key",
+			headers: {},
+		}),
+	}
+}

--- a/src/extensions/__mocks__/model-registry.ts
+++ b/src/extensions/__mocks__/model-registry.ts
@@ -26,5 +26,6 @@ export function createModelRegistry(models: Model<Api>[] = []) {
 			apiKey: "test-key",
 			headers: {},
 		}),
+		hasConfiguredAuth: vi.fn<ModelRegistry["hasConfiguredAuth"]>(() => true),
 	}
 }

--- a/src/extensions/permissions/classifier-health.test.ts
+++ b/src/extensions/permissions/classifier-health.test.ts
@@ -25,6 +25,7 @@ describe("classifierHealth", () => {
 	}) => {
 		expect(classifierHealth({ ...healthy, usedModelId }, candidates, missingRefs)).toMatchObject({
 			channel: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
+			notifyKey: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
 			payload: { usedModelId, missingRefs },
 		})
 	})
@@ -70,8 +71,10 @@ describe("classifierHealth", () => {
 	it("selects actionable copy for no_api_key and generic copy otherwise", () => {
 		const noKey = classifierHealth({ ...healthy, ok: false, failureCode: "no_api_key" }, [primary], [])
 		expect(noKey?.message).toContain("KIMCHI_API_KEY")
+		expect(noKey?.notifyKey).toBe(`${PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE}:no_api_key`)
 		const other = classifierHealth({ ...healthy, ok: false, failureCode: "provider_error" }, [primary], [])
 		expect(other?.message).not.toContain("KIMCHI_API_KEY")
+		expect(other?.notifyKey).toBe(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE)
 		expect(other?.message).toBe(
 			"Permissions classifier unavailable. Calls requiring classification need confirmation or are blocked without a UI.",
 		)

--- a/src/extensions/permissions/classifier-health.test.ts
+++ b/src/extensions/permissions/classifier-health.test.ts
@@ -50,6 +50,7 @@ describe("classifierHealth", () => {
 	})
 
 	it.each<ClassifierFailureCode>([
+		"no_api_key",
 		"provider_error",
 		"invalid_output",
 		"auth_unavailable",
@@ -64,5 +65,15 @@ describe("classifierHealth", () => {
 		)
 		expect(health?.payload).toEqual({ failureCode, missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]] })
 		expect(JSON.stringify(health)).not.toContain("SENTINEL_SECRET")
+	})
+
+	it("selects actionable copy for no_api_key and generic copy otherwise", () => {
+		const noKey = classifierHealth({ ...healthy, ok: false, failureCode: "no_api_key" }, [primary], [])
+		expect(noKey?.message).toContain("KIMCHI_API_KEY")
+		const other = classifierHealth({ ...healthy, ok: false, failureCode: "provider_error" }, [primary], [])
+		expect(other?.message).not.toContain("KIMCHI_API_KEY")
+		expect(other?.message).toBe(
+			"Permissions classifier unavailable. Calls requiring classification need confirmation or are blocked without a UI.",
+		)
 	})
 })

--- a/src/extensions/permissions/classifier-health.test.ts
+++ b/src/extensions/permissions/classifier-health.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { createModel } from "../__mocks__/model-registry.js"
+import { classifierHealth } from "./classifier-health.js"
+import { DEFAULT_CLASSIFIER_CANDIDATE_REFS } from "./classifier-models.js"
+import { PERMISSION_EVENTS } from "./permissions-events.js"
+import type { ClassifierFailureCode, ClassifierResult } from "./types.js"
+
+const primary = createModel("deepseek-v4-flash-0731")
+const fallback = createModel("minimax-m3")
+const healthy: ClassifierResult = { verdict: "safe", ok: true, reason: "fine", usedModelId: primary.id }
+
+describe("classifierHealth", () => {
+	it.each(["safe", "requires-confirmation"] as const)("treats primary %s as healthy", (verdict) => {
+		expect(classifierHealth({ ...healthy, verdict }, [primary, fallback], [])).toBeUndefined()
+	})
+
+	it.each([
+		{ candidates: [primary, fallback], missingRefs: [], usedModelId: fallback.id },
+		{ candidates: [fallback], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[0]], usedModelId: fallback.id },
+		{ candidates: [primary], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]], usedModelId: primary.id },
+	])("reports successful fallback or reduced availability: $usedModelId", ({
+		candidates,
+		missingRefs,
+		usedModelId,
+	}) => {
+		expect(classifierHealth({ ...healthy, usedModelId }, candidates, missingRefs)).toMatchObject({
+			channel: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
+			payload: { usedModelId, missingRefs },
+		})
+	})
+
+	it("reports only unavailable when all models are missing", () => {
+		expect(
+			classifierHealth(
+				{ ...healthy, ok: false, usedModelId: undefined, failureCode: "no_candidates" },
+				[],
+				[...DEFAULT_CLASSIFIER_CANDIDATE_REFS],
+			),
+		).toMatchObject({
+			channel: PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE,
+			payload: { failureCode: "no_candidates", missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS] },
+		})
+	})
+
+	it("does not label cancellation as an outage", () => {
+		expect(classifierHealth({ ...healthy, ok: false, failureCode: "aborted" }, [], [])).toBeUndefined()
+		const controller = new AbortController()
+		controller.abort()
+		expect(classifierHealth({ ...healthy, ok: false }, [], [], controller.signal)).toBeUndefined()
+	})
+
+	it.each<ClassifierFailureCode>([
+		"provider_error",
+		"invalid_output",
+		"auth_unavailable",
+		"auth_timeout",
+		"timeout",
+		"budget_exhausted",
+	])("never emits diagnostics containing secrets for %s", (failureCode) => {
+		const health = classifierHealth(
+			{ ...healthy, ok: false, reason: "SENTINEL_SECRET", failureCode },
+			[primary],
+			[DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]],
+		)
+		expect(health?.payload).toEqual({ failureCode, missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]] })
+		expect(JSON.stringify(health)).not.toContain("SENTINEL_SECRET")
+	})
+})

--- a/src/extensions/permissions/classifier-health.ts
+++ b/src/extensions/permissions/classifier-health.ts
@@ -1,0 +1,48 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+import {
+	type ClassifierDegradedPayload,
+	type ClassifierUnavailablePayload,
+	PERMISSION_EVENTS,
+} from "./permissions-events.js"
+import type { ClassifierResult } from "./types.js"
+
+type ClassifierHealth =
+	| {
+			channel: typeof PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE
+			payload: ClassifierUnavailablePayload
+			message: string
+	  }
+	| {
+			channel: typeof PERMISSION_EVENTS.CLASSIFIER_DEGRADED
+			payload: ClassifierDegradedPayload
+			message: string
+	  }
+
+/** Keep free-form model/provider diagnostics out of health events and notifications. */
+export function classifierHealth(
+	result: ClassifierResult,
+	candidates: readonly Model<Api>[],
+	missingRefs: string[],
+	signal?: AbortSignal,
+): ClassifierHealth | undefined {
+	if (signal?.aborted || result.failureCode === "aborted") return undefined
+	if (!result.ok) {
+		return {
+			channel: PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE,
+			payload: {
+				failureCode: result.failureCode ?? (candidates.length ? "provider_error" : "no_candidates"),
+				missingRefs,
+			},
+			message:
+				"Permissions classifier unavailable. Calls requiring classification need confirmation or are blocked without a UI.",
+		}
+	}
+	if (result.usedModelId && (missingRefs.length > 0 || result.usedModelId !== candidates[0]?.id)) {
+		return {
+			channel: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
+			payload: { usedModelId: result.usedModelId, missingRefs },
+			message: "Permissions classifier is using a fallback model or has reduced model availability.",
+		}
+	}
+	return undefined
+}

--- a/src/extensions/permissions/classifier-health.ts
+++ b/src/extensions/permissions/classifier-health.ts
@@ -27,14 +27,15 @@ export function classifierHealth(
 ): ClassifierHealth | undefined {
 	if (signal?.aborted || result.failureCode === "aborted") return undefined
 	if (!result.ok) {
+		const failureCode = result.failureCode ?? (candidates.length ? "provider_error" : "no_candidates")
 		return {
 			channel: PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE,
-			payload: {
-				failureCode: result.failureCode ?? (candidates.length ? "provider_error" : "no_candidates"),
-				missingRefs,
-			},
+			payload: { failureCode, missingRefs },
+			// Fixed copy per failure code; never interpolate free-form diagnostics.
 			message:
-				"Permissions classifier unavailable. Calls requiring classification need confirmation or are blocked without a UI.",
+				failureCode === "no_api_key"
+					? "Permissions classifier has no Kimchi API key configured. Set KIMCHI_API_KEY to enable auto-approval; calls requiring classification will keep asking for confirmation (or are blocked without a UI)."
+					: "Permissions classifier unavailable. Calls requiring classification need confirmation or are blocked without a UI.",
 		}
 	}
 	if (result.usedModelId && (missingRefs.length > 0 || result.usedModelId !== candidates[0]?.id)) {

--- a/src/extensions/permissions/classifier-health.ts
+++ b/src/extensions/permissions/classifier-health.ts
@@ -11,11 +11,15 @@ type ClassifierHealth =
 			channel: typeof PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE
 			payload: ClassifierUnavailablePayload
 			message: string
+			/** Dedup key for once-per-session warnings: one per distinct notification copy. */
+			notifyKey: string
 	  }
 	| {
 			channel: typeof PERMISSION_EVENTS.CLASSIFIER_DEGRADED
 			payload: ClassifierDegradedPayload
 			message: string
+			/** Dedup key for once-per-session warnings: one per distinct notification copy. */
+			notifyKey: string
 	  }
 
 /** Keep free-form model/provider diagnostics out of health events and notifications. */
@@ -31,6 +35,11 @@ export function classifierHealth(
 		return {
 			channel: PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE,
 			payload: { failureCode, missingRefs },
+			// Only no_api_key has distinct copy; other codes share one generic warning.
+			notifyKey:
+				failureCode === "no_api_key"
+					? `${PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE}:no_api_key`
+					: PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE,
 			// Fixed copy per failure code; never interpolate free-form diagnostics.
 			message:
 				failureCode === "no_api_key"
@@ -42,6 +51,7 @@ export function classifierHealth(
 		return {
 			channel: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
 			payload: { usedModelId: result.usedModelId, missingRefs },
+			notifyKey: PERMISSION_EVENTS.CLASSIFIER_DEGRADED,
 			message: "Permissions classifier is using a fallback model or has reduced model availability.",
 		}
 	}

--- a/src/extensions/permissions/classifier-models.test.ts
+++ b/src/extensions/permissions/classifier-models.test.ts
@@ -3,22 +3,29 @@ import { createModel } from "../__mocks__/model-registry.js"
 import { DEFAULT_CLASSIFIER_CANDIDATE_REFS, resolveClassifierCandidates } from "./classifier-models.js"
 
 const primary = createModel("deepseek-v4-flash-0731")
+const glm = createModel("glm-5.3-flash")
 const fallback = createModel("minimax-m3")
+const [primaryRef, glmRef, fallbackRef] = DEFAULT_CLASSIFIER_CANDIDATE_REFS
 
 describe("resolveClassifierCandidates", () => {
 	it("pins the ordered kimchi-dev ladder", () => {
-		expect(DEFAULT_CLASSIFIER_CANDIDATE_REFS).toEqual(["kimchi-dev/deepseek-v4-flash-0731", "kimchi-dev/minimax-m3"])
+		expect(DEFAULT_CLASSIFIER_CANDIDATE_REFS).toEqual([
+			"kimchi-dev/deepseek-v4-flash-0731",
+			"kimchi-dev/glm-5.3-flash",
+			"kimchi-dev/minimax-m3",
+		])
 	})
 
 	it.each([
-		{ models: [fallback, primary], candidates: [primary, fallback], missingRefs: [] },
-		{ models: [fallback], candidates: [fallback], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[0]] },
-		{ models: [primary], candidates: [primary], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]] },
-		{ models: [], candidates: [], missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS] },
+		{ models: [fallback, glm, primary], candidates: [primary, glm, fallback], missingRefs: [] },
+		{ models: [fallback, glm], candidates: [glm, fallback], missingRefs: [primaryRef] },
+		{ models: [fallback], candidates: [fallback], missingRefs: [primaryRef, glmRef] },
+		{ models: [primary], candidates: [primary], missingRefs: [glmRef, fallbackRef] },
+		{ models: [], candidates: [], missingRefs: [primaryRef, glmRef, fallbackRef] },
 		{
-			models: [createModel(primary.id, "custom"), createModel(fallback.id, "custom")],
+			models: [createModel(primary.id, "custom"), createModel(glm.id, "custom"), createModel(fallback.id, "custom")],
 			candidates: [],
-			missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS],
+			missingRefs: [primaryRef, glmRef, fallbackRef],
 		},
 	])("resolves ordered exact matches from $models", ({ models, candidates, missingRefs }) => {
 		const registry = {

--- a/src/extensions/permissions/classifier-models.test.ts
+++ b/src/extensions/permissions/classifier-models.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { createModel } from "../__mocks__/model-registry.js"
+import { DEFAULT_CLASSIFIER_CANDIDATE_REFS, resolveClassifierCandidates } from "./classifier-models.js"
+
+const primary = createModel("deepseek-v4-flash-0731")
+const fallback = createModel("minimax-m3")
+
+describe("resolveClassifierCandidates", () => {
+	it("pins the ordered kimchi-dev ladder", () => {
+		expect(DEFAULT_CLASSIFIER_CANDIDATE_REFS).toEqual(["kimchi-dev/deepseek-v4-flash-0731", "kimchi-dev/minimax-m3"])
+	})
+
+	it.each([
+		{ models: [fallback, primary], candidates: [primary, fallback], missingRefs: [] },
+		{ models: [fallback], candidates: [fallback], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[0]] },
+		{ models: [primary], candidates: [primary], missingRefs: [DEFAULT_CLASSIFIER_CANDIDATE_REFS[1]] },
+		{ models: [], candidates: [], missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS] },
+		{
+			models: [createModel(primary.id, "custom"), createModel(fallback.id, "custom")],
+			candidates: [],
+			missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS],
+		},
+	])("resolves ordered exact matches from $models", ({ models, candidates, missingRefs }) => {
+		const registry = {
+			find: (provider: string, id: string) => models.find((m) => m.provider === provider && m.id === id),
+		}
+		expect(resolveClassifierCandidates(registry)).toEqual({ candidates, missingRefs })
+	})
+})

--- a/src/extensions/permissions/classifier-models.ts
+++ b/src/extensions/permissions/classifier-models.ts
@@ -1,0 +1,21 @@
+import type { Api, Model } from "@earendil-works/pi-ai"
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
+import { splitModelRef } from "../model-catalog/ref-utils.js"
+
+export const DEFAULT_CLASSIFIER_CANDIDATE_REFS = ["kimchi-dev/deepseek-v4-flash-0731", "kimchi-dev/minimax-m3"] as const
+
+/** The only classifier seam that knows the catalog's model preferences. */
+export function resolveClassifierCandidates(registry: Pick<ModelRegistry, "find">): {
+	candidates: Model<Api>[]
+	missingRefs: string[]
+} {
+	const candidates: Model<Api>[] = []
+	const missingRefs: string[] = []
+	for (const ref of DEFAULT_CLASSIFIER_CANDIDATE_REFS) {
+		const parsed = splitModelRef(ref)
+		const model = parsed && registry.find(parsed.provider, parsed.modelId)
+		if (model) candidates.push(model)
+		else missingRefs.push(ref)
+	}
+	return { candidates, missingRefs }
+}

--- a/src/extensions/permissions/classifier-models.ts
+++ b/src/extensions/permissions/classifier-models.ts
@@ -2,7 +2,11 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { splitModelRef } from "../model-catalog/ref-utils.js"
 
-export const DEFAULT_CLASSIFIER_CANDIDATE_REFS = ["kimchi-dev/deepseek-v4-flash-0731", "kimchi-dev/minimax-m3"] as const
+export const DEFAULT_CLASSIFIER_CANDIDATE_REFS = [
+	"kimchi-dev/deepseek-v4-flash-0731",
+	"kimchi-dev/glm-5.3-flash",
+	"kimchi-dev/minimax-m3",
+] as const
 
 /** The only classifier seam that knows the catalog's model preferences. */
 export function resolveClassifierCandidates(registry: Pick<ModelRegistry, "find">): {

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -1,90 +1,104 @@
-import type { Api, Model } from "@earendil-works/pi-ai"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import {
-	CLASSIFIER_FALLBACK_MODEL_ID,
-	CLASSIFIER_PRIMARY_MODEL_ID,
-	classifyToolCall,
-	parseClassifierOutput,
-} from "./classifier.js"
+import { createModel, createModelRegistry } from "../__mocks__/model-registry.js"
+import { classifyToolCall, parseClassifierOutput } from "./classifier.js"
+import { classifierHealth } from "./classifier-health.js"
+import { resolveClassifierCandidates } from "./classifier-models.js"
 
 const completeMock = vi.fn()
+vi.mock("@earendil-works/pi-ai/compat", () => ({
+	complete: (...args: unknown[]) => completeMock(...args),
+}))
 
-vi.mock("@earendil-works/pi-ai/compat", async () => {
-	const actual = await vi.importActual<typeof import("@earendil-works/pi-ai/compat")>("@earendil-works/pi-ai/compat")
-	return {
-		...actual,
-		complete: (...args: unknown[]) => completeMock(...args),
-	}
-})
-
-function fakeModel(id = "test-model", provider = "openai"): Model<Api> {
-	return { provider, id, api: "openai-completions" } as Model<Api>
+const primary = createModel("deepseek-v4-flash-0731")
+const fallback = createModel("minimax-m3")
+const call = { toolName: "edit", input: { path: "foo.ts" }, cwd: "/tmp" }
+const options = { timeoutMs: 8000 }
+function response(content = '{"verdict":"safe","reason":"fine","riskScore":"low"}', stopReason = "stop") {
+	return { content: [{ type: "text", text: content }], stopReason }
 }
-
-function fakeRegistry(
-	available: Model<Api>[] = [fakeModel(CLASSIFIER_PRIMARY_MODEL_ID)],
-	apiKey = "fake-key",
-): ModelRegistry {
-	return {
-		getAvailable: vi.fn(() => available),
-		getApiKeyAndHeaders: vi.fn().mockResolvedValue({ ok: true, apiKey, headers: {} }),
-	} as unknown as ModelRegistry
-}
-
-function fakeResponse(opts: { stopReason: string; content?: string; errorMessage?: string }) {
-	return {
-		content: opts.content ? [{ type: "text", text: opts.content }] : [],
-		stopReason: opts.stopReason,
-		errorMessage: opts.errorMessage,
-	}
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res
+		reject = rej
+	})
+	return { promise, resolve, reject }
 }
 
 describe("classifyToolCall", () => {
+	it.each([
+		"output",
+		"provider",
+		"auth",
+	])("keeps %s diagnostics and tool inputs out of health events", async (source) => {
+		const secret = "SENTINEL_SECRET"
+		const registry = createModelRegistry()
+		if (source === "auth") registry.getApiKeyAndHeaders.mockRejectedValue(new Error(secret))
+		completeMock.mockResolvedValue(
+			source === "provider" ? { ...response("", "error"), errorMessage: secret } : response(secret),
+		)
+		const promise = classifyToolCall([primary], registry, { ...call, input: { command: secret } }, options)
+		await vi.runAllTimersAsync()
+		const result = await promise
+		expect(result.ok).toBe(false)
+		const health = classifierHealth(result, [primary], [])
+		expect(health).toBeDefined()
+		expect(JSON.stringify(health)).not.toContain(secret)
+		expect(health?.payload).not.toHaveProperty("reason")
+	})
+
+	it("caps retries on every candidate", async () => {
+		completeMock.mockResolvedValue(response("invalid"))
+		const promise = classifyToolCall([primary, fallback], createModelRegistry(), call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: false, failureCode: "invalid_output" })
+		expect(completeMock.mock.calls.map(([model]) => model)).toEqual([
+			primary,
+			primary,
+			primary,
+			fallback,
+			fallback,
+			fallback,
+		])
+	})
+
 	beforeEach(() => {
 		completeMock.mockReset()
 		vi.useFakeTimers()
 	})
-
 	afterEach(() => {
+		expect(vi.getTimerCount()).toBe(0)
 		vi.restoreAllMocks()
 		vi.useRealTimers()
 	})
 
-	it("returns safe verdict on first attempt", async () => {
-		completeMock.mockResolvedValue(
-			fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
-		)
+	it("uses fallback when the primary slug is missing", async () => {
+		const registry = createModelRegistry([fallback])
+		const { candidates } = resolveClassifierCandidates(registry)
+		completeMock.mockResolvedValue(response())
+		const result = await classifyToolCall(candidates, registry, call, options)
+		expect(result).toMatchObject({ ok: true, usedModelId: fallback.id })
+		expect(completeMock.mock.calls[0]?.[0]).toBe(fallback)
+	})
 
-		const result = await classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		expect(result.verdict).toBe("safe")
-		expect(result.riskScore).toBe("low")
-		expect(result.ok).toBe(true)
+	it.each(["safe", "requires-confirmation"])("stops on a valid %s verdict", async (verdict) => {
+		completeMock.mockResolvedValue(response(JSON.stringify({ verdict, reason: "fine", riskScore: "low" })))
+		const result = await classifyToolCall([primary, fallback], createModelRegistry(), call, options)
+		expect(result).toMatchObject({ verdict, ok: true, riskScore: "low", usedModelId: primary.id })
+		expect(result).not.toHaveProperty("retryable")
+		expect(result.failureCode).toBeUndefined()
 		expect(completeMock).toHaveBeenCalledTimes(1)
 	})
 
-	// classifyToolCall only resolves CLASSIFIER_PRIMARY_MODEL_ID /
-	// CLASSIFIER_FALLBACK_MODEL_ID, so a kimi-k3 can never flow through the
-	// classifier — token limits now pass through untouched.
-	it("keeps classifier tags and token limits for classifier models", async () => {
+	it("keeps classifier tags and token limits", async () => {
 		let sentPayload: unknown
-		completeMock.mockImplementation((_model: unknown, _context: unknown, options: unknown) => {
-			const { onPayload } = options as { onPayload: (payload: unknown) => unknown }
-			sentPayload = onPayload({ max_completion_tokens: 100, max_tokens: 100, tags: ["existing"] })
-			return fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' })
+		completeMock.mockImplementation((_model, _context, opts) => {
+			sentPayload = opts.onPayload({ max_completion_tokens: 100, max_tokens: 100, tags: ["existing"] })
+			return response()
 		})
-
-		await classifyToolCall(
-			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID, "kimchi-dev")]),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
+		await classifyToolCall([primary], createModelRegistry(), call, options)
 		expect(sentPayload).toEqual({
 			max_completion_tokens: 100,
 			max_tokens: 100,
@@ -92,184 +106,202 @@ describe("classifyToolCall", () => {
 		})
 	})
 
-	it("retries up to 3 times on abort before giving up", async () => {
-		completeMock.mockResolvedValue(fakeResponse({ stopReason: "aborted" }))
+	it.each([
+		["timeout", () => response("", "aborted")],
+		["provider_error", () => ({ ...response("", "error"), errorMessage: "rate limit exceeded" })],
+		[
+			"provider_error",
+			() => {
+				throw new Error("connection failed")
+			},
+		],
+		["invalid_output", () => response("not json")],
+	] as const)("retries %s then advances to fallback", async (_code, failure) => {
+		completeMock.mockImplementation((model) => (model === primary ? failure() : response()))
+		const promise = classifyToolCall([primary, fallback], createModelRegistry(), call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: true, usedModelId: fallback.id })
+		expect(completeMock.mock.calls.map(([model]) => model)).toEqual([primary, primary, primary, fallback])
+	})
 
-		const promise = classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "edit", input: { path: "foo.ts" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
+	it.each([2, 3])("can succeed on primary attempt %i", async (successAttempt) => {
+		completeMock.mockImplementation(() =>
+			completeMock.mock.calls.length === successAttempt ? response() : response("", "aborted"),
 		)
+		const promise = classifyToolCall([primary], createModelRegistry(), call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: true, usedModelId: primary.id })
+		expect(completeMock).toHaveBeenCalledTimes(successAttempt)
+	})
 
+	it.each([
+		["timeout", response("", "aborted")],
+		["provider_error", { ...response("", "error"), errorMessage: "rate limit exceeded" }],
+		["invalid_output", response("invalid")],
+	] as const)("fails closed with public %s code after the cap", async (failureCode, failure) => {
+		completeMock.mockResolvedValue(failure)
+		const promise = classifyToolCall([primary], createModelRegistry(), call, options)
 		await vi.runAllTimersAsync()
 		const result = await promise
-
-		expect(result.verdict).toBe("requires-confirmation")
-		expect(result.ok).toBe(false)
-		expect(result.reason).toContain("classifier timeout")
-		expect(result.reason).toContain(CLASSIFIER_PRIMARY_MODEL_ID)
+		expect(result).toMatchObject({ verdict: "requires-confirmation", ok: false, failureCode })
+		expect(result).not.toHaveProperty("retryable")
+		expect(result.usedModelId).toBeUndefined()
 		expect(completeMock).toHaveBeenCalledTimes(3)
 	})
 
-	it("succeeds on 2nd attempt after first abort", async () => {
-		completeMock
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(
-				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
-			)
-
-		const promise = classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
+	it("reserves a full fallback attempt after actual primary timeouts", async () => {
+		const starts: number[] = []
+		completeMock.mockImplementation((model) => {
+			starts.push(performance.now())
+			if (model === primary) return new Promise(() => {})
+			return new Promise((resolve) => setTimeout(() => resolve(response()), 7999))
+		})
+		const started = performance.now()
+		const promise = classifyToolCall([primary, fallback], createModelRegistry(), call, options)
 		await vi.runAllTimersAsync()
-		const result = await promise
+		expect(await promise).toMatchObject({ ok: true, usedModelId: fallback.id })
+		expect(starts.map((t) => t - started)).toEqual([0, 8500, 16500])
+		expect(performance.now() - started).toBe(24499)
+	})
 
-		expect(result.verdict).toBe("safe")
-		expect(result.riskScore).toBe("low")
-		expect(result.ok).toBe(true)
+	it("bounds a provider that ignores abort by the total budget", async () => {
+		let attemptSignal: AbortSignal | undefined
+		completeMock.mockImplementation((_model, _context, opts) => {
+			attemptSignal = opts.signal
+			return new Promise(() => {})
+		})
+		const promise = classifyToolCall([primary], createModelRegistry(), call, { timeoutMs: 8000, maxTotalMs: 2000 })
+		const started = performance.now()
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: false, failureCode: "budget_exhausted" })
+		expect(performance.now() - started).toBe(2000)
+		expect(attemptSignal?.aborted).toBe(true)
+		expect(completeMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("starts no work when the budget cannot fit an attempt", async () => {
+		const registry = createModelRegistry()
+		expect(await classifyToolCall([primary], registry, call, { ...options, maxTotalMs: 999 })).toMatchObject({
+			ok: false,
+			failureCode: "budget_exhausted",
+		})
+		expect(registry.getApiKeyAndHeaders).not.toHaveBeenCalled()
+		expect(completeMock).not.toHaveBeenCalled()
+	})
+
+	it.each(["missing", "throws"] as const)("skips %s auth and uses fallback", async (kind) => {
+		const registry = createModelRegistry()
+		if (kind === "missing") registry.getApiKeyAndHeaders.mockResolvedValueOnce({ ok: false, error: "secret" })
+		else registry.getApiKeyAndHeaders.mockRejectedValueOnce(new Error("secret"))
+		completeMock.mockResolvedValue(response())
+		expect(await classifyToolCall([primary, fallback], registry, call, options)).toMatchObject({
+			ok: true,
+			usedModelId: fallback.id,
+		})
+		expect(completeMock.mock.calls[0]?.[0]).toBe(fallback)
+	})
+
+	it("reports auth skips when no candidate can answer", async () => {
+		const registry = createModelRegistry()
+		registry.getApiKeyAndHeaders.mockResolvedValue({ ok: false, error: "secret" })
+		const result = await classifyToolCall([primary, fallback], registry, call, options)
+		expect(result.failureCode).toBe("auth_unavailable")
+		expect(result.reason).toContain(`${primary.id} skipped: no API key`)
+		expect(result.reason).toContain(`${fallback.id} skipped: no API key`)
+		expect(result).not.toHaveProperty("retryable")
+		expect(result.reason).not.toContain("secret")
+	})
+
+	it.each(["resolve", "reject"] as const)("bounds stalled primary auth and ignores late %s", async (settlement) => {
+		const pending = deferred<Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>>()
+		const registry = createModelRegistry()
+		registry.getApiKeyAndHeaders.mockReturnValueOnce(pending.promise)
+		completeMock.mockResolvedValue(response())
+		const promise = classifyToolCall([primary, fallback], registry, call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: true, usedModelId: fallback.id })
+		if (settlement === "resolve") pending.resolve({ ok: true, apiKey: "late", headers: {} })
+		else pending.reject(new Error("late auth error"))
+		await vi.runAllTimersAsync()
+		expect(completeMock).toHaveBeenCalledTimes(1)
+		expect(completeMock.mock.calls[0]?.[0]).toBe(fallback)
+	})
+
+	it("bounds a single stalled auth lookup", async () => {
+		const registry = createModelRegistry()
+		registry.getApiKeyAndHeaders.mockReturnValue(new Promise(() => {}))
+		const started = performance.now()
+		const promise = classifyToolCall([primary], registry, call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ failureCode: "budget_exhausted", ok: false })
+		expect(performance.now() - started).toBe(25000)
+		expect(completeMock).not.toHaveBeenCalled()
+	})
+
+	it.each(["resolve", "reject"] as const)("ignores late completion %s after timeout", async (settlement) => {
+		const pending = deferred<ReturnType<typeof response>>()
+		completeMock.mockReturnValueOnce(pending.promise).mockResolvedValue(response())
+		const promise = classifyToolCall([primary], createModelRegistry(), call, options)
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ ok: true })
+		if (settlement === "resolve") pending.resolve(response())
+		else pending.reject(new Error("late provider error"))
+		await vi.runAllTimersAsync()
 		expect(completeMock).toHaveBeenCalledTimes(2)
 	})
 
-	it("succeeds on 3rd attempt after two aborts", async () => {
-		completeMock
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(
-				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
-			)
-
-		const promise = classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		await vi.runAllTimersAsync()
-		const result = await promise
-
-		expect(result.verdict).toBe("safe")
-		expect(result.riskScore).toBe("low")
-		expect(result.ok).toBe(true)
-		expect(completeMock).toHaveBeenCalledTimes(3)
-	})
-
-	it("calls fallback model after 3 retryable failures and returns its result", async () => {
-		completeMock
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(fakeResponse({ stopReason: "aborted" }))
-			.mockResolvedValueOnce(
-				fakeResponse({ stopReason: "stop", content: '{"verdict":"safe","riskScore":"low","reason":"fine"}' }),
-			)
-
-		const promise = classifyToolCall(
-			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID), fakeModel(CLASSIFIER_FALLBACK_MODEL_ID)]),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		await vi.runAllTimersAsync()
-		const result = await promise
-
-		expect(result.verdict).toBe("safe")
-		expect(result.riskScore).toBe("low")
-		expect(result.ok).toBe(true)
-		expect(completeMock).toHaveBeenCalledTimes(4)
-	})
-
-	it("returns last result when no fallback model is provided", async () => {
-		completeMock.mockResolvedValue(fakeResponse({ stopReason: "aborted" }))
-
-		const promise = classifyToolCall(
-			fakeRegistry([fakeModel(CLASSIFIER_PRIMARY_MODEL_ID)]),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		await vi.runAllTimersAsync()
-		const result = await promise
-
-		expect(result.verdict).toBe("requires-confirmation")
-		expect(result.ok).toBe(false)
-		expect(completeMock).toHaveBeenCalledTimes(3)
-	})
-
-	it("returns 'classifier aborted' when signal aborts during final attempt", async () => {
+	it.each([
+		"empty",
+		"before",
+		"auth",
+		"backoff",
+		"completion",
+		"final",
+	] as const)("returns classifier aborted during %s without advancing", async (stage) => {
 		const controller = new AbortController()
+		const registry = createModelRegistry()
+		completeMock.mockResolvedValue(response("", "aborted"))
+		if (stage === "empty" || stage === "before") controller.abort()
+		if (stage === "auth") registry.getApiKeyAndHeaders.mockReturnValue(new Promise(() => {}))
+		if (stage === "completion") completeMock.mockReturnValue(new Promise(() => {}))
+		if (stage === "final")
+			completeMock
+				.mockImplementation(() => {
+					if (completeMock.mock.calls.length === 3) controller.abort()
+					return response()
+				})
+				.mockResolvedValueOnce(response("", "aborted"))
+				.mockResolvedValueOnce(response("", "aborted"))
+		const promise = classifyToolCall(
+			stage === "empty" ? [] : [primary, fallback],
+			registry,
+			call,
+			options,
+			controller.signal,
+		)
+		if (["auth", "backoff", "completion"].includes(stage)) {
+			await vi.advanceTimersByTimeAsync(100)
+			controller.abort()
+		}
+		await vi.runAllTimersAsync()
+		expect(await promise).toMatchObject({ reason: "classifier aborted", failureCode: "aborted", ok: false })
+		expect(completeMock.mock.calls.every(([model]) => model === primary)).toBe(true)
+		if (stage === "empty" || stage === "before") expect(registry.getApiKeyAndHeaders).not.toHaveBeenCalled()
+	})
 
-		// First two attempts: timeout (retryable). Third attempt: also timeout,
-		// but the outer signal is aborted during this attempt.
-		let callCount = 0
-		completeMock.mockImplementation(() => {
-			callCount++
-			if (callCount === 3) {
-				// Simulate the outer signal aborting during the final classifier call
-				controller.abort()
-			}
-			return fakeResponse({ stopReason: "aborted" })
+	it("fails closed when no candidates exist", async () => {
+		const result = await classifyToolCall([], createModelRegistry(), call, options)
+		expect(result).toEqual({
+			verdict: "requires-confirmation",
+			reason: "no model available for classifier",
+			ok: false,
+			failureCode: "no_candidates",
 		})
-
-		const promise = classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-			controller.signal,
-		)
-
-		await vi.runAllTimersAsync()
-		const result = await promise
-
-		expect(completeMock).toHaveBeenCalledTimes(3)
-		expect(result.verdict).toBe("requires-confirmation")
-		expect(result.ok).toBe(false)
-		expect(result.reason).toBe("classifier aborted")
-	})
-
-	it("does not retry when signal is aborted before first attempt", async () => {
-		const controller = new AbortController()
-		controller.abort()
-
-		const result = await classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-			controller.signal,
-		)
-
 		expect(completeMock).not.toHaveBeenCalled()
-		expect(result.reason).toBe("classifier aborted")
 	})
 
-	it("does not retry on error and returns requires-confirmation", async () => {
-		completeMock.mockResolvedValue(fakeResponse({ stopReason: "error", errorMessage: "rate limit exceeded" }))
-
-		const result = await classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		expect(completeMock).toHaveBeenCalledTimes(1)
-		expect(result.verdict).toBe("requires-confirmation")
-		expect(result.ok).toBe(false)
-		expect(result.reason).toContain("classifier error: rate limit exceeded")
-	})
-
-	it("still falls back to unparseable when text is garbage", async () => {
-		completeMock.mockResolvedValue(fakeResponse({ stopReason: "stop", content: "not json at all" }))
-
-		const result = await classifyToolCall(
-			fakeRegistry(),
-			{ toolName: "bash", input: { command: "ls" }, cwd: "/tmp" },
-			{ timeoutMs: 5000 },
-		)
-
-		expect(result.verdict).toBe("requires-confirmation")
-		expect(result.ok).toBe(false)
-		expect(result.reason).toContain("unparseable")
+	it("does not expose retryable on public parser failures", () => {
+		expect(parseClassifierOutput("invalid")).not.toHaveProperty("retryable")
 	})
 })
 
@@ -375,15 +407,5 @@ describe("parseClassifierOutput", () => {
 		expect(r.ok).toBe(true)
 		expect(r.verdict).toBe("safe")
 		expect(r.riskScore).toBeUndefined()
-	})
-})
-
-describe("classifier model ids", () => {
-	it("primary is deepseek-v4-flash", () => {
-		expect(CLASSIFIER_PRIMARY_MODEL_ID).toBe("deepseek-v4-flash")
-	})
-
-	it("fallback is minimax-m3", () => {
-		expect(CLASSIFIER_FALLBACK_MODEL_ID).toBe("minimax-m3")
 	})
 })

--- a/src/extensions/permissions/classifier.test.ts
+++ b/src/extensions/permissions/classifier.test.ts
@@ -201,14 +201,51 @@ describe("classifyToolCall", () => {
 		expect(completeMock.mock.calls[0]?.[0]).toBe(fallback)
 	})
 
-	it("reports auth skips when no candidate can answer", async () => {
+	it("reports auth lookup failures when auth is configured", async () => {
 		const registry = createModelRegistry()
 		registry.getApiKeyAndHeaders.mockResolvedValue({ ok: false, error: "secret" })
 		const result = await classifyToolCall([primary, fallback], registry, call, options)
 		expect(result.failureCode).toBe("auth_unavailable")
+		expect(result.reason).toContain(`${primary.id} skipped: auth lookup failed`)
+		expect(result.reason).toContain(`${fallback.id} skipped: auth lookup failed`)
+		expect(result).not.toHaveProperty("retryable")
+		expect(result.reason).not.toContain("secret")
+	})
+
+	it("reports no_api_key when no auth is configured", async () => {
+		const registry = createModelRegistry()
+		registry.hasConfiguredAuth.mockReturnValue(false)
+		registry.getApiKeyAndHeaders.mockResolvedValue({ ok: false, error: "secret" })
+		const result = await classifyToolCall([primary, fallback], registry, call, options)
+		expect(result.failureCode).toBe("no_api_key")
 		expect(result.reason).toContain(`${primary.id} skipped: no API key`)
 		expect(result.reason).toContain(`${fallback.id} skipped: no API key`)
 		expect(result).not.toHaveProperty("retryable")
+		expect(result.reason).not.toContain("secret")
+	})
+
+	it("uses the fallback when the primary provider is unconfigured", async () => {
+		const registry = createModelRegistry()
+		registry.hasConfiguredAuth.mockImplementation((model) => model.id !== primary.id)
+		registry.getApiKeyAndHeaders.mockResolvedValueOnce({ ok: false, error: "secret" })
+		completeMock.mockResolvedValue(response())
+		expect(await classifyToolCall([primary, fallback], registry, call, options)).toMatchObject({
+			ok: true,
+			usedModelId: fallback.id,
+		})
+		expect(completeMock.mock.calls[0]?.[0]).toBe(fallback)
+	})
+
+	it("aggregates no_api_key and auth lookup failures across the ladder", async () => {
+		const registry = createModelRegistry()
+		registry.hasConfiguredAuth.mockImplementation((model) => model.id !== primary.id)
+		registry.getApiKeyAndHeaders
+			.mockResolvedValueOnce({ ok: false, error: "secret" })
+			.mockRejectedValueOnce(new Error("secret"))
+		const result = await classifyToolCall([primary, fallback], registry, call, options)
+		expect(result.failureCode).toBe("auth_unavailable")
+		expect(result.reason).toContain(`${primary.id} skipped: no API key`)
+		expect(result.reason).toContain(`${fallback.id} skipped: auth lookup failed`)
 		expect(result.reason).not.toContain("secret")
 	})
 

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -24,7 +24,7 @@ export interface ClassifierOptions {
 
 export async function classifyToolCall(
 	candidates: readonly Model<Api>[],
-	modelRegistry: Pick<ModelRegistry, "getApiKeyAndHeaders">,
+	modelRegistry: Pick<ModelRegistry, "getApiKeyAndHeaders" | "hasConfiguredAuth">,
 	call: ClassifyInput,
 	options: ClassifierOptions,
 	signal?: AbortSignal,
@@ -46,9 +46,14 @@ export async function classifyToolCall(
 		if (signal?.aborted || authResult.status === "aborted") return unavailable("classifier aborted", "aborted")
 		if (authResult.status !== "ok" || !authResult.value.ok || !authResult.value.apiKey) {
 			const timedOut = authResult.status === "timeout"
-			const reason = timedOut ? "auth timeout" : "no API key"
+			// hasConfiguredAuth is a cached provider-level lookup; only consulted on the failure path.
+			const noKey = !timedOut && !modelRegistry.hasConfiguredAuth(model)
+			const reason = timedOut ? "auth timeout" : noKey ? "no API key" : "auth lookup failed"
 			skips.push(`${model.id} skipped: ${reason}`)
-			lastResult = unavailable(`classifier ${reason}`, timedOut ? "auth_timeout" : "auth_unavailable")
+			lastResult = unavailable(
+				`classifier ${reason}`,
+				timedOut ? "auth_timeout" : noKey ? "no_api_key" : "auth_unavailable",
+			)
 			continue
 		}
 

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -2,14 +2,14 @@ import type { Api, Model } from "@earendil-works/pi-ai"
 import { complete } from "@earendil-works/pi-ai/compat"
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent"
 import { omitKimchiMaxTokensFromPayload } from "../omit-kimchi-max-tokens.js"
+import { DEFAULT_CONFIG } from "./constants.js"
 import classifierSystemPrompt from "./prompts/classifier-system-prompt.js"
-import type { ClassifierResult, ClassifierVerdict, RiskScore } from "./types.js"
+import type { ClassifierFailureCode, ClassifierResult, ClassifierVerdict, RiskScore } from "./types.js"
 
 /** Tag added to every classifier LLM request for cost tracking. */
 export const CLASSIFIER_REQUEST_TAG = "source:classifier"
 
-export const CLASSIFIER_PRIMARY_MODEL_ID = "deepseek-v4-flash"
-export const CLASSIFIER_FALLBACK_MODEL_ID = "minimax-m3"
+const MIN_ATTEMPT_MS = 1000
 
 export interface ClassifyInput {
 	toolName: string
@@ -19,136 +19,187 @@ export interface ClassifyInput {
 
 export interface ClassifierOptions {
 	timeoutMs: number
+	maxTotalMs?: number
 }
 
-/** Internal result type that carries a retry hint without touching the public ClassifierResult. */
-type InternalResult = ClassifierResult & { retryable: boolean }
-
 export async function classifyToolCall(
-	modelRegistry: ModelRegistry,
+	candidates: readonly Model<Api>[],
+	modelRegistry: Pick<ModelRegistry, "getApiKeyAndHeaders">,
 	call: ClassifyInput,
 	options: ClassifierOptions,
 	signal?: AbortSignal,
 ): Promise<ClassifierResult> {
-	const available = modelRegistry.getAvailable()
-	const primaryModel = available.find((m) => m.id === CLASSIFIER_PRIMARY_MODEL_ID)
-	if (!primaryModel) return unavailable("no model available for classifier")
-	const fallbackModel = available.find((m) => m.id === CLASSIFIER_FALLBACK_MODEL_ID)
+	const deadline = performance.now() + (options.maxTotalMs ?? DEFAULT_CONFIG.classifierMaxTotalMs)
+	if (signal?.aborted) return unavailable("classifier aborted", "aborted")
+	if (!candidates.length) return unavailable("no model available for classifier", "no_candidates")
+	let lastResult = unavailable("classifier budget exhausted", "budget_exhausted")
+	const skips: string[] = []
 
-	const auth = await modelRegistry.getApiKeyAndHeaders(primaryModel)
-	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
-
-	if (signal?.aborted) return unavailable("classifier aborted")
-
-	const maxAttempts = 3
-	let lastResult: InternalResult = unavailable("classifier unavailable")
-
-	for (let attempt = 0; attempt < maxAttempts; attempt++) {
-		if (attempt > 0) {
-			await sleep(attempt * 500)
-			if (signal?.aborted) return unavailable("classifier aborted")
+	for (const [index, model] of candidates.entries()) {
+		if (signal?.aborted) return unavailable("classifier aborted", "aborted")
+		const remaining = deadline - performance.now()
+		if (remaining < MIN_ATTEMPT_MS) break
+		const reserve =
+			index < candidates.length - 1 && remaining >= 2 * MIN_ATTEMPT_MS ? Math.min(options.timeoutMs, remaining / 2) : 0
+		const candidateDeadline = deadline - reserve
+		const authResult = await withinDeadline(() => modelRegistry.getApiKeyAndHeaders(model), candidateDeadline, signal)
+		if (signal?.aborted || authResult.status === "aborted") return unavailable("classifier aborted", "aborted")
+		if (authResult.status !== "ok" || !authResult.value.ok || !authResult.value.apiKey) {
+			const timedOut = authResult.status === "timeout"
+			const reason = timedOut ? "auth timeout" : "no API key"
+			skips.push(`${model.id} skipped: ${reason}`)
+			lastResult = unavailable(`classifier ${reason}`, timedOut ? "auth_timeout" : "auth_unavailable")
+			continue
 		}
 
-		const result = await runClassifier(primaryModel, auth, call, options, signal)
-		if (result.ok) return result
-
-		if (!result.retryable) return result
-
-		lastResult = result
-	}
-
-	if (signal?.aborted) return unavailable("classifier aborted")
-
-	if (fallbackModel) {
-		const fallbackAuth = await modelRegistry.getApiKeyAndHeaders(fallbackModel)
-		if (fallbackAuth.ok && fallbackAuth.apiKey) {
-			return runClassifier(fallbackModel, fallbackAuth, call, options, signal)
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const backoff = attempt * 500
+			if (candidateDeadline - performance.now() < backoff + MIN_ATTEMPT_MS) break
+			if (backoff) {
+				// A deadline-only wait uses the same cancellation and timer cleanup as requests.
+				await withinDeadline(() => new Promise<never>(() => {}), performance.now() + backoff, signal)
+			}
+			if (signal?.aborted) return unavailable("classifier aborted", "aborted")
+			if (candidateDeadline - performance.now() < MIN_ATTEMPT_MS) break
+			lastResult = await runClassifier(
+				model,
+				authResult.value,
+				call,
+				Math.min(candidateDeadline, performance.now() + options.timeoutMs),
+				signal,
+			)
+			if (signal?.aborted || lastResult.failureCode === "aborted") return unavailable("classifier aborted", "aborted")
+			if (lastResult.ok) return { ...lastResult, usedModelId: model.id }
 		}
 	}
+	if (signal?.aborted) return unavailable("classifier aborted", "aborted")
+	if (performance.now() >= deadline) lastResult = unavailable("classifier budget exhausted", "budget_exhausted")
+	return { ...lastResult, reason: `${lastResult.reason}${skips.length ? ` (${skips.join("; ")})` : ""}` }
+}
 
-	return lastResult
+type WaitResult<T> =
+	| { status: "ok"; value: T }
+	| { status: "error"; error: unknown }
+	| { status: "timeout" }
+	| { status: "aborted" }
+
+/** Bound caller latency even when auth or a provider cannot cancel its work. */
+function withinDeadline<T>(
+	operation: (signal: AbortSignal) => Promise<T>,
+	deadline: number,
+	signal?: AbortSignal,
+): Promise<WaitResult<T>> {
+	if (signal?.aborted) return Promise.resolve({ status: "aborted" })
+	if (performance.now() >= deadline) return Promise.resolve({ status: "timeout" })
+	return new Promise((resolve) => {
+		const controller = new AbortController()
+		let settled = false
+		const finish = (result: WaitResult<T>) => {
+			if (settled) return
+			settled = true
+			clearTimeout(timer)
+			signal?.removeEventListener("abort", onAbort)
+			const outcome: WaitResult<T> = signal?.aborted
+				? { status: "aborted" }
+				: performance.now() >= deadline
+					? { status: "timeout" }
+					: result
+			if (outcome.status === "timeout" || outcome.status === "aborted") controller.abort()
+			resolve(outcome)
+		}
+		const onAbort = () => finish({ status: "aborted" })
+		const timer = setTimeout(() => finish({ status: "timeout" }), Math.ceil(deadline - performance.now()))
+		signal?.addEventListener("abort", onAbort, { once: true })
+		try {
+			// Both handlers stay attached after timeout, observing late rejection without changing the result.
+			Promise.resolve(operation(controller.signal)).then(
+				(value) => finish({ status: "ok", value }),
+				(error: unknown) => finish({ status: "error", error }),
+			)
+		} catch (error) {
+			finish({ status: "error", error })
+		}
+	})
 }
 
 async function runClassifier(
 	model: Model<Api>,
 	auth: Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>,
 	call: ClassifyInput,
-	options: ClassifierOptions,
+	deadline: number,
 	signal?: AbortSignal,
-): Promise<InternalResult> {
-	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier")
-
-	if (signal?.aborted) return unavailable("classifier aborted")
-
-	const controller = new AbortController()
-	const timeoutHandle = setTimeout(() => controller.abort(), options.timeoutMs)
-	const onOuterAbort = () => controller.abort()
-	signal?.addEventListener("abort", onOuterAbort)
-
-	try {
-		const response = await complete(
-			model,
-			{
-				systemPrompt: classifierSystemPrompt,
-				messages: [
-					{
-						role: "user",
-						content: [{ type: "text", text: buildUserPrompt(call) }],
-						timestamp: Date.now(),
-					},
-				],
-			},
-			{
-				apiKey: auth.apiKey,
-				headers: auth.headers,
-				signal: controller.signal,
-				onPayload: (payload: unknown) => {
-					if (payload && typeof payload === "object") {
-						const p = payload as Record<string, unknown>
-						const existing = Array.isArray(p.tags) ? (p.tags as string[]) : []
-						p.tags = [CLASSIFIER_REQUEST_TAG, ...existing]
-					}
-					return omitKimchiMaxTokensFromPayload(payload, model)
+): Promise<ClassifierResult> {
+	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier", "auth_unavailable")
+	const outcome = await withinDeadline(
+		(attemptSignal) =>
+			complete(
+				model,
+				{
+					systemPrompt: classifierSystemPrompt,
+					messages: [
+						{
+							role: "user",
+							content: [{ type: "text", text: buildUserPrompt(call) }],
+							timestamp: Date.now(),
+						},
+					],
 				},
-			},
+				{
+					apiKey: auth.apiKey,
+					headers: auth.headers,
+					signal: attemptSignal,
+					onPayload: (payload: unknown) => {
+						if (payload && typeof payload === "object") {
+							const p = payload as Record<string, unknown>
+							const existing = Array.isArray(p.tags) ? (p.tags as string[]) : []
+							p.tags = [CLASSIFIER_REQUEST_TAG, ...existing]
+						}
+						return omitKimchiMaxTokensFromPayload(payload, model)
+					},
+				},
+			),
+		deadline,
+		signal,
+	)
+	if (signal?.aborted || outcome.status === "aborted") return unavailable("classifier aborted", "aborted")
+	if (outcome.status === "timeout") return unavailable(`classifier timeout (model=${model.id})`, "timeout")
+	if (outcome.status === "error") {
+		const error = outcome.error
+		const aborted = error instanceof Error && error.name === "AbortError"
+		return unavailable(
+			`${aborted ? "classifier timeout" : `classifier error: ${error instanceof Error ? error.message : String(error)}`} (model=${model.id})`,
+			aborted ? "timeout" : "provider_error",
 		)
-
-		if (response.stopReason === "aborted") {
-			return retryable(`classifier timeout (model=${model.id} tool=${call.toolName})`)
-		}
-
-		if (response.stopReason === "error") {
-			return unavailable(
-				`classifier error: ${response.errorMessage || "unknown"} (model=${model.id} tool=${call.toolName})`,
-			)
-		}
-
-		const text = response.content
-			.filter((c): c is { type: "text"; text: string } => c.type === "text")
-			.map((c) => c.text)
-			.join("\n")
-
-		const result = parseClassifierOutput(text)
-
-		if (!result.ok) {
-			const diag = [
-				`model=${model.id}`,
-				`stopReason=${response.stopReason}`,
-				`text=${truncate(text, 200) || "(empty)"}`,
-			].join(" ")
-			return unavailable(`${result.reason} (${diag})`)
-		}
-
-		return { ...result, retryable: false }
-	} catch (err) {
-		const aborted = (err as Error)?.name === "AbortError" || controller.signal.aborted
-		const reason = aborted ? "classifier timeout" : `classifier error: ${(err as Error).message}`
-		const message = `${reason} (model=${model.id} tool=${call.toolName})`
-		return aborted ? retryable(message) : unavailable(message)
-	} finally {
-		clearTimeout(timeoutHandle)
-		signal?.removeEventListener("abort", onOuterAbort)
 	}
+	const response = outcome.value
+	if (response.stopReason === "aborted") {
+		return unavailable(`classifier timeout (model=${model.id} tool=${call.toolName})`, "timeout")
+	}
+
+	if (response.stopReason === "error") {
+		return unavailable(
+			`classifier error: ${response.errorMessage || "unknown"} (model=${model.id} tool=${call.toolName})`,
+			"provider_error",
+		)
+	}
+
+	const text = response.content
+		.filter((c): c is { type: "text"; text: string } => c.type === "text")
+		.map((c) => c.text)
+		.join("\n")
+
+	const result = parseClassifierOutput(text)
+
+	if (!result.ok) {
+		const diag = [
+			`model=${model.id}`,
+			`stopReason=${response.stopReason}`,
+			`text=${truncate(text, 200) || "(empty)"}`,
+		].join(" ")
+		return unavailable(`${result.reason} (${diag})`, "invalid_output")
+	}
+
+	return result
 }
 
 function buildUserPrompt(call: ClassifyInput): string {
@@ -158,11 +209,11 @@ function buildUserPrompt(call: ClassifyInput): string {
 
 export function parseClassifierOutput(raw: string): ClassifierResult {
 	const json = extractJsonObject(stripThinking(raw))
-	if (!json) return unavailable("classifier returned unparseable output")
+	if (!json) return unavailable("classifier returned unparseable output", "invalid_output")
 
 	const verdict = normalizeVerdict(json.verdict)
 	const reason = typeof json.reason === "string" && json.reason.trim() ? json.reason.trim() : "no reason provided"
-	if (!verdict) return unavailable(reason)
+	if (!verdict) return unavailable(reason, "invalid_output")
 	const riskScore = normalizeRiskScore(json.riskScore)
 	return { verdict, reason, ok: true, riskScore }
 }
@@ -191,12 +242,8 @@ export function stripThinking(raw: string): string {
 	return closed
 }
 
-function unavailable(reason: string): InternalResult {
-	return { verdict: "requires-confirmation", reason, ok: false, retryable: false }
-}
-
-function retryable(reason: string): InternalResult {
-	return { verdict: "requires-confirmation", reason, ok: false, retryable: true }
+function unavailable(reason: string, failureCode: ClassifierFailureCode): ClassifierResult {
+	return { verdict: "requires-confirmation", reason, ok: false, failureCode }
 }
 
 function normalizeVerdict(v: unknown): ClassifierVerdict | undefined {
@@ -233,8 +280,4 @@ function safeStringify(value: unknown): string {
 function truncate(s: string, max: number): string {
 	if (s.length <= max) return s
 	return `${s.slice(0, max - 1)}…`
-}
-
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -127,14 +127,16 @@ function withinDeadline<T>(
 	})
 }
 
+/** Auth for a candidate that cleared the engine's auth check: the ok-branch of the registry result. */
+type CandidateAuth = Extract<Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>, { ok: true }>
+
 async function runClassifier(
 	model: Model<Api>,
-	auth: Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>,
+	auth: CandidateAuth,
 	call: ClassifyInput,
 	deadline: number,
 	signal?: AbortSignal,
 ): Promise<ClassifierResult> {
-	if (!auth.ok || !auth.apiKey) return unavailable("no API key for classifier", "auth_unavailable")
 	const outcome = await withinDeadline(
 		(attemptSignal) =>
 			complete(

--- a/src/extensions/permissions/classifier.ts
+++ b/src/extensions/permissions/classifier.ts
@@ -42,6 +42,8 @@ export async function classifyToolCall(
 		const reserve =
 			index < candidates.length - 1 && remaining >= 2 * MIN_ATTEMPT_MS ? Math.min(options.timeoutMs, remaining / 2) : 0
 		const candidateDeadline = deadline - reserve
+		// getApiKeyAndHeaders accepts no signal: withinDeadline races it against the
+		// candidate deadline and outer cancellation, and ignores late settlement.
 		const authResult = await withinDeadline(() => modelRegistry.getApiKeyAndHeaders(model), candidateDeadline, signal)
 		if (signal?.aborted || authResult.status === "aborted") return unavailable("classifier aborted", "aborted")
 		if (authResult.status !== "ok" || !authResult.value.ok || !authResult.value.apiKey) {

--- a/src/extensions/permissions/config.test.ts
+++ b/src/extensions/permissions/config.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { loadConfig } from "./config.js"
 
 let tmpCwd: string
@@ -15,6 +15,62 @@ afterEach(() => {
 })
 
 describe("loadConfig merging", () => {
+	it("inherits user budget through project and local files that omit it", async () => {
+		const userDir = join(tmpCwd, ".config", "kimchi", "harness")
+		mkdirSync(userDir, { recursive: true })
+		writeFileSync(join(userDir, "permissions.json"), JSON.stringify({ classifierMaxTotalMs: 17000 }))
+		mkdirSync(join(tmpCwd, ".kimchi"), { recursive: true })
+		writeFileSync(join(tmpCwd, ".kimchi", "permissions.json"), "{}")
+		writeFileSync(join(tmpCwd, ".kimchi", "permissions.local.json"), "{}")
+		vi.doMock("node:os", async (importOriginal) => ({
+			...(await importOriginal<typeof import("node:os")>()),
+			homedir: () => tmpCwd,
+		}))
+		vi.resetModules()
+		try {
+			const isolatedConfig = await import("./config.js")
+			expect(isolatedConfig.loadConfig({ cwd: tmpCwd }).loaded.config.classifierMaxTotalMs).toBe(17000)
+			writeFileSync(join(tmpCwd, ".kimchi", "permissions.json"), JSON.stringify({ classifierMaxTotalMs: 12000 }))
+			expect(isolatedConfig.loadConfig({ cwd: tmpCwd }).loaded.config.classifierMaxTotalMs).toBe(12000)
+		} finally {
+			vi.doUnmock("node:os")
+			vi.resetModules()
+		}
+	})
+
+	it.each([undefined, 12000])("fills or accepts the classifier total budget (%s)", (budget) => {
+		const path = join(tmpCwd, "override.json")
+		writeFileSync(path, JSON.stringify({ classifierMaxTotalMs: budget }))
+		const { loaded, errors } = loadConfig({ cwd: tmpCwd, cliConfigPath: path })
+		expect(errors).toEqual([])
+		expect(loaded.config.classifierMaxTotalMs).toBe(budget ?? 25000)
+	})
+
+	it("uses explicit local budgets before project budgets and preserves inheritance through sparse local files", () => {
+		mkdirSync(join(tmpCwd, ".kimchi"), { recursive: true })
+		writeFileSync(join(tmpCwd, ".kimchi", "permissions.json"), JSON.stringify({ classifierMaxTotalMs: 12000 }))
+		const local = join(tmpCwd, ".kimchi", "permissions.local.json")
+		writeFileSync(local, JSON.stringify({ classifierMaxTotalMs: 6000 }))
+		expect(loadConfig({ cwd: tmpCwd }).loaded.config.classifierMaxTotalMs).toBe(6000)
+		writeFileSync(local, JSON.stringify({ allow: ["read"] }))
+		expect(loadConfig({ cwd: tmpCwd }).loaded.config.classifierMaxTotalMs).toBe(12000)
+		const override = join(tmpCwd, "override.json")
+		writeFileSync(override, "{}")
+		expect(loadConfig({ cwd: tmpCwd, cliConfigPath: override }).loaded.config.classifierMaxTotalMs).toBe(25000)
+	})
+
+	it.each([
+		{ classifierMaxTotalMs: 0 },
+		{ classifierMaxTotalMs: -1 },
+		{ classifierMaxTotalMs: 1.5 },
+		{ classifierMaxTotalMs: "12000" },
+		{ classifierMaxTotalMs: 12000, unknownSetting: true },
+	])("rejects invalid budgets and unknown settings: %j", (config) => {
+		const path = join(tmpCwd, "invalid.json")
+		writeFileSync(path, JSON.stringify(config))
+		expect(loadConfig({ cwd: tmpCwd, cliConfigPath: path }).errors).toHaveLength(1)
+	})
+
 	it("reads project config and tags rules by source", () => {
 		mkdirSync(join(tmpCwd, ".kimchi"), { recursive: true })
 		writeFileSync(

--- a/src/extensions/permissions/config.ts
+++ b/src/extensions/permissions/config.ts
@@ -13,6 +13,7 @@ const configSchema = z
 		allow: z.array(z.string()).optional(),
 		deny: z.array(z.string()).optional(),
 		classifierTimeoutMs: z.number().int().positive().optional(),
+		classifierMaxTotalMs: z.number().int().positive().optional(),
 	})
 	.strict()
 
@@ -34,7 +35,12 @@ const USER_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "harness", "per
 const PROJECT_CONFIG_SUFFIX = join(".kimchi", "permissions.json")
 const LOCAL_CONFIG_SUFFIX = join(".kimchi", "permissions.local.json")
 
-function readConfigFile(path: string): { data: PermissionsConfig | null; error?: string } {
+function readConfigFile(path: string): {
+	data: PermissionsConfig | null
+	/** Preserve omission so a sparse higher-priority file does not erase an inherited budget. */
+	classifierMaxTotalMs?: number
+	error?: string
+} {
 	if (!existsSync(path)) return { data: null }
 	try {
 		const raw = readFileSync(path, "utf-8")
@@ -44,11 +50,13 @@ function readConfigFile(path: string): { data: PermissionsConfig | null; error?:
 			return { data: null, error: `${path}: ${validated.error.message}` }
 		}
 		return {
+			classifierMaxTotalMs: validated.data.classifierMaxTotalMs,
 			data: {
 				defaultMode: validated.data.defaultMode ?? DEFAULT_CONFIG.defaultMode,
 				allow: validated.data.allow ?? [],
 				deny: validated.data.deny ?? [],
 				classifierTimeoutMs: validated.data.classifierTimeoutMs ?? DEFAULT_CONFIG.classifierTimeoutMs,
+				classifierMaxTotalMs: validated.data.classifierMaxTotalMs ?? DEFAULT_CONFIG.classifierMaxTotalMs,
 			},
 		}
 	} catch (err) {
@@ -86,6 +94,8 @@ export function loadConfig(options: LoadConfigOptions): { loaded: LoadedConfig; 
 			allow: [...user.allow, ...(project?.allow ?? []), ...(local?.allow ?? [])],
 			deny: [...user.deny, ...(project?.deny ?? []), ...(local?.deny ?? [])],
 			classifierTimeoutMs: local?.classifierTimeoutMs ?? project?.classifierTimeoutMs ?? user.classifierTimeoutMs,
+			classifierMaxTotalMs:
+				localRead.classifierMaxTotalMs ?? projectRead.classifierMaxTotalMs ?? user.classifierMaxTotalMs,
 		}
 	}
 

--- a/src/extensions/permissions/constants.ts
+++ b/src/extensions/permissions/constants.ts
@@ -40,6 +40,7 @@ export const DEFAULT_CONFIG: PermissionsConfig = {
 	allow: [],
 	deny: [],
 	classifierTimeoutMs: 8000,
+	classifierMaxTotalMs: 25_000,
 }
 
 /**

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -334,6 +334,30 @@ describe("classifier health reporting", () => {
 		expect(ctx.ui.notify).not.toHaveBeenCalled()
 	})
 
+	it("notifies with actionable KIMCHI_API_KEY copy once per session for no_api_key", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = { ...createClassifierContext(), hasUI: true }
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE, emissions)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		const noApiKey = {
+			verdict: "requires-confirmation",
+			ok: false,
+			reason: "SENTINEL_SECRET",
+			failureCode: "no_api_key",
+		} as const
+		for (let i = 0; i < 2; i++) {
+			vi.mocked(classifyToolCall).mockResolvedValueOnce(noApiKey)
+			await harness.fire("tool_call", event, ctx)
+		}
+		expect(emissions).toHaveBeenCalledTimes(2)
+		expect(emissions).toHaveBeenLastCalledWith({ failureCode: "no_api_key", missingRefs: [] })
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(1)
+		expect(vi.mocked(ctx.ui.notify).mock.calls[0]?.[0]).toContain("KIMCHI_API_KEY")
+		expect(JSON.stringify([emissions.mock.calls, vi.mocked(ctx.ui.notify).mock.calls])).not.toContain("SENTINEL_SECRET")
+	})
+
 	it.each([
 		undefined,
 		9000,

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -13,6 +13,7 @@ import { FermentEventStore } from "../../ferment/event-store.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "../../modes/acp/permission-prompter-registry.js"
 import { createExtensionApi } from "../__mocks__/extension-api.js"
 import { createMiniEventBus } from "../__mocks__/mini-event-bus.js"
+import { createModel, createModelRegistry } from "../__mocks__/model-registry.js"
 import { runAsAgentWorker } from "../agent-worker-context.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../agents/manager/constants.js"
 import { FERMENT_TOOLS } from "../ferment/tool-names.js"
@@ -21,11 +22,13 @@ import { buildSystemPrompt, type EnvironmentInfo } from "../prompt-construction/
 import { createToolVisibility } from "../prompt-construction/tool-visibility.js"
 import { TODO_TOOL_NAMES } from "../todos/tool.js"
 import { classifyToolCall } from "./classifier.js"
+import { DEFAULT_CLASSIFIER_CANDIDATE_REFS, resolveClassifierCandidates } from "./classifier-models.js"
 import { PERMISSIONS_ENV_KEY } from "./constants.js"
 import permissionsExtension, { checkCompoundCommand, handleCompoundConfirm, notifyFermentActive } from "./index.js"
 import { PERMISSION_MODE_SESSION_ENTRY_TYPE } from "./mode.js"
 import { getPermissionMode } from "./mode-controller.js"
 import { unregisterSessionPermissionFlagController } from "./mode-controller-registry.js"
+import { PERMISSION_EVENTS } from "./permissions-events.js"
 import { SessionMemory } from "./session-memory.js"
 import type { PermissionModeState, Rule } from "./types.js"
 
@@ -44,7 +47,24 @@ vi.mock("./classifier.js", async () => {
 	const actual = await vi.importActual<typeof import("./classifier.js")>("./classifier.js")
 	return {
 		...actual,
-		classifyToolCall: vi.fn(async () => ({ verdict: "safe", riskScore: "low", reason: "mock safe" })),
+		classifyToolCall: vi.fn(async () => ({
+			verdict: "safe",
+			riskScore: "low",
+			reason: "mock safe",
+			ok: true,
+			usedModelId: "deepseek-v4-flash-0731",
+		})),
+	}
+})
+
+vi.mock("./classifier-models.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./classifier-models.js")>()
+	return {
+		...actual,
+		resolveClassifierCandidates: vi.fn(() => ({
+			candidates: [createModel("deepseek-v4-flash-0731"), createModel("minimax-m3")],
+			missingRefs: [],
+		})),
 	}
 })
 
@@ -131,20 +151,15 @@ function createMockContext(
 }
 
 function createClassifierContext(): ExtensionContext {
-	// Expose the deterministic classifier models so resolveClassifierModels
-	// finds both primary (deepseek-v4-flash) and fallback (minimax-m3).
-	const primaryModel = { provider: "test-provider", id: "deepseek-v4-flash" }
-	const fallbackModel = { provider: "test-provider", id: "minimax-m3" }
+	const primaryModel = createModel("deepseek-v4-flash-0731")
+	const fallbackModel = createModel("minimax-m3")
 	const model = primaryModel
 	return {
 		...createMockContext([]),
 		hasUI: false,
 		cwd: "/test",
 		model,
-		modelRegistry: {
-			getAvailable: vi.fn(() => [primaryModel, fallbackModel]),
-			find: vi.fn(() => primaryModel),
-		},
+		modelRegistry: createModelRegistry([primaryModel, fallbackModel]),
 	} as unknown as ExtensionContext
 }
 
@@ -217,6 +232,128 @@ function createPermissionsHarness(
 		},
 	}
 }
+
+describe("classifier health reporting", () => {
+	const event = {
+		type: "tool_call",
+		toolCallId: "health-call",
+		toolName: "bash",
+		input: { command: "touch SENTINEL_SECRET" },
+	}
+	const unavailable = {
+		verdict: "requires-confirmation",
+		ok: false,
+		reason: "SENTINEL_SECRET",
+		failureCode: "no_candidates",
+	} as const
+	const degraded = { verdict: "safe", ok: true, reason: "SENTINEL_SECRET", usedModelId: "minimax-m3" } as const
+
+	beforeEach(() => {
+		vi.mocked(classifyToolCall).mockClear()
+	})
+
+	it("warns once per session for missing models and emits only structured unavailable events", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = { ...createClassifierContext(), hasUI: true }
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE, emissions)
+		const degradedEvents = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_DEGRADED, degradedEvents)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		for (let i = 0; i < 2; i++) {
+			vi.mocked(resolveClassifierCandidates).mockReturnValueOnce({
+				candidates: [],
+				missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS],
+			})
+			vi.mocked(classifyToolCall).mockResolvedValueOnce(unavailable)
+			await harness.fire("tool_call", event, ctx)
+		}
+		expect(emissions).toHaveBeenCalledTimes(2)
+		expect(emissions).toHaveBeenLastCalledWith({
+			failureCode: "no_candidates",
+			missingRefs: [...DEFAULT_CLASSIFIER_CANDIDATE_REFS],
+		})
+		expect(degradedEvents).not.toHaveBeenCalled()
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(1)
+		expect(JSON.stringify([emissions.mock.calls, vi.mocked(ctx.ui.notify).mock.calls])).not.toContain("SENTINEL_SECRET")
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		vi.mocked(classifyToolCall).mockResolvedValueOnce(unavailable)
+		await harness.fire("tool_call", event, ctx)
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(1)
+	})
+
+	it("warns once for fallback and allows escalation to unavailable", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = { ...createClassifierContext(), hasUI: true }
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_DEGRADED, emissions)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		for (const result of [degraded, degraded, unavailable]) {
+			vi.mocked(classifyToolCall).mockResolvedValueOnce(result)
+			await harness.fire("tool_call", event, ctx)
+		}
+		expect(emissions).toHaveBeenCalledTimes(2)
+		expect(emissions).toHaveBeenLastCalledWith({ usedModelId: "minimax-m3", missingRefs: [] })
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(2)
+	})
+
+	it("does not let cancellation consume the unavailable warning", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = { ...createClassifierContext(), hasUI: true }
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE, emissions)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		vi.mocked(classifyToolCall).mockResolvedValueOnce({
+			...unavailable,
+			reason: "classifier aborted",
+			failureCode: "aborted",
+		})
+		await harness.fire("tool_call", event, ctx)
+		expect(emissions).not.toHaveBeenCalled()
+		expect(ctx.ui.notify).not.toHaveBeenCalled()
+		vi.mocked(classifyToolCall).mockResolvedValueOnce(unavailable)
+		await harness.fire("tool_call", event, ctx)
+		expect(emissions).toHaveBeenCalledTimes(1)
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(1)
+	})
+
+	it("emits headless failures without UI notifications and blocks the call", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = createClassifierContext()
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE, emissions)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		vi.mocked(classifyToolCall).mockResolvedValueOnce(unavailable)
+		expect(await harness.fire("tool_call", event, ctx)).toMatchObject({ block: true })
+		expect(emissions).toHaveBeenCalledTimes(1)
+		expect(ctx.ui.notify).not.toHaveBeenCalled()
+	})
+
+	it.each([
+		undefined,
+		9000,
+	])("passes the default or configured total budget (%s) without warning on healthy success", async (budget) => {
+		const dir = mkdtempSync(join(tmpdir(), "classifier-config-"))
+		try {
+			const path = join(dir, "permissions.json")
+			writeFileSync(path, JSON.stringify({ classifierMaxTotalMs: budget }))
+			const harness = createPermissionsHarness(["bash"], { auto: true, "permissions-config": path })
+			const ctx = { ...createClassifierContext(), hasUI: true }
+			await harness.fire("session_start", {}, ctx)
+			vi.mocked(ctx.ui.notify).mockClear()
+			expect(await harness.fire("tool_call", event, ctx)).toBeUndefined()
+			expect(vi.mocked(classifyToolCall).mock.calls[0]?.[3]).toEqual({ timeoutMs: 8000, maxTotalMs: budget ?? 25000 })
+			expect(ctx.ui.notify).not.toHaveBeenCalled()
+		} finally {
+			rmSync(dir, { recursive: true, force: true })
+		}
+	})
+})
 
 describe("permissions plan-mode tool visibility", () => {
 	afterEach(() => {
@@ -1152,7 +1289,7 @@ describe("permissions internal tool classification", () => {
 
 		expect(result).toBeUndefined()
 		expect(classifyToolCall).toHaveBeenCalledTimes(1)
-		expect(vi.mocked(classifyToolCall).mock.calls[0]?.[1]).toMatchObject({
+		expect(vi.mocked(classifyToolCall).mock.calls[0]?.[2]).toMatchObject({
 			toolName: "unknown_tool",
 			input: { value: 1 },
 			cwd: "/test",

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -358,6 +358,25 @@ describe("classifier health reporting", () => {
 		expect(JSON.stringify([emissions.mock.calls, vi.mocked(ctx.ui.notify).mock.calls])).not.toContain("SENTINEL_SECRET")
 	})
 
+	it("notifies again when the unavailable copy changes within a session", async () => {
+		const harness = createPermissionsHarness(["bash"], { auto: true })
+		const ctx = { ...createClassifierContext(), hasUI: true }
+		const emissions = vi.fn()
+		harness.pi.events.on(PERMISSION_EVENTS.CLASSIFIER_UNAVAILABLE, emissions)
+		await harness.fire("session_start", {}, ctx)
+		vi.mocked(ctx.ui.notify).mockClear()
+		const noApiKey = { ...unavailable, failureCode: "no_api_key" } as const
+		for (const result of [unavailable, noApiKey, noApiKey]) {
+			vi.mocked(classifyToolCall).mockResolvedValueOnce(result)
+			await harness.fire("tool_call", event, ctx)
+		}
+		expect(emissions).toHaveBeenCalledTimes(3)
+		expect(ctx.ui.notify).toHaveBeenCalledTimes(2)
+		expect(vi.mocked(ctx.ui.notify).mock.calls[0]?.[0]).not.toContain("KIMCHI_API_KEY")
+		expect(vi.mocked(ctx.ui.notify).mock.calls[1]?.[0]).toContain("KIMCHI_API_KEY")
+		expect(JSON.stringify(vi.mocked(ctx.ui.notify).mock.calls)).not.toContain("SENTINEL_SECRET")
+	})
+
 	it.each([
 		undefined,
 		9000,

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -50,6 +50,8 @@ import { isRawInputCaptureActive } from "../shared-input.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { TODO_TOOL_NAMES } from "../todos/tool.js"
 import { classifyToolCall } from "./classifier.js"
+import { classifierHealth } from "./classifier-health.js"
+import { resolveClassifierCandidates } from "./classifier-models.js"
 import { registerCommands } from "./commands.js"
 import { type LoadedConfig, loadConfig } from "./config.js"
 import { BUILTIN_DENY, DEFAULT_CONFIG, PERMISSION_MODES_WITH_META as MODES, PERMISSIONS_ENV_KEY } from "./constants.js"
@@ -249,6 +251,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	})
 
 	const session = new SessionMemory()
+	const classifierWarnings = new Set<string>()
 	const builtinRules: Rule[] = parseRules(BUILTIN_DENY, "deny", "builtin")
 	// Base KIMCHI_PERMISSIONS env var used as a launch-time default. Subagent
 	// inheritance is handled separately in session_start via the parent session's
@@ -489,6 +492,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
+		classifierWarnings.clear()
 		currentCtx = ctx
 		cliMode = undefined
 		activePlanSlug = undefined
@@ -1147,12 +1151,25 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 			// through the classifier; prompts without a frontend fail closed.
 			const promptAvailable = canPrompt(ctx)
 			if (mode === "auto" || !promptAvailable) {
+				const { candidates, missingRefs } = resolveClassifierCandidates(ctx.modelRegistry)
 				const verdict = await classifyToolCall(
+					candidates,
 					ctx.modelRegistry,
 					{ toolName, input, cwd: ctx.cwd },
-					{ timeoutMs: loaded.config.classifierTimeoutMs },
+					{
+						timeoutMs: loaded.config.classifierTimeoutMs,
+						maxTotalMs: loaded.config.classifierMaxTotalMs,
+					},
 					ctx.signal,
 				)
+				const health = classifierHealth(verdict, candidates, missingRefs, ctx.signal)
+				if (health) {
+					pi.events.emit(health.channel, health.payload)
+					if (ctx.hasUI && !classifierWarnings.has(health.channel)) {
+						classifierWarnings.add(health.channel)
+						ctx.ui.notify(health.message, "warning")
+					}
+				}
 
 				if (verdict.verdict === "safe") return undefined
 				if (!promptAvailable) {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -1165,8 +1165,8 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				const health = classifierHealth(verdict, candidates, missingRefs, ctx.signal)
 				if (health) {
 					pi.events.emit(health.channel, health.payload)
-					if (ctx.hasUI && !classifierWarnings.has(health.channel)) {
-						classifierWarnings.add(health.channel)
+					if (ctx.hasUI && !classifierWarnings.has(health.notifyKey)) {
+						classifierWarnings.add(health.notifyKey)
 						ctx.ui.notify(health.message, "warning")
 					}
 				}

--- a/src/extensions/permissions/permissions-events.ts
+++ b/src/extensions/permissions/permissions-events.ts
@@ -16,7 +16,7 @@
  * returning `{ block: true, reason }`.
  */
 
-import type { PermissionMode, PermissionModeState, RiskScore, RuleSource } from "./types.js"
+import type { ClassifierFailureCode, PermissionMode, PermissionModeState, RiskScore, RuleSource } from "./types.js"
 
 export const PERMISSION_EVENTS = {
 	MODE_CHANGED: "permissions:mode_changed",
@@ -24,7 +24,19 @@ export const PERMISSION_EVENTS = {
 	AFTER_DECISION: "permissions:after_decision",
 	CONFIG_LOADED: "permissions:config_loaded",
 	PLAN_APPROVED: "permissions:plan_approved",
+	CLASSIFIER_UNAVAILABLE: "permissions:classifier_unavailable",
+	CLASSIFIER_DEGRADED: "permissions:classifier_degraded",
 } as const
+
+export interface ClassifierUnavailablePayload {
+	failureCode: Exclude<ClassifierFailureCode, "aborted">
+	missingRefs: string[]
+}
+
+export interface ClassifierDegradedPayload {
+	usedModelId: string
+	missingRefs: string[]
+}
 
 export type PermissionEventChannel = (typeof PERMISSION_EVENTS)[keyof typeof PERMISSION_EVENTS]
 

--- a/src/extensions/permissions/types.ts
+++ b/src/extensions/permissions/types.ts
@@ -33,6 +33,8 @@ export type RiskScore = "low" | "medium" | "high"
 
 export type ClassifierFailureCode =
 	| "no_candidates"
+	/** No credentials configured for the candidate's provider; user-fixable (set the provider API key). */
+	| "no_api_key"
 	| "auth_unavailable"
 	| "auth_timeout"
 	| "timeout"

--- a/src/extensions/permissions/types.ts
+++ b/src/extensions/permissions/types.ts
@@ -31,6 +31,16 @@ export type ClassifierVerdict = "safe" | "requires-confirmation"
 /** Risk score returned by the LLM classifier for display in the permission prompt. */
 export type RiskScore = "low" | "medium" | "high"
 
+export type ClassifierFailureCode =
+	| "no_candidates"
+	| "auth_unavailable"
+	| "auth_timeout"
+	| "timeout"
+	| "provider_error"
+	| "invalid_output"
+	| "budget_exhausted"
+	| "aborted"
+
 export interface ClassifierResult {
 	verdict: ClassifierVerdict
 	reason: string
@@ -38,6 +48,10 @@ export interface ClassifierResult {
 	ok: boolean
 	/** Risk score from the classifier LLM. Undefined when the classifier was not called or failed. */
 	riskScore?: RiskScore
+	/** Bare model ID that produced a valid verdict; absent on classifier failure. */
+	usedModelId?: string
+	/** Bounded diagnostic category suitable for health events; never provider/model text. */
+	failureCode?: ClassifierFailureCode
 }
 
 export interface PermissionsConfig {
@@ -45,6 +59,7 @@ export interface PermissionsConfig {
 	allow: string[]
 	deny: string[]
 	classifierTimeoutMs: number
+	classifierMaxTotalMs: number
 }
 
 /** Controller for session-scoped permission flags with subscription support. */

--- a/tests/e2e/tui/ferment-v2-mode.test.ts
+++ b/tests/e2e/tui/ferment-v2-mode.test.ts
@@ -67,11 +67,22 @@ test("experimental Ferment V2 leaves Plan mode, writes, and completes", async ({
 			artifactName: "ferment-v2-from-plan-mode",
 			seedHome: enableFermentV2Mode,
 			extraArgs: ["--plan=true"],
+			// The classifier resolves the kimchi-dev ladder provider-exactly, so the
+			// classifier model needs the dated slug under provider kimchi-dev (with
+			// ai-enabler metadata, catalog refresh preserves that provider).
+			providerId: "kimchi-dev",
 			models: [
-				{ slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 },
 				{
-					slug: "deepseek-v4-flash",
+					slug: "basic",
+					displayName: "Fake Basic",
+					provider: "ai-enabler",
+					contextWindow: 200_000,
+					maxTokens: 8192,
+				},
+				{
+					slug: "deepseek-v4-flash-0731",
 					displayName: "DeepSeek V4 Flash",
+					provider: "ai-enabler",
 					contextWindow: 200_000,
 					maxTokens: 8192,
 				},

--- a/tests/e2e/tui/permission-prompt.test.ts
+++ b/tests/e2e/tui/permission-prompt.test.ts
@@ -2,22 +2,24 @@
  * E2E TUI tests for the permission prompt UX — the terminal-facing surface
  * in `src/extensions/permissions/prompts.ts`.
  *
- * Covers three scenarios:
+ * Covers four scenarios:
  *   1. Auto mode: classifier returns "requires-confirmation" with "high" risk
  *      → the risk badge ("● high risk") and classifier reason appear in the prompt.
  *   2. Auto mode: classifier returns "safe" → tool auto-approves, no prompt shown.
  *   3. Auto mode without classifier model: prompt appears without a risk badge
  *      (classifier unavailable → riskScore undefined → no badge rendered).
+ *   4. Auto mode with only the fallback model: safe calls auto-approve and a health warning appears.
  *
  * Key wiring notes:
  *   - The fixture hardcodes `KIMCHI_PERMISSIONS=yolo`, which bypasses all prompts.
  *     All tests override via `--auto` flag, which takes precedence over env in
  *     `resolveMode` (flag > env > config).
- *   - The classifier makes its own LLM call to `deepseek-v4-flash`, so that model
+ *   - The classifier makes its own LLM call to `deepseek-v4-flash-0731`, so that model
  *     slug must be present in the models config for tests 1 and 2. Both the main
  *     model and classifier hit the same fake server endpoint; response ordering in
  *     the queue must match the real request order: main turn → classifier → main
  *     follow-up.
+ *   - Use kimchi-dev with ai-enabler metadata so catalog refresh preserves the exact classifier provider.
  *   - Test 3 omits the classifier model slug. `classifyToolCall` returns
  *     `{ verdict: "requires-confirmation", riskScore: undefined }`, so the prompt
  *     appears (auto mode + promptAvailable) but `formatRiskBadge` is never called.
@@ -29,10 +31,17 @@ import { runKimchiSession, TUI_TEST_CONFIG } from "./support/kimchi-fixture.js"
 
 test.use(TUI_TEST_CONFIG)
 
-const MAIN_MODEL = { slug: "basic", displayName: "Fake Basic", contextWindow: 200_000, maxTokens: 8192 }
+const MAIN_MODEL = {
+	slug: "basic",
+	displayName: "Fake Basic",
+	provider: "ai-enabler",
+	contextWindow: 200_000,
+	maxTokens: 8192,
+}
 const CLASSIFIER_MODEL = {
-	slug: "deepseek-v4-flash",
+	slug: "deepseek-v4-flash-0731",
 	displayName: "DeepSeek V4 Flash",
+	provider: "ai-enabler",
 	contextWindow: 200_000,
 	maxTokens: 8192,
 }
@@ -47,6 +56,7 @@ test("auto mode shows risk badge when classifier returns high risk", async ({ te
 		terminal,
 		{
 			artifactName: "permission-prompt-risk-badge",
+			providerId: "kimchi-dev",
 			extraArgs: ["--auto"],
 			models: [MAIN_MODEL, CLASSIFIER_MODEL],
 			responses: [
@@ -103,6 +113,7 @@ test("auto mode auto-approves when classifier returns safe verdict", async ({ te
 		terminal,
 		{
 			artifactName: "permission-prompt-safe-auto-approve",
+			providerId: "kimchi-dev",
 			extraArgs: ["--auto"],
 			models: [MAIN_MODEL, CLASSIFIER_MODEL],
 			responses: [
@@ -144,6 +155,7 @@ test("auto mode without classifier model shows prompt without risk badge", async
 		terminal,
 		{
 			artifactName: "permission-prompt-no-risk-badge",
+			providerId: "kimchi-dev",
 			extraArgs: ["--auto"],
 			// No CLASSIFIER_MODEL in the list — classifyToolCall returns unavailable.
 			models: [MAIN_MODEL],
@@ -165,6 +177,8 @@ test("auto mode without classifier model shows prompt without risk badge", async
 			// the verdict is "requires-confirmation", but riskScore is undefined.
 			await waitForText(terminal, ALLOW_PROMPT, { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("permission prompt visible")
+			await waitForText(terminal, "Permissions classifier unavailable", { timeoutMs: INPUT_TIMEOUT_MS })
+			trace.step("classifier unavailable warning visible")
 
 			// Verify no risk badge text is present (riskScore undefined → no badge).
 			const fullBuffer = terminal
@@ -181,6 +195,36 @@ test("auto mode without classifier model shows prompt without risk badge", async
 			// The model's follow-up should appear.
 			await waitForText(terminal, "File written successfully.", { timeoutMs: STREAM_TIMEOUT_MS })
 			trace.step("follow-up stream after approval")
+		},
+	)
+})
+
+test("auto mode uses fallback when the primary model is absent and warns the user", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "permission-classifier-fallback",
+			providerId: "kimchi-dev",
+			extraArgs: ["--auto"],
+			models: [MAIN_MODEL, { ...CLASSIFIER_MODEL, slug: "minimax-m3", displayName: "MiniMax M3" }],
+			responses: [
+				{ stream: ["I'll create the file."], toolCalls: [{ function: { name: "write", arguments: WRITE_ARGS } }] },
+				{ stream: ['{"verdict":"safe","reason":"Routine file write","riskScore":"low"}'] },
+				{ stream: ["File written with fallback approval."] },
+			],
+		},
+		async (_fixture, trace) => {
+			terminal.submit("Write a file called output.txt")
+			trace.step("submitted write with only fallback classifier available")
+			await waitForText(terminal, "File written with fallback approval.", { timeoutMs: STREAM_TIMEOUT_MS })
+			trace.step("write auto-approved by fallback")
+			await waitForText(terminal, "Permissions classifier is using a fallback model", { timeoutMs: INPUT_TIMEOUT_MS })
+			const buffer = terminal
+				.getBuffer()
+				.map((row: string[]) => row.join(""))
+				.join("\n")
+			expect(buffer).not.toContain(ALLOW_PROMPT)
+			trace.step("fallback warning shown without an approval prompt")
 		},
 	)
 })


### PR DESCRIPTION
## Linked issue

Closes #0

## Linked issue

Closes #<issue-number>

## What does this PR do?

Makes the permissions classifier resilient to model rotation and transient provider failures.

The classifier now:

- Resolves an ordered, provider-exact candidate ladder with primary and fallback models.
- Falls back when models are missing, rate-limited, error, time out, or return invalid output.
- Enforces a global time budget while reserving time for fallback inference.
- Bounds stalled authentication and provider requests.
- Preserves fail-closed behavior and prompt cancellation.
- Removes the internal `retryable` field from public results.
- Reports structured classifier health events without exposing tool input or provider error text.
- Shows deduplicated, once-per-session UI warnings for degraded or unavailable classifier health.
- Adds configurable `classifierMaxTotalMs` with a 25-second default.

## Validation

- `pnpm vitest run src/extensions/permissions/`
  - 415 tests passed
- Permission TUI scenarios
  - 4 tests passed, including primary-model absence with fallback success
- `pnpm run typecheck`
  - passed
- `pnpm run lint`
  - passed with two existing warnings in unrelated tests
- Built the Kimchi binary successfully

The live API sunset scenario was validated through deterministic registry and TUI fixtures; no live API key was required.

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [X] Tests pass locally (`pnpm run test`)
- [X] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
