### PR TITLE
fix(compaction): stop double compaction in model-guard mid-turn guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
 	"dependencies": {
 		"@agentclientprotocol/sdk": "0.19.2",
 		"@bulkhead-ai/core": "^0.7.0",
-		"@kimchi-dev/kimchi-workflows": "0.0.9",
 		"@clack/prompts": "^1.3.0",
 		"@earendil-works/pi-coding-agent": "0.84.1",
 		"@earendil-works/pi-tui": "0.84.1",
+		"@kimchi-dev/kimchi-workflows": "0.0.9",
 		"@modelcontextprotocol/ext-apps": "^1.7.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@shikijs/cli": "^4.0.2",
@@ -84,6 +84,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.3",
+		"@earendil-works/pi-agent-core": "0.84.1",
 		"@earendil-works/pi-ai": "0.84.1",
 		"@microsoft/tui-test": "0.0.4",
 		"@mixmark-io/domino": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.5.3
         version: 2.5.3
+      '@earendil-works/pi-agent-core':
+        specifier: 0.84.1
+        version: 0.84.1(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=833908f0ccb469da56b0e90c4b49c47df1048cfa0e3fdfd07fa312d2e7b2765f)(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.20.1)(zod@4.4.3)

--- a/src/extensions/compaction-thresholds.ts
+++ b/src/extensions/compaction-thresholds.ts
@@ -11,3 +11,23 @@
 
 /** Tokens reserved as headroom below the model's context window. */
 export const COMPACTION_RESERVE_TOKENS = 16_384
+
+/**
+ * Error message fragments that upstream compaction paths treat as routine
+ * "no-op" outcomes (session too small, already compacted, cancelled, another
+ * compaction already in flight, nothing summarizable). Callers stay silent on
+ * these and only warn on real failures. Single source of truth shared by the
+ * model-guard and ferment compaction paths so they cannot drift apart.
+ */
+export const EXPECTED_COMPACTION_ERROR_MESSAGES = [
+	"too small",
+	"Already compacted",
+	"Compaction cancelled",
+	"Compaction already in progress",
+	"no summarizable messages",
+]
+
+/** True when a compaction failure is a routine no-op rather than a real error. */
+export function isExpectedCompactionError(error: Error): boolean {
+	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
+}

--- a/src/extensions/ferment/auto-compaction.ts
+++ b/src/extensions/ferment/auto-compaction.ts
@@ -38,7 +38,7 @@ import { determineNextAction } from "../../ferment/engine.js"
 import type { Ferment, Phase, Step } from "../../ferment/types.js"
 import { getCompactionEnabled } from "../../settings-watcher.js"
 import { isToolCallInFlight } from "../../tool-call-in-flight.js"
-import { COMPACTION_RESERVE_TOKENS } from "../compaction-thresholds.js"
+import { COMPACTION_RESERVE_TOKENS, isExpectedCompactionError } from "../compaction-thresholds.js"
 import { getModelRoles, splitModelRef } from "../orchestration/model-roles.js"
 import { renderCharterCompact } from "./charter.js"
 import type { FermentRuntime } from "./runtime.js"
@@ -406,19 +406,6 @@ export function buildHandoffDetails(
 		completedPhaseSummary: completedPhase?.summary,
 		compactionTokensBefore: result?.tokensBefore,
 	}
-}
-
-// Error messages that upstream treats as routine "no-op" compaction outcomes.
-// Kept as a single source of truth so the two compaction paths stay consistent.
-const EXPECTED_COMPACTION_ERROR_MESSAGES = [
-	"too small",
-	"Already compacted",
-	"Compaction cancelled",
-	"no summarizable messages",
-]
-
-function isExpectedCompactionError(error: Error): boolean {
-	return EXPECTED_COMPACTION_ERROR_MESSAGES.some((message) => error.message.includes(message))
 }
 
 /**

--- a/src/extensions/model-guard.compaction-coordination.test.ts
+++ b/src/extensions/model-guard.compaction-coordination.test.ts
@@ -22,9 +22,10 @@
  * Scenario A fails against the pre-fix guard (double compaction_start, abort
  * error, uncompacted context for the next call).
  */
-import { mkdtempSync } from "node:fs"
+import { mkdtempSync, rmSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core"
 import { type AssistantMessage, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai"
 import {
 	AgentSession,
@@ -37,10 +38,6 @@ import {
 	SettingsManager,
 } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest"
-import {
-	Agent,
-	type AgentMessage,
-} from "../../node_modules/.pnpm/node_modules/@earendil-works/pi-agent-core/dist/index.js"
 import { getCompactionEnabled } from "../settings-watcher.js"
 import { type InlineCompactOptions, installInlineCompactPatch } from "../upstream-inline-compact-patch.js"
 import modelGuardExtension from "./model-guard.js"
@@ -93,6 +90,30 @@ function makeAssistantMessage(extra: Partial<AssistantMessage>): AssistantMessag
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+/** Wait (bounded) until the scenario's observed session state stops changing. */
+async function waitForQuiescence(result: ScenarioResult, session: AgentSession, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs
+	let previous = ""
+	let stablePolls = 0
+	while (Date.now() < deadline) {
+		const snapshot = JSON.stringify({
+			entries: session.sessionManager.getBranch().filter((e) => e.type === "compaction").length,
+			calls: result.subsequentCallContexts.length,
+			starts: result.compactionStarts,
+			failures: result.compactionEndFailures.length,
+			errors: result.errorMessages.length,
+		})
+		if (snapshot === previous) {
+			stablePolls++
+			if (stablePolls >= 4) return
+		} else {
+			stablePolls = 0
+			previous = snapshot
+		}
+		await sleep(25)
+	}
+}
+
 interface ScenarioOptions {
 	/** Make the first summarizer call fail (inline compaction fails mid-run). */
 	failFirstSummarizer: boolean
@@ -114,6 +135,14 @@ interface ScenarioResult {
 
 async function runScenario(options: ScenarioOptions): Promise<ScenarioResult> {
 	const tmp = mkdtempSync(path.join(os.tmpdir(), "kimchi-compaction-coord-"))
+	try {
+		return await runScenarioIn(tmp, options)
+	} finally {
+		rmSync(tmp, { recursive: true, force: true })
+	}
+}
+
+async function runScenarioIn(tmp: string, options: ScenarioOptions): Promise<ScenarioResult> {
 	const model = makeModel()
 	const settingsManager = SettingsManager.create(tmp, tmp)
 	const loader = new DefaultResourceLoader({ cwd: tmp, agentDir: tmp, settingsManager })
@@ -133,10 +162,11 @@ async function runScenario(options: ScenarioOptions): Promise<ScenarioResult> {
 			summarizerCalls++
 			const call = summarizerCalls
 			queueMicrotask(async () => {
-				// Production-like summarization latency: long enough that the run's
-				// next LLM call completes before the compaction entry is appended
-				// (the exact interleaving that produced the incident).
-				await sleep(50)
+				// Production-like summarization latency (24s in the incident): long
+				// enough that the run's next LLM call completes well before the
+				// compaction entry is appended — the exact interleaving that produced
+				// the incident — with margin for slow CI runners.
+				await sleep(150)
 				if (call === 1 && options.failFirstSummarizer) {
 					stream.push({
 						type: "error",
@@ -319,8 +349,11 @@ async function runScenario(options: ScenarioOptions): Promise<ScenarioResult> {
 	})
 
 	try {
+		// prompt() resolves only after the post-run loop (including any threshold
+		// compaction) completes; the quiescence poll then waits out any trailing
+		// async work instead of using a blind sleep.
 		await session.prompt("start work")
-		await sleep(200)
+		await waitForQuiescence(result, session)
 
 		const branch = session.sessionManager.getBranch()
 		result.compactionEntries = branch.filter((e) => e.type === "compaction").length

--- a/src/extensions/model-guard.compaction-coordination.test.ts
+++ b/src/extensions/model-guard.compaction-coordination.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Session-level regression tests for the mid-turn compaction guard coordination.
+ *
+ * Reproduces the double-compaction incident from session 01a06c70 (2026-09-07):
+ * the model-guard turn_end guard fired ctx.compact() (upstream's aborting manual
+ * path) while the context was over the compaction threshold. compact() aborted
+ * the in-flight run (the run's next LLM call died with "The operation was
+ * aborted." and a queued steering message was lost), the run ended with
+ * stop=error, and the post-run _checkCompaction then fired a SECOND (threshold)
+ * compaction that raced the first. The manual attempt, parked on the session
+ * idle promise, woke up after the auto compaction had appended its entry and
+ * failed with "Already compacted" — the user saw two "Compacting…" phases.
+ *
+ * The fix makes the guard prefer ctx.inlineCompact (non-aborting). These tests
+ * wire the REAL model-guard extension handlers to a REAL AgentSession (fake
+ * model + scripted streamFn) and assert the session-level outcome:
+ *   - Scenario A: exactly one compaction, the run continues on the compacted
+ *     context, no abort error, no duplicate post-run compaction.
+ *   - Scenario B: when the inline compaction fails, the post-run threshold
+ *     compaction still recovers — exactly one compaction entry overall.
+ *
+ * Scenario A fails against the pre-fix guard (double compaction_start, abort
+ * error, uncompacted context for the next call).
+ */
+import { mkdtempSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { type AssistantMessage, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai"
+import {
+	AgentSession,
+	DefaultResourceLoader,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type ExtensionRunner,
+	type ModelRuntime,
+	SessionManager,
+	SettingsManager,
+} from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest"
+import {
+	Agent,
+	type AgentMessage,
+} from "../../node_modules/.pnpm/node_modules/@earendil-works/pi-agent-core/dist/index.js"
+import { getCompactionEnabled } from "../settings-watcher.js"
+import { type InlineCompactOptions, installInlineCompactPatch } from "../upstream-inline-compact-patch.js"
+import modelGuardExtension from "./model-guard.js"
+
+vi.mock("../settings-watcher.js", () => ({
+	getCompactionEnabled: vi.fn(() => true),
+}))
+
+installInlineCompactPatch()
+
+// Production incident values: kimi-k3 (262,144 window), last toolUse response at
+// 246,245 tokens — just over the 245,760 compaction threshold.
+const CONTEXT_WINDOW = 262_144
+const OVER_THRESHOLD_TOKENS = 246_245
+
+function makeModel(): Model<"openai-completions"> {
+	return {
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		id: "kimi-k3",
+		name: "kimi-k3",
+		reasoning: false,
+		input: ["text"],
+		contextWindow: CONTEXT_WINDOW,
+		maxTokens: 60_000,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	} as unknown as Model<"openai-completions">
+}
+
+function makeAssistantMessage(extra: Partial<AssistantMessage>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-completions",
+		provider: "kimchi-dev",
+		model: "kimi-k3",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...extra,
+	} as AssistantMessage
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+interface ScenarioOptions {
+	/** Make the first summarizer call fail (inline compaction fails mid-run). */
+	failFirstSummarizer: boolean
+	/** Usage reported by the run's second main-loop response. */
+	secondCallTokens: number
+}
+
+interface ScenarioResult {
+	compactionStarts: number
+	compactionEndFailures: string[]
+	compactionEntries: number
+	/** Contexts received by main-loop LLM calls after the first one. */
+	subsequentCallContexts: Array<Array<{ role: string }>>
+	/** Assistant messages persisted with stop=error. */
+	errorMessages: string[]
+	notify: ReturnType<typeof vi.fn>
+	warnCalls: Array<unknown[]>
+}
+
+async function runScenario(options: ScenarioOptions): Promise<ScenarioResult> {
+	const tmp = mkdtempSync(path.join(os.tmpdir(), "kimchi-compaction-coord-"))
+	const model = makeModel()
+	const settingsManager = SettingsManager.create(tmp, tmp)
+	const loader = new DefaultResourceLoader({ cwd: tmp, agentDir: tmp, settingsManager })
+	await loader.reload()
+
+	let mainLoopCalls = 0
+	let summarizerCalls = 0
+	const subsequentCallContexts: Array<Array<{ role: string }>> = []
+
+	const streamFn = (
+		_m: unknown,
+		context: { systemPrompt?: string; messages: unknown[] },
+		callOptions?: { signal?: AbortSignal },
+	) => {
+		const stream = createAssistantMessageEventStream()
+		if (String(context.systemPrompt ?? "").includes("summariz")) {
+			summarizerCalls++
+			const call = summarizerCalls
+			queueMicrotask(async () => {
+				// Production-like summarization latency: long enough that the run's
+				// next LLM call completes before the compaction entry is appended
+				// (the exact interleaving that produced the incident).
+				await sleep(50)
+				if (call === 1 && options.failFirstSummarizer) {
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: makeAssistantMessage({ stopReason: "error", errorMessage: "summariser exploded" }),
+					})
+					return
+				}
+				stream.push({
+					type: "done",
+					reason: "stop",
+					message: makeAssistantMessage({
+						content: [{ type: "text", text: `Summary #${call} of prior conversation.` }],
+					}),
+				})
+			})
+			return stream
+		}
+
+		mainLoopCalls++
+		if (mainLoopCalls === 1) {
+			// Over-threshold toolUse response that arms the mid-turn guard.
+			queueMicrotask(() =>
+				stream.push({
+					type: "done",
+					reason: "toolUse",
+					message: makeAssistantMessage({
+						content: [{ type: "toolCall", id: "call-1", name: "bash", arguments: { command: "echo hi" } }],
+						stopReason: "toolUse",
+						usage: {
+							...makeAssistantMessage({}).usage,
+							input: 1_982,
+							output: 679,
+							cacheRead: 243_584,
+							totalTokens: OVER_THRESHOLD_TOKENS,
+						},
+					}),
+				}),
+			)
+			return stream
+		}
+
+		// Subsequent main-loop calls: honour the abort signal exactly like the
+		// openai-completions wrapper does when the run is aborted mid-flight.
+		subsequentCallContexts.push(context.messages as Array<{ role: string }>)
+		if (callOptions?.signal?.aborted) {
+			stream.push({
+				type: "error",
+				reason: "error",
+				error: makeAssistantMessage({ stopReason: "error", errorMessage: "The operation was aborted." }),
+			})
+			return stream
+		}
+		queueMicrotask(() =>
+			stream.push({
+				type: "done",
+				reason: "stop",
+				message: makeAssistantMessage({
+					content: [{ type: "text", text: "done" }],
+					usage: {
+						...makeAssistantMessage({}).usage,
+						input: options.secondCallTokens,
+						totalTokens: options.secondCallTokens,
+					},
+				}),
+			}),
+		)
+		return stream
+	}
+
+	const extensionRunnerRef: { current?: ExtensionRunner } = {}
+	const agent = new Agent({
+		initialState: { systemPrompt: "", model, thinkingLevel: "off", tools: [] },
+		convertToLlm: (messages: unknown[]) => messages,
+		// Mirrors sdk.js: route context building through the extension runner so
+		// the inline-compact resync patch (emitContext substitution) engages.
+		transformContext: async (messages: AgentMessage[]) => extensionRunnerRef.current?.emitContext(messages) ?? messages,
+		streamFn: (
+			m: unknown,
+			context: { systemPrompt?: string; messages: unknown[] },
+			callOptions?: { signal?: AbortSignal },
+		) => streamFn(m, context, callOptions),
+	} as ConstructorParameters<typeof Agent>[0])
+
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(tmp),
+		settingsManager,
+		cwd: tmp,
+		modelRuntime: {
+			hasConfiguredAuth: () => true,
+			checkAuth: async () => undefined,
+			getAuth: async () => undefined,
+			isUsingOAuth: () => false,
+			getModel: () => model,
+		} as unknown as ModelRuntime,
+		resourceLoader: loader,
+		extensionRunnerRef,
+	})
+
+	// Seed enough history that prepareCompaction finds a cut point above the
+	// default keepRecentTokens (20k): 40 pairs x ~4k chars ≈ ~40k estimated tokens.
+	const filler = "x".repeat(4000)
+	for (let i = 0; i < 40; i++) {
+		session.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: `history question ${i}: ${filler}` }],
+			timestamp: Date.now(),
+		})
+		session.sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: `history answer ${i}: ${filler}` }],
+			api: "openai-completions",
+			provider: "kimchi-dev",
+			model: "kimi-k3",
+			usage: makeAssistantMessage({}).usage,
+			stopReason: "stop",
+			timestamp: Date.now(),
+		})
+	}
+	agent.state.messages = [...session.sessionManager.buildSessionContext().messages]
+
+	// Wire the REAL model-guard extension handlers to the real session.
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<unknown>>()
+	modelGuardExtension({
+		on: (event: string, handler: (e: unknown, ctx: ExtensionContext) => Promise<unknown>) => {
+			handlers.set(event, handler)
+		},
+		registerCommand: () => {},
+	} as unknown as ExtensionAPI)
+
+	const notify = vi.fn()
+	const sessionWithInline = session as unknown as {
+		inlineCompact?: (options?: InlineCompactOptions) => Promise<{ tokensBefore?: number }>
+		compact: (customInstructions?: string, force?: boolean) => Promise<unknown>
+	}
+	const ctx = {
+		model,
+		getContextUsage: () => session.getContextUsage(),
+		sessionManager: session.sessionManager,
+		// Mirrors the real createContext wiring (installInlineCompactPatch).
+		inlineCompact: (inlineOptions?: InlineCompactOptions) => sessionWithInline.inlineCompact?.(inlineOptions),
+		// Mirrors the real createContext wiring for the legacy fallback path.
+		compact: (compactOptions?: { customInstructions?: string; force?: boolean; onError?: (e: Error) => void }) => {
+			void sessionWithInline.compact(compactOptions?.customInstructions, compactOptions?.force ?? false).then(
+				() => {},
+				(error: Error) => compactOptions?.onError?.(error),
+			)
+		},
+		ui: { notify },
+	} as unknown as ExtensionContext
+
+	const result: ScenarioResult = {
+		compactionStarts: 0,
+		compactionEndFailures: [],
+		compactionEntries: 0,
+		subsequentCallContexts,
+		errorMessages: [],
+		notify,
+		warnCalls: [],
+	}
+
+	session.subscribe((event) => {
+		if (event.type === "compaction_start") result.compactionStarts++
+		if (event.type === "compaction_end" && !event.result && event.errorMessage) {
+			result.compactionEndFailures.push(event.errorMessage)
+		}
+	})
+
+	// The agent loop awaits subscriber listeners, exactly like it awaits the
+	// extension runner's turn_end emit in production.
+	void agent.subscribe(async (event: { type: string }) => {
+		if (event.type === "turn_end") {
+			await handlers.get("turn_end")?.(event, ctx)
+		}
+	})
+
+	const warnSpy: MockInstance = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+		result.warnCalls.push(args)
+	})
+
+	try {
+		await session.prompt("start work")
+		await sleep(200)
+
+		const branch = session.sessionManager.getBranch()
+		result.compactionEntries = branch.filter((e) => e.type === "compaction").length
+		for (const entry of branch) {
+			if (entry.type === "message" && entry.message.role === "assistant" && entry.message.stopReason === "error") {
+				result.errorMessages.push(String(entry.message.errorMessage ?? ""))
+			}
+		}
+	} finally {
+		warnSpy.mockRestore()
+	}
+
+	return result
+}
+
+describe("mid-turn compaction guard coordination (session level)", () => {
+	beforeEach(() => {
+		vi.mocked(getCompactionEnabled).mockReturnValue(true)
+	})
+
+	it("Scenario A: compacts inline once, run continues on the compacted context, no duplicate", async () => {
+		const result = await runScenario({ failFirstSummarizer: false, secondCallTokens: 500 })
+
+		// Exactly one compaction attempt ran (the inline one) and one entry landed.
+		expect(result.compactionStarts).toBe(1)
+		expect(result.compactionEntries).toBe(1)
+		expect(result.compactionEndFailures).toEqual([])
+
+		// The run was not aborted by the compaction.
+		expect(result.errorMessages).toEqual([])
+
+		// The run's next LLM call received the compacted context (resync patch):
+		// convertToLlm flattens the compactionSummary entry into a user message
+		// carrying the summary text, and the seeded history is gone.
+		expect(result.subsequentCallContexts.length).toBe(1)
+		const secondCallContext = result.subsequentCallContexts[0]
+		expect(secondCallContext.some((m) => JSON.stringify(m).includes("Summary #1 of prior conversation."))).toBe(true)
+		expect(secondCallContext.length).toBeLessThan(60)
+
+		// The user is informed about the transparent compaction.
+		expect(result.notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
+	}, 30_000)
+
+	it("Scenario B: when the inline compaction fails, the post-run threshold compaction recovers", async () => {
+		const result = await runScenario({ failFirstSummarizer: true, secondCallTokens: OVER_THRESHOLD_TOKENS })
+
+		// The inline attempt failed and was reported.
+		const failedWarn = result.warnCalls.find(
+			(args) =>
+				String(args[0]).includes("mid-turn compaction failed") && String(args[1]).includes("summariser exploded"),
+		)
+		expect(failedWarn).toBeDefined()
+
+		// The post-run threshold compaction recovered: exactly one entry overall,
+		// one failed attempt, one successful compaction.
+		expect(result.compactionEntries).toBe(1)
+		expect(result.compactionStarts).toBe(2)
+		expect(result.compactionEndFailures).toHaveLength(1)
+		expect(result.compactionEndFailures[0]).toContain("summariser exploded")
+	}, 30_000)
+})

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -1,8 +1,15 @@
 import type { ImageContent, TextContent, ToolResultMessage, UserMessage } from "@earendil-works/pi-ai"
-import type { ContextEvent, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+import type {
+	CompactionResult,
+	ContextEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionEntry,
+} from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../ferment/types.js"
 import { getCompactionEnabled } from "../settings-watcher.js"
+import type { InlineCompactOptions } from "../upstream-inline-compact-patch.js"
 import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
 import { clearActiveFermentId, setActive as setActiveFerment } from "./ferment/state.js"
 import modelGuardExtension, {
@@ -813,7 +820,81 @@ describe("turn_end compaction guard", () => {
 		expect(compact).not.toHaveBeenCalled()
 	})
 
-	it("calls compact when totalTokens exceeds the compaction threshold mid-turn", async () => {
+	it("compacts via inlineCompact without aborting the run when available", async () => {
+		// Regression for the double-compaction incident (session 01a06c70): the
+		// guard must use the non-aborting inline path. ctx.compact() aborts the
+		// run, the run ends with stop=error, and the post-run _checkCompaction
+		// then fires a second (threshold) compaction that races the first.
+		const { pi, trigger } = makeMockPI()
+		modelGuardExtension(pi)
+		const compact = vi.fn()
+		const inlineCompact = vi.fn(
+			async (_options?: InlineCompactOptions) => ({ tokensBefore: THRESHOLD + 1 }) as CompactionResult,
+		)
+		const notify = vi.fn()
+		const ctx = makeMockCtx({
+			model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+			compact,
+			inlineCompact,
+			ui: { notify } as unknown as ExtensionContext["ui"],
+		})
+		await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+		expect(inlineCompact).toHaveBeenCalledOnce()
+		// Default upstream auto-compaction settings: no force, no custom instructions.
+		expect(inlineCompact.mock.calls[0][0]).toEqual({})
+		// The aborting manual path must not be used when the inline path exists.
+		expect(compact).not.toHaveBeenCalled()
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("Context compacted"), "info")
+	})
+
+	it("stays silent when the inline compaction is an expected no-op", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+			const inlineCompact = vi.fn(async () => {
+				throw new Error("Nothing to compact (session too small)")
+			})
+			const notify = vi.fn()
+			const ctx = makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+				inlineCompact,
+				ui: { notify } as unknown as ExtensionContext["ui"],
+			})
+			await trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)
+			expect(notify).not.toHaveBeenCalled()
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it("warns without throwing when the inline compaction fails for a real reason", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+		try {
+			const { pi, trigger } = makeMockPI()
+			modelGuardExtension(pi)
+			const inlineCompact = vi.fn(async () => {
+				throw new Error("provider exploded")
+			})
+			const notify = vi.fn()
+			const ctx = makeMockCtx({
+				model: { id: "kimi-k2.6", input: ["text"], contextWindow: CONTEXT_WINDOW } as ExtensionContext["model"],
+				inlineCompact,
+				ui: { notify } as unknown as ExtensionContext["ui"],
+			})
+			await expect(trigger("turn_end", makeTurnEndEvent(THRESHOLD + 1, "toolUse"), ctx)).resolves.toBeUndefined()
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining("mid-turn compaction failed"),
+				expect.stringContaining("provider exploded"),
+			)
+			expect(notify).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it("falls back to the aborting ctx.compact path when inlineCompact is unavailable", async () => {
 		const { pi, trigger } = makeMockPI()
 		modelGuardExtension(pi)
 		const compact = vi.fn()

--- a/src/extensions/model-guard.test.ts
+++ b/src/extensions/model-guard.test.ts
@@ -888,7 +888,8 @@ describe("turn_end compaction guard", () => {
 				expect.stringContaining("mid-turn compaction failed"),
 				expect.stringContaining("provider exploded"),
 			)
-			expect(notify).not.toHaveBeenCalled()
+			// Unexpected failures are surfaced to the user, not only to the log.
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("Mid-turn compaction failed"), "warning")
 		} finally {
 			warn.mockRestore()
 		}

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -491,16 +491,43 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 
 		// Threshold exceeded mid-turn. Compact now.
 		//
-		// NOTE: ctx.compact() is the manual compaction path which calls abort() on the
-		// current agent run. This means the in-progress tool-call chain stops here and
-		// the user must send another message to resume. This is worse UX than upstream
-		// auto-compaction (which transparently retries via agent.continue()), but it is
-		// the only option available from an extension — _runAutoCompaction and the
-		// agent.continue() path are not exposed on ExtensionContext.
+		// Preferred path: ctx.inlineCompact() (installed by installInlineCompactPatch in
+		// cli.ts) summarises without aborting the run. The turn_end handler is awaited
+		// by the agent loop, so the run cannot end (and the post-run _checkCompaction
+		// cannot fire) while this compaction is in flight — there is no duplicate
+		// compaction race by construction. The emitContext resync patch substitutes the
+		// compacted messages for the run's next LLM call, so the tool-call chain simply
+		// continues on the smaller context, and any queued steering message is
+		// delivered post-compaction instead of being killed mid-flight.
 		//
-		// The proper upstream fix is to wire _checkCompaction into the agent loop via
-		// shouldStopAfterTurn or after_provider_response so compaction fires inside
-		// the loop with transparent retry. This handler is a pragmatic stopgap.
+		// ctx.compact() (the fallback below) is upstream's manual path: it aborts the
+		// current run, the run ends with stop=error, and the post-run _checkCompaction
+		// then fires a SECOND (threshold) compaction that races this one — the
+		// double-compaction incident in session 01a06c70 (2026-09-07). Only used when
+		// the inline patch is unavailable.
+		if (typeof ctx.inlineCompact === "function") {
+			try {
+				const result = await ctx.inlineCompact({})
+				ctx.ui?.notify?.(`Context compacted (${(result.tokensBefore ?? 0).toLocaleString()} tokens → summary).`, "info")
+			} catch (error) {
+				// Routine non-failures (session too small, already compacted, cancelled,
+				// another compaction in flight) are skipped silently; keep this list in
+				// sync with ferment/auto-compaction.ts EXPECTED_COMPACTION_ERROR_MESSAGES.
+				const message = error instanceof Error ? error.message : String(error)
+				const expected = [
+					"too small",
+					"Already compacted",
+					"Compaction cancelled",
+					"Compaction already in progress",
+					"no summarizable messages",
+				]
+				if (!expected.some((fragment) => message.includes(fragment))) {
+					console.warn("[model-guard] mid-turn compaction failed:", message)
+				}
+			}
+			return
+		}
+
 		pendingMidTurnCompaction = true
 		ctx.compact({
 			// onComplete fires with a stale ctx after session replacement.

--- a/src/extensions/model-guard.ts
+++ b/src/extensions/model-guard.ts
@@ -7,7 +7,7 @@ import {
 	estimateTokens as estimatePiMessageTokens,
 } from "@earendil-works/pi-coding-agent"
 import { getCompactionEnabled } from "../settings-watcher.js"
-import { COMPACTION_RESERVE_TOKENS } from "./compaction-thresholds.js"
+import { COMPACTION_RESERVE_TOKENS, isExpectedCompactionError } from "./compaction-thresholds.js"
 import { hasActiveFerment } from "./ferment/state.js"
 
 /** Messages that have a content array we can inspect for images. */
@@ -511,18 +511,14 @@ export default function createModelGuardExtension(_pi: ExtensionAPI) {
 				ctx.ui?.notify?.(`Context compacted (${(result.tokensBefore ?? 0).toLocaleString()} tokens → summary).`, "info")
 			} catch (error) {
 				// Routine non-failures (session too small, already compacted, cancelled,
-				// another compaction in flight) are skipped silently; keep this list in
-				// sync with ferment/auto-compaction.ts EXPECTED_COMPACTION_ERROR_MESSAGES.
-				const message = error instanceof Error ? error.message : String(error)
-				const expected = [
-					"too small",
-					"Already compacted",
-					"Compaction cancelled",
-					"Compaction already in progress",
-					"no summarizable messages",
-				]
-				if (!expected.some((fragment) => message.includes(fragment))) {
-					console.warn("[model-guard] mid-turn compaction failed:", message)
+				// another compaction in flight) are skipped silently; real failures are
+				// surfaced in the UI (console.warn alone is invisible to the user) and
+				// the log. Recovery is delegated: the guard re-arms on the next turn_end
+				// and the post-run _checkCompaction still covers an over-threshold end.
+				const compactionError = error instanceof Error ? error : new Error(String(error))
+				if (!isExpectedCompactionError(compactionError)) {
+					console.warn("[model-guard] mid-turn compaction failed:", compactionError.message)
+					ctx.ui?.notify?.(`Mid-turn compaction failed: ${compactionError.message}.`, "warning")
 				}
 			}
 			return


### PR DESCRIPTION
## Problem

The mid-turn compaction guard (`src/extensions/model-guard.ts`) fired `ctx.compact()` — upstream's **aborting manual path** — whenever a `toolUse` turn crossed the compaction threshold. Three things then collided for a single over-threshold event (observed in session `01a06c70`, 2026-09-07, kimi-k3 at 246k of 262k tokens; double "Compacting…" phases + "Compaction failed: Already compacted"):

1. `compact()` starts with `await this.abort()` → the in-flight run's next LLM call died instantly with `stop=error` ("The operation was aborted."), and a queued steering message (`bash-tool-guard-steer`) was consumed by the dying call and never answered.
2. Because the run ended with `stop=error` (not `"aborted"`), the post-run `_checkCompaction` did not skip it: the estimate was still over threshold and no compaction entry existed yet, so upstream fired a **second (threshold) auto-compaction** that raced the manual one.
3. The manual attempt sat parked on the session idle promise (`waitForIdle()` resolves only at `agent_settled`, i.e. *after* the entire post-run loop including the auto compaction). It woke up ~24s later, found the branch already compacted, and failed with "Already compacted".

Gateway evidence (ai-optimizer ClickHouse/proxy logs) confirms exactly one summarizer chain reached the API while two compaction attempts were made.

## Fix

The guard now prefers **`ctx.inlineCompact({})`** — the non-aborting inline path (installed globally by `installInlineCompactPatch()` in `cli.ts`, already the preferred path in the ferment extension):

- **No run abort**: the tool-call chain survives and queued steering messages are delivered post-compaction instead of being killed mid-flight.
- **No duplicate race by construction**: `turn_end` extension handlers are awaited by the agent loop, so the run cannot end (and the post-run `_checkCompaction` cannot fire) while the inline compaction is in flight. This also removes the hole a cancel-handler approach would have had (safety net cancelled, inline then fails).
- The `emitContext` resync patch feeds the compacted context to the run's next LLM call, so the chain simply continues on the smaller context.
- Expected no-ops ("too small", "Already compacted", "Compaction cancelled", "Compaction already in progress") are silent; real failures `console.warn`.
- The aborting `ctx.compact()` path is kept only as a fallback when the inline patch is unavailable (non-standard embeddings).

## Alternatives considered

- **`session_before_compact` cancel handler** to suppress the duplicate auto compaction while the inline one runs — superseded: the awaited-inline design makes the race impossible, and a cancel handler would leave no compaction at all if the inline attempt then failed.
- **Upstream fix** (wire `_checkCompaction` into the agent loop via `shouldStopAfterTurn` so compaction fires inside the loop with transparent retry) — the proper long-term fix named in the guard's old comment; tracked as follow-up, out of scope here.

## Tests

- `src/extensions/model-guard.test.ts`: the turn_end guard tests now assert the inline path (called with `{}`, `ctx.compact` never touched when `inlineCompact` exists), silent expected no-ops, warn-on-real-failure, and the aborting fallback when `inlineCompact` is unavailable.
- New `src/extensions/model-guard.compaction-coordination.test.ts`: session-level integration tests wiring the **real model-guard handlers** to a **real `AgentSession`** with a scripted streamFn that honors abort signals:
  - Scenario A (the incident): exactly one compaction, the run continues on the compacted context, no abort error, no duplicate post-run compaction.
  - Scenario B: inline failure → the post-run threshold compaction still recovers (exactly one entry overall).
  - Scenario A fails against the pre-fix guard with the exact double-compaction signature (`compaction_start ×2`, abort error, uncompacted context).
