### PR TITLE
fix(remote-run): rename Cloud Agent to Remote Agent and revise questionnaire copy

### DIFF
--- a/src/extensions/agents/personas/agent-types.ts
+++ b/src/extensions/agents/personas/agent-types.ts
@@ -116,7 +116,7 @@ export function getConfig(type: string): {
 } {
 	if (type === "Remote-Runner") {
 		return {
-			displayName: "Cloud Agent",
+			displayName: "Remote Agent",
 			description: "Remote agent running on a sandbox worker via ACP",
 			builtinToolNames: [],
 			extensions: false,

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -297,10 +297,10 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 			}
 			runtime.clearPendingPlanReview(fermentId)
 			applyFermentRuntimeToolProfile(pi, runtime)
-			// Pause the ferment before spawning the cloud agent so the scheduler
+			// Pause the ferment before spawning the remote agent so the scheduler
 			// can't nudge the agent to activate_ferment_phase between confirm
 			// and spawn. The ferment is completed (on sync) or resumed (on
-			// review/custom/done) when the cloud agent finishes.
+			// review/custom) when the remote agent finishes.
 			const pauseOutcome = createApplyAndPersist(runtime)(fermentId, { type: "pause" })
 			if (pauseOutcome.ok) {
 				runtime.setActive(pauseOutcome.ferment)
@@ -318,7 +318,7 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 				// user isn't left with a stuck ferment and no recovery path,
 				// and surface the error.
 				const message = err instanceof Error ? err.message : String(err)
-				ui?.notify?.(`Could not start the cloud agent: ${message}`, "error")
+				ui?.notify?.(`Could not start the remote agent: ${message}`, "error")
 				const resumeOutcome = createApplyAndPersist(runtime)(fermentId, { type: "resume" })
 				if (resumeOutcome.ok) {
 					runtime.setActive(resumeOutcome.ferment)

--- a/src/extensions/ferment/plan-review.test.ts
+++ b/src/extensions/ferment/plan-review.test.ts
@@ -185,7 +185,7 @@ describe("PlanReviewComponent", () => {
 		it("includes the cloud execution option after auto mode", () => {
 			const { component } = createComponent()
 			const lines = component.render(80).join("\n")
-			expect(lines).toContain("Start execution in cloud")
+			expect(lines).toContain("Execute the plan in a remote workspace")
 			expect(lines).toContain("Let me say something")
 		})
 
@@ -214,6 +214,6 @@ describe("PlanReviewComponent", () => {
 		vi.mocked(isRemoteRunEnabled).mockReturnValue(false)
 		const { component } = createComponent()
 		const lines = component.render(80).join("\n")
-		expect(lines).not.toContain("Start execution in cloud")
+		expect(lines).not.toContain("Execute the plan in a remote workspace")
 	})
 })

--- a/src/extensions/ferment/plan-review.ts
+++ b/src/extensions/ferment/plan-review.ts
@@ -24,15 +24,15 @@ export type PlanReviewOutcome =
 const pendingPlanReviews = new Map<string, PendingPlanReview>()
 
 const BASE_DECISION_OPTIONS = [
-	"Start execution",
+	"Execute the plan locally",
 	"Start execution in auto mode (run all stages without stopping)",
 	"Let me say something",
 ] as const
 
-const CLOUD_DECISION_OPTION = "Start execution in cloud"
+const CLOUD_DECISION_OPTION = "Execute the plan in a remote workspace"
 
 /** Returns the decision options for the plan review dialog, conditionally
- *  including the cloud execution option when KIMCHI_REMOTE_RUN is set. */
+ *  including the remote execution option when KIMCHI_REMOTE_RUN is set. */
 function getDecisionOptions(): string[] {
 	return isRemoteRunEnabled()
 		? [BASE_DECISION_OPTIONS[0], BASE_DECISION_OPTIONS[1], CLOUD_DECISION_OPTION, BASE_DECISION_OPTIONS[2]]

--- a/src/extensions/permissions/index.test.ts
+++ b/src/extensions/permissions/index.test.ts
@@ -767,7 +767,7 @@ describe("plan mode assumption detection", () => {
 
 		expect(ctx.ui.select).toHaveBeenCalledWith(
 			"Plan complete. How would you like to proceed?",
-			["Execute the plan", "Rework the plan", "Start as ferment"],
+			["Execute the plan locally", "Rework the plan", "Start as ferment"],
 			expect.anything(),
 		)
 		expect(harness.pi.sendMessage).not.toHaveBeenCalled()
@@ -861,7 +861,7 @@ describe("plan mode assumption detection", () => {
 			await harness.fire("session_start", {}, createMockContext([]))
 			const tmpDir = mkdtempSync(join(tmpdir(), "plan-save-execute-"))
 			try {
-				const ctx = createMockContext(["Execute the plan"])
+				const ctx = createMockContext(["Execute the plan locally"])
 				ctx.cwd = tmpDir
 				await submitPlan(harness, PLAN_V1, ctx)
 
@@ -911,7 +911,7 @@ describe("plan mode assumption detection", () => {
 			await harness.fire("session_start", {}, createMockContext([]))
 			const tmpDir = mkdtempSync(join(tmpdir(), "plan-save-v2-execute-"))
 			try {
-				const ctx = createMockContext(["Execute the plan"])
+				const ctx = createMockContext(["Execute the plan locally"])
 				ctx.cwd = tmpDir
 				await submitPlan(harness, PLAN_V1, ctx)
 
@@ -932,7 +932,7 @@ describe("plan mode assumption detection", () => {
 			isResourceEnabledMock.mockImplementation((id) => id === FERMENT_V2_RESOURCE_ID)
 			const harness = createPermissionsHarness(["read", "bash"], { plan: true })
 			await harness.fire("session_start", {}, createMockContext([]))
-			const ctx = createMockContext(["Execute the plan"])
+			const ctx = createMockContext(["Execute the plan locally"])
 
 			await submitPlan(harness, PLAN_V1, ctx)
 
@@ -956,7 +956,7 @@ describe("plan mode assumption detection", () => {
 			const tmpDir = mkdtempSync(join(tmpdir(), "plan-save-v2-inline-"))
 			try {
 				writeFileSync(join(tmpDir, ".kimchi"), "not a directory")
-				const ctx = createMockContext(["Execute the plan"])
+				const ctx = createMockContext(["Execute the plan locally"])
 				ctx.cwd = tmpDir
 
 				await submitPlan(harness, PLAN_V1, ctx)
@@ -982,7 +982,7 @@ describe("plan mode assumption detection", () => {
 			registerFermentV2PlanExecutor(harness.pi, async () => "kept-existing")
 			await harness.fire("session_start", {}, createMockContext([]))
 
-			await submitPlan(harness, PLAN_V1, createMockContext(["Execute the plan"]))
+			await submitPlan(harness, PLAN_V1, createMockContext(["Execute the plan locally"]))
 
 			expect(harness.pi.sendMessage).not.toHaveBeenCalledWith(
 				expect.objectContaining({ customType: "plan-execute" }),
@@ -998,7 +998,7 @@ describe("plan mode assumption detection", () => {
 			})
 			await harness.fire("session_start", {}, createMockContext([]))
 			const tmpDir = mkdtempSync(join(tmpdir(), "plan-save-v2-reject-"))
-			const ctx = createMockContext(["Execute the plan"])
+			const ctx = createMockContext(["Execute the plan locally"])
 			ctx.cwd = tmpDir
 
 			try {

--- a/src/extensions/permissions/index.ts
+++ b/src/extensions/permissions/index.ts
@@ -808,13 +808,14 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				planMenuAbort.abort()
 			})
 
-			const EXECUTE = "Execute the plan"
+			const EXECUTE = "Execute the plan locally"
 			const DECLINE = "Rework the plan"
 			const START_AS_FERMENT = "Start as ferment"
-			const START_IN_CLOUD = "Start execution in cloud"
+			const START_IN_CLOUD = "Execute the plan in a remote workspace"
 
-			const options = [EXECUTE, DECLINE, START_AS_FERMENT]
+			const options = [EXECUTE]
 			if (isRemoteRunEnabled()) options.push(START_IN_CLOUD)
+			options.push(DECLINE, START_AS_FERMENT)
 
 			void withBlocked(pi.events, "Plan complete", () =>
 				withWorkingHidden(ctx, () =>
@@ -1061,7 +1062,7 @@ export default function permissionsExtension(pi: ExtensionAPI): void {
 				// no active plan and no visible error. Surface the error and
 				// restore plan mode so they can retry.
 				const message = err instanceof Error ? err.message : String(err)
-				ctx.ui?.notify?.(`Could not start the cloud agent: ${message}`, "error")
+				ctx.ui?.notify?.(`Could not start the remote agent: ${message}`, "error")
 				activePlanSlug = approvedSlug
 				changeMode(ctx, "auto", { mode: "plan", initiatedBy: "user", source: "runtime" }, "cloud_spawn_failed")
 			}

--- a/src/extensions/permissions/permissions-events.ts
+++ b/src/extensions/permissions/permissions-events.ts
@@ -98,7 +98,7 @@ export interface PermissionAfterDecisionPayload {
 // Plan approved
 // ---------------------------------------------------------------------------
 
-/** Emitted when the user approves a plan-mode plan (the "Execute the plan"
+/** Emitted when the user approves a plan-mode plan (the "Execute the plan locally"
  *  path). Subscribers use this to gate plan-progress reporting: pre-approval
  *  planning todos are the agent's scratchpad, not the plan itself. */
 export interface PermissionPlanApprovedPayload {

--- a/src/extensions/remote-run/post-completion.test.ts
+++ b/src/extensions/remote-run/post-completion.test.ts
@@ -63,7 +63,7 @@ describe("handleRemoteCompletion", () => {
 	it("always injects transcript path into steer message when user picks Review", async () => {
 		const pi = makePi()
 		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Continue locally with the result")
+		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Show the agent's results in the local session")
 
 		await handleRemoteCompletion(pi, ctx, "remote result text", "plan", {
 			transcriptPath: "/tmp/transcripts/agent-1.jsonl",
@@ -78,23 +78,12 @@ describe("handleRemoteCompletion", () => {
 		expect(content).toContain("remote result text")
 	})
 
-	it("does not inject result when user picks Done", async () => {
-		const pi = makePi()
-		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Done")
-
-		await handleRemoteCompletion(pi, ctx, "remote result", "plan", {
-			transcriptPath: "/tmp/transcripts/agent-done.jsonl",
-			agentId: "agent-done",
-		})
-
-		expect(pi.sendMessage).not.toHaveBeenCalled()
-	})
-
 	it("injects transcript path even when user picks Sync", async () => {
 		const pi = makePi()
 		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+			"Download the Remote Agent's output to the local folder",
+		)
 
 		await handleRemoteCompletion(pi, ctx, "remote result", "plan", {
 			transcriptPath: "/tmp/transcripts/agent-sync.jsonl",
@@ -124,7 +113,7 @@ describe("handleRemoteCompletion", () => {
 	it("injects result even when transcriptPath is undefined", async () => {
 		const pi = makePi()
 		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Continue locally with the result")
+		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Show the agent's results in the local session")
 
 		await handleRemoteCompletion(pi, ctx, "remote result", "plan")
 
@@ -155,7 +144,7 @@ describe("handleRemoteCompletion", () => {
 	it("injects custom action text when user picks Custom", async () => {
 		const pi = makePi()
 		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Give a custom instruction")
+		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Describe what to do next")
 		;(ctx.ui.input as ReturnType<typeof vi.fn>).mockResolvedValue("write a summary")
 
 		await handleRemoteCompletion(pi, ctx, "remote result", "plan", {
@@ -173,7 +162,7 @@ describe("handleRemoteCompletion", () => {
 	it("does not inject when user picks Custom but cancels input", async () => {
 		const pi = makePi()
 		const ctx = makeCtx()
-		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Give a custom instruction")
+		;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Describe what to do next")
 		;(ctx.ui.input as ReturnType<typeof vi.fn>).mockResolvedValue("")
 
 		await handleRemoteCompletion(pi, ctx, "remote result", "plan", {
@@ -209,7 +198,9 @@ describe("handleRemoteCompletion", () => {
 		it("uses remoteSession metadata directly — authenticates with known workspaceId", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+				"Download the Remote Agent's output to the local folder",
+			)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "plan", { remoteSession })
 
@@ -225,7 +216,9 @@ describe("handleRemoteCompletion", () => {
 		it("rsyncs from the unique remoteSession.cwd with .git and secrets excluded", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+				"Download the Remote Agent's output to the local folder",
+			)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "plan", { remoteSession })
 
@@ -244,7 +237,9 @@ describe("handleRemoteCompletion", () => {
 		it("notifies error and does not sync when remoteSession is absent", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+				"Download the Remote Agent's output to the local folder",
+			)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "plan")
 
@@ -258,7 +253,9 @@ describe("handleRemoteCompletion", () => {
 		it("notifies error when sync fails", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+				"Download the Remote Agent's output to the local folder",
+			)
 			vi.mocked(runRsync).mockRejectedValue(new Error("rsync connection refused"))
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "plan", { remoteSession })
@@ -287,7 +284,9 @@ describe("handleRemoteCompletion", () => {
 		it("completes the ferment when user picks Sync", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Sync changes and finish")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue(
+				"Download the Remote Agent's output to the local folder",
+			)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "ferment plan", {
 				fermentId,
@@ -311,7 +310,7 @@ describe("handleRemoteCompletion", () => {
 		it("resumes the ferment when user picks Review and confirms", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Continue locally with the result")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Show the agent's results in the local session")
 			;(ctx.ui.confirm as ReturnType<typeof vi.fn>).mockResolvedValue(true)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "ferment plan", { fermentId })
@@ -323,7 +322,7 @@ describe("handleRemoteCompletion", () => {
 		it("does not resume the ferment when user picks Review but declines confirm", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Continue locally with the result")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Show the agent's results in the local session")
 			;(ctx.ui.confirm as ReturnType<typeof vi.fn>).mockResolvedValue(false)
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "ferment plan", { fermentId })
@@ -331,24 +330,10 @@ describe("handleRemoteCompletion", () => {
 			expect(mockApplyAndPersist).not.toHaveBeenCalledWith(fermentId, { type: "resume" })
 		})
 
-		it("completes the ferment when user picks Done", async () => {
-			const pi = makePi()
-			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Done")
-
-			await handleRemoteCompletion(pi, ctx, "remote result", "ferment plan", { fermentId })
-
-			expect(mockApplyAndPersist).toHaveBeenCalledWith(fermentId, { type: "resume" })
-			expect(mockApplyAndPersist).toHaveBeenCalledWith(fermentId, {
-				type: "complete_ferment",
-				finalSummary: "Executed in cloud sandbox",
-			})
-		})
-
 		it("resumes the ferment when user picks Custom and confirms", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Give a custom instruction")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Describe what to do next")
 			;(ctx.ui.input as ReturnType<typeof vi.fn>).mockResolvedValue("write tests")
 			;(ctx.ui.confirm as ReturnType<typeof vi.fn>).mockResolvedValue(true)
 
@@ -360,7 +345,7 @@ describe("handleRemoteCompletion", () => {
 		it("does not call applyAndPersist when no fermentId is provided", async () => {
 			const pi = makePi()
 			const ctx = makeCtx()
-			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Continue locally with the result")
+			;(ctx.ui.select as ReturnType<typeof vi.fn>).mockResolvedValue("Show the agent's results in the local session")
 
 			await handleRemoteCompletion(pi, ctx, "remote result", "plan")
 

--- a/src/extensions/remote-run/post-completion.ts
+++ b/src/extensions/remote-run/post-completion.ts
@@ -1,12 +1,11 @@
 /**
  * Post-completion handler for remote plan execution.
  *
- * After the remote cloud agent finishes, shows a dropdown asking the user
+ * After the remote agent finishes, shows a dropdown asking the user
  * what to do next. Options:
- * - "Review the result and continue locally" — injects result + triggers turn
- * - "Sync remote changes" — rsyncs changed files from sandbox to local
- * - "Type your own action" — injects result + triggers turn with custom action
- * - "Done" — no further action
+ * - "Show the agent's results in the local session" — injects result + triggers turn
+ * - "Download the Remote Agent's output to the local folder" — rsyncs changed files from sandbox to local
+ * - "Describe what to do next" — injects result + triggers turn with custom action
  */
 
 import { basename } from "node:path"
@@ -24,10 +23,9 @@ import { SANDBOX_USER } from "../teleport/provisioning/constants.js"
 import { runRsync } from "../teleport/provisioning/rsync-runner.js"
 import { DIFF_RSYNC_EXCLUDES } from "../teleport/provisioning/sync-local-changes.js"
 
-const REVIEW = "Continue locally with the result"
-const SYNC = "Sync changes and finish"
-const CUSTOM = "Give a custom instruction"
-const DONE = "Done"
+const REVIEW = "Show the agent's results in the local session"
+const SYNC = "Download the Remote Agent's output to the local folder"
+const CUSTOM = "Describe what to do next"
 
 /** Options for handleRemoteCompletion. */
 export interface HandleRemoteCompletionOpts {
@@ -35,19 +33,19 @@ export interface HandleRemoteCompletionOpts {
 	agentId?: string
 	/** Remote session metadata — when present, sync reuses the connection directly. */
 	remoteSession?: RemoteSessionMeta
-	/** Ferment ID when the cloud agent executed a ferment plan. The ferment is
+	/** Ferment ID when the remote agent executed a ferment plan. The ferment is
 	 *  paused during cloud execution; on completion it is completed (sync) or
 	 *  resumed (review/custom/done) so the user can continue locally. */
 	fermentId?: string
 }
 
 /**
- * Shows a post-completion dropdown after the remote cloud agent finishes.
- * Handles the user's choice: inject result, sync changes, or do nothing.
+ * Shows a post-completion dropdown after the remote agent finishes.
+ * Handles the user's choice: inject result, sync changes, or collect a custom action.
  *
  * The remote agent's result and transcript path are ALWAYS injected into the
- * local agent's context via a steer message — even when the user picks "Sync"
- * or "Done" — so the agent always knows where to find the full transcript.
+ * local agent's context via a steer message — even when the user picks the
+ * download option — so the agent always knows where to find the full transcript.
  *
  * @param pi - Extension API
  * @param ctx - Extension context
@@ -68,7 +66,7 @@ export async function handleRemoteCompletion(
 
 	const choice = await withBlocked(pi.events, "Remote execution complete", () =>
 		withWorkingHidden(ctx.ui, () =>
-			ctx.ui.select("Remote cloud agent finished. What would you like to do next?", [REVIEW, SYNC, CUSTOM, DONE]),
+			ctx.ui.select("Remote agent run finished. What would you like to do with its output?", [REVIEW, SYNC, CUSTOM]),
 		),
 	)
 
@@ -76,11 +74,6 @@ export async function handleRemoteCompletion(
 	if (!choice) return
 
 	switch (choice) {
-		case DONE: {
-			trackRemoteExecution("done", promptPrefix)
-			completeFerment(opts?.fermentId)
-			return
-		}
 		case SYNC: {
 			trackRemoteExecution("sync.started", promptPrefix)
 			const synced = await syncRemoteChanges(ctx, opts?.remoteSession)
@@ -131,7 +124,7 @@ function injectRemoteResult(
 		: ""
 	const actionSuffix = extra?.actionSuffix ?? ""
 
-	const steer = `The approved ${promptPrefix} was executed by a remote cloud agent on a Linux sandbox. The plan has ALREADY been executed — do not re-plan or re-execute it. The code changes made by the remote agent are NOT in your local working tree unless the user synced them. Here is the remote agent's result:\n\n---\n\n${result}${transcriptInfo}${agentInfo}${actionSuffix}`
+	const steer = `The approved ${promptPrefix} was executed by a remote agent on a Linux sandbox. The plan has ALREADY been executed — do not re-plan or re-execute it. The code changes made by the remote agent are NOT in your local working tree unless the user synced them. Here is the remote agent's result:\n\n---\n\n${result}${transcriptInfo}${agentInfo}${actionSuffix}`
 
 	pi.sendMessage(
 		{
@@ -213,7 +206,7 @@ async function syncRemoteChanges(ctx: ExtensionContext, remoteSession?: RemoteSe
 
 /**
  * Completes the ferment after a successful cloud execution + sync.
- * The ferment was paused when the cloud agent was spawned; syncing means
+ * The ferment was paused when the remote agent was spawned; syncing means
  * the user accepted the remote work, so we mark the ferment as complete.
  *
  * The ferment was never locally activated (no phase ran locally) — the cloud
@@ -252,8 +245,8 @@ function completeFerment(fermentId?: string): void {
 }
 
 /**
- * Resumes the ferment so the user can continue locally after the cloud agent
- * finishes. Called for Review, Custom, and Done choices — the cloud agent's
+ * Resumes the ferment so the user can continue locally after the remote agent
+ * finishes. Called for Review and Custom choices — the remote agent's
  * work is available in the transcript, but the ferment stays open for local
  * follow-up.
  */

--- a/src/extensions/remote-run/prompt-builder.ts
+++ b/src/extensions/remote-run/prompt-builder.ts
@@ -2,7 +2,7 @@
  * Prompt builder for remote plan execution.
  *
  * Constructs the prompt sent to the remote agent when the user picks
- * "Start execution in cloud" from either the plan-mode or ferment review
+ * "Execute the plan in a remote workspace" from either the plan-mode or ferment review
  * dialog. The prompt includes:
  *
  * 1. Origin-specific instructions (plain execution vs ferment execution)

--- a/src/extensions/remote-run/runner.test.ts
+++ b/src/extensions/remote-run/runner.test.ts
@@ -163,7 +163,7 @@ describe("runCloudAgent", () => {
 		expect(res.id).toBe("agent-bg")
 		// Should show a 'started in background' notification
 		expect(ctx.ui.notify).toHaveBeenCalledWith(
-			"Cloud agent started in background. You'll be notified when it completes.",
+			"Remote agent started in background. You'll be notified when it completes.",
 			"info",
 		)
 		// Should trigger a new turn so the LLM can acknowledge

--- a/src/extensions/remote-run/runner.ts
+++ b/src/extensions/remote-run/runner.ts
@@ -1,5 +1,5 @@
 /**
- * Shared lifecycle wrapper for spawning remote cloud agents.
+ * Shared lifecycle wrapper for spawning remote agents.
  *
  * Named `runCloudAgent` (not `runRemoteAgent`) to avoid collision
  * with the low-level `runRemoteAgent()` in `agents/manager/remote-agent-runner.ts`,
@@ -24,7 +24,7 @@ export function isRemoteRunEnabled(): boolean {
 }
 
 /**
- * Spawns a remote cloud agent as a background agent.
+ * Spawns a remote agent as a background agent.
  *
  * The agent runs on a remote sandbox via ACP. The function returns immediately
  * with the agent ID. `handleRemoteCompletion` fires automatically when the agent
@@ -45,19 +45,19 @@ export async function runCloudAgent(
 	trackRemoteExecution("started", opts?.origin ?? "plan")
 
 	if (backgrounded) {
-		ctx.ui.notify("Cloud agent started in background. You'll be notified when it completes.", "info")
+		ctx.ui.notify("Remote agent started in background. You'll be notified when it completes.", "info")
 		if (opts?.fermentId) {
 			ctx.ui.notify(
-				"Ferment paused while the cloud agent executes the plan. It will resume or complete when the cloud agent finishes.",
+				"Ferment paused while the remote agent executes the plan. It will resume or complete when the remote agent finishes.",
 				"info",
 			)
 		}
 		pi.sendMessage(
 			{
 				customType: "cloud_agent_started",
-				content: `A cloud agent has been started in the background to execute the plan. It is running on a remote sandbox. You will be notified when it completes —${
+				content: `A remote agent has been started in the background to execute the plan. It is running on a remote sandbox. You will be notified when it completes —${
 					opts?.fermentId
-						? " do not re-plan, re-execute, create todos, or call activate_ferment_phase. The ferment is paused while the cloud agent works."
+						? " do not re-plan, re-execute, create todos, or call activate_ferment_phase. The ferment is paused while the remote agent works."
 						: " do not re-plan or re-execute."
 				} Wait for the completion notification. The agent ID is ${id}.`,
 				display: false,

--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -108,15 +108,14 @@ Fired from `session-context.ts` via `ctx.emit()`. Batched (max 20) and flushed e
 | `command_executed` | `bash` tool runs | `model`, `command_type`, `exit_code`, `duration_ms` |
 | `error` | Agent, tool, or transport error | `model`, `error_type` (`agent_error` / `tool_failure` / `transport_error`), `error_message` *(truncated to 300 chars)* |
 | `subagent.spawned` | Sub-agent created | `model`, `agent_type`, `reason` |
-| `remote_execution.started` | Remote cloud agent successfully spawned | `origin` |
-| `remote_execution.completed` | Remote cloud agent finished successfully | `origin`, `duration_ms`, `tool_calls`, `turns`, `input_tokens`, `output_tokens` |
-| `remote_execution.failed` | Remote cloud agent errored / was stopped | `origin`, `duration_ms`, `tool_calls`, `turns`, `input_tokens`, `output_tokens` |
-| `remote_execution.sync.started` | User chose "Sync" in the post-completion dropdown; rsync begins | `origin` |
+| `remote_execution.started` | Remote agent successfully spawned | `origin` |
+| `remote_execution.completed` | Remote agent finished successfully | `origin`, `duration_ms`, `tool_calls`, `turns`, `input_tokens`, `output_tokens` |
+| `remote_execution.failed` | Remote agent errored / was stopped | `origin`, `duration_ms`, `tool_calls`, `turns`, `input_tokens`, `output_tokens` |
+| `remote_execution.sync.started` | User chose "Download the Remote Agent's output to the local folder"; rsync begins | `origin` |
 | `remote_execution.sync.completed` | Sync rsync succeeded | `origin` |
 | `remote_execution.sync.failed` | Sync failed (missing session metadata, no API key, or rsync error) | `origin` |
-| `remote_execution.viewed` | User chose "Review/continue locally" in the post-completion dropdown | `origin` |
-| `remote_execution.custom_action` | User chose "Give a custom instruction" and confirmed a non-empty action | `origin` |
-| `remote_execution.done` | User chose "Done" in the post-completion dropdown | `origin` |
+| `remote_execution.viewed` | User chose "Show the agent's results in the local session" in the post-completion dropdown | `origin` |
+| `remote_execution.custom_action` | User chose "Describe what to do next" and confirmed a non-empty action | `origin` |
 
 > **Privacy:** `remote_execution.*` events carry only the `origin` enum
 > (`"plan"` / `"plan-mode"` / `"ferment plan"`) plus numeric aggregates


### PR DESCRIPTION
## Summary

Copy revision for the Remote Execution feature's questionnaires (behind `KIMCHI_REMOTE_RUN`).

### 1. Cloud Agent → Remote Agent
Renamed across user-facing strings: toasts, steer messages, error notifications, and the persona `displayName`. Internal identifiers (`runCloudAgent`, `cloud_agent_started` message type) are unchanged.

### 2. "Plan complete. How would you like to proceed?"
- "Execute the plan" → **Execute the plan locally**
- "Start execution in cloud" → **Execute the plan in a remote workspace**
- New option order: Execute locally → remote workspace → Rework the plan → Start as ferment

### 3. Ferment plan-review dialog ("Proceed with this plan?")
Mirrors both option renames; option order and remaining labels unchanged.

### 4. Post-completion dialog
- Question: **"Remote agent run finished. What would you like to do with its output?"**
- "Continue locally with the result" → **Show the agent's results in the local session**
- "Sync changes and finish" → **Download the Remote Agent's output to the local folder**
- "Give a custom instruction" → **Describe what to do next**
- **Done option removed** — option, handler branch, and its two tests. Dismiss (Esc) still no-ops; a paused ferment stays paused.

## Notes

- The `remote_execution.done` telemetry event can no longer fire (its only call site was the deleted Done branch); removed its README row, left the stage type and its test in place.
- E2E tests wait on the substring "Execute the plan", which "Execute the plan locally" still contains — unaffected.

## Test plan

- [x] vitest: 243/243 across affected suites (remote-run, plan-review, permissions, telemetry)
- [x] `tsc --noEmit` clean
- [x] biome check clean on all changed files
