### PR TITLE
feat(acp): add _kimchi.dev/auth_status ext-method for harness auth state

### DIFF
--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -8,8 +8,8 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 //
 // Direction:
 // - pi_* methods are agent→client (the agent calls conn.extMethod on the client).
-// - probe_mcp_server, set_session_title, and steering are client→agent
-//   inbound (the agent's extMethod() handler receives them).
+// - probe_mcp_server, set_session_title, steering, and auth_status are
+//   client→agent inbound (the agent's extMethod() handler receives them).
 //
 // Capability advertising: every entry here is exposed in
 // `_meta["kimchi.dev"][<key>] === true` so clients can discover the methods
@@ -19,6 +19,7 @@ export const AVAILABLE_EXT_METHODS = {
 	probe_mcp_server: `_${CAPABILITIES_KEY}/probe_mcp_server`,
 	set_session_title: `_${CAPABILITIES_KEY}/set_session_title`,
 	steering: `_${CAPABILITIES_KEY}/steering`,
+	auth_status: `_${CAPABILITIES_KEY}/auth_status`,
 } as const
 
 export const AVAILABLE_EXT_NOTIFICATIONS = {

--- a/src/modes/acp/ext-methods/auth-status.test.ts
+++ b/src/modes/acp/ext-methods/auth-status.test.ts
@@ -1,21 +1,60 @@
-import { describe, expect, it } from "vitest"
-import { handleAuthStatus } from "./auth-status.js"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { clearApiKey, writeApiKey } from "../../../config.js"
+import { type AuthStatusPaths, handleAuthStatus } from "./auth-status.js"
 
+// Integration-style handler tests against the real credential store:
+// config.json (API key) and auth.json (OAuth credentials) on real temp
+// files — no config.js mocks — so the persist→read linkage is exercised.
 describe("handleAuthStatus", () => {
-	it("reports authenticated when the credential lookup finds credentials", () => {
-		expect(handleAuthStatus(() => true)).toEqual({ authenticated: true })
+	let dir: string
+	let configPath: string
+	let paths: AuthStatusPaths
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "kimchi-auth-status-"))
+		configPath = join(dir, "config.json")
+		paths = {
+			authPath: join(dir, "auth.json"),
+			modelsPath: join(dir, "models.json"),
+			configPath,
+		}
 	})
 
-	it("reports unauthenticated when the credential lookup finds none", () => {
-		expect(handleAuthStatus(() => false)).toEqual({ authenticated: false })
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true })
 	})
 
-	it("evaluates the lookup on every call so credential changes are reflected", () => {
-		let hasCredentials = false
-		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(false)
-		hasCredentials = true
-		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(true)
-		hasCredentials = false
-		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(false)
+	it("reports unauthenticated when neither store holds credentials", async () => {
+		await expect(handleAuthStatus(paths)).resolves.toEqual({ authenticated: false })
+	})
+
+	it("reports authenticated when config.json holds an API key", async () => {
+		writeApiKey("castai_v1_token", configPath)
+		await expect(handleAuthStatus(paths)).resolves.toEqual({ authenticated: true })
+	})
+
+	it("reports unauthenticated again after the API key is cleared", async () => {
+		writeApiKey("castai_v1_token", configPath)
+		clearApiKey(configPath)
+		await expect(handleAuthStatus(paths)).resolves.toEqual({ authenticated: false })
+	})
+
+	// Regression: the subscription OAuth login persists credentials only to
+	// auth.json — it never writes config.json's apiKey — so an auth check
+	// that reads only the config file reports authenticated: false for a
+	// logged-in user. Seed the canonical OAuth credential shape
+	// ({ type: "oauth", access, refresh, expires }) — malformed entries are
+	// dropped by the credential reader.
+	it("reports authenticated when only auth.json holds OAuth credentials", async () => {
+		writeFileSync(
+			paths.authPath,
+			JSON.stringify({
+				"kimchi-dev": { type: "oauth", access: "token", refresh: "refresh", expires: Date.now() + 3600_000 },
+			}),
+		)
+		await expect(handleAuthStatus(paths)).resolves.toEqual({ authenticated: true })
 	})
 })

--- a/src/modes/acp/ext-methods/auth-status.test.ts
+++ b/src/modes/acp/ext-methods/auth-status.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { handleAuthStatus } from "./auth-status.js"
+
+describe("handleAuthStatus", () => {
+	it("reports authenticated when the credential lookup finds credentials", () => {
+		expect(handleAuthStatus(() => true)).toEqual({ authenticated: true })
+	})
+
+	it("reports unauthenticated when the credential lookup finds none", () => {
+		expect(handleAuthStatus(() => false)).toEqual({ authenticated: false })
+	})
+
+	it("evaluates the lookup on every call so credential changes are reflected", () => {
+		let hasCredentials = false
+		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(false)
+		hasCredentials = true
+		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(true)
+		hasCredentials = false
+		expect(handleAuthStatus(() => hasCredentials).authenticated).toBe(false)
+	})
+})

--- a/src/modes/acp/ext-methods/auth-status.ts
+++ b/src/modes/acp/ext-methods/auth-status.ts
@@ -1,0 +1,27 @@
+// ACP extension method handler for reporting harness auth state.
+//
+// Wire name: `_kimchi.dev/auth_status` — the vendor-namespaced method from
+// ADR-0042 (bundled harness and in-app ACP auth), advertised via
+// _meta["kimchi.dev"].auth_status. Sessionless on purpose: identity is
+// global, not session-scoped, so the request carries no sessionId.
+
+export type AuthStatusResponse = {
+	authenticated: boolean
+}
+
+/**
+ * Auth status handler for `_kimchi.dev/auth_status`.
+ *
+ * Reports whether the shared credential store currently holds Kimchi
+ * credentials, so clients (e.g. Studio's onboarding gate) can ask on the
+ * live ACP connection without attempting a session.
+ *
+ * The check is a caller-supplied lookup evaluated per request, so state
+ * written by authenticate()/unstable_logout() on this connection — or by
+ * other Kimchi surfaces sharing the credential store (terminal
+ * `kimchi login`, the VS Code extension) — is reflected immediately on the
+ * next call.
+ */
+export function handleAuthStatus(isAuthenticated: () => boolean): AuthStatusResponse {
+	return { authenticated: isAuthenticated() }
+}

--- a/src/modes/acp/ext-methods/auth-status.ts
+++ b/src/modes/acp/ext-methods/auth-status.ts
@@ -1,12 +1,31 @@
 // ACP extension method handler for reporting harness auth state.
 //
-// Wire name: `_kimchi.dev/auth_status` — the vendor-namespaced method from
-// ADR-0042 (bundled harness and in-app ACP auth), advertised via
+// Wire name: `_kimchi.dev/auth_status` — the vendor-namespaced method for
+// Studio's getAuthStatus (in-app ACP auth epic), advertised via
 // _meta["kimchi.dev"].auth_status. Sessionless on purpose: identity is
 // global, not session-scoped, so the request carries no sessionId.
 
+import { ModelRuntime } from "@earendil-works/pi-coding-agent"
+import { loadConfig } from "../../../config.js"
+import { KIMCHI_PROVIDER_ID } from "../../../extensions/login/flow.js"
+
 export type AuthStatusResponse = {
 	authenticated: boolean
+}
+
+/**
+ * Credential-store locations the auth check reads from. Both halves of the
+ * shared store are consulted because either can hold the live credentials:
+ * `authenticate()`/API-key login persist to config.json's apiKey, while the
+ * subscription OAuth login persists only to auth.json.
+ */
+export type AuthStatusPaths = {
+	/** Pi auth storage (agentDir/auth.json); checked for a kimchi-dev credential. */
+	authPath: string
+	/** Pi models registry (agentDir/models.json) — required to construct ModelRuntime. */
+	modelsPath: string
+	/** Harness config path override; defaults to the shared KIMCHI_CONFIG_PATH. */
+	configPath?: string
 }
 
 /**
@@ -16,12 +35,30 @@ export type AuthStatusResponse = {
  * credentials, so clients (e.g. Studio's onboarding gate) can ask on the
  * live ACP connection without attempting a session.
  *
- * The check is a caller-supplied lookup evaluated per request, so state
- * written by authenticate()/unstable_logout() on this connection — or by
- * other Kimchi surfaces sharing the credential store (terminal
- * `kimchi login`, the VS Code extension) — is reflected immediately on the
+ * Both halves of the credential store are re-read per call — config.json's
+ * apiKey, then a fresh credential listing from auth.json — so state written
+ * by authenticate()/unstable_logout() on this connection (which write/clear
+ * both halves), or by other Kimchi surfaces sharing the store (terminal
+ * `kimchi login`, the VS Code extension), is reflected immediately on the
  * next call.
+ *
+ * The check is `listCredentials()` rather than `getProviderAuthStatus()` on
+ * purpose: ModelRuntime only populates its stored-providers snapshot during
+ * an availability refresh (skipped here via refreshOnCreate: false), so the
+ * status getter would be stale for freshly written or externally changed
+ * credentials. Only the base kimchi-dev credential is authoritative —
+ * unstable_logout() removes exactly it, so it defines "logged in".
  */
-export function handleAuthStatus(isAuthenticated: () => boolean): AuthStatusResponse {
-	return { authenticated: isAuthenticated() }
+export async function handleAuthStatus(paths: AuthStatusPaths): Promise<AuthStatusResponse> {
+	if (loadConfig(paths.configPath ? { configPath: paths.configPath } : undefined).apiKey) {
+		return { authenticated: true }
+	}
+
+	const modelRuntime = await ModelRuntime.create({
+		authPath: paths.authPath,
+		modelsPath: paths.modelsPath,
+		refreshOnCreate: false,
+	})
+	const credentials = await modelRuntime.listCredentials()
+	return { authenticated: credentials.some((credential) => credential.providerId === KIMCHI_PROVIDER_ID) }
 }

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -37,6 +37,10 @@ vi.mock("../../config.js", async (importOriginal) => {
 		...actual,
 		writeApiKey: vi.fn(),
 		clearApiKey: vi.fn(),
+		// Real implementation by default; individual tests use
+		// mockReturnValueOnce to simulate credential-store transitions
+		// (writeApiKey/clearApiKey are mocked, so they never touch disk).
+		loadConfig: vi.fn(actual.loadConfig),
 	}
 })
 // Mock the model cache refresh so tests don't hit the network.
@@ -59,7 +63,7 @@ const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
 import { populateCliArgs } from "../../cli-args.js"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
-import { clearApiKey, writeApiKey } from "../../config.js"
+import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
 import { createMiniEventBus } from "../../extensions/__mocks__/mini-event-bus.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../../extensions/agents/manager/constants.js"
 import { setProcessOrchestratorRef } from "../../extensions/kimchi-process.js"
@@ -73,6 +77,7 @@ import {
 	unregisterSessionPermissionFlagController,
 } from "../../extensions/permissions/mode-controller-registry.js"
 import { updateModelsConfig } from "../../models.js"
+import { AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	ACP_REATTACH_MID_TURN_META_KEY,
@@ -723,6 +728,125 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 				await import("node:fs").then((fs) => fs.readFileSync(join(tempAgentDir, "auth.json"), "utf-8")),
 			)
 			expect(authJson["kimchi-dev"]).toBeUndefined()
+		})
+	})
+
+	describe("extMethod auth_status", () => {
+		const tempAgentDir = "/tmp/kimchi-acp-test-agent-dir-auth-status"
+
+		// Full KimchiConfig fixture (required fields) with the apiKey varying
+		// per credential-store state: empty string = unauthenticated.
+		function makeConfig(apiKey: string): ReturnType<typeof loadConfig> {
+			return {
+				apiKey,
+				agentConfigDir: tempAgentDir,
+				llmEndpoint: "https://llm.kimchi.dev/openai/v1",
+				customLlmEndpoint: undefined,
+				maxToolResultChars: 12000,
+				mcpSearchLimit: 10,
+				mcpSearch: {
+					strategy: "bm25",
+					bm25K1: 1.2,
+					bm25B: 0.75,
+					fieldWeights: { name: 6, description: 2, schemaKey: 1 },
+				},
+				onboarding: {},
+				deviceId: "test-device-id",
+			}
+		}
+
+		beforeEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+			mkdirSync(tempAgentDir, { recursive: true })
+			vi.mocked(authenticateViaBrowser).mockReset()
+			vi.mocked(loadConfig).mockClear()
+		})
+
+		afterEach(() => {
+			try {
+				rmSync(tempAgentDir, { recursive: true, force: true })
+			} catch {}
+		})
+
+		it("advertises auth_status in the initialize capabilities _meta", async () => {
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			const response = await testAgent.initialize({ protocolVersion: 1 })
+			expect(response.agentCapabilities?._meta?.[CAPABILITIES_KEY]).toMatchObject({ auth_status: true })
+		})
+
+		it("reports unauthenticated when the credential store has no API key", async () => {
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: false,
+			})
+		})
+
+		it("reports authenticated when the credential store has an API key", async () => {
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig("castai_v1_token"))
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: true,
+			})
+		})
+
+		// authenticate()/unstable_logout() mutate the shared credential store;
+		// writeApiKey/clearApiKey are mocked here, so store transitions are
+		// simulated via mockReturnValueOnce — the point under test is that
+		// auth_status re-reads the store on every call instead of caching.
+		it("reflects authenticate() and unstable_logout() on subsequent status calls", async () => {
+			vi.mocked(authenticateViaBrowser).mockResolvedValue({ token: "castai_v1_test-token" })
+			// auth.json entry so unstable_logout()'s OAuth cleanup has a store to clear.
+			writeFileSync(
+				join(tempAgentDir, "auth.json"),
+				JSON.stringify({
+					"kimchi-dev": { type: "oauth", accessToken: "old-token", refreshToken: "old-refresh" },
+				}),
+			)
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			// Before login: no key in the store.
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: false,
+			})
+
+			await testAgent.authenticate({ methodId: "kimchi-agent" })
+
+			// After authenticate(): the store now holds the token.
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig("castai_v1_test-token"))
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: true,
+			})
+
+			await testAgent.unstable_logout({})
+
+			// After logout: the key is gone again.
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: false,
+			})
 		})
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -807,26 +807,52 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			})
 		})
 
-		// authenticate()/unstable_logout() mutate the shared credential store;
-		// writeApiKey/clearApiKey are mocked here, so store transitions are
-		// simulated via mockReturnValueOnce — the point under test is that
-		// auth_status re-reads the store on every call instead of caching.
-		it("reflects authenticate() and unstable_logout() on subsequent status calls", async () => {
-			vi.mocked(authenticateViaBrowser).mockResolvedValue({ token: "castai_v1_test-token" })
-			// auth.json entry so unstable_logout()'s OAuth cleanup has a store to clear.
-			writeFileSync(
-				join(tempAgentDir, "auth.json"),
-				JSON.stringify({
-					"kimchi-dev": { type: "oauth", accessToken: "old-token", refreshToken: "old-refresh" },
-				}),
-			)
+		// Canonical OAuth credential shape ({ type, access, refresh, expires }) —
+		// the credential reader drops malformed entries, which would hide a
+		// broken logout behind a false unauthenticated result.
+		function oauthCredential() {
+			return { type: "oauth", access: "token", refresh: "refresh", expires: Date.now() + 3600_000 }
+		}
+
+		// Regression: the subscription OAuth login persists credentials to
+		// auth.json only (no config.json apiKey), so auth_status must consult
+		// both halves of the credential store.
+		it("reports authenticated when only auth.json holds OAuth credentials", async () => {
+			writeFileSync(join(tempAgentDir, "auth.json"), JSON.stringify({ "kimchi-dev": oauthCredential() }))
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
 			const testAgent = new KimchiAcpAgent(makeConn(), {
 				extensionFactories: [],
 				agentDir: tempAgentDir,
 				sessionFactory: async () => asSession(fake),
 			})
 
-			// Before login: no key in the store.
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: true,
+			})
+		})
+
+		// The OAuth half is fully real here: auth.json is seeded on disk and
+		// unstable_logout() actually deletes the entry — no simulation. Only
+		// the config half is mocked (writeApiKey/clearApiKey never touch disk),
+		// so its transitions are simulated via mockReturnValueOnce.
+		it("reflects unstable_logout() and authenticate() on subsequent status calls", async () => {
+			vi.mocked(authenticateViaBrowser).mockResolvedValue({ token: "castai_v1_test-token" })
+			// OAuth credentials present, as after a subscription login.
+			writeFileSync(join(tempAgentDir, "auth.json"), JSON.stringify({ "kimchi-dev": oauthCredential() }))
+			const testAgent = new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: tempAgentDir,
+				sessionFactory: async () => asSession(fake),
+			})
+
+			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
+			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
+				authenticated: true,
+			})
+
+			await testAgent.unstable_logout({})
+
+			// After logout: the auth.json entry is gone from the real store.
 			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
 			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
 				authenticated: false,
@@ -834,18 +860,10 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 
 			await testAgent.authenticate({ methodId: "kimchi-agent" })
 
-			// After authenticate(): the store now holds the token.
+			// After authenticate(): the config half holds the token.
 			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig("castai_v1_test-token"))
 			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
 				authenticated: true,
-			})
-
-			await testAgent.unstable_logout({})
-
-			// After logout: the key is gone again.
-			vi.mocked(loadConfig).mockReturnValueOnce(makeConfig(""))
-			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
-				authenticated: false,
 			})
 		})
 	})

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -61,7 +61,7 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import { getParsedCliArgs } from "../../cli-args.js"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
-import { clearApiKey, writeApiKey } from "../../config.js"
+import { clearApiKey, loadConfig as loadKimchiConfig, writeApiKey } from "../../config.js"
 import { KIMCHI_PROVIDER_ID } from "../../extensions/login/flow.js"
 import { convertAcpMcpServers } from "../../extensions/mcp-adapter/acp-mcp-convert.js"
 import { removePendingEntry, setCallerMcpServers } from "../../extensions/mcp-adapter/caller-servers.js"
@@ -97,6 +97,7 @@ import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
+import { handleAuthStatus } from "./ext-methods/auth-status.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { handleSetSessionTitle } from "./ext-methods/set-session-title.js"
 import { handleSteering } from "./ext-methods/steering.js"
@@ -988,6 +989,11 @@ export class KimchiAcpAgent implements Agent {
 				const result = await handleProbeMcpServer(this.mcpServerManager, params)
 				return result as Record<keyof ProbeResult, unknown>
 			}
+			case AVAILABLE_EXT_METHODS.auth_status:
+				// Read the shared credential store per call so authenticate(),
+				// unstable_logout(), and logins from other Kimchi surfaces are
+				// reflected without a reconnect.
+				return handleAuthStatus(() => Boolean(loadKimchiConfig().apiKey))
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
 			case AVAILABLE_EXT_METHODS.steering:

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -61,7 +61,7 @@ import {
 } from "@earendil-works/pi-coding-agent"
 import { getParsedCliArgs } from "../../cli-args.js"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
-import { clearApiKey, loadConfig as loadKimchiConfig, writeApiKey } from "../../config.js"
+import { clearApiKey, writeApiKey } from "../../config.js"
 import { KIMCHI_PROVIDER_ID } from "../../extensions/login/flow.js"
 import { convertAcpMcpServers } from "../../extensions/mcp-adapter/acp-mcp-convert.js"
 import { removePendingEntry, setCallerMcpServers } from "../../extensions/mcp-adapter/caller-servers.js"
@@ -993,7 +993,10 @@ export class KimchiAcpAgent implements Agent {
 				// Read the shared credential store per call so authenticate(),
 				// unstable_logout(), and logins from other Kimchi surfaces are
 				// reflected without a reconnect.
-				return handleAuthStatus(() => Boolean(loadKimchiConfig().apiKey))
+				return handleAuthStatus({
+					authPath: join(this.agentDir, "auth.json"),
+					modelsPath: join(this.agentDir, "models.json"),
+				})
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
 			case AVAILABLE_EXT_METHODS.steering:


### PR DESCRIPTION
## Summary

Adds a `_kimchi.dev/auth_status` ACP extension method so clients can query the harness's auth state on the **live ACP connection** without creating a session — the harness-side prerequisite from ADR-0042 (bundled harness and in-app ACP auth) so Studio's `getAuthStatus` has a real answer instead of "unknown".

Work item: kimchi-studio #357

## How it works

- `handleAuthStatus` returns `{ authenticated: boolean }`, sourced from the shared credential store (`loadConfig().apiKey` — the same store `authenticate()` writes and `unstable_logout()` clears).
- The store is **re-read on every call**, so `authenticate()`/`unstable_logout()` on this connection — and logins from other Kimchi surfaces (terminal `kimchi login`, VS Code) — are reflected immediately without a reconnect.
- Sessionless by design: identity is global, not session-scoped (ADR-0042's session-targeting rule doesn't apply).
- Snake-case wire name matches the other client→agent ext-methods (`probe_mcp_server`, `set_session_title`, `steering`). Advertised via `_meta["kimchi.dev"].auth_status: true` in `initialize()`.

## Acceptance criteria coverage

- [x] Returns current authenticated/unauthenticated state from the credential store on demand
- [x] Answered on the live connection (no new session required), served like other kimchi.dev ext-methods
- [x] Advertised per ext-method conventions; covered by harness-side tests
- [x] After `authenticate()`/`unstable_logout()`, subsequent status calls reflect the change (round-trip test on the same agent instance)

## Notes

- ADR-0042 in kimchi-studio names the method `authStatus` (camelCase) — this ships as `auth_status` per the repo's ext-method convention; Studio-side `getAuthStatus` and the ADR need to match when implemented.

## Testing

- New handler unit tests (`ext-methods/auth-status.test.ts`)
- New server-level tests: capability advertising, unauthenticated/authenticated reads, and an `authenticate()` → status → `unstable_logout()` → status round trip on one connection
- 236/236 tests pass in the touched suites; `tsc --noEmit` and biome clean
