### PR TITLE
fix(compaction): enable overflow recovery for Auto (router) sessions

### DIFF
--- a/src/upstream-compaction-recovery.test.ts
+++ b/src/upstream-compaction-recovery.test.ts
@@ -1,6 +1,8 @@
+import type { Model } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { getRawErrorMessage, preserveRawErrorMessage } from "./extensions/error-preservation.js"
+import { clearAutoRoutingState, setAutoRoutingState } from "./extensions/router/state.js"
 import { installCompactionRecoveryPatch } from "./upstream-retry-patch.js"
 
 /**
@@ -323,5 +325,189 @@ describe("resume path: raw error recovered from session audit entries", () => {
 		await patchedCheckCompaction(cls).call(session as never, msg)
 
 		expect(original.mock.calls[0][0]).toBe(msg)
+	})
+})
+
+describe("installCompactionRecoveryPatch: Auto sameModel stamping", () => {
+	const SESSION_ID = "test-auto-session"
+
+	const autoModel: Model<string> = {
+		id: "auto",
+		name: "Auto",
+		api: "kimchi-auto",
+		provider: "kimchi-dev",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_000,
+	}
+
+	const routedModel: Model<string> = {
+		id: "routed",
+		name: "Routed",
+		api: "openai-completions",
+		provider: "ai-enabler",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 8_192,
+	}
+
+	const concreteModel: Model<string> = {
+		id: "kimi-k2",
+		name: "Kimi K2",
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		baseUrl: "",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262_144,
+		maxTokens: 131_072,
+	}
+
+	const RAW_OVERFLOW =
+		'{"error":{"type":"invalid_request_error","message":"The input (313972 tokens) is longer than the model\'s context length (262144 tokens).","retryable":false,"code":"400"}}'
+
+	afterEach(() => {
+		clearAutoRoutingState(SESSION_ID)
+	})
+
+	it("stamps the session model on the copy so sameModel passes for Auto sessions", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: routedModel })
+
+		const session = {
+			model: autoModel,
+			sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [] },
+		}
+		const msg: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: routedModel.provider,
+			model: routedModel.id,
+		}
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		expect(captured).toHaveLength(1)
+		// The copy is stamped with the SESSION model's identity (kimchi-dev/auto),
+		// not the routed model — upstream's sameModel compares message against
+		// this.model, so the message must match this.model (auto).
+		expect(captured[0].provider).toBe(autoModel.provider)
+		expect(captured[0].model).toBe(autoModel.id)
+		// The original message keeps its routed model identity.
+		expect(msg.provider).toBe(routedModel.provider)
+		expect(msg.model).toBe(routedModel.id)
+	})
+
+	it("does not stamp when routing is unresolved (no effective model to resolve)", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return false
+		})
+		const cls = createPatchedClass(original)
+
+		// No setAutoRoutingState → state is "unresolved"
+		const session = {
+			model: autoModel,
+			sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [] },
+		}
+		const msg: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: routedModel.provider,
+			model: routedModel.id,
+		}
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		// No stamping: resolveEffectiveModel returns the Auto model itself,
+		// which equals sessionModel, so stampEffectiveModel returns undefined.
+		// The message is passed through unchanged (identity, not a copy).
+		expect(captured).toHaveLength(1)
+		expect(captured[0]).toBe(msg)
+	})
+
+	it("does not modify message for concrete (non-Auto) sessions (sameModel guard preserved)", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return false
+		})
+		const cls = createPatchedClass(original)
+
+		// A concrete session where the message came from a DIFFERENT model
+		// (simulating a user switch from kimi-k2 to claude-opus-4).
+		// The sameModel guard must block stale overflow — no stamping.
+		const session = {
+			model: concreteModel,
+			sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [] },
+		}
+		const msg: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: "anthropic",
+			model: "claude-opus-4",
+		}
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		expect(captured).toHaveLength(1)
+		// Identity pass-through: the message is NOT a copy, NOT stamped.
+		expect(captured[0]).toBe(msg)
+		expect(captured[0].provider).toBe("anthropic")
+		expect(captured[0].model).toBe("claude-opus-4")
+	})
+
+	it("combines raw-error restoration and model stamping on the same copy", async () => {
+		const captured: Record<string, unknown>[] = []
+		const original = vi.fn<CheckCompaction>(async (message) => {
+			captured.push(message)
+			return true
+		})
+		const cls = createPatchedClass(original)
+
+		setAutoRoutingState(SESSION_ID, { status: "resolved", model: routedModel })
+
+		const session = {
+			model: autoModel,
+			sessionManager: { getSessionId: () => SESSION_ID, getBranch: () => [] },
+		}
+		const msg: Record<string, unknown> = {
+			role: "assistant",
+			stopReason: "error",
+			errorMessage: RAW_OVERFLOW,
+			provider: routedModel.provider,
+			model: routedModel.id,
+		}
+		// Simulate interactive-error-surface sanitizing the message.
+		preserveRawErrorMessage(msg)
+		msg.errorMessage = SANITIZED_OVERFLOW
+
+		await patchedCheckCompaction(cls).call(session as never, msg)
+
+		expect(captured).toHaveLength(1)
+		// Both fixes land on the same copy: raw error restored AND model stamped
+		// to the session model (auto), not the routed model.
+		expect(captured[0].errorMessage).toBe(RAW_OVERFLOW)
+		expect(captured[0].provider).toBe(autoModel.provider)
+		expect(captured[0].model).toBe(autoModel.id)
+		// The original message keeps its sanitized display text.
+		expect(msg.errorMessage).toBe(SANITIZED_OVERFLOW)
 	})
 })

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -275,8 +275,12 @@ function stampEffectiveModel(
 
 	const sessionId = session.sessionManager?.getSessionId?.()
 	const effective = resolveEffectiveModel(sessionModel, sessionId ?? "")
-	// Only stamp when routing resolved to a different concrete model.
-	if (!effective || effective === sessionModel) return undefined
+	// Only stamp when routing resolved to a different concrete model. Compare by
+	// identity (provider/id), not reference — resolveEffectiveModel may return a
+	// distinct object that still represents the same Auto model.
+	if (!effective || (effective.provider === sessionModel.provider && effective.id === sessionModel.id)) {
+		return undefined
+	}
 
 	// Stamp the copy with the session model's identity so sameModel passes.
 	const msgProvider = message.provider

--- a/src/upstream-retry-patch.ts
+++ b/src/upstream-retry-patch.ts
@@ -1,6 +1,8 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai"
+import type { AssistantMessage, Model } from "@earendil-works/pi-ai"
 import { AgentSession } from "@earendil-works/pi-coding-agent"
 import { getRawErrorMessage, hasPreservedRawErrorMessage } from "./extensions/error-preservation.js"
+import { isAutoModel } from "./extensions/router/constants.js"
+import { resolveEffectiveModel } from "./extensions/router/state.js"
 import { GATEWAY_CLASSIFICATION_AUDIT_TYPE } from "./infrastructure-error.js"
 import { classifyLLMGatewayError, parseRateLimitRetryAt } from "./llm-gateway-error.js"
 
@@ -16,7 +18,8 @@ type SessionBranchEntry = {
 	data?: { rawMessage?: unknown }
 }
 type BranchBackedSession = {
-	sessionManager?: { getBranch?: () => SessionBranchEntry[] }
+	model?: Model<string>
+	sessionManager?: { getBranch?: () => SessionBranchEntry[]; getSessionId?: () => string }
 }
 type PatchableAgentSession = {
 	prototype: {
@@ -244,6 +247,46 @@ function rawErrorForCompactionRecovery(
 }
 
 /**
+ * For Auto sessions, upstream's `sameModel` gate compares the assistant
+ * message's `provider`/`model` against `this.model` — which is the
+ * user-selected `kimchi-dev/auto`. But the message carries the routed
+ * concrete model (stamped by the Auto API provider when it delegates to the
+ * target model's `stream()`). This mismatch causes `sameModel` to always be
+ * `false`, blocking overflow recovery.
+ *
+ * This helper checks whether the session is an Auto session that has routed to
+ * a concrete model. If so, the assistant message carries the routed model's
+ * `provider`/`id`, while `this.model` is `kimchi-dev/auto`. Upstream's
+ * `sameModel` gate compares the message against `this.model` and fails.
+ *
+ * To fix this, we stamp the copy with the *session* model's identity
+ * (`kimchi-dev/auto`) so `sameModel` passes. Returns `undefined` when no
+ * stamping is needed (non-Auto sessions, unresolved routing, or the message
+ * already matches the session model).
+ *
+ * Only the returned copy is modified — the original message is untouched.
+ */
+function stampEffectiveModel(
+	message: CompactionCheckMessage,
+	session: BranchBackedSession | undefined,
+): CompactionCheckMessage | undefined {
+	const sessionModel = session?.model
+	if (!sessionModel || !isAutoModel(sessionModel)) return undefined
+
+	const sessionId = session.sessionManager?.getSessionId?.()
+	const effective = resolveEffectiveModel(sessionModel, sessionId ?? "")
+	// Only stamp when routing resolved to a different concrete model.
+	if (!effective || effective === sessionModel) return undefined
+
+	// Stamp the copy with the session model's identity so sameModel passes.
+	const msgProvider = message.provider
+	const msgModel = message.model
+	if (msgProvider === sessionModel.provider && msgModel === sessionModel.id) return undefined
+
+	return { ...message, provider: sessionModel.provider, model: sessionModel.id }
+}
+
+/**
  * Companion to {@link installInfrastructureRetryPatch}: teaches upstream's
  * `_checkCompaction` to classify overflow from the preserved raw provider
  * error rather than the sanitized display text.
@@ -266,14 +309,30 @@ export function installCompactionRecoveryPatch(
 		message: CompactionCheckMessage,
 		skipAbortedCheck?: boolean,
 	): Promise<boolean> {
-		// Restore the raw provider error for the classification, leaving the
-		// display text untouched. A shared copy (not the session message) is
-		// passed through so nothing downstream observes the swap.
+		// Build a throwaway copy with both fixes applied so the original message
+		// is never mutated:
+		//   1. Restore the raw provider error (so isContextOverflow can match it).
+		//   2. Stamp the effective model's provider/id for Auto sessions (so the
+		//      sameModel gate passes — upstream compares message.model against
+		//      this.model, but Auto keeps kimchi-dev/auto while the message
+		//      carries the routed concrete model).
+		let copy: CompactionCheckMessage | undefined
+
 		if (typeof message.errorMessage === "string") {
 			const raw = rawErrorForCompactionRecovery(message, this)
 			if (raw && raw !== message.errorMessage) {
-				return original.call(this, { ...message, errorMessage: raw }, skipAbortedCheck)
+				copy = { ...message, errorMessage: raw }
 			}
+		}
+
+		// Stamp on the copy (if one exists) so both fixes land on the same object.
+		const stamped = stampEffectiveModel(copy ?? message, this)
+		if (stamped) {
+			copy = stamped
+		}
+
+		if (copy) {
+			return original.call(this, copy, skipAbortedCheck)
 		}
 		return original.call(this, message, skipAbortedCheck)
 	}

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -58,6 +58,25 @@ const MODELS_WITH_RANKED_FALLBACK = [
 	},
 ]
 
+const OVERFLOW_MODEL = {
+	slug: "routed",
+	displayName: "Fake Routed",
+	provider: "ai-enabler",
+	input: ["text"] as const,
+	// Large window so proactive threshold compaction never fires during priming;
+	// the context-length 400 is the only compaction trigger in this scenario.
+	contextWindow: 100_000,
+	maxTokens: 8_192,
+}
+
+const OVERFLOW_ERROR_BODY = {
+	error: {
+		message: "BadRequestError: The input (104857 tokens) is longer than the model's context length (1048576 tokens).",
+		type: "invalid_request_error",
+		code: 400,
+	},
+}
+
 function requestsTo<T extends { url: string }>(fixture: { fake: { requests: T[] } }, path: string): T[] {
 	return fixture.fake.requests.filter((request) => request.url.startsWith(path))
 }
@@ -122,6 +141,21 @@ function agentCall(id: string, model?: string, runInBackground = false) {
 			}),
 		},
 	}
+}
+
+/** Generate a long prompt so the chars÷4 token estimate creates a summarizable prefix. */
+function largePrompt(base: string, tokens: number): string {
+	const chunk = "one two three four five six seven eight nine ten "
+	const repeats = Math.ceil((tokens * 4) / chunk.length)
+	return `${base}: ${chunk.repeat(repeats)}`
+}
+
+function seedCompactionSettings(homeDir: string) {
+	const settingsPath = join(homeDir, ".config", "kimchi", "harness", "settings.json")
+	const settings = JSON.parse(readFileSync(settingsPath, "utf-8"))
+	settings.compaction = { keepRecentTokens: 1_000 }
+	writeFileSync(settingsPath, JSON.stringify(settings, null, "\t"), "utf-8")
+	return {}
 }
 
 test("/model autocomplete shows and selects Auto when experimental features are enabled", async ({ terminal }) => {
@@ -583,6 +617,64 @@ test("an explicitly selected concrete child model bypasses Auto routing", async 
 			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
 			expect(chatRequests).toHaveLength(3)
 			expect(chatRequests.map((request) => requestModel(request.body))).toEqual(["routed", "routed", "routed"])
+		},
+	)
+})
+
+test("Auto sessions auto-compact and recover from a context-window overflow", async ({ terminal }) => {
+	await runKimchiSession(
+		terminal,
+		{
+			artifactName: "auto-model-overflow-compaction",
+			providerId: "kimchi-dev",
+			initialModel: "auto",
+			extraArgs: ["--enable-experimental-features"],
+			gitInit: true,
+			models: [OVERFLOW_MODEL],
+			routerResponses: [ROUTED_ROUTER_RESPONSE],
+			seedHome: seedCompactionSettings,
+			responses: [
+				// Prime enough history that compaction has something to summarize.
+				{ stream: ["Ack 1."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				{ stream: ["Ack 2."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				{ stream: ["Ack 3."], usage: { prompt_tokens: 400, completion_tokens: 1 } },
+				// The overflow 400.
+				{ status: 400, body: OVERFLOW_ERROR_BODY },
+				// Compaction summary request.
+				{ stream: ["Summary", " of", " prior", " context."], usage: { prompt_tokens: 100, completion_tokens: 4 } },
+				// Retry after compaction.
+				{ stream: ["Recovered", " after", " compaction."], usage: { prompt_tokens: 1000, completion_tokens: 3 } },
+			],
+		},
+		async (fixture, trace) => {
+			terminal.submit(largePrompt("First prompt", 500))
+			await waitForText(terminal, "Ack 1.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForText(terminal, "auto (routed) → ctrl+p", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("auto resolved to routed; turn 1 complete")
+
+			terminal.submit(largePrompt("Second prompt", 500))
+			await waitForText(terminal, "Ack 2.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("turn 2 complete")
+
+			terminal.submit(largePrompt("Third prompt", 500))
+			await waitForText(terminal, "Ack 3.", { timeoutMs: STREAM_TIMEOUT_MS })
+			await waitForTurnToSettle(fixture.fake.requests)
+			trace.step("turn 3 complete")
+
+			terminal.submit("Continue the task")
+			trace.step("submitted follow-up that will overflow")
+
+			await waitForText(terminal, "Recovered after compaction.", { timeoutMs: STREAM_TIMEOUT_MS })
+
+			const chatRequests = requestsTo(fixture, "/openai/v1/chat/completions")
+			expect(chatRequests.length).toBeGreaterThanOrEqual(6)
+			const hasCompactionSummary = chatRequests.some((request) =>
+				JSON.stringify(request.body).includes("context summarization assistant"),
+			)
+			expect(hasCompactionSummary).toBe(true)
+			expect(chatRequests.every((request) => requestModel(request.body) === "routed")).toBe(true)
 		},
 	)
 })


### PR DESCRIPTION
## Problem

Auto (router) sessions cannot recover from context-window overflow. Upstream's `_checkCompaction` gates overflow recovery behind a `sameModel` check that compares the assistant message's `provider`/`model` against `this.model`. In Auto sessions, `this.model` is `kimchi-dev/auto` (the user-selected model, kept by design), but the assistant message carries the routed concrete model (e.g. `ai-enabler/routed`) — stamped by the Auto API provider when it delegates to the concrete model's `stream()`. So `sameModel` is always `false`, the overflow recovery branch never fires, and the session wedges on the 400 instead of compacting and retrying.

The existing `installCompactionRecoveryPatch` wrapper already handles the *other* half of this problem — restoring the raw provider error text so `isContextOverflow` can match it — but it cannot help if `sameModel` never lets execution reach that check.

## Fix

Extended the existing `installCompactionRecoveryPatch` wrapper in `src/upstream-retry-patch.ts` to stamp the throwaway message copy with the *session model's* identity (`kimchi-dev/auto`) when an Auto session has resolved routing. This makes `sameModel` pass because the copy's `provider`/`model` now match `this.model`. The original message is never mutated — the stamping operates on the same throwaway copy the wrapper already creates for raw-error restoration. Non-Auto sessions are a no-op, preserving the model-switch guard.

## Alternatives Considered

1. **Temporarily swap `this.agent.state.model`** — Set the session model to the routed concrete model during `_checkCompaction`, then restore it in a `finally` block. Rejected because `_checkCompaction` sets `this._overflowRecoveryAttempted = true` internally — the flag would correctly land on the real session, but concurrent reads (e.g. status-line renders) could briefly see the routed model instead of `auto`. Stamping the copy avoids mutating session state entirely.

2. **Patch upstream `_checkCompaction` source via `patches/`** — Add a source-level patch to modify the `sameModel` gate in `agent-session.js`. Rejected because patches are debt — they require tracking issues and expire when upstream changes. Additionally, the effective (routed) model is tracked in Kimchi's router state (`stateBySession`), which is not accessible from upstream's `AgentSession` context, making it hard to resolve the correct model identity inside a source patch. The existing wrapper approach already intercepts `_checkCompaction` cleanly and has access to the session via `this`, where the router state can be resolved.

## Tests

- 4 unit tests in `src/upstream-compaction-recovery.test.ts`: Auto stamping, unresolved routing no-op, concrete-session no-op, combined raw-error + model stamping.
- 1 e2e test in `tests/e2e/tui/auto-model.test.ts`: Auto session routes to a concrete model, hits a context-length 400, runs compaction summary, and retries successfully.