### PR TITLE
add workspace spec to create requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,21 @@ Hand off an in-progress session to a cloud sandbox with `/teleport` — the agen
 | `--no-git-token` | Skip git credentials prompt |
 | `--skip-session` | Start remote agent fresh (don't upload current session history) |
 
+### Workspace sizing (`kimchi_workspace.yaml`)
+
+Declare CPU, memory, and disk requests for the sandboxes your project creates — workspaces minted by `/teleport` and headless cloud agents alike — in a `kimchi_workspace.yaml` at the **root of your project**:
+
+```yaml
+# kimchi_workspace.yaml — safe to commit; no secrets belong here
+resources:
+  cpu: "250m"
+  memory: "1Gi"
+  pvcSize: "20Gi"
+```
+
+Values are Kubernetes quantity strings (`500m`, `1Gi`, `20Gi`) — quote them: unquoted plain numbers (`cpu: 2`) are read as numbers by YAML and refused, naming the field. Omit a field to inherit the org default. Unknown fields under `resources:` are likewise refused rather than silently ignored. When you run kimchi from a subdirectory, the file is looked up walking toward the repository root.
+
+Sizing applies **only when a workspace is created** — resources are immutable once provisioned. Editing the file later won't resize an existing workspace: delete it (`/remote-sessions`) and re-teleport to pick up new values. Invalid values stop the command before anything is sent, naming the offending field.
 
 Once teleported, you're in the **PTY overlay** — a fullscreen tabbed terminal. Use `Ctrl+B c` / `n` / `p` to open and switch tabs. Press `Ctrl+D` to drop back to local kimchi; the sandbox and agent keep running.
 

--- a/src/extensions/agents/manager/agent-manager.test.ts
+++ b/src/extensions/agents/manager/agent-manager.test.ts
@@ -17,6 +17,15 @@ vi.mock("../../../sandbox/cloud/workspaces.js", () => ({
 	listWorkspaces: vi.fn().mockResolvedValue([]),
 }))
 
+const { loadWorkspaceFileMock } = vi.hoisted(() => ({ loadWorkspaceFileMock: vi.fn() }))
+
+// resources.js stays real (pure validator); the loader is stubbed, but the
+// real WorkspaceFileError class stays (importOriginal) so behavior matches reality.
+vi.mock("../../../sandbox/cloud/workspace-file.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../../sandbox/cloud/workspace-file.js")>()),
+	loadWorkspaceFile: loadWorkspaceFileMock,
+}))
+
 vi.mock("../../teleport/provisioning/clone-plan.js", () => ({
 	resolveClonePlan: vi.fn(),
 }))
@@ -40,6 +49,8 @@ vi.mock("../../teleport/provisioning/git-token.js", () => ({
 }))
 
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { loadWorkspaceFile, WorkspaceFileError } from "../../../sandbox/cloud/workspace-file.js"
+import { listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
 import { resolveClonePlan } from "../../teleport/provisioning/clone-plan.js"
 import { resolveGitToken } from "../../teleport/provisioning/git-token.js"
 import type { AgentRecord } from "../personas/types.js"
@@ -55,6 +66,8 @@ const mockResolveGitToken = vi.mocked(resolveGitToken)
 const mockRunRemoteAgent = vi.mocked(runRemoteAgent)
 const mockAttachRemoteAgent = vi.mocked(attachRemoteAgent)
 const mockIsRemoteSessionConnected = vi.mocked(isRemoteSessionConnected)
+const mockListWorkspaces = vi.mocked(listWorkspaces)
+const mockLoadWorkspaceFile = vi.mocked(loadWorkspaceFile)
 
 function fakePi(): ExtensionAPI {
 	return {} as ExtensionAPI
@@ -1023,6 +1036,8 @@ describe("AgentManager remote git credential resolution", () => {
 			branch: "main",
 		})
 		mockResolveGitToken.mockResolvedValue(undefined)
+		mockListWorkspaces.mockResolvedValue([])
+		mockLoadWorkspaceFile.mockReturnValue(undefined)
 		mockRunRemoteAgent.mockResolvedValue({
 			responseText: "done",
 			stopReason: "end_turn",
@@ -1056,6 +1071,60 @@ describe("AgentManager remote git credential resolution", () => {
 				gitCredential: { host: "gitlab.com", token: "glpat-cached-token" },
 			}),
 		)
+	})
+
+	it("forwards kimchi_workspace.yaml resources to runRemoteAgent when minting a workspace", async () => {
+		mockLoadWorkspaceFile.mockReturnValue({ resources: { cpu: " 500m ", pvcSize: "20Gi" } })
+		manager = new AgentManager()
+
+		await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		// No name-matched workspace (listWorkspaces → []) → mint → resources ride.
+		// Outer whitespace trimmed by the real validator.
+		expect(mockRunRemoteAgent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.any(String),
+			expect.objectContaining({ resources: { cpu: "500m", pvcSize: "20Gi" } }),
+		)
+	})
+
+	it("broken kimchi_workspace.yaml surfaces as an agent error and never starts a remote run", async () => {
+		mockLoadWorkspaceFile.mockImplementation(() => {
+			throw new WorkspaceFileError(
+				"Could not parse /work/myrepo/kimchi_workspace.yaml: bad indentation",
+				"/work/myrepo/kimchi_workspace.yaml",
+			)
+		})
+		manager = new AgentManager()
+
+		const record = await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		expect(record.status).toBe("error")
+		expect(record.error).toContain("Could not parse /work/myrepo/kimchi_workspace.yaml")
+		expect(mockRunRemoteAgent).not.toHaveBeenCalled()
+	})
+
+	it("does not forward resources when a name-matched workspace is reused", async () => {
+		mockLoadWorkspaceFile.mockReturnValue({ resources: { cpu: "500m" } })
+		mockListWorkspaces.mockResolvedValue([
+			{ id: "ws-existing", name: "myrepo", createdAt: new Date(), lastActivityAt: new Date(), status: "active" },
+		])
+		manager = new AgentManager()
+
+		const record = await manager.spawnAndWait(fakePi(), fakeRemoteCtx(), "Explore", "test", {
+			description: "test",
+			remote: true,
+		})
+
+		expect(record.status).toBe("completed")
+		expect(mockLoadWorkspaceFile).not.toHaveBeenCalled()
+		expect(mockRunRemoteAgent.mock.calls[0][2]).not.toHaveProperty("resources")
 	})
 
 	it("passes undefined gitCredential when no token is resolved (non-interactive mode)", async () => {

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -4,6 +4,8 @@ import type { SessionNotification } from "@agentclientprotocol/sdk"
 import type { Api, Model } from "@earendil-works/pi-ai"
 import type { AgentSession, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { loadConfig } from "../../../config.js"
+import { resolveWorkspaceResources } from "../../../sandbox/cloud/resources.js"
+import { loadWorkspaceFile } from "../../../sandbox/cloud/workspace-file.js"
 import { listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
 import type { AcpSessionCallbacks } from "../../../sandbox/worker/acp-client.js"
 import { type ClonePlan, resolveClonePlan } from "../../teleport/provisioning/clone-plan.js"
@@ -402,6 +404,10 @@ export class AgentManager {
 		const dirName = basename(ctx.cwd) || "kimchi"
 		const byName = workspaces.find((w) => w.name.toLowerCase() === dirName.toLowerCase())
 		const workspaceId = byName?.id ?? randomUUID()
+		// Resource requests (kimchi_workspace.yaml) ride the upsert PUT only
+		// when minting — a name-matched workspace keeps its existing size
+		// (resources are create-time-only and immutable server-side).
+		const workspaceResources = byName ? undefined : resolveWorkspaceResources(loadWorkspaceFile(ctx.cwd)?.resources)
 
 		// Resolve git clone plan from the local repo so the sandbox gets a
 		// shallow clone of the repo (like /teleport --fast) instead of an empty dir.
@@ -455,6 +461,7 @@ export class AgentManager {
 			localPath: ctx.cwd,
 			workspaceName: dirName,
 			outputFile: record.outputFile,
+			...(workspaceResources ? { resources: workspaceResources } : {}),
 			onReady: (acpClient, meta) => {
 				remoteSession.bindClient(acpClient, meta)
 				// Capture the ACP session id for resume-after-restart persistence

--- a/src/extensions/agents/manager/remote-agent-runner.test.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.test.ts
@@ -395,6 +395,23 @@ describe("runRemoteAgent", () => {
 		)
 	})
 
+	it("forwards resources to authenticateWorkspace when provided", async () => {
+		await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ resources: { cpu: "250m", memory: "1Gi" } }))
+
+		expect(authenticateWorkspace).toHaveBeenCalledWith(WORKSPACE_ID, "test-api-key", "kimchi", {
+			endpoint: undefined,
+			resources: { cpu: "250m", memory: "1Gi" },
+		})
+	})
+
+	it("omits the resources key when not provided", async () => {
+		await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions())
+
+		expect(authenticateWorkspace).toHaveBeenCalledWith(WORKSPACE_ID, "test-api-key", "kimchi", {
+			endpoint: undefined,
+		})
+	})
+
 	it("passes signal through to createSession and AcpSessionClient", async () => {
 		const controller = new AbortController()
 		await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ signal: controller.signal }))

--- a/src/extensions/agents/manager/remote-agent-runner.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.ts
@@ -32,7 +32,7 @@ import { randomUUID } from "node:crypto"
 import { setTimeout as timersSleep } from "node:timers/promises"
 import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
-import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
+import type { WorkspaceCredentials, WorkspaceResourcesConfig } from "../../../sandbox/cloud/types.js"
 import {
 	type AcpSessionCallbacks,
 	AcpSessionClient,
@@ -73,6 +73,12 @@ export interface RemoteRunOptions {
 	gitCredential?: { host: string; token: string }
 	/** Workspace name passed to authenticateWorkspace (used for matching/reuse). */
 	workspaceName?: string
+	/**
+	 * Workspace resource requests (Kubernetes quantity strings) forwarded on
+	 * the upsert PUT. The caller passes them only when minting the workspace —
+	 * resources are create-time-only and immutable server-side.
+	 */
+	resources?: WorkspaceResourcesConfig
 	/**
 	 * Called after `acpClient.initialize()` and before `acpClient.prompt()`,
 	 * giving the caller access to the live AcpSessionClient so it can be
@@ -623,7 +629,10 @@ export async function runRemoteAgent(
 	const cwd = `/home/sandbox/${sessionName}`
 
 	// 1. Authenticate
-	const creds: WorkspaceCredentials = await authenticateWorkspace(workspaceId, apiKey, workspaceName, { endpoint })
+	const creds: WorkspaceCredentials = await authenticateWorkspace(workspaceId, apiKey, workspaceName, {
+		endpoint,
+		...(options.resources ? { resources: options.resources } : {}),
+	})
 
 	// 2. Wait for sandbox readiness
 	await waitForWorkspaceReady({

--- a/src/extensions/teleport/commands/attach.test.ts
+++ b/src/extensions/teleport/commands/attach.test.ts
@@ -48,6 +48,7 @@ vi.mock("../ui/progress.js", () => ({
 	},
 }))
 
+import { RemoteQuotaError } from "../../../sandbox/cloud/types.js"
 import type { TeleportContext } from "../types.js"
 import { runAttachSession } from "./attach.js"
 import { TeleportRefusal } from "./errors.js"
@@ -172,6 +173,17 @@ describe("runAttachSession", () => {
 		expect(ui.notify).toHaveBeenCalledWith(expect.stringMatching(/Authentication failed.*auth boom/), "error")
 		expect(waitReadyMock).not.toHaveBeenCalled()
 		expect(listSessionsMock).not.toHaveBeenCalled()
+	})
+
+	it("refuses with the quota message verbatim, without the 'Authentication failed' prefix", async () => {
+		authMock.mockRejectedValueOnce(new RemoteQuotaError("Unable to provision workspace: user CPU limit exceeded", 429))
+		const { ctx, ui } = makeCtx()
+
+		await expect(runAttachSession({ workspaceId: "w-1", sessionName: "x" }, ctx)).rejects.toBeInstanceOf(
+			TeleportRefusal,
+		)
+		expect(ui.notify).toHaveBeenCalledWith("Unable to provision workspace: user CPU limit exceeded", "error")
+		expect(waitReadyMock).not.toHaveBeenCalled()
 	})
 
 	it("refuses when waitForWorkspaceReady fails", async () => {

--- a/src/extensions/teleport/commands/attach.ts
+++ b/src/extensions/teleport/commands/attach.ts
@@ -8,7 +8,7 @@ import type { Session } from "../../../sandbox/worker/types.js"
 import { createTabsOverlay } from "../overlay/overlay-component.js"
 import type { TeleportContext } from "../types.js"
 import { createTeleportProgress } from "../ui/progress.js"
-import { refuse } from "./errors.js"
+import { authFailureMessage, refuse } from "./errors.js"
 
 export interface AttachArgs {
 	workspaceId: string
@@ -34,7 +34,7 @@ export async function runAttachSession(args: AttachArgs, ctx: TeleportContext): 
 		try {
 			creds = await authenticateWorkspace(workspaceId, ctx.apiKey, description, { endpoint: ctx.endpoint })
 		} catch (err) {
-			refuse(ctx, `Authentication failed: ${err instanceof Error ? err.message : String(err)}`)
+			refuse(ctx, authFailureMessage(err))
 		}
 		progress.complete("Authenticated")
 

--- a/src/extensions/teleport/commands/errors.ts
+++ b/src/extensions/teleport/commands/errors.ts
@@ -1,3 +1,4 @@
+import { RemoteQuotaError } from "../../../sandbox/cloud/types.js"
 import { STATUS_KEY, type TeleportContext } from "../types.js"
 
 export class TeleportRefusal extends Error {
@@ -11,6 +12,17 @@ export function refuse(ctx: TeleportContext, message: string): never {
 	ctx.ui.setStatus(STATUS_KEY, undefined)
 	ctx.ui.notify(message, "error")
 	throw new TeleportRefusal(message)
+}
+
+/**
+ * Message shown when authenticateWorkspace() throws. Quota errors already
+ * carry final user-facing text ("Unable to provision workspace: …") and are
+ * passed through verbatim; anything else keeps the historical
+ * "Authentication failed: …" framing.
+ */
+export function authFailureMessage(err: unknown): string {
+	if (err instanceof RemoteQuotaError) return err.message
+	return `Authentication failed: ${err instanceof Error ? err.message : String(err)}`
 }
 
 export function warn(ctx: TeleportContext, message: string) {

--- a/src/extensions/teleport/commands/sync.ts
+++ b/src/extensions/teleport/commands/sync.ts
@@ -11,7 +11,7 @@ import type { TeleportContext } from "../types.js"
 import { formatBytes } from "../ui/format-bytes.js"
 import { SyncProgressRow } from "../ui/sync-progress-row.js"
 import { parseSyncArgs, type SyncArgs } from "./args.js"
-import { info, refuse } from "./errors.js"
+import { authFailureMessage, info, refuse } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
 export async function runSync(rawArgs: string, ctx: TeleportContext): Promise<void> {
@@ -54,7 +54,7 @@ export async function runSync(rawArgs: string, ctx: TeleportContext): Promise<vo
 				endpoint: ctx.endpoint,
 			})
 		} catch (err) {
-			refuse(ctx, `Authentication failed: ${err instanceof Error ? err.message : String(err)}`)
+			refuse(ctx, authFailureMessage(err))
 		}
 
 		try {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -32,6 +32,7 @@ const {
 	buildIncludeListMock,
 	buildChangedFilesListMock,
 	sumIncludeListBytesMock,
+	loadWorkspaceFileMock,
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	waitReadyMock: vi.fn(),
@@ -68,10 +69,18 @@ const {
 	buildIncludeListMock: vi.fn(),
 	buildChangedFilesListMock: vi.fn(),
 	sumIncludeListBytesMock: vi.fn(),
+	loadWorkspaceFileMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
 vi.mock("../../../sandbox/cloud/readiness.js", () => ({ waitForWorkspaceReady: waitReadyMock }))
+// resources.js stays real (pure validator); the loader is stubbed, but the
+// real WorkspaceFileError class stays (importOriginal) so instanceof checks
+// in production code behave as in reality.
+vi.mock("../../../sandbox/cloud/workspace-file.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../../sandbox/cloud/workspace-file.js")>()),
+	loadWorkspaceFile: loadWorkspaceFileMock,
+}))
 vi.mock("../../../sandbox/cloud/workspaces.js", () => ({ listWorkspaces: listWorkspacesMock }))
 vi.mock("../../../sandbox/worker/client.js", () => ({
 	WorkerClient: class {},
@@ -142,6 +151,7 @@ vi.mock("../ui/progress.js", () => ({
 	},
 }))
 
+import { WorkspaceFileError } from "../../../sandbox/cloud/workspace-file.js"
 import type { TeleportContext } from "../types.js"
 import { TeleportRefusal } from "./errors.js"
 import {
@@ -253,6 +263,7 @@ beforeEach(() => {
 	buildIncludeListMock.mockReset().mockResolvedValue(["src/a.ts", ".git/HEAD", ".git/refs/heads/main"])
 	buildChangedFilesListMock.mockReset().mockResolvedValue(["src/a.ts", "README.md"])
 	sumIncludeListBytesMock.mockReset().mockResolvedValue(123)
+	loadWorkspaceFileMock.mockReset().mockReturnValue(undefined)
 })
 
 afterEach(() => {
@@ -302,6 +313,99 @@ describe("runTeleport", () => {
 		// Let auth finish so the rest of runTeleport can complete.
 		releaseAuth(CREDS)
 		await p
+	})
+
+	it("sends kimchi_workspace.yaml resources on the upsert PUT when minting a new workspace", async () => {
+		loadWorkspaceFileMock.mockReturnValue({ resources: { cpu: " 500m ", memory: "1Gi" } })
+		// List is empty (default) → empty-list mint = client-minted id.
+		const { ctx } = makeCtx()
+
+		await runTeleport("mysession", ctx)
+
+		expect(authMock).toHaveBeenCalledOnce()
+		// Outer whitespace trimmed by the real validator.
+		expect(authMock.mock.calls[0][3]).toMatchObject({ resources: { cpu: "500m", memory: "1Gi" } })
+	})
+
+	it("does not send resources when attaching to an existing workspace — the file is never read", async () => {
+		loadWorkspaceFileMock.mockReturnValue({ resources: { cpu: "500m" } })
+		listWorkspacesMock.mockResolvedValue([
+			{
+				id: "22222222-2222-4222-8222-222222222222",
+				name: "existing-ws",
+				createdAt: new Date(),
+				lastActivityAt: new Date(),
+				status: "active",
+			},
+		])
+		const { ctx } = makeCtx()
+
+		await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+		expect(authMock).toHaveBeenCalledOnce()
+		expect(loadWorkspaceFileMock).not.toHaveBeenCalled()
+		expect(authMock.mock.calls[0][3]).not.toHaveProperty("resources")
+	})
+
+	it("treats an unlisted explicit UUID as attach-intent — the file is never read, no resources on the PUT", async () => {
+		loadWorkspaceFileMock.mockReturnValue({ resources: { cpu: "500m" } })
+		// List is empty (default): the UUID is trusted but was not minted
+		// client-side, so create-time-only resources must not ride its PUT.
+		const { ctx } = makeCtx()
+
+		await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+		expect(authMock).toHaveBeenCalledOnce()
+		expect(loadWorkspaceFileMock).not.toHaveBeenCalled()
+		expect(authMock.mock.calls[0][3]).not.toHaveProperty("resources")
+	})
+
+	it("a broken kimchi_workspace.yaml cannot block attaching to an existing workspace", async () => {
+		loadWorkspaceFileMock.mockImplementation(() => {
+			throw new WorkspaceFileError(
+				"Could not parse /work/proj/kimchi_workspace.yaml: bad indentation",
+				"/work/proj/kimchi_workspace.yaml",
+			)
+		})
+		listWorkspacesMock.mockResolvedValue([
+			{
+				id: "22222222-2222-4222-8222-222222222222",
+				name: "existing-ws",
+				createdAt: new Date(),
+				lastActivityAt: new Date(),
+				status: "active",
+			},
+		])
+		const { ctx } = makeCtx()
+
+		await runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)
+
+		expect(authMock).toHaveBeenCalledOnce()
+		expect(loadWorkspaceFileMock).not.toHaveBeenCalled()
+		expect(authMock.mock.calls[0][3]).not.toHaveProperty("resources")
+	})
+
+	it("refuses before the upsert PUT when minting with an invalid resource value", async () => {
+		loadWorkspaceFileMock.mockReturnValue({ resources: { cpu: "1Gii" } })
+		const { ctx, ui } = makeCtx()
+
+		await expect(runTeleport("mysession", ctx)).rejects.toBeInstanceOf(TeleportRefusal)
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("cpu"), "error")
+		expect(authMock).not.toHaveBeenCalled()
+	})
+
+	it("refuses before the upsert PUT when minting with a malformed kimchi_workspace.yaml", async () => {
+		loadWorkspaceFileMock.mockImplementation(() => {
+			throw new WorkspaceFileError(
+				"Could not parse /work/proj/kimchi_workspace.yaml: bad indentation",
+				"/work/proj/kimchi_workspace.yaml",
+			)
+		})
+		const { ctx, ui } = makeCtx()
+
+		await expect(runTeleport("mysession", ctx)).rejects.toBeInstanceOf(TeleportRefusal)
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Could not parse"), "error")
+		expect(authMock).not.toHaveBeenCalled()
 	})
 
 	it("happy path: creates PTY session, opens overlay", async () => {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -151,6 +151,7 @@ vi.mock("../ui/progress.js", () => ({
 	},
 }))
 
+import { RemoteQuotaError } from "../../../sandbox/cloud/types.js"
 import { WorkspaceFileError } from "../../../sandbox/cloud/workspace-file.js"
 import type { TeleportContext } from "../types.js"
 import { TeleportRefusal } from "./errors.js"
@@ -576,6 +577,18 @@ describe("runTeleport", () => {
 
 		await expect(runTeleport("--bogus", ctx)).rejects.toBeInstanceOf(TeleportRefusal)
 		expect(ui.notify).toHaveBeenCalledWith(expect.stringMatching(/Unknown flag/), "error")
+	})
+
+	it("refuses with the quota message verbatim, without the 'Authentication failed' prefix", async () => {
+		authMock.mockRejectedValueOnce(new RemoteQuotaError("Unable to provision workspace: user CPU limit exceeded", 429))
+		const { ctx, ui } = makeCtx()
+
+		await expect(runTeleport("mysession --workspace 22222222-2222-4222-8222-222222222222", ctx)).rejects.toBeInstanceOf(
+			TeleportRefusal,
+		)
+		expect(ui.notify).toHaveBeenCalledWith("Unable to provision workspace: user CPU limit exceeded", "error")
+		expect(waitReadyMock).not.toHaveBeenCalled()
+		expect(overlayMock).not.toHaveBeenCalled()
 	})
 
 	it("generates a default session name when none is given", async () => {

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -34,7 +34,7 @@ import { formatBytes } from "../ui/format-bytes.js"
 import { promptTeleportHelp } from "../ui/help-modal.js"
 import { createTeleportProgress } from "../ui/progress.js"
 import { parseTeleportArgs } from "./args.js"
-import { refuse, warn } from "./errors.js"
+import { authFailureMessage, refuse, warn } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
 /** Per-call timeout for createSession: 5min — the 30s WorkerClient default aborts mid-flight on large repos. */
@@ -174,7 +174,7 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 			})
 		} catch (err) {
 			if (signal.aborted) throw err
-			refuse(ctx, `Authentication failed: ${err instanceof Error ? err.message : String(err)}`)
+			refuse(ctx, authFailureMessage(err))
 		}
 		progress.complete("Authenticated")
 

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -5,7 +5,9 @@ import { basename, dirname } from "node:path"
 import { readTeleportCompactHintEnabled, readTeleportHelpSeenAt, writeTeleportHelpSeenAt } from "../../../config.js"
 import { authenticateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { waitForWorkspaceReady } from "../../../sandbox/cloud/readiness.js"
+import { resolveWorkspaceResources, WorkspaceResourcesError } from "../../../sandbox/cloud/resources.js"
 import type { WorkspaceCredentials } from "../../../sandbox/cloud/types.js"
+import { loadWorkspaceFile, WorkspaceFileError } from "../../../sandbox/cloud/workspace-file.js"
 import { getGitRemoteHost, parseHostFromRemoteUrl, readLocalGitConfig } from "../../../sandbox/git-credentials.js"
 import { WorkerClient } from "../../../sandbox/worker/client.js"
 import { createSession, listSessions } from "../../../sandbox/worker/sessions.js"
@@ -81,6 +83,24 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 	} finally {
 		ctx.ui.setStatus(STATUS_KEY, undefined)
 	}
+
+	// Resolve workspace resource requests (kimchi_workspace.yaml) only when
+	// this resolution mints the workspace: resources are create-time-only
+	// and immutable server-side — sending them on re-auth is a 400 landmine.
+	// Attaching to an existing workspace never reads the file, so a broken
+	// one cannot block a teleport that would ignore it anyway. Invalid
+	// values or a malformed file refuse before the upsert PUT is sent.
+	let workspaceResources: ReturnType<typeof resolveWorkspaceResources>
+	if (resolved.isNew) {
+		try {
+			workspaceResources = resolveWorkspaceResources(loadWorkspaceFile(ctx.cwd)?.resources)
+		} catch (err) {
+			if (err instanceof WorkspaceFileError || err instanceof WorkspaceResourcesError) {
+				refuse(ctx, err.message)
+			}
+			throw err
+		}
+	}
 	const workspaceId = resolved.id
 	const sessionName = args.name ?? generateSessionName()
 	// For an existing workspace, preserve its stored name. For a newly minted
@@ -148,7 +168,10 @@ export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promis
 	try {
 		progress.step("Authenticating")
 		try {
-			creds = await authenticateWorkspace(workspaceId, ctx.apiKey, description, { endpoint: ctx.endpoint })
+			creds = await authenticateWorkspace(workspaceId, ctx.apiKey, description, {
+				endpoint: ctx.endpoint,
+				...(workspaceResources ? { resources: workspaceResources } : {}),
+			})
 		} catch (err) {
 			if (signal.aborted) throw err
 			refuse(ctx, `Authentication failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/extensions/teleport/commands/terminal.ts
+++ b/src/extensions/teleport/commands/terminal.ts
@@ -9,7 +9,7 @@ import { provisionGitCredential } from "../provisioning/git-provision.js"
 import { buildProxyCommand } from "../provisioning/proxy-command.js"
 import type { TeleportContext } from "../types.js"
 import { runChildWithTTYHandoff as runChildWithTTYHandoffImpl } from "../ui/tty-handoff.js"
-import { info, refuse, status, warn } from "./errors.js"
+import { authFailureMessage, info, refuse, status, warn } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
 type RunChildFn = typeof runChildWithTTYHandoffImpl
@@ -52,7 +52,7 @@ export async function runTerminal(
 		if (err instanceof RemoteAuthError) {
 			refuse(ctx, `Authentication failed for ${workspaceId}: ${err.message}`)
 		}
-		refuse(ctx, `Authentication failed: ${err instanceof Error ? err.message : String(err)}`)
+		refuse(ctx, authFailureMessage(err))
 	}
 	status(ctx, undefined)
 

--- a/src/extensions/teleport/commands/workspace-ref.test.ts
+++ b/src/extensions/teleport/commands/workspace-ref.test.ts
@@ -135,33 +135,35 @@ describe("matchesHostNickname", () => {
 })
 
 describe("resolveWorkspaceRef", () => {
-	it("returns {id, name} when a UUID ref matches a known workspace", async () => {
+	it("returns {id, name, isNew:false} when a UUID ref matches a known workspace", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A, name: "kimchi-dev" })])
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, UUID_A, { onEmpty: { kind: "mint" } })
-		expect(resolved).toEqual({ id: UUID_A, name: "kimchi-dev" })
+		expect(resolved).toEqual({ id: UUID_A, name: "kimchi-dev", isNew: false })
 		expect(listWorkspacesMock).toHaveBeenCalledOnce()
 	})
 
-	it("returns id with no name when UUID ref is not in the list (server stale/paginated)", async () => {
+	it("returns id with no name and isNew:false (attach-intent) when UUID ref is not in the list (server stale/paginated)", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_B, name: "other" })])
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, UUID_A, { onEmpty: { kind: "mint" } })
-		expect(resolved).toEqual({ id: UUID_A })
+		// Not minted client-side → create-time-only resources never ride the
+		// PUT: if the workspace exists, mismatched values would 400.
+		expect(resolved).toEqual({ id: UUID_A, isNew: false })
 	})
 
 	it("resolves a unique name match (case-insensitive) with the workspace's stored name", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A, name: "kimchi-dev" })])
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, "KIMCHI-DEV", { onEmpty: { kind: "mint" } })
-		expect(resolved).toEqual({ id: UUID_A, name: "kimchi-dev" })
+		expect(resolved).toEqual({ id: UUID_A, name: "kimchi-dev", isNew: false })
 	})
 
 	it("resolves a unique host-nickname prefix match", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A, name: "other-name" })])
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, "trusting-ruling", { onEmpty: { kind: "mint" } })
-		expect(resolved).toEqual({ id: UUID_A, name: "other-name" })
+		expect(resolved).toEqual({ id: UUID_A, name: "other-name", isNew: false })
 	})
 
 	it("treats name+nickname collision on the same workspace as a single match", async () => {
@@ -208,11 +210,12 @@ describe("resolveWorkspaceRef", () => {
 		expect(ui.notify).toHaveBeenCalledWith(expect.stringMatching(/No workspace matching "bogus"/), "error")
 	})
 
-	it("mints a new id (no name) when no ref, no workspaces (onEmpty=mint)", async () => {
+	it("mints a new id (no name, isNew:true) when no ref, no workspaces (onEmpty=mint)", async () => {
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
 		expect(resolved.id).toMatch(/^[0-9a-f-]{36}$/i)
 		expect(resolved.name).toBeUndefined()
+		expect(resolved.isNew).toBe(true)
 	})
 
 	it("refuses when no ref, no workspaces (onEmpty=refuse)", async () => {
@@ -223,12 +226,12 @@ describe("resolveWorkspaceRef", () => {
 		expect(ui.notify).toHaveBeenCalledWith("no ws", "error")
 	})
 
-	it("opens the picker when no ref but workspaces exist; returns the chosen id+name", async () => {
+	it("opens the picker when no ref but workspaces exist; returns the chosen id+name, isNew:false", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A, name: "picked-one" })])
 		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
-		expect(resolved).toEqual({ id: UUID_A, name: "picked-one" })
+		expect(resolved).toEqual({ id: UUID_A, name: "picked-one", isNew: false })
 	})
 
 	it("picker is opened with allowNew=true when onEmpty.kind === 'mint'", async () => {
@@ -248,7 +251,7 @@ describe("resolveWorkspaceRef", () => {
 		expect(pickWorkspaceMock.mock.calls[0][2]).toMatchObject({ allowNew: false, hideSessions: true })
 	})
 
-	it("picker 'new' with onEmpty=mint → fresh id, no name", async () => {
+	it("picker 'new' with onEmpty=mint → fresh id, no name, isNew:true", async () => {
 		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A })])
 		pickWorkspaceMock.mockResolvedValue({ action: "new" })
 		const { ctx } = makeCtx()
@@ -256,6 +259,7 @@ describe("resolveWorkspaceRef", () => {
 		expect(resolved.id).toMatch(/^[0-9a-f-]{36}$/i)
 		expect(resolved.id).not.toBe(UUID_A)
 		expect(resolved.name).toBeUndefined()
+		expect(resolved.isNew).toBe(true)
 	})
 
 	it("picker cancelled → TeleportRefusal('cancelled')", async () => {

--- a/src/extensions/teleport/commands/workspace-ref.ts
+++ b/src/extensions/teleport/commands/workspace-ref.ts
@@ -40,6 +40,15 @@ export interface ResolvedWorkspace {
 	 * `authenticateWorkspace` calls so the server-stored name is preserved.
 	 */
 	name?: string
+	/**
+	 * True only when this resolution *mints* the id client-side (empty-list
+	 * mint or picker "new"). A trusted explicit UUID absent from the server
+	 * listing stays attach-intent: resource requests (create-time-only,
+	 * immutable server-side) may ride the upsert PUT only for client-minted
+	 * ids — otherwise a workspace that actually exists 400s on any value
+	 * mismatch.
+	 */
+	isNew: boolean
 }
 
 export async function resolveWorkspaceRef(
@@ -60,15 +69,17 @@ export async function resolveWorkspaceRef(
 	if (ref) {
 		if (isUuid(ref)) {
 			const match = workspaces.find((w) => w.id === ref)
-			if (match) return { id: match.id, name: match.name }
+			if (match) return { id: match.id, name: match.name, isNew: false }
 			// UUID provided but not present in the list. Trust the user — the
-			// listing may be stale or paginated. Hand back the id with no name.
-			return { id: ref }
+			// listing may be stale or paginated. Remains attach-intent (not
+			// minted client-side), so create-time-only resources never ride its
+			// PUT: if the workspace exists, mismatched values would 400.
+			return { id: ref, isNew: false }
 		}
 		const matches = workspaces.filter(
 			(w) => w.name.toLowerCase() === ref.toLowerCase() || matchesHostNickname(w.host, ref),
 		)
-		if (matches.length === 1) return { id: matches[0].id, name: matches[0].name }
+		if (matches.length === 1) return { id: matches[0].id, name: matches[0].name, isNew: false }
 		if (matches.length === 0) {
 			refuse(ctx, `No workspace matching "${ref}". Try /remote-sessions to see the available ones.`)
 		}
@@ -79,7 +90,7 @@ export async function resolveWorkspaceRef(
 	}
 
 	if (workspaces.length === 0) {
-		if (opts.onEmpty.kind === "mint") return { id: randomUUID() }
+		if (opts.onEmpty.kind === "mint") return { id: randomUUID(), isNew: true }
 		refuse(ctx, opts.onEmpty.message)
 	}
 
@@ -98,8 +109,8 @@ export async function resolveWorkspaceRef(
 		throw new TeleportRefusal(opts.cancelledMessage ?? "cancelled")
 	}
 	if (choice.action === "new") {
-		return { id: randomUUID() }
+		return { id: randomUUID(), isNew: true }
 	}
 	const picked = workspaces.find((w) => w.id === choice.row.id)
-	return { id: choice.row.id, name: picked?.name }
+	return { id: choice.row.id, name: picked?.name, isNew: false }
 }

--- a/src/sandbox/cloud/auth.test.ts
+++ b/src/sandbox/cloud/auth.test.ts
@@ -94,6 +94,38 @@ describe("authenticateWorkspace", () => {
 		expect(putBody.options.agentApiKey).toBe("key1")
 	})
 
+	it("includes resources at the top level of the create/update body when provided", async () => {
+		const mockFetch = mockAuthFlow("wss://h.example.com")
+		await authenticateWorkspace("ws-1", "key1", "desc", {
+			endpoint: BASE,
+			fetch: mockFetch,
+			resources: { cpu: "250m", memory: "1Gi", pvcSize: "20Gi" },
+		})
+
+		const putBody = JSON.parse(mockFetch.mock.calls[1][1].body as string)
+		expect(putBody.resources).toEqual({ cpu: "250m", memory: "1Gi", pvcSize: "20Gi" })
+	})
+
+	it("sends only the resource fields that are set", async () => {
+		const mockFetch = mockAuthFlow("wss://h.example.com")
+		await authenticateWorkspace("ws-1", "key1", "desc", {
+			endpoint: BASE,
+			fetch: mockFetch,
+			resources: { memory: "1Gi" },
+		})
+
+		const putBody = JSON.parse(mockFetch.mock.calls[1][1].body as string)
+		expect(putBody.resources).toEqual({ memory: "1Gi" })
+	})
+
+	it("omits the resources key entirely when not provided (re-auth stays byte-identical)", async () => {
+		const mockFetch = mockAuthFlow("wss://h.example.com")
+		await authenticateWorkspace("ws-1", "key1", "desc", { endpoint: BASE, fetch: mockFetch })
+
+		const putBody = JSON.parse(mockFetch.mock.calls[1][1].body as string)
+		expect(Object.keys(putBody).sort()).toEqual(["description", "options"])
+	})
+
 	it("normalizes a bare-hostname URI returned by the server", async () => {
 		const bare = "trusting-titan.remote.kimchi.dev"
 		const mockFetch = mockAuthFlow(bare)

--- a/src/sandbox/cloud/auth.ts
+++ b/src/sandbox/cloud/auth.ts
@@ -70,6 +70,9 @@ export async function createOrUpdateWorkspace(
 					agentApiKey: apiKey,
 					...(options?.gitToken ? { gitToken: options.gitToken } : {}),
 				},
+				// Create-time-only resource requests — sent verbatim; omitted
+				// entirely when unset so re-auth PUTs stay byte-identical.
+				...(options?.resources ? { resources: options.resources } : {}),
 			}),
 		},
 		fetchImpl,

--- a/src/sandbox/cloud/http.test.ts
+++ b/src/sandbox/cloud/http.test.ts
@@ -51,6 +51,33 @@ describe("checkResponse", () => {
 		})
 	})
 
+	it("maps 429 quota bodies to a friendly RemoteQuotaError", async () => {
+		const resp = new Response('{"message":"quota exceeded: user CPU limit exceeded","fieldViolations":[]}', {
+			status: 429,
+		})
+		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
+			name: "RemoteQuotaError",
+			message: "Unable to provision workspace: user CPU limit exceeded",
+			statusCode: 429,
+		})
+	})
+
+	it("keeps a 429 message verbatim when it has no 'quota exceeded' prefix", async () => {
+		const resp = new Response('{"message":"user memory limit exceeded"}', { status: 429 })
+		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
+			name: "RemoteQuotaError",
+			message: "Unable to provision workspace: user memory limit exceeded",
+		})
+	})
+
+	it("falls back to the raw format for 429s without a JSON message", async () => {
+		const resp = new Response("slow down", { status: 429 })
+		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
+			name: "RemoteNetworkError",
+			message: expect.stringContaining("HTTP 429 from https://x"),
+		})
+	})
+
 	it("maps non-auth statuses without a body to RemoteNetworkError", async () => {
 		await expect(checkResponse(new Response(null, { status: 502 }), "https://x")).rejects.toBeInstanceOf(
 			RemoteNetworkError,

--- a/src/sandbox/cloud/http.ts
+++ b/src/sandbox/cloud/http.ts
@@ -1,5 +1,5 @@
 import type { AuthenticateOptions } from "./types.js"
-import { RemoteAuthError, RemoteNetworkError } from "./types.js"
+import { RemoteAuthError, RemoteNetworkError, RemoteQuotaError } from "./types.js"
 
 export function resolveEndpoint(options?: AuthenticateOptions): string {
 	const fromEnv = process.env.KIMCHI_REMOTE_ENDPOINT
@@ -39,8 +39,36 @@ export async function checkResponse(resp: Response, endpoint: string): Promise<v
 			throw new RemoteAuthError(`Workspace not found or endpoint not available. ${endpoint}`, 404)
 		case 409:
 			throw new RemoteAuthError(`Workspace conflict - another client may already own this workspace. ${endpoint}`, 409)
+		case 429: {
+			// Quota-exceeded bodies look like
+			// {"message":"quota exceeded: user CPU limit exceeded","fieldViolations":[]}.
+			// Surface the server's reason without the raw URL/JSON dump — the
+			// message below is final, user-facing text.
+			const detail = parseQuotaDetail(body)
+			if (detail !== undefined) {
+				throw new RemoteQuotaError(`Unable to provision workspace: ${detail}`, 429)
+			}
+			throw new RemoteNetworkError(`HTTP ${resp.status} from ${endpoint}${body ? `: ${body}` : ""}`)
+		}
 		default: {
 			throw new RemoteNetworkError(`HTTP ${resp.status} from ${endpoint}${body ? `: ${body}` : ""}`)
 		}
+	}
+}
+
+/**
+ * Extract the human-readable reason from a 429 body. Returns undefined when
+ * the body is not JSON with a "message" string (e.g. a plain rate-limit
+ * response) — callers then fall back to the raw error. A leading
+ * "quota exceeded: " prefix is redundant next to the friendly wrapper and
+ * is stripped.
+ */
+function parseQuotaDetail(body: string): string | undefined {
+	try {
+		const parsed = JSON.parse(body) as { message?: unknown }
+		if (typeof parsed.message !== "string" || parsed.message.length === 0) return undefined
+		return parsed.message.replace(/^quota exceeded:\s*/i, "")
+	} catch {
+		return undefined
 	}
 }

--- a/src/sandbox/cloud/resources.test.ts
+++ b/src/sandbox/cloud/resources.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import { resolveWorkspaceResources, WorkspaceResourcesError } from "./resources.js"
+
+describe("resolveWorkspaceResources", () => {
+	it("returns undefined for undefined or empty config", () => {
+		expect(resolveWorkspaceResources(undefined)).toBeUndefined()
+		expect(resolveWorkspaceResources({})).toBeUndefined()
+	})
+
+	it("passes through valid quantities verbatim", () => {
+		expect(resolveWorkspaceResources({ cpu: "250m", memory: "1Gi", pvcSize: "20Gi" })).toEqual({
+			cpu: "250m",
+			memory: "1Gi",
+			pvcSize: "20Gi",
+		})
+	})
+
+	it("trims surrounding whitespace but rejects internal whitespace (a typo must not silently change the value)", () => {
+		expect(resolveWorkspaceResources({ cpu: " 250m ", memory: "\t1Gi\n" })).toEqual({ cpu: "250m", memory: "1Gi" })
+		expect(() => resolveWorkspaceResources({ cpu: "250 m" })).toThrowError(WorkspaceResourcesError)
+		expect(() => resolveWorkspaceResources({ memory: "1 Gi" })).toThrowError(WorkspaceResourcesError)
+		expect(() => resolveWorkspaceResources({ pvcSize: "2 0 Gi" })).toThrowError(WorkspaceResourcesError)
+	})
+
+	it("accepts every suffix family, plain numbers, fractions and exponents", () => {
+		expect(resolveWorkspaceResources({ cpu: "500m" })).toEqual({ cpu: "500m" })
+		expect(resolveWorkspaceResources({ cpu: "2" })).toEqual({ cpu: "2" })
+		expect(resolveWorkspaceResources({ cpu: "0.25" })).toEqual({ cpu: "0.25" })
+		expect(resolveWorkspaceResources({ cpu: ".5" })).toEqual({ cpu: ".5" })
+		expect(resolveWorkspaceResources({ cpu: "2500n" })).toEqual({ cpu: "2500n" })
+		expect(resolveWorkspaceResources({ cpu: "2500u" })).toEqual({ cpu: "2500u" })
+		expect(resolveWorkspaceResources({ memory: "128k" })).toEqual({ memory: "128k" })
+		expect(resolveWorkspaceResources({ memory: "128Ki" })).toEqual({ memory: "128Ki" })
+		expect(resolveWorkspaceResources({ memory: "2M" })).toEqual({ memory: "2M" })
+		expect(resolveWorkspaceResources({ memory: "2Mi" })).toEqual({ memory: "2Mi" })
+		expect(resolveWorkspaceResources({ pvcSize: "1T" })).toEqual({ pvcSize: "1T" })
+		expect(resolveWorkspaceResources({ pvcSize: "1Ti" })).toEqual({ pvcSize: "1Ti" })
+		expect(resolveWorkspaceResources({ pvcSize: "1P" })).toEqual({ pvcSize: "1P" })
+		expect(resolveWorkspaceResources({ pvcSize: "1Pi" })).toEqual({ pvcSize: "1Pi" })
+		expect(resolveWorkspaceResources({ pvcSize: "1E" })).toEqual({ pvcSize: "1E" })
+		expect(resolveWorkspaceResources({ pvcSize: "1Ei" })).toEqual({ pvcSize: "1Ei" })
+		expect(resolveWorkspaceResources({ memory: "1e9" })).toEqual({ memory: "1e9" })
+		expect(resolveWorkspaceResources({ memory: "1E3" })).toEqual({ memory: "1E3" })
+	})
+
+	it("omits unset fields (inherit org policy)", () => {
+		expect(resolveWorkspaceResources({ memory: "1Gi" })).toEqual({ memory: "1Gi" })
+	})
+
+	it.each([
+		"1Gii",
+		"half a cpu",
+		"500mi",
+		"10meg",
+		"m",
+		"",
+		"Gi",
+		"-1Gi",
+		"1.2.3",
+		"--1",
+		"1xGi",
+		// exponent and suffix are mutually exclusive — the server rejects these
+		"1e3m",
+		"1E3Gi",
+	])("rejects invalid quantity %j naming the field and value", (bad) => {
+		expect(() => resolveWorkspaceResources({ cpu: bad })).toThrowError(WorkspaceResourcesError)
+		try {
+			resolveWorkspaceResources({ pvcSize: bad })
+		} catch (err) {
+			expect(err).toBeInstanceOf(WorkspaceResourcesError)
+			expect((err as Error).message).toContain("pvcSize")
+			expect((err as Error).message).toContain(bad)
+		}
+	})
+
+	it.each(["0", "0m", "0.0Gi", "0e3"])("rejects non-positive quantity %j with a positivity message", (zero) => {
+		expect(() => resolveWorkspaceResources({ memory: zero })).toThrowError(/must be positive/)
+	})
+
+	it("a bad value in one field does not hide a good value in another field's error", () => {
+		expect(() => resolveWorkspaceResources({ cpu: "250m", memory: "bogus" })).toThrowError(/memory/)
+	})
+})

--- a/src/sandbox/cloud/resources.ts
+++ b/src/sandbox/cloud/resources.ts
@@ -1,0 +1,58 @@
+import { WORKSPACE_RESOURCE_FIELDS, type WorkspaceResourcesConfig } from "./types.js"
+import { WORKSPACE_FILE_NAME } from "./workspace-file.js"
+
+/**
+ * Thrown when a resource value in `kimchi_workspace.yaml` is not a valid,
+ * positive Kubernetes quantity. The message names the field and the offending
+ * value; surfaced as a refusal before any network call.
+ */
+export class WorkspaceResourcesError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = "WorkspaceResourcesError"
+	}
+}
+
+/**
+ * Kubernetes quantity: numeric part (optionally decimal), then EITHER an
+ * exponent OR a decimal-SI (n,u,m,k,M,G,T,P,E) / binary-SI (Ki…Ei) suffix —
+ * never both (`1e3m` passes client validation only to 400 server-side, so it
+ * is rejected here). Group 1 captures the mantissa for the positivity check.
+ */
+const QUANTITY_RE = /^([0-9]+(?:\.[0-9]+)?|\.[0-9]+)(?:(?:[eE][+-]?[0-9]+)|(?:n|u|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei))?$/
+
+/**
+ * Validate and normalize resource requests from `kimchi_workspace.yaml`.
+ *
+ * The client owns syntax only — values pass through to the server verbatim
+ * as quantity strings; no millicore/byte conversion here. Normalization is
+ * outer-whitespace trimming only — internal whitespace makes the value
+ * invalid (a typo like "2 0Gi" must never silently become "20Gi").
+ * Positivity is enforced (zero and unparseable values rejected); a field
+ * left unset is omitted (inherits org policy). Returns undefined when no
+ * resources are set at all.
+ */
+export function resolveWorkspaceResources(
+	config: WorkspaceResourcesConfig | undefined,
+): WorkspaceResourcesConfig | undefined {
+	if (!config) return undefined
+	const out: WorkspaceResourcesConfig = {}
+	for (const field of WORKSPACE_RESOURCE_FIELDS) {
+		const raw = config[field]
+		if (raw === undefined) continue
+		const normalized = raw.trim()
+		const match = QUANTITY_RE.exec(normalized)
+		if (!match) {
+			throw new WorkspaceResourcesError(
+				`Invalid ${field} value "${raw}" in ${WORKSPACE_FILE_NAME} — expected a Kubernetes quantity (e.g. "500m", "1Gi", "20Gi").`,
+			)
+		}
+		if (Number.parseFloat(match[1]) <= 0) {
+			throw new WorkspaceResourcesError(
+				`Invalid ${field} value "${raw}" in ${WORKSPACE_FILE_NAME} — must be positive; remove the field to inherit the org default.`,
+			)
+		}
+		out[field] = normalized
+	}
+	return Object.keys(out).length > 0 ? out : undefined
+}

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -9,6 +9,20 @@ export interface Workspace {
 	host?: string
 }
 
+/**
+ * Workspace resource requests — Kubernetes quantity strings
+ * (e.g. "250m", "1Gi", "20Gi"). Carries both the raw form as authored in
+ * `kimchi_workspace.yaml` and the validated/normalized form sent on the wire.
+ */
+export interface WorkspaceResourcesConfig {
+	cpu?: string
+	memory?: string
+	pvcSize?: string
+}
+
+/** Field names accepted under `resources:` — single source of truth for file parsing and quantity validation. */
+export const WORKSPACE_RESOURCE_FIELDS = ["cpu", "memory", "pvcSize"] as const
+
 export interface WorkspaceCredentials {
 	connectToken: string
 	expiresAt: string
@@ -33,6 +47,13 @@ export interface AuthenticateOptions {
 	 * can push/pull on behalf of the user.
 	 */
 	gitToken?: string
+	/**
+	 * Workspace resource requests sent on workspace-create PUTs. Resources
+	 * are create-time-only and immutable server-side (a re-PUT with changed
+	 * values 400s) — only pass these when the workspace is being created,
+	 * never on re-auth of an existing workspace.
+	 */
+	resources?: WorkspaceResourcesConfig
 }
 
 export interface ListWorkspacesOptions extends AuthenticateOptions {

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -89,3 +89,19 @@ export class RemoteNetworkError extends Error {
 		this.name = "RemoteNetworkError"
 	}
 }
+
+/**
+ * Thrown when the cloud API rejects a request because the user's resource
+ * quota is exhausted (HTTP 429 with a quota body, e.g. "user CPU limit
+ * exceeded"). Carries an already user-facing message — surfaced verbatim
+ * instead of being wrapped in "Authentication failed: ...".
+ */
+export class RemoteQuotaError extends RemoteNetworkError {
+	constructor(
+		message: string,
+		public readonly statusCode: number,
+	) {
+		super(message)
+		this.name = "RemoteQuotaError"
+	}
+}

--- a/src/sandbox/cloud/workspace-file.test.ts
+++ b/src/sandbox/cloud/workspace-file.test.ts
@@ -1,0 +1,158 @@
+import type { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { loadWorkspaceFile, WORKSPACE_FILE_NAME, WorkspaceFileError } from "./workspace-file.js"
+
+let repoRoot: string
+let outsideDir: string
+
+/** execFile stub that answers `git rev-parse --show-toplevel` for the fixture repo; throws elsewhere. */
+function gitExecReturning(root: string): typeof execFileSync {
+	return vi.fn((_cmd: string, args?: readonly string[]) => {
+		if (args?.includes("--show-toplevel")) return `${root}\n`
+		throw new Error("unexpected git call")
+	}) as unknown as typeof execFileSync
+}
+
+const gitExecFailing = vi.fn(() => {
+	throw new Error("not a git repository")
+}) as unknown as typeof execFileSync
+
+function writeWorkspaceFile(dir: string, content: string): string {
+	const path = join(dir, WORKSPACE_FILE_NAME)
+	writeFileSync(path, content)
+	return path
+}
+
+beforeEach(() => {
+	repoRoot = mkdtempSync(join(tmpdir(), "workspace-file-repo-"))
+	outsideDir = mkdtempSync(join(tmpdir(), "workspace-file-outside-"))
+})
+
+afterEach(() => {
+	rmSync(repoRoot, { recursive: true, force: true })
+	rmSync(outsideDir, { recursive: true, force: true })
+})
+
+describe("loadWorkspaceFile discovery", () => {
+	it("finds the file at cwd (cwd == repo root)", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 250m\n")
+		const cfg = loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { cpu: "250m" } })
+	})
+
+	it("walks up from a nested subdir to the repo root", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  memory: 1Gi\n")
+		const nested = join(repoRoot, "packages", "app")
+		mkdirSync(nested, { recursive: true })
+		const cfg = loadWorkspaceFile(nested, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { memory: "1Gi" } })
+	})
+
+	it("uses the nearest file when several exist up the tree", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 100m\n")
+		const nested = join(repoRoot, "sub")
+		mkdirSync(nested)
+		writeWorkspaceFile(nested, "resources:\n  cpu: 999m\n")
+		const cfg = loadWorkspaceFile(join(nested), { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { cpu: "999m" } })
+	})
+
+	it("never looks above the repo root", () => {
+		// File lives in the *parent* of the repo root — must not be picked up.
+		writeWorkspaceFile(outsideDir, "resources:\n  cpu: 500m\n")
+		const nestedRepo = join(outsideDir, "repo")
+		mkdirSync(nestedRepo)
+		const cfg = loadWorkspaceFile(nestedRepo, { execFile: gitExecReturning(nestedRepo) })
+		expect(cfg).toBeUndefined()
+	})
+
+	it("checks only cwd outside a git repo", () => {
+		writeWorkspaceFile(outsideDir, "resources:\n  pvcSize: 20Gi\n")
+		expect(loadWorkspaceFile(outsideDir, { execFile: gitExecFailing })).toEqual({
+			resources: { pvcSize: "20Gi" },
+		})
+		const child = join(outsideDir, "child")
+		mkdirSync(child)
+		expect(loadWorkspaceFile(child, { execFile: gitExecFailing })).toBeUndefined()
+	})
+
+	it("returns undefined when no file exists", () => {
+		expect(loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })).toBeUndefined()
+	})
+})
+
+describe("loadWorkspaceFile parsing", () => {
+	it("extracts cpu/memory/pvcSize string values", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 250m\n  memory: 1Gi\n  pvcSize: 20Gi\n")
+		const cfg = loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { cpu: "250m", memory: "1Gi", pvcSize: "20Gi" } })
+	})
+
+	it("ignores unknown top-level sections", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 250m\nunknown-section:\n  x: 1\n")
+		const cfg = loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { cpu: "250m" } })
+	})
+
+	it("throws WorkspaceFileError naming the field for a non-string value (unquoted YAML number)", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 250\n")
+		try {
+			loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+			expect.unreachable()
+		} catch (err) {
+			expect(err).toBeInstanceOf(WorkspaceFileError)
+			expect((err as Error).message).toContain('"cpu"')
+			expect((err as Error).message).toContain("Quote the value")
+		}
+	})
+
+	it("throws WorkspaceFileError naming an unknown key under resources", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  ram: 1Gi\n")
+		try {
+			loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+			expect.unreachable()
+		} catch (err) {
+			expect(err).toBeInstanceOf(WorkspaceFileError)
+			expect((err as Error).message).toContain('"ram"')
+			expect((err as Error).message).toContain("cpu, memory, pvcSize")
+		}
+	})
+
+	it("throws WorkspaceFileError when resources is not a mapping", () => {
+		writeWorkspaceFile(repoRoot, "resources: 5\n")
+		expect(() => loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })).toThrowError(WorkspaceFileError)
+	})
+
+	it("returns {} when the resources mapping is empty", () => {
+		writeWorkspaceFile(repoRoot, "resources: {}\n")
+		const cfg = loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({})
+	})
+
+	it("passes quantities through unvalidated (validation is the resolver's job)", () => {
+		writeWorkspaceFile(repoRoot, "resources:\n  cpu: 250 m\n")
+		const cfg = loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		expect(cfg).toEqual({ resources: { cpu: "250 m" } })
+	})
+
+	it("throws WorkspaceFileError on malformed YAML, naming the file", () => {
+		const path = writeWorkspaceFile(repoRoot, "resources:\n  cpu: [unclosed\n")
+		expect(() => loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })).toThrowError(WorkspaceFileError)
+		try {
+			loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })
+		} catch (err) {
+			expect(err).toBeInstanceOf(WorkspaceFileError)
+			// loadWorkspaceFile realpaths the start dir (macOS /var → /private/var).
+			expect((err as WorkspaceFileError).filePath).toBe(realpathSync(path))
+			expect((err as Error).message).toContain(WORKSPACE_FILE_NAME)
+		}
+	})
+
+	it("throws WorkspaceFileError when the top level is not a mapping", () => {
+		writeWorkspaceFile(repoRoot, "- just\n- a\n- list\n")
+		expect(() => loadWorkspaceFile(repoRoot, { execFile: gitExecReturning(repoRoot) })).toThrowError(WorkspaceFileError)
+	})
+})

--- a/src/sandbox/cloud/workspace-file.ts
+++ b/src/sandbox/cloud/workspace-file.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { parse as parseYaml } from "yaml"
+import { WORKSPACE_RESOURCE_FIELDS, type WorkspaceResourcesConfig } from "./types.js"
+
+/**
+ * Project-root file carrying workspace provisioning settings (resource
+ * requests today; room for future sandbox-scoped keys). Single-purpose and
+ * safe to commit — secrets never belong here.
+ */
+export const WORKSPACE_FILE_NAME = "kimchi_workspace.yaml"
+
+export interface WorkspaceFileConfig {
+	resources?: WorkspaceResourcesConfig
+}
+
+/**
+ * Thrown when `kimchi_workspace.yaml` exists but cannot be read or parsed.
+ * Surfaced as a refusal: silently ignoring a broken file would fall back to
+ * default sizing the user believes is overridden.
+ */
+export class WorkspaceFileError extends Error {
+	constructor(
+		message: string,
+		public readonly filePath: string,
+	) {
+		super(message)
+		this.name = "WorkspaceFileError"
+	}
+}
+
+export interface LoadWorkspaceFileOptions {
+	/** Override execFile (used by tests to stub the git boundary probe). */
+	execFile?: typeof execFileSync
+}
+
+/**
+ * Load workspace provisioning settings from the nearest
+ * `kimchi_workspace.yaml`.
+ *
+ * Discovery walks up from `cwd` and returns the first hit, stopping after the
+ * git repository root so a stray file above it (e.g. in the home directory)
+ * never affects a project. Outside a git repo, only `cwd` itself is checked.
+ *
+ * Returns undefined when no file is found. Throws WorkspaceFileError when
+ * the file exists but cannot be read or parsed.
+ */
+export function loadWorkspaceFile(cwd: string, options?: LoadWorkspaceFileOptions): WorkspaceFileConfig | undefined {
+	const start = toRealPath(cwd)
+	const boundaryRaw = gitRepoRoot(start, options)
+	const boundary = boundaryRaw ? toRealPath(boundaryRaw) : undefined
+
+	let dir = start
+	for (;;) {
+		const candidate = join(dir, WORKSPACE_FILE_NAME)
+		if (existsSync(candidate)) return parseWorkspaceFile(candidate)
+		if (boundary === undefined || dir === boundary) return undefined
+		const parent = dirname(dir)
+		if (parent === dir) return undefined
+		dir = parent
+	}
+}
+
+function toRealPath(path: string): string {
+	try {
+		return realpathSync.native(path)
+	} catch {
+		return resolve(path)
+	}
+}
+
+/** Git toplevel for `cwd`, or undefined when not inside a repo (or git is unavailable). */
+function gitRepoRoot(cwd: string, options?: LoadWorkspaceFileOptions): string | undefined {
+	const execImpl = options?.execFile ?? execFileSync
+	try {
+		const stdout = execImpl("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 5_000,
+		})
+		const trimmed = stdout.trim()
+		return trimmed.length > 0 ? trimmed : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function parseWorkspaceFile(filePath: string): WorkspaceFileConfig {
+	let raw: unknown
+	try {
+		raw = parseYaml(readFileSync(filePath, "utf-8"))
+	} catch (err) {
+		throw new WorkspaceFileError(
+			`Could not parse ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+			filePath,
+		)
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		throw new WorkspaceFileError(`Could not parse ${filePath}: expected a mapping at the top level`, filePath)
+	}
+	const resources = parseResourcesSection((raw as Record<string, unknown>).resources, filePath)
+	return resources ? { resources } : {}
+}
+
+/**
+ * Strict extraction: unknown keys, non-string values, and non-mapping
+ * sections are WorkspaceFileErrors naming the offender — silently dropping
+ * them would fall back to default sizing the user believes is overridden
+ * (e.g. unquoted `cpu: 2` parses as a number in YAML).
+ */
+function parseResourcesSection(value: unknown, filePath: string): WorkspaceResourcesConfig | undefined {
+	if (value === undefined) return undefined
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new WorkspaceFileError(
+			`Could not parse ${filePath}: "resources" must be a mapping of ${WORKSPACE_RESOURCE_FIELDS.join(", ")} to quantity strings`,
+			filePath,
+		)
+	}
+	const raw = value as Record<string, unknown>
+	for (const key of Object.keys(raw)) {
+		if (!WORKSPACE_RESOURCE_FIELDS.some((field) => field === key)) {
+			throw new WorkspaceFileError(
+				`Unknown field "${key}" in resources in ${filePath} — valid fields: ${WORKSPACE_RESOURCE_FIELDS.join(", ")}`,
+				filePath,
+			)
+		}
+	}
+	const out: WorkspaceResourcesConfig = {}
+	for (const field of WORKSPACE_RESOURCE_FIELDS) {
+		const fieldValue = raw[field]
+		if (fieldValue === undefined) continue
+		if (typeof fieldValue !== "string") {
+			throw new WorkspaceFileError(
+				`Invalid "${field}" value in ${filePath} — expected a quoted quantity string (e.g. ${field}: "500m"), got ${typeof fieldValue}. Quote the value.`,
+				filePath,
+			)
+		}
+		out[field] = fieldValue
+	}
+	return Object.keys(out).length > 0 ? out : undefined
+}


### PR DESCRIPTION
## Linked issue

Closes #1150

## What does this PR do?
 
- before creating remote workspace, read `kimchi_workspace.yaml`
- if available, get resource spec from file, and provision instance accordingly

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
