### PR TITLE
fix(acp): clear entire Kimchi credential map on unstable_logout

### DIFF
--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -779,14 +779,8 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			} catch {}
 		})
 
-		// Regression (kimchi-studio #364): logout used to remove only the exact
-		// "kimchi-dev" entry, leaving sub-provider credentials like
-		// "kimchi-dev/anthropic" in the shared credential map. A freshly started
-		// harness would then find the survivor and report authenticated again.
+		// Regression: logout must remove kimchi-dev/* sub-provider entries, not just kimchi-dev.
 		it("clears API key from config and every Kimchi credential from auth storage", async () => {
-			// Seed auth.json with kimchi-dev plus a sub-provider OAuth entry and
-			// an unrelated provider entry so we can verify logout removes all
-			// Kimchi credentials but leaves other providers untouched.
 			writeFileSync(
 				join(tempAgentDir, "auth.json"),
 				JSON.stringify({
@@ -808,8 +802,6 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// clearApiKey is mocked — verify it was called to clear the config file.
 			expect(clearApiKey).toHaveBeenCalledOnce()
 
-			// Every Kimchi entry must be gone from auth.json; the unrelated
-			// provider entry must survive. Read it back and verify.
 			const authJson = JSON.parse(
 				// eslint-disable-next-line no-restricted-syntax
 				await import("node:fs").then((fs) => fs.readFileSync(join(tempAgentDir, "auth.json"), "utf-8")),

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -779,13 +779,20 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			} catch {}
 		})
 
-		it("clears API key from config and OAuth credentials from auth storage", async () => {
-			// Seed auth.json with a kimchi-dev OAuth entry so we can verify
-			// logout actually removes it.
+		// Regression (kimchi-studio #364): logout used to remove only the exact
+		// "kimchi-dev" entry, leaving sub-provider credentials like
+		// "kimchi-dev/anthropic" in the shared credential map. A freshly started
+		// harness would then find the survivor and report authenticated again.
+		it("clears API key from config and every Kimchi credential from auth storage", async () => {
+			// Seed auth.json with kimchi-dev plus a sub-provider OAuth entry and
+			// an unrelated provider entry so we can verify logout removes all
+			// Kimchi credentials but leaves other providers untouched.
 			writeFileSync(
 				join(tempAgentDir, "auth.json"),
 				JSON.stringify({
 					"kimchi-dev": { type: "oauth", accessToken: "old-token", refreshToken: "old-refresh" },
+					"kimchi-dev/anthropic": { type: "api_key", key: "old-api-key" },
+					anthropic: { type: "oauth", accessToken: "keep-token", refreshToken: "keep-refresh" },
 				}),
 			)
 
@@ -801,13 +808,19 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			// clearApiKey is mocked — verify it was called to clear the config file.
 			expect(clearApiKey).toHaveBeenCalledOnce()
 
-			// AuthStorage.logout("kimchi-dev") should have removed the entry
-			// from auth.json. Read it back and verify.
+			// Every Kimchi entry must be gone from auth.json; the unrelated
+			// provider entry must survive. Read it back and verify.
 			const authJson = JSON.parse(
 				// eslint-disable-next-line no-restricted-syntax
 				await import("node:fs").then((fs) => fs.readFileSync(join(tempAgentDir, "auth.json"), "utf-8")),
 			)
 			expect(authJson["kimchi-dev"]).toBeUndefined()
+			expect(authJson["kimchi-dev/anthropic"]).toBeUndefined()
+			expect(authJson.anthropic).toEqual({
+				type: "oauth",
+				accessToken: "keep-token",
+				refreshToken: "keep-refresh",
+			})
 		})
 	})
 

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -92,7 +92,7 @@ import type { PermissionMode, PermissionModeState } from "../../extensions/permi
 import { configureHttpIdleTimeout } from "../../http/proxy.js"
 import { KIMCHI_PROVIDER_ID } from "../../kimchi-provider.js"
 import { updateModelsConfig } from "../../models.js"
-import { syncPiAuth } from "../../pi-auth.js"
+import { clearPiAuth } from "../../pi-auth.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
 import { getVersion } from "../../utils.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
@@ -543,8 +543,8 @@ export class KimchiAcpAgent implements Agent {
 		// kimchi-dev/* sub-provider entries. AuthStorage.logout() only removes
 		// the exact provider id, leaving e.g. kimchi-dev/anthropic behind; the
 		// surviving entry would make a freshly started process look
-		// authenticated again. syncPiAuth matches the CLI logout path.
-		await syncPiAuth(join(this.agentDir, "auth.json"), join(this.agentDir, "models.json"), "")
+		// authenticated again. Matches the CLI logout path.
+		await clearPiAuth(join(this.agentDir, "auth.json"))
 
 		return {}
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -539,14 +539,12 @@ export class KimchiAcpAgent implements Agent {
 		// new sessions no longer pick it up via the login extension.
 		clearApiKey()
 
-		// Clear stored OAuth credentials (refresh tokens etc.) for the
-		// kimchi-dev provider from auth.json.
-		const modelRuntime = await ModelRuntime.create({
-			authPath: join(this.agentDir, "auth.json"),
-			modelsPath: join(this.agentDir, "models.json"),
-			refreshOnCreate: false,
-		})
-		await modelRuntime.logout(KIMCHI_PROVIDER_ID)
+		// Remove every Kimchi credential from auth.json — kimchi-dev plus all
+		// kimchi-dev/* sub-provider entries. AuthStorage.logout() only removes
+		// the exact provider id, leaving e.g. kimchi-dev/anthropic behind; the
+		// surviving entry would make a freshly started process look
+		// authenticated again. syncPiAuth matches the CLI logout path.
+		await syncPiAuth(join(this.agentDir, "auth.json"), join(this.agentDir, "models.json"), "")
 
 		return {}
 	}

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -92,7 +92,7 @@ import type { PermissionMode, PermissionModeState } from "../../extensions/permi
 import { configureHttpIdleTimeout } from "../../http/proxy.js"
 import { KIMCHI_PROVIDER_ID } from "../../kimchi-provider.js"
 import { updateModelsConfig } from "../../models.js"
-import { clearPiAuth } from "../../pi-auth.js"
+import { clearPiAuth, syncPiAuth } from "../../pi-auth.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
 import { getVersion } from "../../utils.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -539,11 +539,8 @@ export class KimchiAcpAgent implements Agent {
 		// new sessions no longer pick it up via the login extension.
 		clearApiKey()
 
-		// Remove every Kimchi credential from auth.json — kimchi-dev plus all
-		// kimchi-dev/* sub-provider entries. AuthStorage.logout() only removes
-		// the exact provider id, leaving e.g. kimchi-dev/anthropic behind; the
-		// surviving entry would make a freshly started process look
-		// authenticated again. Matches the CLI logout path.
+		// clearPiAuth over AuthStorage.logout(): it removes kimchi-dev/*
+		// sub-provider entries, not just the exact kimchi-dev id.
 		await clearPiAuth(join(this.agentDir, "auth.json"))
 
 		return {}

--- a/src/pi-auth.test.ts
+++ b/src/pi-auth.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { syncKimchiAuth } from "./extensions/login/flow.js"
-import { syncPiAuth } from "./pi-auth.js"
+import { clearPiAuth, syncPiAuth } from "./pi-auth.js"
 
 const tempDirs: string[] = []
 
@@ -221,5 +221,36 @@ describe("syncPiAuth", () => {
 			"kimchi-dev": { type: "api_key", key: "new-account-token" },
 		})
 		expect(await registry.getApiKeyForProvider("kimchi-dev")).toBe("stale-runtime-token")
+	})
+})
+
+describe("clearPiAuth", () => {
+	it("removes every Kimchi credential, keeps other providers, and needs no models.json", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-"))
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+		writeFileSync(
+			authPath,
+			JSON.stringify({
+				"kimchi-dev": { type: "api_key", key: "old" },
+				"kimchi-dev/anthropic": { type: "api_key", key: "old" },
+				"kimchi-experimental": { type: "api_key", key: "old" },
+				anthropic: { type: "api_key", key: "keep" },
+			}),
+		)
+
+		await clearPiAuth(authPath)
+
+		expect(JSON.parse(readFileSync(authPath, "utf-8"))).toEqual({
+			anthropic: { type: "api_key", key: "keep" },
+		})
+	})
+
+	it("is a no-op when auth.json does not exist", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "kimchi-pi-auth-"))
+		tempDirs.push(dir)
+		const authPath = join(dir, "auth.json")
+
+		await expect(clearPiAuth(authPath)).resolves.toBeUndefined()
 	})
 })

--- a/src/pi-auth.ts
+++ b/src/pi-auth.ts
@@ -14,11 +14,7 @@ function isKimchiProvider(providerId: string): boolean {
 	)
 }
 
-/**
- * Remove every Kimchi credential from auth.json (logout). Delegates to
- * syncPiAuth's deletion mode; modelsPath is never read in that mode, so
- * callers clearing credentials need no models.json path.
- */
+/** Remove all Kimchi credentials from auth.json — kimchi-dev, kimchi-dev/*, kimchi-experimental. */
 export async function clearPiAuth(authPath: string): Promise<void> {
 	await syncPiAuth(authPath, "", "")
 }

--- a/src/pi-auth.ts
+++ b/src/pi-auth.ts
@@ -14,6 +14,15 @@ function isKimchiProvider(providerId: string): boolean {
 	)
 }
 
+/**
+ * Remove every Kimchi credential from auth.json (logout). Delegates to
+ * syncPiAuth's deletion mode; modelsPath is never read in that mode, so
+ * callers clearing credentials need no models.json path.
+ */
+export async function clearPiAuth(authPath: string): Promise<void> {
+	await syncPiAuth(authPath, "", "")
+}
+
 export async function syncPiAuth(authPath: string, modelsPath: string, apiKey: string): Promise<void> {
 	mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 })
 	const release = await lock(authPath, { realpath: false, retries: 10 })


### PR DESCRIPTION
## Problem

`unstable_logout` (called by Studio's Settings → Account → Log out) removed only the exact `kimchi-dev` entry from `auth.json`. Sub-provider credentials like `kimchi-dev/anthropic` survived, so a freshly started harness found a valid credential and reported `authenticated` again — the logout silently reverted on the next app start.

## Fix

Replace the throwaway `ModelRuntime` + single-entry `AuthStorage.logout("kimchi-dev")` with a new `clearPiAuth(authPath)` helper — the named, deletion-only form of `syncPiAuth`, which the TUI logout path also uses. It atomically (under `proper-lockfile`) removes **every** Kimchi entry:

- `kimchi-dev`
- all `kimchi-dev/*` sub-providers (e.g. `kimchi-dev/anthropic`)
- `kimchi-experimental`

Non-Kimchi providers' credentials are left untouched. `clearApiKey()` still runs first to clear the config half of the credential store, so both halves agree after logout.

## Testing

- Regression test in `src/modes/acp/server.test.ts`: seeds `kimchi-dev`, `kimchi-dev/anthropic`, and an unrelated `anthropic` entry, then asserts both Kimchi entries are removed after `unstable_logout` while the foreign provider's credential survives.
- New `clearPiAuth` tests in `src/pi-auth.test.ts`: removes all Kimchi entries without a models.json, keeps other providers, and is a no-op when auth.json is missing.
- `tsc --noEmit` clean, biome clean, 243 ACP server + pi-auth tests pass.

🤖 Generated with [Kimchi](https://github.com/getkimchi/kimchi)