### PR TITLE
fix(todos,ferment): persist state blocks on change to restore prompt-cache stability

### DIFF
--- a/src/extensions/__mocks__/context.ts
+++ b/src/extensions/__mocks__/context.ts
@@ -51,6 +51,7 @@ export function createContext(
 			getSessionDir: () => "",
 			getSessionFile: () => undefined,
 			getEntries: () => [],
+			getBranch: () => [],
 			getHeader: () => null,
 			...overrides?.sessionManager,
 		} as SessionManager,

--- a/src/extensions/aborted-run.ts
+++ b/src/extensions/aborted-run.ts
@@ -1,0 +1,27 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+
+type MessageEntryLike = { type: "message"; message: { role?: string; stopReason?: string } } | { type?: string }
+
+/**
+ * True when the newest message in branch history is an assistant message
+ * that was aborted (e.g. the user ran /compact mid-stream).
+ *
+ * Persisted state blocks (`todo-state`, `ferment-lifecycle`) must not be
+ * flushed after an aborted run: the flush would make the block the newest
+ * turn-start entry, and upstream compaction (`findCutPoint`) treats custom
+ * messages as turn starts — under a small `keepRecentTokens` budget the cut
+ * then lands on the block, so the interrupted turn is swallowed into the
+ * summary instead of surviving in the kept tail. The pending block is
+ * flushed at the settle of the next (unaborted) run instead.
+ */
+export function latestRunTailIsAborted(ctx: ExtensionContext): boolean {
+	const branch = ctx.sessionManager.getBranch() as readonly MessageEntryLike[]
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const entry = branch[i]
+		if (entry?.type !== "message") continue
+		const message = (entry as { message?: { role?: string; stopReason?: string } }).message
+		if (!message?.role) continue
+		return message.role === "assistant" && message.stopReason === "aborted"
+	}
+	return false
+}

--- a/src/extensions/aborted-run.ts
+++ b/src/extensions/aborted-run.ts
@@ -1,7 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
 
-type MessageEntryLike = { type: "message"; message: { role?: string; stopReason?: string } } | { type?: string }
-
 /**
  * True when the newest message in branch history is an assistant message
  * that was aborted (e.g. the user ran /compact mid-stream).
@@ -15,12 +13,11 @@ type MessageEntryLike = { type: "message"; message: { role?: string; stopReason?
  * flushed at the settle of the next (unaborted) run instead.
  */
 export function latestRunTailIsAborted(ctx: ExtensionContext): boolean {
-	const branch = ctx.sessionManager.getBranch() as readonly MessageEntryLike[]
+	const branch = ctx.sessionManager.getBranch()
 	for (let i = branch.length - 1; i >= 0; i--) {
 		const entry = branch[i]
-		if (entry?.type !== "message") continue
-		const message = (entry as { message?: { role?: string; stopReason?: string } }).message
-		if (!message?.role) continue
+		if (entry.type !== "message") continue
+		const message = entry.message
 		return message.role === "assistant" && message.stopReason === "aborted"
 	}
 	return false

--- a/src/extensions/ferment/index.ts
+++ b/src/extensions/ferment/index.ts
@@ -143,8 +143,6 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 	// events for every state mutation without importing from telemetry.
 	runtime.events = pi.events
 
-	registerFermentLifecycleContext(pi, runtime)
-
 	const unregisterFermentTips = registerTipProvider(createFermentTipProvider(runtime))
 	let unregisterFermentTodoSync: (() => void) | undefined
 	let planReviewTimer: ReturnType<typeof setTimeout> | undefined
@@ -459,6 +457,12 @@ export default function fermentExtension(pi: ExtensionAPI, runtime: FermentRunti
 		}
 		finalCompletionNudgedThisRun = false
 	})
+
+	// Registered after this module's own agent event handlers: the lifecycle
+	// persistence layer subscribes to agent_start/agent_end/agent_settled, and
+	// its handlers must not precede the main agent_end handler in the
+	// registration order (test fixtures fetch the first-registered handler).
+	registerFermentLifecycleContext(pi, runtime)
 
 	pi.registerMessageRenderer(FERMENT_REQUEST_MESSAGE_TYPE, fermentRequestRenderer)
 	registerFermentStopPolicyShortcut(pi, runtime)

--- a/src/extensions/ferment/lifecycle-context.test.ts
+++ b/src/extensions/ferment/lifecycle-context.test.ts
@@ -91,7 +91,7 @@ function makeMutableRuntime(initial: Ferment | undefined): {
 	}
 }
 
-function createHarness(branch: MessageLike[] = []) {
+function createHarness(branch: Record<string, unknown>[] = []) {
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const bus = createEventBus()
 	const pi = {
@@ -192,7 +192,7 @@ describe("registerFermentLifecycleContext", () => {
 			timestamp: "",
 			message: { role: "assistant", stopReason: "aborted", content: [] },
 		}
-		const branch: MessageLike[] = []
+		const branch: Record<string, unknown>[] = []
 		const harness = createHarness(branch)
 		const { runtime } = makeMutableRuntime(makeFerment())
 		registerFermentLifecycleContext(harness.pi, runtime)
@@ -201,7 +201,7 @@ describe("registerFermentLifecycleContext", () => {
 		await harness.fire("agent_start", {})
 		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
 		await harness.fire("agent_end", {})
-		branch.push(abortedAssistant as MessageLike)
+		branch.push(abortedAssistant)
 		await harness.fire("agent_settled", {})
 		expect(harness.persistedBlocks()).toHaveLength(0)
 
@@ -213,7 +213,7 @@ describe("registerFermentLifecycleContext", () => {
 			parentId: null,
 			timestamp: "",
 			message: { role: "assistant", stopReason: "stop", content: [] },
-		} as MessageLike)
+		})
 		await harness.fire("agent_settled", {})
 		expect(harness.persistedBlocks()).toHaveLength(1)
 	})
@@ -392,10 +392,25 @@ describe("registerFermentLifecycleContext", () => {
 		const persistedContent = harness.persistedBlocks()[0]?.content
 
 		// Simulate a fresh registration against a resumed session whose branch
-		// already contains that exact block: no duplicate persist.
+		// already contains that exact block: no duplicate persist. History
+		// entries use the real journal shape (custom_message, no `role`).
 		const resumed = createHarness([
-			{ role: "user", content: "resume me" },
-			{ role: "custom", customType: FERMENT_LIFECYCLE_CUSTOM_TYPE, content: persistedContent },
+			{
+				type: "message",
+				id: "msg-1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				message: { role: "user", content: "resume me" },
+			},
+			{
+				type: "custom_message",
+				id: "entry-1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				customType: FERMENT_LIFECYCLE_CUSTOM_TYPE,
+				content: persistedContent,
+				display: false,
+			},
 		])
 		registerFermentLifecycleContext(resumed.pi, runtime)
 		await resumed.fire("session_start", { reason: "resume" })

--- a/src/extensions/ferment/lifecycle-context.test.ts
+++ b/src/extensions/ferment/lifecycle-context.test.ts
@@ -91,7 +91,7 @@ function makeMutableRuntime(initial: Ferment | undefined): {
 	}
 }
 
-function createHarness(branch: Record<string, unknown>[] = []) {
+function createHarness(branch: Record<string, unknown>[] | (() => Record<string, unknown>[]) = []) {
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const bus = createEventBus()
 	const pi = {
@@ -107,7 +107,7 @@ function createHarness(branch: Record<string, unknown>[] = []) {
 	const ctx = createContext({
 		sessionManager: {
 			getSessionId: () => TEST_SESSION_ID,
-			getBranch: () => branch as unknown as SessionEntry[],
+			getBranch: () => (typeof branch === "function" ? branch() : branch) as unknown as SessionEntry[],
 		},
 	})
 
@@ -216,6 +216,28 @@ describe("registerFermentLifecycleContext", () => {
 		})
 		await harness.fire("agent_settled", {})
 		expect(harness.persistedBlocks()).toHaveLength(1)
+	})
+
+	it("re-emits the newest lifecycle block at the next settle when compaction cut it from the branch", async () => {
+		let branch: Record<string, unknown>[] = []
+		const harness = createHarness(() => branch)
+		registerFermentLifecycleContext(harness.pi, makeRuntime())
+		await startSession(harness)
+
+		await harness.fire("agent_start", {})
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+		await harness.fire("agent_end", {})
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(1)
+
+		// Compaction summarizes the block: the journal entry leaves the branch.
+		branch = []
+		await harness.fire("session_compact", { reason: "threshold" })
+		await harness.fire("agent_start", {})
+		await harness.fire("agent_end", {})
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(2)
+		expect(harness.persistedBlocks()[1]?.content).toBe(harness.persistedBlocks()[0]?.content)
 	})
 
 	it("persists a hidden lifecycle block once per transition for a running ferment", async () => {

--- a/src/extensions/ferment/lifecycle-context.test.ts
+++ b/src/extensions/ferment/lifecycle-context.test.ts
@@ -1,9 +1,12 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+import { createEventBus } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, FermentStatus } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
 import { runAsAgentWorker } from "../agent-worker-context.js"
-import { registerFermentLifecycleContext } from "./lifecycle-context.js"
+import { markHarnessSteer } from "../steer-marker.js"
+import { FERMENT_EVENTS } from "./domain-events.js"
+import { FERMENT_LIFECYCLE_CUSTOM_TYPE, registerFermentLifecycleContext } from "./lifecycle-context.js"
 import { createDefaultFermentRuntime, type FermentRuntime } from "./runtime.js"
 import type { ContinuationPolicy } from "./state.js"
 
@@ -19,8 +22,10 @@ type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Pro
 
 const TEST_SESSION_ID = "test-session"
 
-function makeMockCtx(): ExtensionContext {
-	return createContext({ sessionManager: { getSessionId: () => TEST_SESSION_ID } })
+interface MessageLike {
+	role?: string
+	customType?: string
+	content?: unknown
 }
 
 function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
@@ -67,11 +72,31 @@ function makeNoActiveRuntime(): FermentRuntime {
 	}
 }
 
-type ContextResult = { messages: Array<{ role?: string; customType?: string; content?: unknown }> } | undefined
+/** A runtime whose active ferment can be swapped mid-test to simulate
+ *  lifecycle transitions (the persistence layer re-renders on domain events
+ *  and dedupes against the previously persisted block). */
+function makeMutableRuntime(initial: Ferment | undefined): {
+	runtime: FermentRuntime
+	setActive: (f?: Ferment) => void
+} {
+	let active = initial
+	return {
+		runtime: {
+			...createDefaultFermentRuntime(),
+			getActive: () => active,
+		},
+		setActive: (f) => {
+			active = f
+		},
+	}
+}
 
-function createHarness() {
+function createHarness(branch: MessageLike[] = []) {
 	const handlers = new Map<string, ExtensionHandler[]>()
+	const bus = createEventBus()
 	const pi = {
+		events: bus,
+		sendMessage: vi.fn(),
 		on: vi.fn((event: string, handler: ExtensionHandler) => {
 			const list = handlers.get(event) ?? []
 			list.push(handler)
@@ -79,25 +104,35 @@ function createHarness() {
 		}),
 	} as unknown as ExtensionAPI
 
-	const ctx = makeMockCtx()
+	const ctx = createContext({
+		sessionManager: {
+			getSessionId: () => TEST_SESSION_ID,
+			getBranch: () => branch as unknown as SessionEntry[],
+		},
+	})
 
-	async function fireContext(
-		messages: Array<{ role?: string; customType?: string; content?: unknown }> = [],
-	): Promise<ContextResult> {
-		let result: ContextResult
-		for (const handler of handlers.get("context") ?? []) {
-			result = (await handler({ messages }, ctx)) as ContextResult
+	async function fire(event: string, payload: unknown): Promise<unknown> {
+		let result: unknown
+		for (const handler of handlers.get(event) ?? []) {
+			result = await handler(payload, ctx)
 		}
 		return result
 	}
 
-	return { pi, ctx, fireContext }
+	type SentMessage = { customType?: string; display?: boolean; content?: unknown }
+
+	function persistedBlocks(): SentMessage[] {
+		return vi
+			.mocked(pi.sendMessage)
+			.mock.calls.map(([message]) => message as unknown as SentMessage)
+			.filter((message) => message.customType === FERMENT_LIFECYCLE_CUSTOM_TYPE)
+	}
+
+	return { pi, bus, ctx, fire, persistedBlocks }
 }
 
-function extractLifecycleMessage(result: ContextResult): { content?: string } | undefined {
-	const message = result?.messages?.find((m) => m.role === "custom" && m.customType === "ferment-lifecycle")
-	if (!message) return undefined
-	return { content: typeof message.content === "string" ? message.content : undefined }
+async function startSession(harness: ReturnType<typeof createHarness>): Promise<void> {
+	await harness.fire("session_start", { reason: "new" })
 }
 
 describe("registerFermentLifecycleContext", () => {
@@ -105,47 +140,78 @@ describe("registerFermentLifecycleContext", () => {
 		getMultiModelEnabledMock.mockReturnValue(true)
 	})
 
-	it("injects volatile lifecycle state for a running ferment with an active phase", async () => {
-		const { pi, fireContext } = createHarness()
-		registerFermentLifecycleContext(pi, makeRuntime())
+	it("persists a hidden lifecycle block once per transition for a running ferment", async () => {
+		const harness = createHarness()
+		const { runtime, setActive } = makeMutableRuntime(makeFerment())
+		registerFermentLifecycleContext(harness.pi, runtime)
+		await startSession(harness)
 
-		const result = await fireContext([])
-		const lifecycle = extractLifecycleMessage(result)
-		expect(lifecycle).toBeDefined()
-		expect(lifecycle?.content).toContain("## Current lifecycle state")
-		expect(lifecycle?.content).toContain('Scoping is COMPLETE (ferment status "running"')
-		expect(lifecycle?.content).toContain(
-			'active phase "phase-1" ("Build the feature"), 1/2 steps terminal in phase "phase-1"',
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+
+		expect(harness.persistedBlocks()).toHaveLength(1)
+		const block = harness.persistedBlocks()[0]
+		expect(block?.display).toBe(false)
+		const content = block?.content as string
+		expect(content).toMatch(/^<system-reminder>\n/)
+		expect(content).toContain("## Current lifecycle state")
+		expect(content).toContain('Scoping is COMPLETE (ferment status "running"')
+		expect(content).toContain('active phase "phase-1" ("Build the feature"), 1/2 steps terminal in phase "phase-1"')
+		expect(content).toContain("Next action:")
+
+		// A repeated event without an actual transition persists nothing new.
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+		expect(harness.persistedBlocks()).toHaveLength(1)
+
+		// A real transition (step completes → 2/2 terminal) persists exactly
+		// one more block.
+		const phase = makeFerment().phases[0]
+		if (!phase) throw new Error("expected phase fixture")
+		setActive(
+			makeFerment({
+				phases: [
+					{
+						...phase,
+						steps: [
+							{ id: "step-1", index: 1, description: "Do thing one", status: "done" },
+							{ id: "step-2", index: 2, description: "Do thing two", status: "done" },
+						],
+					},
+				],
+			}),
 		)
-		expect(lifecycle?.content).toContain("Next action:")
+		harness.bus.emit(FERMENT_EVENTS.STEP_COMPLETED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-2" })
+		expect(harness.persistedBlocks()).toHaveLength(2)
+		expect(harness.persistedBlocks()[1]?.content).toContain('2/2 steps terminal in phase "phase-1"')
 	})
 
-	it("injects the next-action hint for a planned ferment", async () => {
-		const { pi, fireContext } = createHarness()
+	it("persists the next-action hint for a planned ferment", async () => {
+		const harness = createHarness()
 		const phase = makeFerment().phases[0]
 		if (!phase) throw new Error("expected phase fixture")
 		registerFermentLifecycleContext(
-			pi,
+			harness.pi,
 			makeRuntime({
 				status: "planned",
 				phases: [{ ...phase, status: "planned" }],
 			}),
 		)
+		await startSession(harness)
 
-		const result = await fireContext([])
-		const lifecycle = extractLifecycleMessage(result)
-		expect(lifecycle).toBeDefined()
-		expect(lifecycle?.content).toContain('ferment status "planned"')
-		expect(lifecycle?.content).toContain("Next action: call `activate_ferment_phase`")
-		expect(lifecycle?.content).toContain('phase_id "phase-1"')
+		harness.bus.emit(FERMENT_EVENTS.SCOPING_COMPLETE, { fermentId: "ferment-1" })
+
+		expect(harness.persistedBlocks()).toHaveLength(1)
+		const content = harness.persistedBlocks()[0]?.content as string
+		expect(content).toContain('ferment status "planned"')
+		expect(content).toContain("Next action: call `activate_ferment_phase`")
+		expect(content).toContain('phase_id "phase-1"')
 	})
 
 	it("counts failed steps as terminal in active-phase progress", async () => {
-		const { pi, fireContext } = createHarness()
+		const harness = createHarness()
 		const phase = makeFerment().phases[0]
 		if (!phase) throw new Error("expected phase fixture")
 		registerFermentLifecycleContext(
-			pi,
+			harness.pi,
 			makeRuntime({
 				phases: [
 					{
@@ -155,18 +221,18 @@ describe("registerFermentLifecycleContext", () => {
 				],
 			}),
 		)
+		await startSession(harness)
 
-		const result = await fireContext([])
-		const lifecycle = extractLifecycleMessage(result)
-		expect(lifecycle?.content).toContain('1/1 steps terminal in phase "phase-1"')
+		harness.bus.emit(FERMENT_EVENTS.STEP_FAILED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+		expect(harness.persistedBlocks()[0]?.content).toContain('1/1 steps terminal in phase "phase-1"')
 	})
 
 	it("reports progress for every active phase in a parallel group", async () => {
-		const { pi, fireContext } = createHarness()
+		const harness = createHarness()
 		const phase = makeFerment().phases[0]
 		if (!phase) throw new Error("expected phase fixture")
 		registerFermentLifecycleContext(
-			pi,
+			harness.pi,
 			makeRuntime({
 				phases: [
 					{ ...phase, parallel: true, groupIndex: 1 },
@@ -182,66 +248,124 @@ describe("registerFermentLifecycleContext", () => {
 				],
 			}),
 		)
+		await startSession(harness)
 
-		const result = await fireContext([])
-		const lifecycle = extractLifecycleMessage(result)
-		expect(lifecycle?.content).toContain('1/2 steps terminal in phase "phase-1"')
-		expect(lifecycle?.content).toContain('0/1 steps terminal in phase "phase-2"')
+		harness.bus.emit(FERMENT_EVENTS.PHASE_STARTED, { fermentId: "ferment-1", phaseId: "phase-1" })
+		const content = harness.persistedBlocks()[0]?.content as string
+		expect(content).toContain('1/2 steps terminal in phase "phase-1"')
+		expect(content).toContain('0/1 steps terminal in phase "phase-2"')
 	})
 
 	for (const status of ["draft", "paused", "complete", "abandoned"] as FermentStatus[]) {
-		it(`does not inject for a ${status} ferment`, async () => {
-			const { pi, fireContext } = createHarness()
-			registerFermentLifecycleContext(pi, makeRuntime({ status }))
+		it(`persists nothing for a ${status} ferment`, async () => {
+			const harness = createHarness()
+			registerFermentLifecycleContext(harness.pi, makeRuntime({ status }))
+			await startSession(harness)
 
-			const result = await fireContext([])
-			expect(extractLifecycleMessage(result)).toBeUndefined()
+			harness.bus.emit(FERMENT_EVENTS.RESUMED, { fermentId: "ferment-1" })
+			harness.bus.emit(FERMENT_EVENTS.PHASE_STARTED, { fermentId: "ferment-1" })
+			expect(harness.persistedBlocks()).toHaveLength(0)
 		})
 	}
 
-	it("does not inject when no ferment is active", async () => {
-		const { pi, fireContext } = createHarness()
-		registerFermentLifecycleContext(pi, makeNoActiveRuntime())
+	it("a complete transition persists nothing (the last running block stays in history)", async () => {
+		const harness = createHarness()
+		const { runtime, setActive } = makeMutableRuntime(makeFerment())
+		registerFermentLifecycleContext(harness.pi, runtime)
+		await startSession(harness)
 
-		const result = await fireContext([])
-		expect(extractLifecycleMessage(result)).toBeUndefined()
+		harness.bus.emit(FERMENT_EVENTS.PHASE_STARTED, { fermentId: "ferment-1", phaseId: "phase-1" })
+		expect(harness.persistedBlocks()).toHaveLength(1)
+
+		setActive(makeFerment({ status: "complete" }))
+		harness.bus.emit(FERMENT_EVENTS.COMPLETED, { fermentId: "ferment-1" })
+		expect(harness.persistedBlocks()).toHaveLength(1)
 	})
 
-	it("does not inject for agent workers", async () => {
-		const { pi, fireContext } = createHarness()
-		registerFermentLifecycleContext(pi, makeRuntime())
+	it("persists nothing when no ferment is active", async () => {
+		const harness = createHarness()
+		registerFermentLifecycleContext(harness.pi, makeNoActiveRuntime())
+		await startSession(harness)
+
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1" })
+		expect(harness.persistedBlocks()).toHaveLength(0)
+	})
+
+	it("persists nothing for agent workers", async () => {
+		const harness = createHarness()
+		registerFermentLifecycleContext(harness.pi, makeRuntime())
+		await startSession(harness)
 
 		await runAsAgentWorker(async () => {
-			const result = await fireContext([])
-			expect(extractLifecycleMessage(result)).toBeUndefined()
+			harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1" })
+			expect(harness.persistedBlocks()).toHaveLength(0)
 		})
 	})
 
-	it("strips prior lifecycle messages so they do not stack", async () => {
-		const { pi, fireContext } = createHarness()
-		registerFermentLifecycleContext(pi, makeRuntime())
+	it("does not re-persist on resume when history already holds the current block", async () => {
+		const harness = createHarness()
+		const { runtime } = makeMutableRuntime(makeFerment())
+		registerFermentLifecycleContext(harness.pi, runtime)
+		await startSession(harness)
 
-		const first = await fireContext([])
-		const firstMessage = extractLifecycleMessage(first)
-		expect(firstMessage).toBeDefined()
+		// Produce the definitive current block first.
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1" })
+		expect(harness.persistedBlocks()).toHaveLength(1)
+		const persistedContent = harness.persistedBlocks()[0]?.content
 
-		const second = await fireContext(first?.messages ?? [])
-		const lifecycleMessages = second?.messages?.filter(
-			(m) => m.role === "custom" && m.customType === "ferment-lifecycle",
-		)
-		expect(lifecycleMessages).toHaveLength(1)
-		expect(second?.messages?.at(-1)?.content).toBe(firstMessage?.content)
+		// Simulate a fresh registration against a resumed session whose branch
+		// already contains that exact block: no duplicate persist.
+		const resumed = createHarness([
+			{ role: "user", content: "resume me" },
+			{ role: "custom", customType: FERMENT_LIFECYCLE_CUSTOM_TYPE, content: persistedContent },
+		])
+		registerFermentLifecycleContext(resumed.pi, runtime)
+		await resumed.fire("session_start", { reason: "resume" })
+
+		resumed.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1" })
+		expect(resumed.persistedBlocks()).toHaveLength(0)
+	})
+
+	it("strip-only context handler keeps the newest lifecycle block", async () => {
+		const newest = markHarnessSteer("## Current lifecycle state\n- newest")
+		const messages: MessageLike[] = [
+			{ role: "user", content: "u1" },
+			{ role: "custom", customType: FERMENT_LIFECYCLE_CUSTOM_TYPE, content: markHarnessSteer("older") },
+			{ role: "assistant", content: "asst" },
+			{ role: "custom", customType: FERMENT_LIFECYCLE_CUSTOM_TYPE, content: newest },
+			{ role: "user", content: "u2" },
+		]
+
+		const harness = createHarness()
+		registerFermentLifecycleContext(harness.pi, makeRuntime())
+		await startSession(harness)
+
+		const result = (await harness.fire("context", { messages })) as { messages: MessageLike[] }
+		const retained = result.messages.filter((m) => m.customType === FERMENT_LIFECYCLE_CUSTOM_TYPE)
+		expect(retained).toHaveLength(1)
+		expect(retained[0]?.content).toBe(newest)
+		expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant", "custom", "user"])
+	})
+
+	it("context handler never appends a lifecycle block (no tail push)", async () => {
+		const harness = createHarness()
+		registerFermentLifecycleContext(harness.pi, makeRuntime())
+		await startSession(harness)
+
+		const result = (await harness.fire("context", { messages: [] })) as unknown
+		expect(result).toBeUndefined()
 	})
 
 	it("uses the multi-model flag to shape delegation hints", async () => {
-		const { pi, fireContext } = createHarness()
+		const harness = createHarness()
 		getMultiModelEnabledMock.mockReturnValue(false)
-		registerFermentLifecycleContext(pi, makeRuntime())
+		registerFermentLifecycleContext(harness.pi, makeRuntime())
+		await startSession(harness)
 
-		const result = await fireContext([])
-		const lifecycle = extractLifecycleMessage(result)
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1" })
+		const content = harness.persistedBlocks()[0]?.content as string
 		// In single-model mode, the next-action suffix tells the planner it should
 		// execute the step directly instead of always spawning a subagent.
-		expect(lifecycle?.content).toContain("Then execute the step directly")
+		expect(content).toContain("Then execute the step directly")
 	})
 })

--- a/src/extensions/ferment/lifecycle-context.test.ts
+++ b/src/extensions/ferment/lifecycle-context.test.ts
@@ -140,6 +140,84 @@ describe("registerFermentLifecycleContext", () => {
 		getMultiModelEnabledMock.mockReturnValue(true)
 	})
 
+	it("defers transitions while the agent is busy and flushes once on agent_settled, not agent_end", async () => {
+		const harness = createHarness()
+		const { runtime, setActive } = makeMutableRuntime(makeFerment())
+		registerFermentLifecycleContext(harness.pi, runtime)
+		await startSession(harness)
+
+		await harness.fire("agent_start", {})
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+		expect(harness.persistedBlocks()).toHaveLength(0)
+
+		// agent_end must NOT flush: while the run is still settling upstream,
+		// a steered send would be queued as a pending agent steer.
+		await harness.fire("agent_end", {})
+		expect(harness.persistedBlocks()).toHaveLength(0)
+
+		// At agent_settled the run is fully inactive: plain append, no steer.
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(1)
+		expect(harness.persistedBlocks()[0]?.content).toContain("## Current lifecycle state")
+
+		// Further transitions during the next busy run coalesce.
+		const phase = makeFerment().phases[0]
+		if (!phase) throw new Error("expected phase fixture")
+		setActive(
+			makeFerment({
+				phases: [
+					{
+						...phase,
+						steps: [
+							{ id: "step-1", index: 1, description: "Do thing one", status: "done" },
+							{ id: "step-2", index: 2, description: "Do thing two", status: "done" },
+						],
+					},
+				],
+			}),
+		)
+		await harness.fire("agent_start", {})
+		harness.bus.emit(FERMENT_EVENTS.STEP_COMPLETED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-2" })
+		await harness.fire("agent_end", {})
+		expect(harness.persistedBlocks()).toHaveLength(1)
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(2)
+	})
+
+	it("does not flush after an aborted run; the block lands at the next normal settle", async () => {
+		const abortedAssistant = {
+			type: "message",
+			id: "aborted-1",
+			parentId: null,
+			timestamp: "",
+			message: { role: "assistant", stopReason: "aborted", content: [] },
+		}
+		const branch: MessageLike[] = []
+		const harness = createHarness(branch)
+		const { runtime } = makeMutableRuntime(makeFerment())
+		registerFermentLifecycleContext(harness.pi, runtime)
+		await startSession(harness)
+
+		await harness.fire("agent_start", {})
+		harness.bus.emit(FERMENT_EVENTS.STEP_STARTED, { fermentId: "ferment-1", phaseId: "phase-1", stepId: "step-1" })
+		await harness.fire("agent_end", {})
+		branch.push(abortedAssistant as MessageLike)
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(0)
+
+		await harness.fire("agent_start", {})
+		await harness.fire("agent_end", {})
+		branch.push({
+			type: "message",
+			id: "normal-1",
+			parentId: null,
+			timestamp: "",
+			message: { role: "assistant", stopReason: "stop", content: [] },
+		} as MessageLike)
+		await harness.fire("agent_settled", {})
+		expect(harness.persistedBlocks()).toHaveLength(1)
+	})
+
 	it("persists a hidden lifecycle block once per transition for a running ferment", async () => {
 		const harness = createHarness()
 		const { runtime, setActive } = makeMutableRuntime(makeFerment())

--- a/src/extensions/ferment/lifecycle-context.ts
+++ b/src/extensions/ferment/lifecycle-context.ts
@@ -1,42 +1,18 @@
-import type { ContextEvent, ExtensionAPI, ExtensionContext, SessionManager } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, SessionManager } from "@earendil-works/pi-coding-agent"
 
 type SessionManagerHandle = Pick<SessionManager, "getEntries" | "getSessionId">
 
 import { TERMINAL_STEP_STATUSES } from "../../ferment/state-machine.js"
 import type { Ferment } from "../../ferment/types.js"
-import { latestRunTailIsAborted } from "../aborted-run.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { getMultiModelEnabled } from "../multi-model.js"
+import { registerStateBlockPersistence } from "../state-block-persistence.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { FERMENT_EVENTS } from "./domain-events.js"
 import type { FermentRuntime } from "./runtime.js"
 import { formatNextActionHint } from "./tool-helpers.js"
 
-type OrchestratorMessages = ContextEvent["messages"]
-
 export const FERMENT_LIFECYCLE_CUSTOM_TYPE = "ferment-lifecycle"
-
-function isFermentLifecycleMessage(m: unknown): boolean {
-	return (
-		m !== null &&
-		typeof m === "object" &&
-		(m as { role?: string }).role === "custom" &&
-		(m as { customType?: string }).customType === FERMENT_LIFECYCLE_CUSTOM_TYPE
-	)
-}
-
-function extractTextContent(content: unknown): string | undefined {
-	if (typeof content === "string") return content
-	if (Array.isArray(content)) {
-		for (const part of content) {
-			if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
-				const text = (part as { text?: unknown }).text
-				if (typeof text === "string") return text
-			}
-		}
-	}
-	return undefined
-}
 
 /** Renders the volatile part of the ferment lifecycle state: active phase
  *  details with step-progress counts, and the next-action hint. This is the
@@ -62,156 +38,58 @@ function buildFermentLifecycleContext(f: Ferment, multiModelEnabled: boolean): s
 	return lines.join("\n")
 }
 
-/** Replay dedupe: find the newest persisted ferment-lifecycle block in
- *  session history so a resumed session does not re-persist an identical
- *  block on its first transition. */
-function newestLifecycleContentFromHistory(ctx: ExtensionContext): string | undefined {
-	const branch = ctx.sessionManager.getBranch()
-	for (let i = branch.length - 1; i >= 0; i--) {
-		const m = branch[i] as { role?: string; customType?: string; content?: unknown }
-		if (isFermentLifecycleMessage(m)) {
-			return extractTextContent(m.content)
-		}
-	}
-	return undefined
-}
+/** Channels that can change the rendered block (or the planned/running gate). */
+const LIFECYCLE_CHANGE_EVENTS = [
+	FERMENT_EVENTS.PHASE_STARTED,
+	FERMENT_EVENTS.STEP_STARTED,
+	FERMENT_EVENTS.STEP_COMPLETED,
+	FERMENT_EVENTS.STEP_FAILED,
+	FERMENT_EVENTS.PHASE_COMPLETED,
+	FERMENT_EVENTS.SUSPENDED,
+	FERMENT_EVENTS.RESUMED,
+	FERMENT_EVENTS.SCOPING_COMPLETE,
+] as const
 
 /**
- * Persist-on-change delivery of the ferment lifecycle state block.
+ * Persist-on-change delivery of the ferment lifecycle state block. Machinery
+ * (dedupe, busy-run deferral, settle flush, history replay dedupe,
+ * strip-only context view) lives in the shared `state-block-persistence`
+ * registrar — see its module comment for the cache-breakpoint rationale.
  *
- * Replaces the previous transient tail-injection (a fresh `ferment-lifecycle`
- * message appended inside the `context` handler on every LLM request), which
- * permanently poisoned the request-level cache breakpoint: every stored
- * prefix ended at a moving block, so every request rewrote the whole context.
- *
- * This registrar subscribes to ferment domain events and writes the rendered
- * block into session history — as a hidden custom message delivered as a
- * steer so it lands at the tool boundary — exactly once per rendered-content
- * change. The persisted entry then sits at a fixed chronological position and
- * joins the growing stable prefix.
- *
- * History is append-only for extensions, so superseded copies remain in the
- * branch. The `context` handler registered here is therefore strip-only: it
- * deterministically drops every `ferment-lifecycle` message except the
- * newest. The request view is a pure function of persisted history —
- * identical every round between real transitions, so each transition causes
- * exactly one bounded invalidation instead of a permanent cache freeze.
- *
- * Timing: upstream compaction (`findCutPoint`) treats every custom message
- * as a turn start, so a block persisted mid-turn becomes a turn boundary
- * and compaction produces an extra split-turn prefix-summarization request.
- * Writes are therefore deferred while the agent is busy and flushed at
- * `agent_settled`, when the run is fully inactive and the plain append
- * path lands after all turn entries.
+ * Ferment-specific bits retained here: the render source (active phase
+ * progress + next-action hint), the planned/running gate (draft, paused,
+ * complete, and abandoned have their own dedicated prompt blocks or no
+ * block — a transition out persists nothing; the last running block remains
+ * in history), the agent-worker suppression, and the domain-event channels
+ * as the change source.
  *
  * Registered once at extension init; the TUI is a single-session process.
  */
 export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: FermentRuntime): void {
-	/** Newest persisted block content; `undefined` = nothing persisted yet. */
-	let lastPersistedContent: string | undefined
 	/** Latest session handle, used to resolve the multi-model flag. */
 	let sessionManager: SessionManagerHandle | undefined
 
-	function renderCurrent(): string | undefined {
-		if (isAgentWorker()) return undefined
-		const f = runtime.getActive()
-		if (!f) return undefined
-		// Only persist for planned/running states — draft, paused, complete, and
-		// abandoned have their own dedicated prompt blocks or no block at all.
-		// A transition out of those states persists nothing; the previous
-		// block remains in history as the last known lifecycle state.
-		if (f.status !== "planned" && f.status !== "running") return undefined
-		if (!sessionManager) return undefined
-		const content = buildFermentLifecycleContext(f, getMultiModelEnabled(sessionManager))
-		if (!content) return undefined
-		return markHarnessSteer(content)
-	}
-
-	/** Whether a lifecycle transition happened while the agent was busy. */
-	let pendingFlush = false
-	let agentBusy = 0
-
-	function persistIfChanged(): void {
-		const content = renderCurrent()
-		if (content === undefined || content === lastPersistedContent) return
-		lastPersistedContent = content
-		pi.sendMessage(
-			{
-				customType: FERMENT_LIFECYCLE_CUSTOM_TYPE,
-				display: false,
-				content,
-				details: { reason: "state_sync" },
-			},
-			{ deliverAs: "steer" },
-		)
-	}
-
-	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
-		sessionManager = ctx.sessionManager
-		lastPersistedContent = newestLifecycleContentFromHistory(ctx)
-	}
-	pi.on("session_start", initFromHistory)
-	pi.on("session_tree", initFromHistory)
-
-	// While the agent is busy, coalesce all transitions into one block flushed
-	// after the run — see the module comment for the compaction rationale.
-	pi.on("agent_start", () => {
-		agentBusy++
-	})
-	pi.on("agent_end", () => {
-		agentBusy = Math.max(0, agentBusy - 1)
-	})
-	// Flush on agent_settled rather than agent_end: during agent_end the run
-	// is still streaming upstream, so a steered send would be queued as a
-	// pending agent steer. At agent_settled the run is fully inactive, so
-	// sendCustomMessage takes the plain append path (no steer, no pending
-	// messages, no new turn) and downstream agent_settled handlers that gate
-	// on ctx.hasPendingMessages() (e.g. the Ferment V2 evaluation gate) are
-	// unaffected.
-	pi.on("agent_settled", (_event, ctx) => {
-		if (agentBusy > 0 || !pendingFlush) return
-		// Skip aborted runs: the flushed block would become the newest turn
-		// start and steal the interrupted turn's slot in a compaction cut.
-		if (latestRunTailIsAborted(ctx)) return
-		pendingFlush = false
-		persistIfChanged()
-	})
-
-	// Re-render + dedupe on every lifecycle transition that can change the
-	// rendered block (or the planned/running gate).
-	for (const channel of [
-		FERMENT_EVENTS.PHASE_STARTED,
-		FERMENT_EVENTS.STEP_STARTED,
-		FERMENT_EVENTS.STEP_COMPLETED,
-		FERMENT_EVENTS.STEP_FAILED,
-		FERMENT_EVENTS.PHASE_COMPLETED,
-		FERMENT_EVENTS.SUSPENDED,
-		FERMENT_EVENTS.RESUMED,
-		FERMENT_EVENTS.SCOPING_COMPLETE,
-	] as const) {
-		pi.events.on(channel, () => {
-			if (agentBusy > 0) {
-				pendingFlush = true
-				return
+	registerStateBlockPersistence(pi, {
+		customType: FERMENT_LIFECYCLE_CUSTOM_TYPE,
+		onSessionEvent: (ctx: ExtensionContext) => {
+			sessionManager = ctx.sessionManager
+		},
+		render: () => {
+			if (isAgentWorker()) return undefined
+			const f = runtime.getActive()
+			if (!f) return undefined
+			if (f.status !== "planned" && f.status !== "running") return undefined
+			if (!sessionManager) return undefined
+			const content = buildFermentLifecycleContext(f, getMultiModelEnabled(sessionManager))
+			if (!content) return undefined
+			return markHarnessSteer(content)
+		},
+		subscribe: (notify) => {
+			for (const channel of LIFECYCLE_CHANGE_EVENTS) {
+				pi.events.on(channel, () => {
+					notify()
+				})
 			}
-			persistIfChanged()
-		})
-	}
-
-	// Strip-only context pass: drop every ferment-lifecycle message except the
-	// newest. Never appends — the write path (domain events above and the
-	// current-context check below) is the only place these messages originate.
-	pi.on("context", async (event) => {
-		const messages = event.messages
-		let newestIndex = -1
-		for (let i = 0; i < messages.length; i++) {
-			if (isFermentLifecycleMessage(messages[i])) newestIndex = i
-		}
-		if (newestIndex === -1) return undefined
-		const hasSuperseded = messages.some((m, i) => i !== newestIndex && isFermentLifecycleMessage(m))
-		if (!hasSuperseded) return undefined
-
-		const stripped: OrchestratorMessages = messages.filter((m, i) => !isFermentLifecycleMessage(m) || i === newestIndex)
-		return { messages: stripped }
+		},
 	})
 }

--- a/src/extensions/ferment/lifecycle-context.ts
+++ b/src/extensions/ferment/lifecycle-context.ts
@@ -4,6 +4,7 @@ type SessionManagerHandle = Pick<SessionManager, "getEntries" | "getSessionId">
 
 import { TERMINAL_STEP_STATUSES } from "../../ferment/state-machine.js"
 import type { Ferment } from "../../ferment/types.js"
+import { latestRunTailIsAborted } from "../aborted-run.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { getMultiModelEnabled } from "../multi-model.js"
 import { markHarnessSteer } from "../steer-marker.js"
@@ -96,6 +97,13 @@ function newestLifecycleContentFromHistory(ctx: ExtensionContext): string | unde
  * identical every round between real transitions, so each transition causes
  * exactly one bounded invalidation instead of a permanent cache freeze.
  *
+ * Timing: upstream compaction (`findCutPoint`) treats every custom message
+ * as a turn start, so a block persisted mid-turn becomes a turn boundary
+ * and compaction produces an extra split-turn prefix-summarization request.
+ * Writes are therefore deferred while the agent is busy and flushed at
+ * `agent_settled`, when the run is fully inactive and the plain append
+ * path lands after all turn entries.
+ *
  * Registered once at extension init; the TUI is a single-session process.
  */
 export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: FermentRuntime): void {
@@ -119,6 +127,10 @@ export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: Ferme
 		return markHarnessSteer(content)
 	}
 
+	/** Whether a lifecycle transition happened while the agent was busy. */
+	let pendingFlush = false
+	let agentBusy = 0
+
 	function persistIfChanged(): void {
 		const content = renderCurrent()
 		if (content === undefined || content === lastPersistedContent) return
@@ -141,6 +153,30 @@ export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: Ferme
 	pi.on("session_start", initFromHistory)
 	pi.on("session_tree", initFromHistory)
 
+	// While the agent is busy, coalesce all transitions into one block flushed
+	// after the run — see the module comment for the compaction rationale.
+	pi.on("agent_start", () => {
+		agentBusy++
+	})
+	pi.on("agent_end", () => {
+		agentBusy = Math.max(0, agentBusy - 1)
+	})
+	// Flush on agent_settled rather than agent_end: during agent_end the run
+	// is still streaming upstream, so a steered send would be queued as a
+	// pending agent steer. At agent_settled the run is fully inactive, so
+	// sendCustomMessage takes the plain append path (no steer, no pending
+	// messages, no new turn) and downstream agent_settled handlers that gate
+	// on ctx.hasPendingMessages() (e.g. the Ferment V2 evaluation gate) are
+	// unaffected.
+	pi.on("agent_settled", (_event, ctx) => {
+		if (agentBusy > 0 || !pendingFlush) return
+		// Skip aborted runs: the flushed block would become the newest turn
+		// start and steal the interrupted turn's slot in a compaction cut.
+		if (latestRunTailIsAborted(ctx)) return
+		pendingFlush = false
+		persistIfChanged()
+	})
+
 	// Re-render + dedupe on every lifecycle transition that can change the
 	// rendered block (or the planned/running gate).
 	for (const channel of [
@@ -154,6 +190,10 @@ export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: Ferme
 		FERMENT_EVENTS.SCOPING_COMPLETE,
 	] as const) {
 		pi.events.on(channel, () => {
+			if (agentBusy > 0) {
+				pendingFlush = true
+				return
+			}
 			persistIfChanged()
 		})
 	}

--- a/src/extensions/ferment/lifecycle-context.ts
+++ b/src/extensions/ferment/lifecycle-context.ts
@@ -1,35 +1,49 @@
-import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI, ExtensionContext, SessionManager } from "@earendil-works/pi-coding-agent"
+
+type SessionManagerHandle = Pick<SessionManager, "getEntries" | "getSessionId">
+
 import { TERMINAL_STEP_STATUSES } from "../../ferment/state-machine.js"
 import type { Ferment } from "../../ferment/types.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { getMultiModelEnabled } from "../multi-model.js"
+import { markHarnessSteer } from "../steer-marker.js"
+import { FERMENT_EVENTS } from "./domain-events.js"
 import type { FermentRuntime } from "./runtime.js"
 import { formatNextActionHint } from "./tool-helpers.js"
 
 type OrchestratorMessages = ContextEvent["messages"]
 
-const FERMENT_LIFECYCLE_CUSTOM_TYPE = "ferment-lifecycle"
+export const FERMENT_LIFECYCLE_CUSTOM_TYPE = "ferment-lifecycle"
 
-/** Strips prior ferment-lifecycle injections from a transient message array
- *  so we never double-stack if the handler chain runs more than once. */
-function stripFermentLifecycleMessages(messages: OrchestratorMessages): OrchestratorMessages {
-	return messages.filter(
-		(m) =>
-			!(
-				m.role === "custom" &&
-				"customType" in m &&
-				(m as { customType: string }).customType === FERMENT_LIFECYCLE_CUSTOM_TYPE
-			),
+function isFermentLifecycleMessage(m: unknown): boolean {
+	return (
+		m !== null &&
+		typeof m === "object" &&
+		(m as { role?: string }).role === "custom" &&
+		(m as { customType?: string }).customType === FERMENT_LIFECYCLE_CUSTOM_TYPE
 	)
+}
+
+function extractTextContent(content: unknown): string | undefined {
+	if (typeof content === "string") return content
+	if (Array.isArray(content)) {
+		for (const part of content) {
+			if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
+				const text = (part as { text?: unknown }).text
+				if (typeof text === "string") return text
+			}
+		}
+	}
+	return undefined
 }
 
 /** Renders the volatile part of the ferment lifecycle state: active phase
  *  details with step-progress counts, and the next-action hint. This is the
  *  content that was previously baked into the system prompt by
- *  `buildCurrentStateSection` but which changes on every step/phase
- *  transition, breaking prefix-cache stability. Moving it to the transient
- *  context channel keeps the system prompt byte-stable across transitions
- *  while still delivering the same information to the model every turn. */
+ *  `buildCurrentStateSection` (which broke system-prompt prefix stability),
+ *  and later pushed transiently at the request tail (which broke the
+ *  request-level cache breakpoint). It is now persisted once per actual
+ *  transition — see `registerFermentLifecycleContext`. */
 function buildFermentLifecycleContext(f: Ferment, multiModelEnabled: boolean): string | undefined {
 	const activePhaseStates = f.phases
 		.filter((phase) => phase.status === "active")
@@ -47,48 +61,117 @@ function buildFermentLifecycleContext(f: Ferment, multiModelEnabled: boolean): s
 	return lines.join("\n")
 }
 
+/** Replay dedupe: find the newest persisted ferment-lifecycle block in
+ *  session history so a resumed session does not re-persist an identical
+ *  block on its first transition. */
+function newestLifecycleContentFromHistory(ctx: ExtensionContext): string | undefined {
+	const branch = ctx.sessionManager.getBranch()
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const m = branch[i] as { role?: string; customType?: string; content?: unknown }
+		if (isFermentLifecycleMessage(m)) {
+			return extractTextContent(m.content)
+		}
+	}
+	return undefined
+}
+
 /**
- * Registers a `context` event handler that injects the volatile ferment
- * lifecycle state (active phase, step progress, next-action hint) at the tail
- * of the message array on every LLM call. This is transient — the injected
- * message lives only in the single LLM request, never in the persistent
- * session history, and never touches the system prompt.
+ * Persist-on-change delivery of the ferment lifecycle state block.
  *
- * This is the volatile counterpart to the static `## Current lifecycle state`
- * section in `buildFermentPromptBlock` (prompt-block.ts). The static section
- * (scoping is COMPLETE, no-replanning guidance) stays in the system prompt;
- * only the parts that change across step/phase transitions move here, keeping
- * the system prompt byte-stable for prefix caching.
+ * Replaces the previous transient tail-injection (a fresh `ferment-lifecycle`
+ * message appended inside the `context` handler on every LLM request), which
+ * permanently poisoned the request-level cache breakpoint: every stored
+ * prefix ended at a moving block, so every request rewrote the whole context.
  *
- * Registered once at extension init — the handler reads the active ferment
- * from `runtime.getActive()` and no-ops when no ferment is planned/running.
- * The TUI is a single-session process, so a single global registration is
- * sufficient.
+ * This registrar subscribes to ferment domain events and writes the rendered
+ * block into session history — as a hidden custom message delivered as a
+ * steer so it lands at the tool boundary — exactly once per rendered-content
+ * change. The persisted entry then sits at a fixed chronological position and
+ * joins the growing stable prefix.
+ *
+ * History is append-only for extensions, so superseded copies remain in the
+ * branch. The `context` handler registered here is therefore strip-only: it
+ * deterministically drops every `ferment-lifecycle` message except the
+ * newest. The request view is a pure function of persisted history —
+ * identical every round between real transitions, so each transition causes
+ * exactly one bounded invalidation instead of a permanent cache freeze.
+ *
+ * Registered once at extension init; the TUI is a single-session process.
  */
 export function registerFermentLifecycleContext(pi: ExtensionAPI, runtime: FermentRuntime): void {
-	pi.on("context", async (event, ctx) => {
-		if (isAgentWorker()) return undefined
+	/** Newest persisted block content; `undefined` = nothing persisted yet. */
+	let lastPersistedContent: string | undefined
+	/** Latest session handle, used to resolve the multi-model flag. */
+	let sessionManager: SessionManagerHandle | undefined
 
+	function renderCurrent(): string | undefined {
+		if (isAgentWorker()) return undefined
 		const f = runtime.getActive()
 		if (!f) return undefined
-
-		// Only inject for planned/running states — draft, paused, complete, and
+		// Only persist for planned/running states — draft, paused, complete, and
 		// abandoned have their own dedicated prompt blocks or no block at all.
+		// A transition out of those states persists nothing; the previous
+		// block remains in history as the last known lifecycle state.
 		if (f.status !== "planned" && f.status !== "running") return undefined
-
-		const multiModelEnabled = getMultiModelEnabled(ctx.sessionManager)
-		const content = buildFermentLifecycleContext(f, multiModelEnabled)
+		if (!sessionManager) return undefined
+		const content = buildFermentLifecycleContext(f, getMultiModelEnabled(sessionManager))
 		if (!content) return undefined
+		return markHarnessSteer(content)
+	}
 
-		const messages = stripFermentLifecycleMessages(event.messages)
-		messages.push({
-			role: "custom",
-			customType: FERMENT_LIFECYCLE_CUSTOM_TYPE,
-			content,
-			display: false,
-			timestamp: Date.now(),
+	function persistIfChanged(): void {
+		const content = renderCurrent()
+		if (content === undefined || content === lastPersistedContent) return
+		lastPersistedContent = content
+		pi.sendMessage(
+			{
+				customType: FERMENT_LIFECYCLE_CUSTOM_TYPE,
+				display: false,
+				content,
+				details: { reason: "state_sync" },
+			},
+			{ deliverAs: "steer" },
+		)
+	}
+
+	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
+		sessionManager = ctx.sessionManager
+		lastPersistedContent = newestLifecycleContentFromHistory(ctx)
+	}
+	pi.on("session_start", initFromHistory)
+	pi.on("session_tree", initFromHistory)
+
+	// Re-render + dedupe on every lifecycle transition that can change the
+	// rendered block (or the planned/running gate).
+	for (const channel of [
+		FERMENT_EVENTS.PHASE_STARTED,
+		FERMENT_EVENTS.STEP_STARTED,
+		FERMENT_EVENTS.STEP_COMPLETED,
+		FERMENT_EVENTS.STEP_FAILED,
+		FERMENT_EVENTS.PHASE_COMPLETED,
+		FERMENT_EVENTS.SUSPENDED,
+		FERMENT_EVENTS.RESUMED,
+		FERMENT_EVENTS.SCOPING_COMPLETE,
+	] as const) {
+		pi.events.on(channel, () => {
+			persistIfChanged()
 		})
+	}
 
-		return { messages }
+	// Strip-only context pass: drop every ferment-lifecycle message except the
+	// newest. Never appends — the write path (domain events above and the
+	// current-context check below) is the only place these messages originate.
+	pi.on("context", async (event) => {
+		const messages = event.messages
+		let newestIndex = -1
+		for (let i = 0; i < messages.length; i++) {
+			if (isFermentLifecycleMessage(messages[i])) newestIndex = i
+		}
+		if (newestIndex === -1) return undefined
+		const hasSuperseded = messages.some((m, i) => i !== newestIndex && isFermentLifecycleMessage(m))
+		if (!hasSuperseded) return undefined
+
+		const stripped: OrchestratorMessages = messages.filter((m, i) => !isFermentLifecycleMessage(m) || i === newestIndex)
+		return { messages: stripped }
 	})
 }

--- a/src/extensions/ferment/todo-headless-wiring.test.ts
+++ b/src/extensions/ferment/todo-headless-wiring.test.ts
@@ -16,7 +16,7 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { createEventBus } from "@earendil-works/pi-coding-agent"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
 import { __test_renderTodoStateMarkdown, renderTodoStateBlock } from "../todos/state-markdown.js"
@@ -26,6 +26,8 @@ import { setActive } from "./state.js"
 import {
 	__getRunningSteps,
 	bumpStallCounter,
+	FERMENT_STEP_STALL_CUSTOM_TYPE,
+	fireStepStallSteerIfStalled,
 	getTurnsSinceStepTodoWrite,
 	registerFermentTodoSync,
 } from "./todo-sync.js"
@@ -63,11 +65,16 @@ function makeFerment(overrides: Partial<Ferment> = {}): Ferment {
 }
 
 /** Minimal ExtensionAPI stub that delegates events to a real EventBus. */
-function makePiWithRealEventBus(): { pi: ExtensionAPI; unsubscribe: () => void } {
+function makePiWithRealEventBus(): {
+	pi: ExtensionAPI
+	sendMessage: ReturnType<typeof vi.fn>
+	unsubscribe: () => void
+} {
 	const bus = createEventBus()
-	const pi = { events: bus } as unknown as ExtensionAPI
+	const sendMessage = vi.fn()
+	const pi = { events: bus, sendMessage } as unknown as ExtensionAPI
 	const unsubscribe = registerFermentTodoSync(pi, TEST_SESSION_ID)
-	return { pi, unsubscribe }
+	return { pi, sendMessage, unsubscribe }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -483,7 +490,7 @@ describe("stall detection via step todo write tracking", () => {
 		}
 	})
 
-	it("stall warning appears in rendered markdown after threshold", () => {
+	it("stall pressure fires as a one-shot persistent steer after threshold (not in the rendered block)", () => {
 		const ferment = makeFerment({
 			phases: [
 				{
@@ -497,7 +504,7 @@ describe("stall detection via step todo write tracking", () => {
 			],
 		})
 		setActive(ferment)
-		const { pi, unsubscribe } = makePiWithRealEventBus()
+		const { pi, sendMessage, unsubscribe } = makePiWithRealEventBus()
 
 		try {
 			emitFermentDomainEvent(pi.events, { type: "activate_phase", phaseId: "phase-1" }, ferment)
@@ -515,9 +522,30 @@ describe("stall detection via step todo write tracking", () => {
 			// Bump past threshold (12 turns — one long step = genuine thrash)
 			for (let i = 0; i < 13; i++) bumpStallCounter(TEST_SESSION_ID)
 
+			// The rendered block no longer carries volatile staleness text — it
+			// must stay byte-stable between real store writes for prefix caching.
 			const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-			expect(md).toContain("\u26a0 Step todos have not been updated for 13 turns")
-			expect(md).toContain("reassess your approach")
+			expect(md).not.toContain("have not been updated")
+
+			// The pressure is delivered as a one-shot persistent steer instead.
+			fireStepStallSteerIfStalled(pi, TEST_SESSION_ID)
+			const stallSteers = sendMessage.mock.calls.filter(
+				(call) => (call[0] as { customType?: string }).customType === FERMENT_STEP_STALL_CUSTOM_TYPE,
+			)
+			expect(stallSteers).toHaveLength(1)
+			expect((stallSteers[0]?.[0] as { content: string }).content).toContain(
+				"Step todos have not been updated for 13 turns",
+			)
+			expect((stallSteers[0]?.[0] as { content: string }).content).toContain("reassess your approach")
+			expect(stallSteers[0]?.[1]).toEqual({ deliverAs: "steer" })
+
+			// One-shot: firing again without a new epoch persists nothing more.
+			fireStepStallSteerIfStalled(pi, TEST_SESSION_ID)
+			expect(
+				sendMessage.mock.calls.filter(
+					(call) => (call[0] as { customType?: string }).customType === FERMENT_STEP_STALL_CUSTOM_TYPE,
+				),
+			).toHaveLength(1)
 		} finally {
 			unsubscribe()
 		}

--- a/src/extensions/ferment/todo-sync.ts
+++ b/src/extensions/ferment/todo-sync.ts
@@ -31,6 +31,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import type { Phase, StepStatus } from "../../ferment/types.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "../todos/constants.js"
 import { parseTodoScopeKey } from "../todos/scope.js"
+import { createThresholdSteerTracker, sendHiddenSteer } from "../todos/staleness-steers.js"
 import {
 	applyWriteTodos,
 	getTodoState,
@@ -408,6 +409,36 @@ export function getTurnsSinceStepTodoWrite(sessionId: string): number {
 	return turnsSinceStepTodoWrite.get(sessionId) ?? 0
 }
 
+// ─── Step stall steer ───────────────────────────────────────────────────────
+// The step-stall warning used to be rendered inside the todo state block,
+// which made the block depend on this volatile counter. The block is now a
+// pure function of the store (persisted for cache stability), so the warning
+// moved here: a one-shot persistent steer fired once per stall epoch.
+
+export const FERMENT_STEP_STALL_CUSTOM_TYPE = "ferment-step-stall"
+export const FERMENT_STEP_STALL_THRESHOLD = 12
+
+const stallSteerTracker = createThresholdSteerTracker()
+
+/** Fire a one-shot hidden steer when the step-todo stall counter has crossed
+ *  the threshold for the current epoch. The epoch (and tracker) resets on any
+ *  running step-scope todo write or when a new step starts. */
+export function fireStepStallSteerIfStalled(pi: ExtensionAPI, sessionId: string): void {
+	const count = getTurnsSinceStepTodoWrite(sessionId)
+	stallSteerTracker.fireCrossed({
+		sessionId,
+		count,
+		thresholds: [FERMENT_STEP_STALL_THRESHOLD],
+		send: () =>
+			sendHiddenSteer(
+				pi,
+				FERMENT_STEP_STALL_CUSTOM_TYPE,
+				`⚠ Step todos have not been updated for ${count} turns. If you are iterating without progress, step back and reassess your approach. Update your todo plan with what you have tried and what to try next.`,
+				{ reason: "step_stall", threshold: FERMENT_STEP_STALL_THRESHOLD },
+			),
+	})
+}
+
 function handleStepStarted(raw: unknown, sessionId: string, appendEntry?: AppendEntryFn): void {
 	const payload = raw as FermentStepStartedPayload
 	const ferment = getActive()
@@ -457,6 +488,7 @@ function handleStepStarted(raw: unknown, sessionId: string, appendEntry?: Append
 		stepId: payload.stepId,
 	})
 	turnsSinceStepTodoWrite.set(sessionId, 0)
+	stallSteerTracker.reset(sessionId)
 }
 
 function clearStepTodos(phaseId: string, stepId: string, sessionId: string, appendEntry?: AppendEntryFn): void {
@@ -689,6 +721,7 @@ export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): ()
 		const scope = details.scope as { phaseId: string; stepId: string }
 		if (bucket.has(stepKey(scope.phaseId, scope.stepId))) {
 			turnsSinceStepTodoWrite.set(sessionId, 0)
+			stallSteerTracker.reset(sessionId)
 		}
 	})
 
@@ -732,6 +765,7 @@ export function registerFermentTodoSync(pi: ExtensionAPI, sessionId: string): ()
 		// the process keep their buckets intact.
 		runningSteps.delete(sessionId)
 		turnsSinceStepTodoWrite.delete(sessionId)
+		stallSteerTracker.reset(sessionId)
 
 		todoIdMaps.get(sessionId)?.clear()
 		todoIdMaps.delete(sessionId)

--- a/src/extensions/prompt-construction/anthropic-prefix-cache.test.ts
+++ b/src/extensions/prompt-construction/anthropic-prefix-cache.test.ts
@@ -24,9 +24,10 @@
  */
 import type { Message, Model } from "@earendil-works/pi-ai"
 import { stream } from "@earendil-works/pi-ai/api/anthropic-messages"
-import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { convertToLlm } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
 import todosExtension from "../todos/index.js"
 import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
 
@@ -97,15 +98,14 @@ function createHarness() {
 		}),
 	} as unknown as ExtensionAPI
 
-	const ctx = {
+	const ctx = createContext({
 		hasUI: false,
-		cwd: "/tmp",
 		hasPendingMessages: () => false,
 		sessionManager: {
 			getSessionId: () => SESSION_ID,
-			getBranch: () => history,
+			getBranch: () => history as unknown as SessionEntry[],
 		},
-	} as unknown as ExtensionContext
+	})
 
 	todosExtension(pi)
 

--- a/src/extensions/prompt-construction/anthropic-prefix-cache.test.ts
+++ b/src/extensions/prompt-construction/anthropic-prefix-cache.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Anthropic prefix-cache reproduction.
+ *
+ * Anthropic prompt caching works like this: pi-ai places `cache_control`
+ * breakpoints on the system prompt, the last tool, and the LAST user-role
+ * block of the converted message stream (see anthropic-messages.js). A later
+ * request hits the cache only at a previously stored marker prefix that is a
+ * byte-identical *prefix* of the new request body.
+ *
+ * The bug this test reproduces (frozen cache_read, ~full-context cache_write
+ * every round): todo/ferment state was injected as a transient message at the
+ * tail of the message array on every context event, with content that moved
+ * position every round — every stored tail breakpoint ended at a poisoned
+ * block, so no later request could ever reuse it.
+ *
+ * After the fix (persist-on-change + strip-only context view), consecutive
+ * request bodies are strict prefix-extensions of each other except at a real
+ * todo write, which causes exactly one bounded invalidation at the position
+ * of the superseded state block.
+ *
+ * The serializer under test is the REAL anthropic-messages conversion from
+ * pi-ai, captured through a stub fetch — the same technique as
+ * /tmp/replay-diff.mjs, which was used to diagnose the original freeze.
+ */
+import type { Message, Model } from "@earendil-works/pi-ai"
+import { stream } from "@earendil-works/pi-ai/api/anthropic-messages"
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { convertToLlm } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import todosExtension from "../todos/index.js"
+import { __resetTodoStore, applyWriteTodos } from "../todos/store.js"
+
+const SESSION_ID = "cache-replay-session"
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>
+/** Session-pipeline message shape — the same element type the `context`
+ *  event carries (pi-coding-agent does not re-export `AgentMessage` from
+ *  its package root). */
+type AgentMessage = ContextEvent["messages"][number]
+
+// ─── Session fixture ─────────────────────────────────────────────────────────
+
+function userMessage(text: string, timestamp: number): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp } as unknown as AgentMessage
+}
+
+function assistantToolCall(callId: string, command: string, timestamp: number): AgentMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-5",
+		content: [{ type: "toolCall", id: callId, name: "bash", arguments: { command } }],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp,
+	} as unknown as AgentMessage
+}
+
+function toolResult(callId: string, text: string, timestamp: number): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId: callId,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		timestamp,
+	} as unknown as AgentMessage
+}
+
+// ─── Harness: real extension over a simulated growing session ────────────────
+
+function createHarness() {
+	const handlers = new Map<string, ExtensionHandler[]>()
+	/** Simulated persistent session history. pi.sendMessage persists here,
+	 *  mirroring what the session manager does with hidden custom messages. */
+	const history: AgentMessage[] = []
+
+	const pi = {
+		registerTool: vi.fn(),
+		registerCommand: vi.fn(),
+		registerShortcut: vi.fn(),
+		appendEntry: vi.fn(),
+		sendMessage: vi.fn((message: Record<string, unknown>) => {
+			history.push({ role: "custom", timestamp: Date.now(), ...message } as unknown as AgentMessage)
+		}),
+		getActiveTools: vi.fn(() => []),
+		on: vi.fn((event: string, handler: ExtensionHandler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		}),
+	} as unknown as ExtensionAPI
+
+	const ctx = {
+		hasUI: false,
+		cwd: "/tmp",
+		hasPendingMessages: () => false,
+		sessionManager: {
+			getSessionId: () => SESSION_ID,
+			getBranch: () => history,
+		},
+	} as unknown as ExtensionContext
+
+	todosExtension(pi)
+
+	async function fire(event: string, payload: unknown): Promise<unknown> {
+		let result: unknown
+		let currentPayload = payload
+		for (const handler of handlers.get(event) ?? []) {
+			result = await handler(currentPayload, ctx)
+			const contextResult = result as { messages?: AgentMessage[] } | undefined
+			if (event === "context" && contextResult?.messages) {
+				currentPayload = { type: "context", messages: contextResult.messages }
+			}
+		}
+		return result
+	}
+
+	/** The model-visible view for the next LLM call: persistent history run
+	 *  through every registered context handler (the strip-only pass). */
+	async function requestView(): Promise<AgentMessage[]> {
+		const result = (await fire("context", { type: "context", messages: [...history] })) as
+			| { messages?: AgentMessage[] }
+			| undefined
+		return result?.messages ?? history
+	}
+
+	return { history, pi, fire, requestView }
+}
+
+// ─── Real anthropic-messages wire capture ─────────────────────────────────────
+
+const model = {
+	id: "claude-sonnet-5",
+	name: "claude-sonnet-5",
+	api: "anthropic-messages",
+	provider: "kimchi-dev/anthropic",
+	baseUrl: "http://localhost:9", // intercepted by the capture fetch below
+	maxTokens: 128000,
+	input: ["text"],
+	output: ["text"],
+	reasoning: false,
+} as unknown as Model<"anthropic-messages">
+
+const TEST_TOOLS = [
+	{
+		name: "bash",
+		description: "run bash",
+		parameters: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+	},
+	{
+		name: "read",
+		description: "read file",
+		parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+	},
+]
+
+interface CapturedBody {
+	system: unknown
+	tools: unknown
+	messages: Array<Record<string, unknown>>
+}
+
+async function captureRequestBody(messages: AgentMessage[]): Promise<CapturedBody> {
+	let capturedBody: string | undefined
+	const captureFetch = async (_url: unknown, init: unknown) => {
+		capturedBody = String((init as { body?: unknown })?.body ?? "")
+		return new Response(JSON.stringify({ type: "error", error: { type: "api_error", message: "captured" } }), {
+			status: 500,
+			headers: { "content-type": "application/json" },
+		})
+	}
+	try {
+		const s = stream(
+			model,
+			{
+				systemPrompt: "You are a cache replay test.",
+				tools: TEST_TOOLS,
+				messages: convertToLlm(messages) as Message[],
+			},
+			{ apiKey: "replay-key", fetch: captureFetch as unknown as typeof fetch },
+		)
+		for await (const ev of s) {
+			if (ev?.type === "error") break
+		}
+	} catch {
+		// The stub fetch always fails after the body was captured — expected.
+	}
+	expect(capturedBody, "request body was captured").toBeTruthy()
+	return JSON.parse(capturedBody as string) as CapturedBody
+}
+
+// ─── Cache simulation ─────────────────────────────────────────────────────────
+
+/** Anthropic stores a cache entry at every cache_control marker prefix; a
+ *  later request reads only stored entries that are byte-identical prefixes.
+ *  The only moving marker in these bodies is the tail marker on the last
+ *  user-role block, so the stored set is exactly the set of prior
+ *  serialized message arrays. */
+function simulateCache(bodies: CapturedBody[]): { cacheRead: number[]; cacheWrite: number[] } {
+	const stored: string[] = []
+	const cacheRead: number[] = []
+	const cacheWrite: number[] = []
+	for (const body of bodies) {
+		// Content-only comparison: cache_control markers steer writes; reads
+		// match on content bytes at previously stored breakpoint prefixes.
+		const key = JSON.stringify(body.messages.map(stripCacheControl))
+		let read = 0
+		for (const prior of stored) {
+			// Array-prefix containment in JSON space: prior is a byte-prefix of
+			// current iff current starts with prior minus the closing bracket.
+			if (key.startsWith(prior.slice(0, -1))) {
+				read = Math.max(read, prior.length)
+			}
+		}
+		cacheRead.push(read)
+		cacheWrite.push(key.length - read)
+		stored.push(key)
+	}
+	return { cacheRead, cacheWrite }
+}
+
+function stripCacheControl(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stripCacheControl)
+	if (value !== null && typeof value === "object") {
+		const out: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(value)) {
+			if (k === "cache_control") continue
+			out[k] = stripCacheControl(v)
+		}
+		return out
+	}
+	return value
+}
+
+function serializedMessages(body: CapturedBody): string[] {
+	return body.messages.map((m) => JSON.stringify(stripCacheControl(m)))
+}
+
+/** Returns the index of the first divergent message between two serialized
+ *  request bodies (messages arrays fully prefix-match up to that index). */
+function firstDivergence(prev: CapturedBody, next: CapturedBody): number {
+	const a = serializedMessages(prev)
+	const b = serializedMessages(next)
+	const n = Math.min(a.length, b.length)
+	for (let i = 0; i < n; i++) {
+		if (a[i] !== b[i]) return i
+	}
+	return n
+}
+
+function indexOfTodoStateBlock(body: CapturedBody): number {
+	return body.messages.findIndex((m) => JSON.stringify(m).includes("## Current Todos"))
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("anthropic prefix-cache reproduction (persist-on-change)", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+	})
+
+	it("consecutive request bodies strictly prefix-extend each other between todo writes", async () => {
+		const harness = createHarness()
+		let ts = 1000
+		harness.history.push(userMessage("add a feature with several steps", ts++))
+		await harness.fire("session_start", { reason: "new" })
+
+		// Todo write #1: one persisted state block joins history.
+		applyWriteTodos({ todos: [{ content: "explore", status: "in_progress" }] }, SESSION_ID)
+
+		const bodies: CapturedBody[] = []
+		bodies.push(await captureRequestBody(await harness.requestView()))
+		expect(indexOfTodoStateBlock(bodies[0])).toBeGreaterThan(0)
+
+		// Five working rounds with no further todo writes.
+		for (let i = 1; i <= 5; i++) {
+			harness.history.push(assistantToolCall(`call-${i}`, `echo ${i}`, ts++))
+			harness.history.push(toolResult(`call-${i}`, `${i}`, ts++))
+			bodies.push(await captureRequestBody(await harness.requestView()))
+		}
+
+		// THE reproduction property: every no-write round's body contains the
+		// previous body as a strict byte-prefix. On the old tail-push design
+		// the state block sat at a different position every round (and carried
+		// a moving staleness counter), so this failed on every single pair —
+		// that is the frozen cache_read / ~135k cache_write-per-round freeze.
+		for (let i = 1; i < bodies.length; i++) {
+			expect(firstDivergence(bodies[i - 1] ?? [], bodies[i] ?? [])).toBe(
+				(bodies[i - 1] as CapturedBody).messages.length,
+			)
+
+			// And the tail breakpoint candidate (last message) is a real
+			// persistent history message, never a transient injection.
+			const last = (bodies[i] as CapturedBody).messages.at(-1)
+			expect(JSON.stringify(last)).not.toContain("## Current Todos")
+		}
+
+		const { cacheRead, cacheWrite } = simulateCache(bodies)
+		// cache_read grows with the conversation (victim metric: frozen ~16.8k).
+		expect(cacheRead[0]).toBe(0)
+		for (let i = 1; i < cacheRead.length; i++) {
+			expect(cacheRead[i]).toBeGreaterThan(cacheRead[i - 1] ?? 0)
+		}
+		// cache_write per no-write round is bounded to the new tail chunk
+		// (victim metric: ~full-context rewrite every round).
+		const bodyLen = JSON.stringify(bodies.at(-1)?.messages).length
+		for (let i = 1; i < cacheWrite.length; i++) {
+			expect((cacheWrite[i] ?? 0) / bodyLen).toBeLessThan(0.2)
+		}
+	})
+
+	it("a todo write causes exactly one bounded invalidation, then prefix growth resumes", async () => {
+		const harness = createHarness()
+		let ts = 1000
+		harness.history.push(userMessage("multi-step task", ts++))
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "first", status: "completed" },
+					{ content: "second", status: "in_progress" },
+				],
+			},
+			SESSION_ID,
+		)
+
+		const bodies: CapturedBody[] = []
+		bodies.push(await captureRequestBody(await harness.requestView()))
+		for (let i = 1; i <= 2; i++) {
+			harness.history.push(assistantToolCall(`a-${i}`, `true ${i}`, ts++))
+			harness.history.push(toolResult(`a-${i}`, "", ts++))
+			bodies.push(await captureRequestBody(await harness.requestView()))
+		}
+
+		// Todo write #2 (mid-sequence): a new state block is appended and the
+		// superseded one is stripped from the next view.
+		applyWriteTodos(
+			{
+				todos: [
+					{ content: "first", status: "completed" },
+					{ content: "second", status: "completed" },
+				],
+			},
+			SESSION_ID,
+		)
+		bodies.push(await captureRequestBody(await harness.requestView()))
+
+		// The write round is the one bounded invalidation: the divergence is
+		// exactly at the superseded block's position, not beyond.
+		const writeRound = bodies.length - 1
+		const divergence = firstDivergence(bodies[writeRound - 1] ?? [], bodies[writeRound] ?? [])
+		expect(divergence).toBe(indexOfTodoStateBlock(bodies[writeRound - 1] ?? []))
+
+		// Prefix growth resumes immediately after.
+		for (let i = 0; i < 3; i++) {
+			harness.history.push(assistantToolCall(`b-${i}`, `true b${i}`, ts++))
+			harness.history.push(toolResult(`b-${i}`, "", ts++))
+			bodies.push(await captureRequestBody(await harness.requestView()))
+			const prev = bodies[bodies.length - 2] as CapturedBody
+			const curr = bodies[bodies.length - 1] as CapturedBody
+			expect(firstDivergence(prev, curr)).toBe(prev.messages.length)
+		}
+
+		// Cache accounting across the whole sequence: reads stay monotonic
+		// aside from the single write-round reset, and no round rewrites more
+		// than the tail it actually changed.
+		const { cacheRead } = simulateCache(bodies)
+		expect(cacheRead[0]).toBe(0)
+		for (let i = writeRound + 1; i < cacheRead.length; i++) {
+			expect(cacheRead[i]).toBeGreaterThan(cacheRead[i - 1] ?? 0)
+		}
+	})
+
+	it("the tail cache breakpoint always lands on persistent history, including rounds after writes", async () => {
+		const harness = createHarness()
+		let ts = 1000
+		harness.history.push(userMessage("work with todos", ts++))
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos({ todos: [{ content: "step one", status: "pending" }] }, SESSION_ID)
+
+		for (let i = 0; i < 4; i++) {
+			harness.history.push(assistantToolCall(`m-${i}`, `true ${i}`, ts++))
+			harness.history.push(toolResult(`m-${i}`, "", ts++))
+			if (i === 1) {
+				applyWriteTodos({ todos: [{ id: 1, content: "step one", status: "in_progress" }] }, SESSION_ID)
+			}
+			const view = await harness.requestView()
+			// The strip-only view contains no message that isn't in history:
+			// whatever pi-ai marks at the tail is a persisted session message.
+			for (const message of view) {
+				expect(harness.history).toContain(message)
+			}
+		}
+	})
+})

--- a/src/extensions/prompt-construction/context-handlers-cache-audit.test.ts
+++ b/src/extensions/prompt-construction/context-handlers-cache-audit.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Transient context-handler cache audit (replay technique).
+ *
+ * For each context handler, drives the REAL registered `context` test path
+ * over a synthesized growing session and measures, at the byte level:
+ *
+ *  1. Prefix growth: no-state-change rounds must strictly prefix-extend the
+ *     previous request body (any deviation = cache invalidation at that
+ *     position).
+ * 2. Bounded transitions: config/state flips (strip toggles, mid-history
+ *     nudges aging out, resume) must cause at most one bounded invalidation.
+ * 3. Idempotency: the same resolved history must produce the same bytes on
+ *     every round.
+ * 4. History integrity (in-place mutators): the original history objects
+ *     must not be mutated — upstream emitContext() deep-clones; our fires do
+ *     the same via structuredClone.
+ *
+ * Byte comparison runs on JSON.stringify(convertToLlm(...)) — the exact
+ * array that gets serialized into the request body (cache_control marker
+ * placement is pi-ai-fixed at sys/tools/tail, so it doesn't affect the
+ * relative stability we measure here; verified by
+ * anthropic-prefix-cache.test.ts for the full wire path).
+ */
+import type { Api, AssistantMessage, ImageContent, Model, TextContent } from "@earendil-works/pi-ai"
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { convertToLlm } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
+import hideThinkingExtension, { _resetState, _setHideThinking } from "../hide-thinking.js"
+import modelGuardExtension from "../model-guard.js"
+import {
+	brandUnmarkedSteers,
+	NUDGE_CUSTOM_TYPE,
+	stripStaleNudges,
+	stripUiOnlyMessages,
+	tagSelfEchoes,
+} from "../orchestration/continuation-nudge.js"
+import toolRenderingExtension from "../tool-rendering.js"
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+type AgentMessage = ContextEvent["messages"][number]
+type OrchestratorMessages = ContextEvent["messages"]
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>
+
+let ts = 1000
+const nextTs = () => ts++
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: nextTs() } as unknown as AgentMessage
+}
+
+function userMessageWithImage(text: string, imageTag: string): AgentMessage {
+	return {
+		role: "user",
+		content: [
+			{ type: "text", text },
+			{ type: "image", data: `b64_${imageTag}`, mimeType: "image/png" } as ImageContent,
+		],
+		timestamp: nextTs(),
+	} as unknown as AgentMessage
+}
+
+function assistantText(text: string): AgentMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-5",
+		content: [{ type: "text", text } as TextContent],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: nextTs(),
+	} as unknown as AgentMessage
+}
+
+function assistantToolCall(callId: string): AgentMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-5",
+		content: [{ type: "toolCall", id: callId, name: "bash", arguments: { command: `echo ${callId}` } }],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: nextTs(),
+	} as unknown as AgentMessage
+}
+
+function toolResult(callId: string, text: string): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId: callId,
+		toolName: "bash",
+		content: [{ type: "text", text }],
+		timestamp: nextTs(),
+	} as unknown as AgentMessage
+}
+
+function customMessage(customType: string, content: string): AgentMessage {
+	return { role: "custom", customType, content, display: false, timestamp: nextTs() } as unknown as AgentMessage
+}
+
+/** Mirrors upstream emitContext: every context fire sees a fresh deep clone. */
+function cloneForFire(messages: OrchestratorMessages): OrchestratorMessages {
+	return structuredClone(messages)
+}
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+function createPiHarness(register: (pi: ExtensionAPI) => void, ctx: ExtensionContext) {
+	const handlers = new Map<string, ExtensionHandler[]>()
+	const stubCache = new Map<string, unknown>()
+	// Auto-stub every pi member (extensions register commands, tools, shortcuts,
+	// events...) while capturing `on(...)` handler registrations for firing.
+	const pi = new Proxy({ sendMessage: vi.fn(), appendEntry: vi.fn() } as Record<string, unknown>, {
+		get(target, prop: string) {
+			if (prop === "on") {
+				return (event: string, handler: ExtensionHandler) => {
+					const list = handlers.get(event) ?? []
+					list.push(handler)
+					handlers.set(event, list)
+				}
+			}
+			if (prop in target) return target[prop]
+			if (!stubCache.has(prop)) stubCache.set(prop, vi.fn())
+			return stubCache.get(prop)
+		},
+	}) as unknown as ExtensionAPI
+	register(pi)
+
+	async function fire(event: string, payload: unknown): Promise<unknown> {
+		let result: unknown
+		let currentPayload = payload
+		for (const handler of handlers.get(event) ?? []) {
+			result = await handler(currentPayload, ctx)
+			const contextResult = result as { messages?: OrchestratorMessages } | undefined
+			if (event === "context" && contextResult?.messages) {
+				currentPayload = { ...(currentPayload as object), messages: contextResult.messages }
+			}
+		}
+		return result
+	}
+
+	/** The model-visible view for the next LLM call: every registered context
+	 *  handler runs over a fresh deep clone; both `{messages}` returns AND
+	 *  in-place mutations of the payload get carried through (this is exactly
+	 *  upstream's emitContext semantics). */
+	async function contextView(history: OrchestratorMessages): Promise<OrchestratorMessages> {
+		const list = handlers.get("context") ?? []
+		const payload: { type: string; messages: OrchestratorMessages } = {
+			type: "context",
+			messages: cloneForFire(history),
+		}
+		for (const handler of list) {
+			const result = (await handler(payload, ctx)) as { messages?: OrchestratorMessages } | undefined
+			if (result?.messages) payload.messages = result.messages
+		}
+		return payload.messages
+	}
+
+	return { pi, fire, contextView }
+}
+
+// ─── Metrics ─────────────────────────────────────────────────────────────────
+
+/** Converted-request byte string (with cache_control-free content). */
+function bodyBytes(messages: OrchestratorMessages): string {
+	return JSON.stringify(convertToLlm(structuredClone(messages)))
+}
+
+interface RoundMetrics {
+	/** True when this round's body strictly contains the previous round's body as a byte prefix. */
+	containsPrior: boolean
+	/** -1 when identical, else first differing byte index. */
+	firstDivergence: number
+	bodyLength: number
+}
+
+async function measureRounds(
+	historySteps: Array<AgentMessage[]>,
+	pipeline: (history: OrchestratorMessages) => Promise<OrchestratorMessages>,
+): Promise<{ metrics: RoundMetrics[]; bodies: string[] }> {
+	const bodies: string[] = []
+	const metrics: RoundMetrics[] = []
+	let prev = ""
+	for (const history of historySteps) {
+		const body = bodyBytes(await pipeline(history as OrchestratorMessages))
+		if (prev === "") {
+			metrics.push({ containsPrior: false, firstDivergence: -1, bodyLength: body.length })
+		} else {
+			let div = -1
+			if (body !== prev) {
+				const n = Math.min(body.length, prev.length)
+				for (let i = 0; i < n; i++) {
+					if (body[i] !== prev[i]) {
+						div = i
+						break
+					}
+				}
+				if (div === -1 && body.length < prev.length) div = body.length
+			}
+			// JSON arrays are closed strings: the extended body's byte-prefix
+			// relation holds against prev-minus-its-closing-']', not the full
+			// prev (this is exactly how the simulateCache prefix containment in
+			// anthropic-prefix-cache.test.ts works).
+			const prevCore = prev.endsWith("]") ? prev.slice(0, -1) : prev
+			metrics.push({
+				containsPrior: body.startsWith(prevCore) && body.length > prev.length,
+				firstDivergence: div,
+				bodyLength: body.length,
+			})
+		}
+		bodies.push(body)
+		prev = body
+	}
+	return { metrics, bodies }
+}
+
+/** Sequential history snapshots: each round appends the next fixed chunk. */
+function growHistory(seed: AgentMessage[], rounds: AgentMessage[][]): AgentMessage[][] {
+	const steps: AgentMessage[][] = []
+	let current = [...seed]
+	for (const chunk of rounds) {
+		current = [...current, ...chunk]
+		steps.push([...current])
+	}
+	return steps
+}
+
+const growth = (i: number): AgentMessage[] => [assistantToolCall(`c-${i}`), toolResult(`c-${i}`, `out-${i}`)]
+
+// ─── model-guard ─────────────────────────────────────────────────────────────
+
+function modelGuardCtx(model: Partial<Model<Api>>): ExtensionContext {
+	return createContext({
+		model: { id: "claude-sonnet-5", name: "claude-sonnet-5", ...model },
+	})
+}
+
+describe("audit: model-guard context handler", () => {
+	it("steady state (vision model, no images): never modifies — strict prefix growth", async () => {
+		const ctx = modelGuardCtx({ input: ["text", "image"], contextWindow: 200_000 })
+		const harness = createPiHarness(modelGuardExtension, ctx)
+		const { metrics } = await measureRounds(
+			growHistory([userMessage("u1")], [growth(1), growth(2), growth(3)]),
+			harness.contextView,
+		)
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+	})
+
+	it("non-vision model with an image in history: deterministic strip; stable across rounds", async () => {
+		const ctx = modelGuardCtx({ input: ["text"], contextWindow: 200_000 })
+		const harness = createPiHarness(modelGuardExtension, ctx)
+		const seed = [userMessageWithImage("look", "picA"), assistantText("ok")]
+		const steps = growHistory(seed, [growth(1), growth(2)])
+		const { metrics, bodies } = await measureRounds(steps, harness.contextView)
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+		// The strip actually happened (placeholder replaces the image bytes).
+		expect(bodies[1]).toContain("[image removed:")
+		expect(bodies[1]).not.toContain("b64_picA")
+	})
+
+	it("emergency truncation regime (oversized context): per-round invalidation — documented emergency path", async () => {
+		const ctx = modelGuardCtx({ input: ["text"], contextWindow: 120 })
+		const harness = createPiHarness(modelGuardExtension, ctx)
+		// Each message ≈ 600 chars ≈ 150 estimated tokens → the estimate always
+		// exceeds the 120-token window, keeping the emergency truncate path hot.
+		const long = (s: string) => s.repeat(600)
+		const steps = growHistory(
+			[userMessage(long("u"))],
+			[[assistantText(long("a"))], [assistantText(long("b"))], [assistantText(long("c"))]],
+		)
+		const { metrics, bodies } = await measureRounds(steps, harness.contextView)
+		// Sanity: the truncate path is genuinely engaged (notice emitted).
+		expect(bodies.at(-1)).toContain("Context truncated")
+		// In this regime EVERY round rewrites from a fresh cutoff → prefix is
+		// not preserved (cache is unfixable while oversized; compaction owns growth).
+		const breaks = metrics.slice(1).filter((m) => !m.containsPrior).length
+		expect(breaks).toBeGreaterThan(0)
+	})
+})
+
+// ─── prompt-enrichment strips ────────────────────────────────────────────────
+
+/** The orchestrator chain as registered for claude targets (no kimi branch). */
+async function stripChain(history: OrchestratorMessages): Promise<OrchestratorMessages> {
+	let messages = stripStaleNudges(cloneForFire(history))
+	messages = stripUiOnlyMessages(messages)
+	messages = tagSelfEchoes(messages)
+	messages = brandUnmarkedSteers(messages)
+	return messages
+}
+
+describe("audit: prompt-enrichment strips (orchestrator chain)", () => {
+	it("empty-turn nudge aging out: exactly one bounded tail-adjacent invalidation, then stable growth", async () => {
+		const nudge = customMessage(NUDGE_CUSTOM_TYPE, "nudge text")
+		// R1 ends with the nudge still tail. R2 appends an assistant reply →
+		// nudge becomes stale and is stripped → bounded invalidation AT the
+		// nudge position (tail-adjacent). R3+ resume strict growth.
+		// Shared object references across steps: persisted history entries are
+		// the SAME objects (fixed timestamps) in every round — building fresh
+		// per-step fixtures would model a history that doesn't exist.
+		const s0 = userMessage("u1")
+		const a1 = assistantToolCall("a1")
+		const r1 = toolResult("a1", "ok")
+		const a2 = assistantToolCall("a2")
+		const r2 = toolResult("a2", "ok")
+		const steps = [
+			[s0, nudge],
+			[s0, nudge, a1, r1],
+			[s0, nudge, a1, r1, a2, r2],
+		]
+		const { metrics, bodies } = await measureRounds(steps, stripChain)
+		expect(metrics[1]?.containsPrior).toBe(false) // nudge aged out → one invalidation
+		expect(metrics[2]?.containsPrior).toBe(true) // growth resumed
+		// The divergence lands at the nudge's own position in the R1 body —
+		// i.e. bounded, tail-adjacent, not a full-context rewrite: the shared
+		// user-turn prefix survives intact.
+		const div = metrics[1]?.firstDivergence ?? -1
+		// convertToLlm folds custom → user role (customType is not in the wire
+		// body), so locate the nudge by its content text
+		const nudgePos = (bodies[0] ?? "").indexOf("nudge text")
+		expect(div).toBeGreaterThan(0)
+		expect(div).toBeLessThanOrEqual(nudgePos)
+		expect(bodies[1]).not.toContain("nudge text")
+	})
+
+	it("ui-only customs + unmarked steer: deterministic transforms; strict growth across rounds", async () => {
+		const steps = growHistory(
+			[userMessage("u1"), customMessage("ferment_breadcrumb", "crumb"), customMessage("plain-steer", "unbranded")],
+			[growth(1), growth(2), growth(3)],
+		)
+		const { metrics, bodies } = await measureRounds(steps, stripChain)
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+		expect(bodies[0]).not.toContain("crumb") // ui-only stripped
+		expect(bodies[0]).toContain("<system-reminder>") // unmarked steer branded
+	})
+
+	it("self-echo tagging: deterministic across rounds (no per-round volatility)", async () => {
+		const echo = "Identify yourself briefly."
+		const steps = growHistory([assistantText(echo), userMessage(echo)], [growth(1), growth(2)])
+		const { metrics, bodies } = await measureRounds(steps, stripChain)
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+		expect(bodies[1]).toContain("verbatim echo")
+	})
+})
+
+// ─── hide-thinking ───────────────────────────────────────────────────────────
+
+function thinkMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-5",
+		content: [{ type: "text", text: `intro <think>${text}</think> outro` }],
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: nextTs(),
+	} as unknown as AssistantMessage
+}
+
+describe("audit: hide-thinking restore path", () => {
+	it("same-session (shadow map intact): restored originals → strict prefix growth", async () => {
+		_resetState()
+		_setHideThinking(true)
+		const ctx = createContext({ hasUI: true })
+		const harness = createPiHarness(hideThinkingExtension, ctx)
+
+		const persisted = (await harness.fire("message_end", { message: thinkMessage("plan A") })) as
+			| { message: AssistantMessage }
+			| undefined
+		const historyEntry = persisted?.message as unknown as AgentMessage
+		expect(JSON.stringify(historyEntry)).not.toContain("plan A") // display text persisted
+
+		const steps = growHistory([userMessage("u1"), historyEntry], [growth(1), growth(2)])
+		const { metrics, bodies } = await measureRounds(steps, harness.contextView)
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+		expect(bodies[1]).toContain("plan A") // original restored on the wire
+	})
+
+	it("resumed process (shadow map empty): thinking is NOT restored → one resume-boundary invalidation; hide=false leaves ANSI in LLM context", async () => {
+		_resetState()
+		_setHideThinking(true)
+		const ctx = createContext({ hasUI: true })
+		const harness = createPiHarness(hideThinkingExtension, ctx)
+		const persisted = (await harness.fire("message_end", { message: thinkMessage("plan B") })) as
+			| { message: AssistantMessage }
+			| undefined
+		const historyEntry = persisted?.message as unknown as AgentMessage
+
+		// Emulate a process restart: shadow map is in-memory only.
+		_resetState()
+		_setHideThinking(true)
+
+		const steps = growHistory([userMessage("u1"), historyEntry], [growth(1), growth(2)])
+		const { metrics, bodies } = await measureRounds(steps, harness.contextView)
+		// No restore after restart → the wire keeps the stripped display text.
+		expect(bodies[1]).not.toContain("plan B")
+		// Still stable across rounds (deterministic lossy view).
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+
+		// dim-mode (hideThinking=false) persists ANSI-escaped display text.
+		_resetState()
+		_setHideThinking(false)
+		const persistedDim = (await harness.fire("message_end", { message: thinkMessage("plan C") })) as
+			| { message: AssistantMessage }
+			| undefined
+		_resetState()
+		_setHideThinking(false)
+		const dimBodies = (
+			await measureRounds(
+				growHistory([persistedDim?.message as unknown as AgentMessage], [growth(1)]),
+				harness.contextView,
+			)
+		).bodies
+		expect(dimBodies[0]).toContain("\\u001b[") // ANSI codes leak to the model after restart
+	})
+})
+
+// ─── tool-rendering ──────────────────────────────────────────────────────────
+
+describe("audit: tool-rendering in-place context mutation", () => {
+	it("thinking artifacts + legacy duration lines: idempotent stable view; history objects untouched", async () => {
+		const ctx = createContext({ hasUI: true })
+		const harness = createPiHarness(toolRenderingExtension, ctx)
+
+		const dirtyThinking: AgentMessage = {
+			role: "assistant",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-5",
+			content: [
+				{ type: "thinking", thinking: "\x1b[2mthinking: hidden work\x1b[0m", thinkingSignature: "" },
+				{ type: "text", text: "done\n\n\x1b[38;5;8m✻ Worked for 12s\x1b[0m" },
+			],
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: nextTs(),
+		} as unknown as AgentMessage
+		const beforeHistory = JSON.stringify(dirtyThinking)
+
+		const history: AgentMessage[] = [userMessage("u1"), dirtyThinking]
+		const steps = growHistory(history, [growth(1), growth(2)])
+		const { metrics, bodies } = await measureRounds(steps, harness.contextView)
+
+		// Stable, byte-reproducible transformed view every round.
+		expect(metrics.slice(1).every((m) => m.containsPrior)).toBe(true)
+		expect(bodies[1]).not.toContain("\\u001b[2mthinking:")
+		// In-place mutation is confined to the context clone: history intact.
+		expect(JSON.stringify(dirtyThinking)).toBe(beforeHistory)
+	})
+})

--- a/src/extensions/prompt-construction/prompt-enrichment.ts
+++ b/src/extensions/prompt-construction/prompt-enrichment.ts
@@ -35,7 +35,7 @@ import { getAvailableModels } from "../../startup-context.js"
 import { getGitBranch } from "../../utils.js"
 import { isAgentWorker } from "../agent-worker-context.js"
 import { getConfiguredSkillResourcePaths } from "../claude-code-skills/definition.js"
-import { bumpStallCounter } from "../ferment/todo-sync.js"
+import { bumpStallCounter, fireStepStallSteerIfStalled } from "../ferment/todo-sync.js"
 import { getProcessOrchestratorRef, setProcessOrchestratorRef } from "../kimchi-process.js"
 import { getMultiModelEnabled, setAndPersistMultiModelEnabled } from "../multi-model.js"
 import {
@@ -387,6 +387,7 @@ export default function (skillPathsFromConfig: string[]) {
 				// block can detect when the orchestrator hasn't updated step todos.
 				// Scoped to this session so concurrent sessions do not share a counter.
 				bumpStallCounter(sessionId)
+				fireStepStallSteerIfStalled(pi, sessionId)
 
 				// Mark each delegation tool call so the continuation nudge stays
 				// suppressed until all delegated-agent results have been received.

--- a/src/extensions/prompt-construction/system-prompt-stability.contract.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.contract.test.ts
@@ -250,10 +250,14 @@ describe("system-prompt block cache contract (source)", () => {
 		const todosIndex = readSource("src/extensions/todos/index.ts")
 
 		// Persist-on-change: state blocks are written to session history via
-		// sendMessage, so they join the growing stable prefix.
-		expect(contextState).toContain("pi.sendMessage")
+		// sendMessage, so they join the growing stable prefix. The machinery is
+		// shared; each registrar wires its customType + render source into it.
+		const sharedPersistence = readSource("src/extensions/state-block-persistence.ts")
+		expect(sharedPersistence).toContain("pi.sendMessage")
+		expect(sharedPersistence).toContain("isStateBlockEntry")
+		expect(contextState).toContain("registerStateBlockPersistence")
 		expect(contextState).toContain("renderTodoStateMarkdown")
-		expect(lifecycleContext).toContain("pi.sendMessage")
+		expect(lifecycleContext).toContain("registerStateBlockPersistence")
 
 		// Tail-push ban: no writes to the message array inside a context handler.
 		// The context handlers in these files are strip-only (drop superseded
@@ -263,6 +267,8 @@ describe("system-prompt block cache contract (source)", () => {
 		expect(contextState).not.toContain("event.messages.push")
 		expect(lifecycleContext).not.toContain("messages.push")
 		expect(lifecycleContext).not.toContain("event.messages.push")
+		expect(sharedPersistence).not.toContain("messages.push")
+		expect(sharedPersistence).not.toContain("event.messages.push")
 
 		// The todos index wires persistence, not transient injection.
 		expect(todosIndex).toContain("registerTodoStatePersistence(pi)")

--- a/src/extensions/prompt-construction/system-prompt-stability.contract.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.contract.test.ts
@@ -238,21 +238,44 @@ describe("system-prompt block cache contract (source)", () => {
 
 		expect(fermentBlock).toContain('id: "todo-guidance-ferment"')
 
-		expect(index).toContain("registerTodoContextState(pi)")
+		expect(index).toContain("registerTodoStatePersistence(pi)")
 		expect(index).toContain("registerFermentTodoPromptBlock(pi)")
 		expect(index).not.toContain("registerTodoStateBlock")
 	})
 
-	it("keeps dynamic todo state in the transient context event path only", () => {
+	it("delivers dynamic state via persist-on-change, never via tail-push", () => {
 		const contextState = readSource("src/extensions/todos/context-state.ts")
+		const lifecycleContext = readSource("src/extensions/ferment/lifecycle-context.ts")
 		const stateMarkdown = readSource("src/extensions/todos/state-markdown.ts")
+		const todosIndex = readSource("src/extensions/todos/index.ts")
 
-		expect(contextState).toContain('pi.on("context"')
-		expect(contextState).toContain("customType: TODO_STATE_CUSTOM_TYPE")
+		// Persist-on-change: state blocks are written to session history via
+		// sendMessage, so they join the growing stable prefix.
+		expect(contextState).toContain("pi.sendMessage")
 		expect(contextState).toContain("renderTodoStateMarkdown")
+		expect(lifecycleContext).toContain("pi.sendMessage")
 
-		// The volatile renderer lives outside any registrar file so the static
+		// Tail-push ban: no writes to the message array inside a context handler.
+		// The context handlers in these files are strip-only (drop superseded
+		// copies of persisted blocks) — appending state blocks at the request
+		// tail permanently poisons the provider cache breakpoint.
+		expect(contextState).not.toContain("messages.push")
+		expect(contextState).not.toContain("event.messages.push")
+		expect(lifecycleContext).not.toContain("messages.push")
+		expect(lifecycleContext).not.toContain("event.messages.push")
+
+		// The todos index wires persistence, not transient injection.
+		expect(todosIndex).toContain("registerTodoStatePersistence(pi)")
+		expect(todosIndex).not.toContain("registerTodoContextState")
+
+		// The renderer lives outside any registrar file so the static
 		// import guard above can be strict (zero allowlisted exceptions).
 		expect(stateMarkdown).toContain("renderTodoStateMarkdown")
+
+		// The persisted block is a pure function of the store: no volatile
+		// staleness counters, no wall-clock.
+		expect(stateMarkdown).not.toContain("getToolCallsSinceTodoWrite")
+		expect(stateMarkdown).not.toContain("getTurnsSinceStepTodoWrite")
+		expect(stateMarkdown).not.toContain("Date.now(")
 	})
 })

--- a/src/extensions/prompt-construction/system-prompt-stability.test.ts
+++ b/src/extensions/prompt-construction/system-prompt-stability.test.ts
@@ -32,6 +32,20 @@ type ContextResult = { messages?: Array<{ content?: unknown }> } | undefined
 
 type SendMessageCall = { message: unknown; options?: { deliverAs?: string } }
 
+interface MessageLike {
+	role?: string
+	customType?: string
+	content?: unknown
+}
+
+/** Custom types whose persisted history entries are multi-copy suppressed by
+ *  the deterministic context-view strip (keep newest only). */
+const SUPPRESSED_STATE_TYPES = new Set(["todo-state", "ferment-lifecycle"])
+
+function nonStateMessages(view: MessageLike[]): MessageLike[] {
+	return view.filter((m) => !SUPPRESSED_STATE_TYPES.has(String(m.customType)))
+}
+
 const SESSION_ID = "system-prompt-stability-session"
 
 const testEnv: EnvironmentInfo = {
@@ -97,9 +111,14 @@ interface TestHarness {
 	fire(event: string, payload: unknown): Promise<unknown>
 	registerPlanningBlock(): void
 	buildFinalSystemPrompt(): Promise<string>
+	buildContextView(): Promise<MessageLike[]>
 	buildContextText(): Promise<string>
 	buildModelVisiblePrefix(): Promise<string>
 	getSentMessages(): SendMessageCall[]
+	/** Messages persisted so far, in append order (mirrors the session manager's
+	 *  append of custom messages sent via pi.sendMessage). */
+	getHistory(): readonly MessageLike[]
+	appendHistory(...messages: MessageLike[]): void
 }
 
 function createHarness(surface: WorkflowSurface): TestHarness {
@@ -109,6 +128,11 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 
 	const runtime = createDefaultFermentRuntime()
 
+	// Messages sent via pi.sendMessage persist into session history in
+	// production (custom_message entries); the harness mirrors that append so
+	// the strip-only context handlers operate over the same growing stream.
+	const history: MessageLike[] = []
+
 	const pi = {
 		events: createEventBus(),
 		registerTool: vi.fn(),
@@ -116,7 +140,9 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		registerShortcut: vi.fn(),
 		registerMessageRenderer: vi.fn(),
 		appendEntry: vi.fn(),
-		sendMessage: vi.fn(),
+		sendMessage: vi.fn((message: MessageLike) => {
+			history.push({ role: "custom", ...message })
+		}),
 		sendUserMessage: vi.fn(),
 		getActiveTools: vi.fn(() => []),
 		getAllTools: vi.fn(() => []),
@@ -161,7 +187,10 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 				currentPayload = { type: "context", messages: contextResult.messages }
 			}
 		}
-		return result
+		// For context events the effective request view is the final chained
+		// payload — a handler returning undefined means "no change", not
+		// "empty view".
+		return event === "context" ? currentPayload : result
 	}
 
 	async function buildFinalSystemPrompt(): Promise<string> {
@@ -187,9 +216,13 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		return prompt
 	}
 
+	async function buildContextView(): Promise<MessageLike[]> {
+		const result = (await fire("context", { type: "context", messages: [...history] })) as ContextResult
+		return (result?.messages ?? []) as MessageLike[]
+	}
+
 	async function buildContextText(): Promise<string> {
-		const result = (await fire("context", { type: "context", messages: [] })) as ContextResult
-		return extractTodoContextText(result)
+		return extractTodoContextText({ messages: await buildContextView() })
 	}
 
 	/* The provider's cache key is the model-visible prefix of the whole
@@ -199,8 +232,7 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 	 * sees, so excluding them is correctness-preserving, not a codified
 	 * carve-out. */
 	async function buildModelVisiblePrefix(): Promise<string> {
-		const result = (await fire("context", { type: "context", messages: [] })) as ContextResult
-		const messages = (result?.messages ?? []).map((message) => {
+		const messages = (await buildContextView()).map((message) => {
 			const projected = message as { role?: string; customType?: string; content?: unknown }
 			return { role: projected.role, customType: projected.customType, content: projected.content }
 		})
@@ -220,9 +252,14 @@ function createHarness(surface: WorkflowSurface): TestHarness {
 		fire,
 		registerPlanningBlock,
 		buildFinalSystemPrompt,
+		buildContextView,
 		buildContextText,
 		buildModelVisiblePrefix,
 		getSentMessages,
+		getHistory: () => history,
+		appendHistory: (...messages: MessageLike[]) => {
+			history.push(...messages)
+		},
 	}
 }
 
@@ -256,39 +293,38 @@ describe("system prompt stability contract", () => {
 
 				it("keeps the assembled system prompt stable when todos are added, updated, and cleared", async () => {
 					const promptBefore = await harness.buildFinalSystemPrompt()
-					const contextBefore = await harness.buildContextText()
 					expect(promptBefore).toContain("## Todos")
-					if (surface === "non-ferment") {
-						expect(contextBefore).toBe("")
-					} else {
-						expect(contextBefore).toContain("## Current lifecycle state")
+					expect(await harness.buildContextText()).not.toContain("## Current Todos")
+
+					if (surface !== "non-ferment") {
+						// Production emits phase activation before the first running-phase
+						// turn; the lifecycle block arrives via that persisted event.
+						emitFermentDomainEvent(harness.pi.events, { type: "activate_phase", phaseId: "phase-1" }, makeFerment())
+						expect(await harness.buildContextText()).toContain("## Current lifecycle state")
 					}
 
 					applyWriteTodos({ todos: [{ content: "initial task", status: "pending" }] }, SESSION_ID)
-					const promptAfterAdd = await harness.buildFinalSystemPrompt()
-					const contextAfterAdd = await harness.buildContextText()
-					expect(promptAfterAdd).toBe(promptBefore)
-					expect(contextAfterAdd).not.toBe(contextBefore)
-					expect(contextAfterAdd).toContain("initial task")
+					const afterAdd = await harness.buildContextText()
+					expect(await harness.buildFinalSystemPrompt()).toBe(promptBefore)
+					expect(afterAdd).toContain("initial task")
 
 					applyWriteTodos({ todos: [{ id: 1, content: "updated task", status: "in_progress" }] }, SESSION_ID)
-					const promptAfterUpdate = await harness.buildFinalSystemPrompt()
-					const contextAfterUpdate = await harness.buildContextText()
-					expect(promptAfterUpdate).toBe(promptBefore)
-					expect(contextAfterUpdate).not.toBe(contextAfterAdd)
-					expect(contextAfterUpdate).toContain("updated task")
+					const afterUpdate = await harness.buildContextText()
+					expect(await harness.buildFinalSystemPrompt()).toBe(promptBefore)
+					expect(afterUpdate).toContain("updated task")
+					// The superseded state block is stripped from the request view.
+					expect(afterUpdate).not.toContain("initial task")
 
 					applyWriteTodos({ todos: [] }, SESSION_ID)
-					const promptAfterClear = await harness.buildFinalSystemPrompt()
-					const contextAfterClear = await harness.buildContextText()
-					expect(promptAfterClear).toBe(promptBefore)
-					expect(contextAfterClear).toBe(contextBefore)
+					const afterClear = await harness.buildContextText()
+					expect(await harness.buildFinalSystemPrompt()).toBe(promptBefore)
+					expect(afterClear).not.toContain("updated task")
 				})
 			})
 		}
 	})
 
-	describe("context message determinism", () => {
+	describe("persisted state delivery", () => {
 		for (const surface of ["non-ferment", "ferment-interactive", "ferment-oneshot"] as WorkflowSurface[]) {
 			describe(`workflow: ${surface}`, () => {
 				let harness: TestHarness
@@ -313,12 +349,34 @@ describe("system prompt stability contract", () => {
 				})
 
 				/* Prefix caching cares about the whole request, not just the system
-				 * prompt. The transient `context` message is the other channel that
-				 * volatile state flows through, so it must be *deterministic*: the
-				 * same state must render the same bytes on every call, and restoring
-				 * a prior state must restore the exact prior bytes. */
+				 * prompt. Todo/ferment state now flows through *persisted* custom
+				 * messages (one per actual change), never through transient pushes
+				 * inside the context event. The request view must be a deterministic
+				 * function of persisted history: identical renders for identical
+				 * history, and identical block bytes when the store returns to prior
+				 * contents. */
 
-				it("renders byte-identical context for identical state", async () => {
+				it("delivers state via persisted messages, never via the context event itself", async () => {
+					// Nothing in history → the context event appends nothing.
+					expect(await harness.buildContextView()).toEqual([])
+
+					applyWriteTodos({ todos: [{ content: "determinism task", status: "pending" }] }, SESSION_ID)
+
+					const stateCalls = harness
+						.getSentMessages()
+						.filter((call) => (call.message as { customType?: string }).customType === "todo-state")
+					expect(stateCalls).toHaveLength(1)
+					expect(stateCalls[0]?.options?.deliverAs).toBe("steer")
+					expect((stateCalls[0]?.message as { display?: boolean }).display).toBe(false)
+
+					// The persisted block appears in the next request's view exactly
+					// because it is part of history — not because a handler appended it.
+					const view = await harness.buildContextView()
+					expect(view).toHaveLength(1)
+					expect(String(view[0]?.content)).toContain("determinism task")
+				})
+
+				it("renders a byte-identical view across consecutive renders with no state change", async () => {
 					applyWriteTodos({ todos: [{ content: "determinism task", status: "pending" }] }, SESSION_ID)
 
 					const first = await harness.buildContextText()
@@ -328,31 +386,25 @@ describe("system prompt stability contract", () => {
 					expect(second).toBe(first)
 				})
 
-				it("restores byte-identical context when todos are cleared back to baseline", async () => {
-					const baseline = await harness.buildContextText()
-
-					applyWriteTodos({ todos: [{ content: "clear task", status: "pending" }] }, SESSION_ID)
-					expect(await harness.buildContextText()).not.toBe(baseline)
-
-					applyWriteTodos({ todos: [] }, SESSION_ID)
-					expect(await harness.buildContextText()).toBe(baseline)
-				})
-
-				it("restores byte-identical context when a mutated list is restored to its prior contents", async () => {
+				it("re-renders identical block bytes when the store returns to prior contents", async () => {
 					applyWriteTodos({ todos: [{ id: 1, content: "restore task", status: "pending" }] }, SESSION_ID)
-					const baseline = await harness.buildContextText()
-
 					applyWriteTodos({ todos: [{ id: 1, content: "restore task mutated", status: "in_progress" }] }, SESSION_ID)
-					expect(await harness.buildContextText()).not.toBe(baseline)
-
 					applyWriteTodos({ todos: [{ id: 1, content: "restore task", status: "pending" }] }, SESSION_ID)
-					expect(await harness.buildContextText()).toBe(baseline)
+
+					const blocks = harness
+						.getSentMessages()
+						.map((call) => call.message as { customType?: string; content?: string })
+						.filter((message) => message.customType === "todo-state")
+					expect(blocks).toHaveLength(3)
+					// Persist-on-change purity: returning to the prior store contents
+					// persists byte-identical block content.
+					expect(blocks[2]?.content).toBe(blocks[0]?.content)
 				})
 			})
 		}
 	})
 
-	describe("multi-turn request prefix identity", () => {
+	describe("request-level prefix containment", () => {
 		for (const surface of ["non-ferment", "ferment-interactive", "ferment-oneshot"] as WorkflowSurface[]) {
 			describe(`workflow: ${surface}`, () => {
 				let harness: TestHarness
@@ -376,31 +428,64 @@ describe("system prompt stability contract", () => {
 					__resetTodoStore()
 				})
 
-				/* A later turn in the same session reuses the provider's cached
-				 * prefix only if the whole model-visible prefix (system prompt +
-				 * transient context messages) is byte-identical. Restoring volatile
-				 * state must restore that combined prefix — this is the integration
-				 * guarantee that the per-channel suites prove separately. */
+				/* The provider's cache can only hit when each request's message list
+				 * is a strict prefix-extension of the previous request. With state
+				 * persisted into history, a real state change causes one bounded
+				 * invalidation (the superseded block is stripped, the new block is
+				 * appended); everything else must remain a growing prefix. This is
+				 * the property the old transient tail-push permanently violated. */
 
-				it("restores the full model-visible prefix when todo state returns to a prior snapshot", async () => {
-					applyWriteTodos({ todos: [{ id: 1, content: "prefix task", status: "pending" }] }, SESSION_ID)
-					const baseline = await harness.buildModelVisiblePrefix()
+				it("each request view prefix-extends the previous, modulo superseded state blocks", async () => {
+					const u1: MessageLike = { role: "user", content: "u1" }
+					const asst: MessageLike = { role: "assistant", content: "a1" }
+					const toolResult: MessageLike = { role: "toolResult", content: "t1" }
+					const u2: MessageLike = { role: "user", content: "u2" }
 
-					applyWriteTodos(
-						{
-							todos: [
-								{ id: 1, content: "prefix task", status: "completed" },
-								{ id: 2, content: "second task", status: "pending", note: "note" },
-							],
-						},
-						SESSION_ID,
-					)
-					const mutated = await harness.buildModelVisiblePrefix()
-					expect(mutated).not.toBe(baseline)
+					harness.appendHistory(u1)
+					const view1 = await harness.buildContextView()
 
-					applyWriteTodos({ todos: [{ id: 1, content: "prefix task", status: "pending" }] }, SESSION_ID)
-					const restored = await harness.buildModelVisiblePrefix()
-					expect(restored).toBe(baseline)
+					applyWriteTodos({ todos: [{ content: "prefix task", status: "pending" }] }, SESSION_ID)
+					const view2 = await harness.buildContextView()
+
+					harness.appendHistory(asst, toolResult)
+					const view3 = await harness.buildContextView()
+
+					// Mid-sequence todo write: the superseded block is stripped, the
+					// new block is appended — exactly one bounded invalidation.
+					applyWriteTodos({ todos: [{ id: 1, content: "prefix task", status: "completed" }] }, SESSION_ID)
+					harness.appendHistory(u2)
+					const view4 = await harness.buildContextView()
+
+					// Non-state messages form a growing prefix chain.
+					const views = [view1, view2, view3, view4]
+					for (let i = 1; i < views.length; i++) {
+						const prev = nonStateMessages(views[i - 1] ?? [])
+						const curr = nonStateMessages(views[i] ?? [])
+						expect(curr.length).toBeGreaterThanOrEqual(prev.length)
+						expect(curr.slice(0, prev.length)).toEqual(prev)
+					}
+
+					// At most one persisted block per state type in every view — the
+					// deterministic strip keeps the view stable between writes.
+					for (const view of views) {
+						expect(view.filter((m) => m.customType === "todo-state")).toHaveLength(
+							view.some((m) => m.customType === "todo-state") ? 1 : 0,
+						)
+					}
+
+					// Every message in every request view is a persisted history
+					// entry: nothing is injected transiently, so the tail breakpoint
+					// candidate (last message) is always real history.
+					for (const view of views) {
+						for (const message of view) {
+							expect(harness.getHistory()).toContain(message)
+						}
+					}
+
+					// The newest state is visible; the superseded one is not.
+					const text4 = view4.map((m) => String(m.content)).join("\n")
+					expect(text4).toContain("✓ prefix task")
+					expect(text4).not.toContain("○ prefix task")
 				})
 
 				it("keeps the full prefix byte-identical across consecutive turns with no state change", async () => {
@@ -458,6 +543,14 @@ describe("system prompt stability contract", () => {
 					expect(contextBefore).toContain("## Current Todos")
 					expect(contextBefore).toContain("## Current lifecycle state")
 					expect(contextBefore).toContain("write parser")
+
+					// State blocks must have arrived via persistence, not context pushes.
+					expect(
+						harness
+							.getSentMessages()
+							.map((call) => (call.message as { customType?: string }).customType)
+							.filter((type) => type === "todo-state" || type === "ferment-lifecycle"),
+					).not.toHaveLength(0)
 
 					const completedStepFerment: Ferment = {
 						...ferment,

--- a/src/extensions/state-block-persistence.test.ts
+++ b/src/extensions/state-block-persistence.test.ts
@@ -1,0 +1,217 @@
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
+import { describe, expect, it, vi } from "vitest"
+import { createContext } from "./__mocks__/context.js"
+import { registerStateBlockPersistence } from "./state-block-persistence.js"
+
+const CUSTOM_TYPE = "test-state"
+const RETRACTION = "## State cleared"
+const TEST_SESSION_ID = "test-session"
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>
+
+function stateEntry(content: string): Record<string, unknown> {
+	return { type: "custom_message", customType: CUSTOM_TYPE, content, id: "e1", parentId: null, timestamp: "" }
+}
+
+function abortedAssistantEntry(): Record<string, unknown> {
+	return { type: "message", message: { role: "assistant", content: [], stopReason: "aborted" } }
+}
+
+function userEntry(): Record<string, unknown> {
+	return { type: "message", message: { role: "user", content: [{ type: "text", text: "hi" }] } }
+}
+
+interface HarnessOptions {
+	initialBranch?: Record<string, unknown>[]
+}
+
+/** Registrar harness: a mutable in-memory store whose render mirrors the
+ *  wrappers' semantics (empty store + previous ⇒ retraction), a branch the
+ *  test can mutate to model compaction cuts, and a notify captured from
+ *  `subscribe` so tests drive change signals directly. */
+function createHarness(options: HarnessOptions = {}) {
+	let store: string | undefined
+	let branch: Record<string, unknown>[] = options.initialBranch ?? []
+	const handlers = new Map<string, ExtensionHandler[]>()
+	let notify: ((key?: string) => void) | undefined
+
+	const pi = {
+		sendMessage: vi.fn(),
+		on: vi.fn((event: string, handler: ExtensionHandler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		}),
+	} as unknown as ExtensionAPI
+
+	const ctx = createContext({
+		sessionManager: {
+			getSessionId: () => TEST_SESSION_ID,
+			getBranch: () => branch as unknown as SessionEntry[],
+		},
+	})
+
+	registerStateBlockPersistence(pi, {
+		customType: CUSTOM_TYPE,
+		render: (_key, previous) =>
+			store !== undefined ? `## State\n${store}` : previous !== undefined ? RETRACTION : undefined,
+		subscribe: (n) => {
+			notify = n
+		},
+	})
+
+	async function fire(event: string, payload: unknown = {}): Promise<unknown> {
+		let result: unknown
+		for (const handler of handlers.get(event) ?? []) {
+			result = await handler(payload, ctx)
+		}
+		return result
+	}
+
+	function persisted(): string[] {
+		return vi
+			.mocked(pi.sendMessage)
+			.mock.calls.map(([m]) => (m as { content?: unknown }).content)
+			.filter((c): c is string => typeof c === "string")
+	}
+
+	return {
+		fire,
+		notify: () => {
+			if (!notify) throw new Error("subscribe not wired")
+			notify()
+		},
+		setStore: (value: string | undefined) => {
+			store = value
+		},
+		setBranch: (entries: Record<string, unknown>[]) => {
+			branch = entries
+		},
+		persisted,
+	}
+}
+
+async function startSession(h: ReturnType<typeof createHarness>): Promise<void> {
+	await h.fire("session_start", { reason: "new" })
+}
+
+describe("registerStateBlockPersistence — compaction re-emit", () => {
+	it("re-persists the same bytes at the next settle after compaction cut the newest copy", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		expect(h.persisted()).toEqual(["## State\nitem A"])
+
+		// Compaction summarizes the block: entry leaves the branch.
+		h.setBranch([])
+		await h.fire("session_compact", { reason: "threshold" })
+		expect(h.persisted()).toHaveLength(1) // no mid-run send
+
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toEqual(["## State\nitem A", "## State\nitem A"])
+	})
+
+	it("does nothing when the newest copy survived compaction", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		h.setBranch([stateEntry("## State\nitem A")])
+		await h.fire("session_compact", { reason: "manual" })
+
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(1)
+	})
+
+	it("marks nothing when there was never persisted state", async () => {
+		const h = createHarness()
+		await startSession(h)
+		await h.fire("session_compact", { reason: "threshold" })
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(0)
+	})
+
+	it("re-persists the retraction after compaction cut the cleared marker", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		h.setStore(undefined)
+		h.notify()
+		expect(h.persisted()).toEqual(["## State\nitem A", RETRACTION])
+
+		h.setBranch([])
+		await h.fire("session_compact", { reason: "overflow" })
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toEqual(["## State\nitem A", RETRACTION, RETRACTION])
+	})
+
+	it("defers past an aborted settle and re-emits at the next healthy settle", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		h.setBranch([])
+		await h.fire("session_compact", { reason: "threshold" })
+
+		// Aborted run (e.g. /compact mid-stream): flush must skip.
+		h.setBranch([abortedAssistantEntry()])
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(1)
+
+		// Next healthy settle re-emits.
+		h.setBranch([userEntry()])
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(2)
+	})
+
+	it("back-to-back compactions before a settle produce exactly one re-emit", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		h.setBranch([])
+		await h.fire("session_compact", { reason: "threshold" })
+		await h.fire("session_compact", { reason: "threshold" })
+
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(2)
+	})
+
+	it("a store change between compact and settle satisfies the re-emit (single write)", async () => {
+		const h = createHarness()
+		await startSession(h)
+		h.setStore("item A")
+		h.notify()
+		h.setBranch([])
+		await h.fire("session_compact", { reason: "threshold" })
+
+		await h.fire("agent_start")
+		h.setStore("item B")
+		h.notify() // busy → coalesced into pendingFlush
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toEqual(["## State\nitem A", "## State\nitem B"])
+
+		// And nothing extra at the following settle.
+		await h.fire("agent_start")
+		await h.fire("agent_end")
+		await h.fire("agent_settled")
+		expect(h.persisted()).toHaveLength(2)
+	})
+})

--- a/src/extensions/state-block-persistence.ts
+++ b/src/extensions/state-block-persistence.ts
@@ -59,6 +59,17 @@ function newestStateBlockContentFromHistory(ctx: ExtensionContext, customType: s
 	return undefined
 }
 
+/** True when the newest persisted copy of this customType is still present in
+ *  the branch. Post-compaction it is not (the journal entries it summarized
+ *  leave the branch), which is the sole re-emit signal. */
+function newestStateBlockSurvivesInBranch(ctx: ExtensionContext, customType: string): boolean {
+	const branch = ctx.sessionManager.getBranch()
+	for (let i = branch.length - 1; i >= 0; i--) {
+		if (isStateBlockEntry(branch[i], customType)) return true
+	}
+	return false
+}
+
 export interface StateBlockPersistenceOptions {
 	customType: string
 	/** Render the block to persist for `key` — content must be final (e.g.
@@ -111,13 +122,20 @@ export function registerStateBlockPersistence(pi: ExtensionAPI, options: StateBl
 	const lastPersisted = new Map<string, string | undefined>()
 	/** Session keys whose rendered block changed while the agent was busy. */
 	const pendingFlush = new Set<string>()
+	/** Keys whose newest persisted copy was compacted out of the branch: the
+	 *  journal entry is gone, so the next write must bypass the bytes-equality
+	 *  short-circuit (equal bytes is the desired outcome — the copy must exist). */
+	const forceReemit = new Set<string>()
 	let agentBusy = 0
 	let currentSessionKey = ""
 
-	function persistIfChanged(key: string): void {
+	/** Persist the rendered block if it changed (or `force` bypasses equality).
+	 *  Returns true when a new entry was written. */
+	function persistIfChanged(key: string, force = false): boolean {
 		const previous = lastPersisted.get(key)
 		const content = render(key, previous)
-		if (content === undefined || content === previous) return
+		if (content === undefined) return false
+		if (!force && content === previous) return false
 		lastPersisted.set(key, content)
 		pi.sendMessage(
 			{
@@ -128,6 +146,7 @@ export function registerStateBlockPersistence(pi: ExtensionAPI, options: StateBl
 			},
 			{ deliverAs: "steer" },
 		)
+		return true
 	}
 
 	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
@@ -147,15 +166,34 @@ export function registerStateBlockPersistence(pi: ExtensionAPI, options: StateBl
 		agentBusy = Math.max(0, agentBusy - 1)
 	})
 	pi.on("agent_settled", (_event, ctx) => {
-		if (agentBusy > 0 || pendingFlush.size === 0) return
+		if (agentBusy > 0) return
+		if (pendingFlush.size === 0 && forceReemit.size === 0) return
 		// Skip aborted runs: the flushed block would become the newest turn
 		// start and steal the interrupted turn's slot in a compaction cut.
 		if (latestRunTailIsAborted(ctx)) return
+		// Change-flushes first: a store change between compact and settle
+		// already re-persists the newest bytes, satisfying forceReemit.
 		const keys = [...pendingFlush]
 		pendingFlush.clear()
 		for (const key of keys) {
-			persistIfChanged(key)
+			if (persistIfChanged(key, forceReemit.has(key))) forceReemit.delete(key)
 		}
+		for (const key of [...forceReemit]) {
+			if (persistIfChanged(key, true)) forceReemit.delete(key)
+		}
+	})
+
+	// Compacted-away copies: master re-rendered state after every compacted
+	// summary by construction; persist-on-change blocks are ordinary history
+	// and eligible cuts. When the newest copy left the branch, mark the key so
+	// the next settled flush re-emits (bytes unchanged is the desired
+	// outcome). Emission stays at the settle boundary — writing here would be
+	// the mid-run send the module comment forbids.
+	pi.on("session_compact", (_event, ctx) => {
+		const key = currentSessionKey
+		if (!key || !lastPersisted.get(key)) return
+		if (newestStateBlockSurvivesInBranch(ctx, customType)) return
+		forceReemit.add(key)
 	})
 
 	subscribe((key?: string) => {
@@ -164,7 +202,7 @@ export function registerStateBlockPersistence(pi: ExtensionAPI, options: StateBl
 			pendingFlush.add(effectiveKey)
 			return
 		}
-		persistIfChanged(effectiveKey)
+		persistIfChanged(effectiveKey, forceReemit.delete(effectiveKey))
 	})
 
 	// Strip-only context pass: drop every block of this customType except the

--- a/src/extensions/state-block-persistence.ts
+++ b/src/extensions/state-block-persistence.ts
@@ -1,0 +1,188 @@
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { latestRunTailIsAborted } from "./aborted-run.js"
+
+type OrchestratorMessages = ContextEvent["messages"]
+
+/** The two shapes a persisted state block takes in this process:
+ *
+ * 1. `context` event payloads (`event.messages`): the session manager has
+ *    already converted custom blocks into the conversation view, where they
+ *    appear as `{ role: "custom", customType, content, ... }`.
+ * 2. `sessionManager.getBranch()` history entries: the append-only session
+ *    journal, where they persist as `CustomMessageEntry`
+ *    `{ type: "custom_message", customType, content, ... }` — there is NO
+ *    `role` field on entries.
+ *
+ * Keep these predicates apart: using the conversation-view predicate on
+ * history entries silently matches nothing, which dead-letters the replay
+ * dedupe (resumed sessions re-persist blocks that already exist). */
+export function isStateBlockMessage(m: unknown, customType: string): boolean {
+	return (
+		m !== null &&
+		typeof m === "object" &&
+		(m as { role?: string }).role === "custom" &&
+		(m as { customType?: string }).customType === customType
+	)
+}
+
+export function isStateBlockEntry(e: unknown, customType: string): boolean {
+	return (
+		e !== null &&
+		typeof e === "object" &&
+		(e as { type?: string }).type === "custom_message" &&
+		(e as { customType?: string }).customType === customType
+	)
+}
+
+function extractTextContent(content: unknown): string | undefined {
+	if (typeof content === "string") return content
+	if (Array.isArray(content)) {
+		for (const part of content) {
+			if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
+				const text = (part as { text?: unknown }).text
+				if (typeof text === "string") return text
+			}
+		}
+	}
+	return undefined
+}
+
+/** Replay dedupe: find the newest persisted block in session history so a
+ *  resumed session does not re-persist an identical block on its first change. */
+function newestStateBlockContentFromHistory(ctx: ExtensionContext, customType: string): string | undefined {
+	const branch = ctx.sessionManager.getBranch()
+	for (let i = branch.length - 1; i >= 0; i--) {
+		if (isStateBlockEntry(branch[i], customType)) {
+			return extractTextContent((branch[i] as { content?: unknown }).content)
+		}
+	}
+	return undefined
+}
+
+export interface StateBlockPersistenceOptions {
+	customType: string
+	/** Render the block to persist for `key` — content must be final (e.g.
+	 *  already steer-marked). `previous` is the newest persisted content for
+	 *  the key (`undefined` = nothing persisted yet). Return `undefined` to
+	 *  make this change a no-op (the retraction-marker decision belongs to
+	 *  the renderer, which receives `previous` for exactly that reason). */
+	render: (key: string, previous: string | undefined) => string | undefined
+	/** Wire change sources: call `notify(key)` whenever the rendered block
+	 *  for that session key may have changed. Keys default to the current
+	 *  session id captured at session_start/session_tree. */
+	subscribe: (notify: (key?: string) => void) => void
+	/** Optional hook on session_start/session_tree, before the history scan
+	 *  (e.g. to capture the sessionManager handle for flag lookups). */
+	onSessionEvent?: (ctx: ExtensionContext) => void
+}
+
+/**
+ * Persist-on-change delivery for hidden state blocks (`todo-state`,
+ * `ferment-lifecycle`).
+ *
+ * Replaces transient `context`-event tail-injection, which permanently
+ * poisoned the request-level cache breakpoint (every stored prefix ended at
+ * a moving block). Blocks are written into session history — hidden custom
+ * messages delivered as steers so they land at the tool boundary — exactly
+ * once per rendered-content change. The persisted entry then sits at a fixed
+ * chronological position and joins the growing stable prefix; the one real
+ * change round causes a single bounded invalidation instead of a permanent
+ * freeze.
+ *
+ * History is append-only for extensions, so superseded copies stay in the
+ * branch. The `context` handler registered here is strip-only: it drops
+ * every block of this customType except the newest, making the request view
+ * a pure function of persisted history.
+ *
+ * Timing: upstream compaction (`findCutPoint`) treats every custom message
+ * as a turn start, so a block persisted mid-turn becomes a turn boundary
+ * and compaction produces an extra split-turn prefix-summarization request.
+ * Writes are deferred while the agent is busy and flushed at `agent_settled`
+ * (not `agent_end`: at agent_end the run is still streaming, so a steered
+ * send would be queued as a pending agent steer — that disturbs compaction
+ * and trips downstream `hasPendingMessages()` gates like the Ferment V2
+ * evaluation gate). Aborted runs skip the flush: the block would become the
+ * newest turn start and steal the interrupted turn's slot in a cut.
+ */
+export function registerStateBlockPersistence(pi: ExtensionAPI, options: StateBlockPersistenceOptions): void {
+	const { customType, render, subscribe, onSessionEvent } = options
+
+	/** Newest persisted content per session key; `undefined` = nothing yet. */
+	const lastPersisted = new Map<string, string | undefined>()
+	/** Session keys whose rendered block changed while the agent was busy. */
+	const pendingFlush = new Set<string>()
+	let agentBusy = 0
+	let currentSessionKey = ""
+
+	function persistIfChanged(key: string): void {
+		const previous = lastPersisted.get(key)
+		const content = render(key, previous)
+		if (content === undefined || content === previous) return
+		lastPersisted.set(key, content)
+		pi.sendMessage(
+			{
+				customType,
+				display: false,
+				content,
+				details: { reason: "state_sync" },
+			},
+			{ deliverAs: "steer" },
+		)
+	}
+
+	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
+		onSessionEvent?.(ctx)
+		currentSessionKey = ctx.sessionManager.getSessionId()
+		lastPersisted.set(currentSessionKey, newestStateBlockContentFromHistory(ctx, customType))
+	}
+	pi.on("session_start", initFromHistory)
+	pi.on("session_tree", initFromHistory)
+
+	// While the agent is busy, coalesce all changes into one block flushed
+	// after the run — see the module comment for the compaction rationale.
+	pi.on("agent_start", () => {
+		agentBusy++
+	})
+	pi.on("agent_end", () => {
+		agentBusy = Math.max(0, agentBusy - 1)
+	})
+	pi.on("agent_settled", (_event, ctx) => {
+		if (agentBusy > 0 || pendingFlush.size === 0) return
+		// Skip aborted runs: the flushed block would become the newest turn
+		// start and steal the interrupted turn's slot in a compaction cut.
+		if (latestRunTailIsAborted(ctx)) return
+		const keys = [...pendingFlush]
+		pendingFlush.clear()
+		for (const key of keys) {
+			persistIfChanged(key)
+		}
+	})
+
+	subscribe((key?: string) => {
+		const effectiveKey = key ?? currentSessionKey
+		if (agentBusy > 0) {
+			pendingFlush.add(effectiveKey)
+			return
+		}
+		persistIfChanged(effectiveKey)
+	})
+
+	// Strip-only context pass: drop every block of this customType except the
+	// newest. Never appends — the write paths wired by `subscribe` are the
+	// only places these messages are created.
+	pi.on("context", async (event) => {
+		const messages = event.messages
+		let newestIndex = -1
+		for (let i = 0; i < messages.length; i++) {
+			if (isStateBlockMessage(messages[i], customType)) newestIndex = i
+		}
+		if (newestIndex === -1) return undefined
+		const hasSuperseded = messages.some((m, i) => i !== newestIndex && isStateBlockMessage(m, customType))
+		if (!hasSuperseded) return undefined
+
+		const stripped: OrchestratorMessages = messages.filter(
+			(m, i) => !isStateBlockMessage(m, customType) || i === newestIndex,
+		)
+		return { messages: stripped }
+	})
+}

--- a/src/extensions/todos/context-state.test.ts
+++ b/src/extensions/todos/context-state.test.ts
@@ -67,6 +67,79 @@ describe("registerTodoStatePersistence", () => {
 		__resetTodoStore()
 	})
 
+	it("defers persistence while the agent is busy and flushes once on agent_settled, not agent_end", async () => {
+		const harness = createHarness()
+		await harness.fire("session_start", { reason: "new" })
+
+		await harness.fire("agent_start", {})
+		applyWriteTodos({ todos: [{ content: "mid-turn task", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(0)
+
+		// agent_end must NOT flush: while the run is still settling upstream,
+		// a steered send would be queued as a pending agent steer, which
+		// disturbs compaction and makes hasPendingMessages()-gated handlers
+		// (e.g. the Ferment V2 evaluation gate) drop their continuations.
+		await harness.fire("agent_end", {})
+		expect(harness.stateSyncCalls()).toHaveLength(0)
+
+		// At agent_settled the run is fully inactive: plain append, no steer.
+		await harness.fire("agent_settled", {})
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+		expect(harness.stateSyncCalls()[0]?.options).toEqual({ deliverAs: "steer" })
+
+		// Busy writes coalesce into one flush per settled run.
+		await harness.fire("agent_start", {})
+		applyWriteTodos({ todos: [{ id: 1, content: "mid-turn task", status: "in_progress" }] }, SESSION_ID)
+		applyWriteTodos({ todos: [{ id: 1, content: "mid-turn task", status: "completed" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+		await harness.fire("agent_end", {})
+		await harness.fire("agent_settled", {})
+		expect(harness.stateSyncCalls()).toHaveLength(2)
+
+		// No change while busy: nothing to flush.
+		await harness.fire("agent_start", {})
+		await harness.fire("agent_end", {})
+		await harness.fire("agent_settled", {})
+		expect(harness.stateSyncCalls()).toHaveLength(2)
+	})
+
+	it("does not flush after an aborted run; the block lands at the next normal settle", async () => {
+		const abortedAssistant = {
+			type: "message",
+			id: "aborted-1",
+			parentId: null,
+			timestamp: "",
+			message: { role: "assistant", stopReason: "aborted", content: [] },
+		}
+		const normalAssistant = {
+			type: "message",
+			id: "normal-1",
+			parentId: null,
+			timestamp: "",
+			message: { role: "assistant", stopReason: "stop", content: [] },
+		}
+		const branch: MessageLike[] = []
+		const harness = createHarness(branch)
+		await harness.fire("session_start", { reason: "new" })
+
+		await harness.fire("agent_start", {})
+		applyWriteTodos({ todos: [{ content: "interrupted task", status: "pending" }] }, SESSION_ID)
+		await harness.fire("agent_end", {})
+		branch.push(abortedAssistant as MessageLike)
+		await harness.fire("agent_settled", {})
+		// Flushing now would make the block the newest turn start; under a
+		// small keep-recent budget compaction would swallow the interrupted
+		// turn into the summary instead of keeping it.
+		expect(harness.stateSyncCalls()).toHaveLength(0)
+
+		await harness.fire("agent_start", {})
+		await harness.fire("agent_end", {})
+		branch.push(normalAssistant as MessageLike)
+		await harness.fire("agent_settled", {})
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+		expect(String(harness.stateSyncCalls()[0]?.message.content)).toContain("interrupted task")
+	})
+
 	it("persists exactly one hidden state block per actual store change", async () => {
 		const harness = createHarness()
 		await harness.fire("session_start", { reason: "new" })

--- a/src/extensions/todos/context-state.test.ts
+++ b/src/extensions/todos/context-state.test.ts
@@ -1,5 +1,6 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createContext } from "../__mocks__/context.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { registerTodoStatePersistence, TODO_STATE_CUSTOM_TYPE } from "./context-state.js"
 import { __resetTodoStore, applyWriteTodos, restoreTodoStoreFromDetails } from "./store.js"
@@ -8,13 +9,29 @@ type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Pro
 
 const SESSION_ID = "context-state-test"
 
+/** Conversation-view message shape (as carried by the `context` event). */
 interface MessageLike {
 	role?: string
 	customType?: string
 	content?: unknown
 }
 
-function createHarness(branch: MessageLike[] = []) {
+/** Real session-history entry shape for a persisted hidden custom message —
+ *  the journal has NO `role` field; matching on one is the bug these
+ *  fixtures guard against. */
+function stateEntry(content: unknown): Record<string, unknown> {
+	return {
+		type: "custom_message",
+		id: `entry-${String(content)}`.slice(0, 24),
+		parentId: null,
+		timestamp: "2026-01-01T00:00:00.000Z",
+		customType: TODO_STATE_CUSTOM_TYPE,
+		content,
+		display: false,
+	}
+}
+
+function createHarness(branch: Record<string, unknown>[] = []) {
 	const handlers = new Map<string, ExtensionHandler[]>()
 	const pi = {
 		sendMessage: vi.fn(),
@@ -27,12 +44,12 @@ function createHarness(branch: MessageLike[] = []) {
 
 	registerTodoStatePersistence(pi)
 
-	const ctx = {
+	const ctx = createContext({
 		sessionManager: {
 			getSessionId: () => SESSION_ID,
-			getBranch: () => branch,
+			getBranch: () => branch as unknown as SessionEntry[],
 		},
-	} as unknown as ExtensionContext
+	})
 
 	async function fire(event: string, payload: unknown): Promise<unknown> {
 		let result: unknown
@@ -118,14 +135,14 @@ describe("registerTodoStatePersistence", () => {
 			timestamp: "",
 			message: { role: "assistant", stopReason: "stop", content: [] },
 		}
-		const branch: MessageLike[] = []
+		const branch: Record<string, unknown>[] = []
 		const harness = createHarness(branch)
 		await harness.fire("session_start", { reason: "new" })
 
 		await harness.fire("agent_start", {})
 		applyWriteTodos({ todos: [{ content: "interrupted task", status: "pending" }] }, SESSION_ID)
 		await harness.fire("agent_end", {})
-		branch.push(abortedAssistant as MessageLike)
+		branch.push(abortedAssistant)
 		await harness.fire("agent_settled", {})
 		// Flushing now would make the block the newest turn start; under a
 		// small keep-recent budget compaction would swallow the interrupted
@@ -134,7 +151,7 @@ describe("registerTodoStatePersistence", () => {
 
 		await harness.fire("agent_start", {})
 		await harness.fire("agent_end", {})
-		branch.push(normalAssistant as MessageLike)
+		branch.push(normalAssistant)
 		await harness.fire("agent_settled", {})
 		expect(harness.stateSyncCalls()).toHaveLength(1)
 		expect(String(harness.stateSyncCalls()[0]?.message.content)).toContain("interrupted task")
@@ -210,10 +227,19 @@ describe("registerTodoStatePersistence", () => {
 			(await import("./state-markdown.js")).renderTodoStateMarkdown(SESSION_ID) ?? "",
 		)
 
+		// History holds real session entries (custom_message), NOT the
+		// conversation-view shape — the old bug matched on role === "custom"
+		// and replay dedupe never fired in production.
 		const harness = createHarness([
-			{ role: "user", content: [{ type: "text", text: "hello" }] },
-			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: persistedContent, display: false },
-		] as MessageLike[])
+			{
+				type: "message",
+				id: "msg-1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				message: { role: "user", content: [{ type: "text", text: "hello" }] },
+			},
+			stateEntry(persistedContent),
+		])
 		await harness.fire("session_start", { reason: "resume" })
 
 		// The store write path replays the same content → dedupe against history.
@@ -222,9 +248,7 @@ describe("registerTodoStatePersistence", () => {
 	})
 
 	it("persists when the resumed store differs from the newest history block", async () => {
-		const harness = createHarness([
-			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: markHarnessSteer("stale block") },
-		] as MessageLike[])
+		const harness = createHarness([stateEntry(markHarnessSteer("stale block"))])
 		await harness.fire("session_start", { reason: "resume" })
 
 		applyWriteTodos({ todos: [{ content: "new task", status: "pending" }] }, SESSION_ID)

--- a/src/extensions/todos/context-state.test.ts
+++ b/src/extensions/todos/context-state.test.ts
@@ -1,0 +1,209 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { markHarnessSteer } from "../steer-marker.js"
+import { registerTodoStatePersistence, TODO_STATE_CUSTOM_TYPE } from "./context-state.js"
+import { __resetTodoStore, applyWriteTodos, restoreTodoStoreFromDetails } from "./store.js"
+
+type ExtensionHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>
+
+const SESSION_ID = "context-state-test"
+
+interface MessageLike {
+	role?: string
+	customType?: string
+	content?: unknown
+}
+
+function createHarness(branch: MessageLike[] = []) {
+	const handlers = new Map<string, ExtensionHandler[]>()
+	const pi = {
+		sendMessage: vi.fn(),
+		on: vi.fn((event: string, handler: ExtensionHandler) => {
+			const list = handlers.get(event) ?? []
+			list.push(handler)
+			handlers.set(event, list)
+		}),
+	} as unknown as ExtensionAPI
+
+	registerTodoStatePersistence(pi)
+
+	const ctx = {
+		sessionManager: {
+			getSessionId: () => SESSION_ID,
+			getBranch: () => branch,
+		},
+	} as unknown as ExtensionContext
+
+	async function fire(event: string, payload: unknown): Promise<unknown> {
+		let result: unknown
+		for (const handler of handlers.get(event) ?? []) {
+			result = await handler(payload, ctx)
+		}
+		return result
+	}
+
+	type SentMessage = MessageLike & { display?: boolean; details?: { reason?: string } }
+
+	function stateSyncCalls(): Array<{ message: SentMessage; options?: unknown }> {
+		return vi
+			.mocked(pi.sendMessage)
+			.mock.calls.map(
+				([message, options]) =>
+					({ message: message as unknown as SentMessage, options }) as {
+						message: SentMessage
+						options?: unknown
+					},
+			)
+			.filter(
+				({ message }) => message.customType === TODO_STATE_CUSTOM_TYPE && message.details?.reason === "state_sync",
+			)
+	}
+
+	return { pi, ctx, fire, stateSyncCalls }
+}
+
+describe("registerTodoStatePersistence", () => {
+	beforeEach(() => {
+		__resetTodoStore()
+	})
+
+	it("persists exactly one hidden state block per actual store change", async () => {
+		const harness = createHarness()
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos({ todos: [{ content: "first task", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+
+		const [call] = harness.stateSyncCalls()
+		expect(call?.message.role).toBeUndefined() // role is added upstream when persisting
+		expect(call?.message.display).toBe(false)
+		expect(call?.options).toEqual({ deliverAs: "steer" })
+		const content = call?.message.content as string
+		expect(content).toMatch(/^<system-reminder>\n/)
+		expect(content).toContain("## Current Todos")
+		expect(content).toContain("first task")
+
+		// Identical re-write: no additional persist.
+		applyWriteTodos({ todos: [{ id: 1, content: "first task", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+
+		// A real change persists exactly one more block.
+		applyWriteTodos({ todos: [{ id: 1, content: "first task", status: "in_progress" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(2)
+	})
+
+	it("persists nothing when the rendered block would be empty and nothing was ever persisted", async () => {
+		const harness = createHarness()
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos({ todos: [] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(0)
+	})
+
+	it("persists a retraction marker when the list is cleared after a block", async () => {
+		const harness = createHarness()
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos({ todos: [{ content: "gone soon", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+
+		// History is append-only: clearing the list must retract the visible
+		// block, otherwise the strip-only view keeps showing stale todos.
+		applyWriteTodos({ todos: [] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(2)
+		const retraction = harness.stateSyncCalls()[1]?.message.content as string
+		expect(retraction).toContain("## Current Todos")
+		expect(retraction).toContain("cleared")
+		expect(retraction).not.toContain("gone soon")
+
+		// Repeated clears dedupe against the fixed marker.
+		applyWriteTodos({ todos: [] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(2)
+	})
+
+	it("does not re-persist on resume when history already holds the current block", async () => {
+		restoreTodoStoreFromDetails(
+			[
+				{
+					schemaVersion: 1,
+					scope: { kind: "global" },
+					todos: [{ id: 1, content: "resumed task", status: "pending" }],
+					updatedAt: "2026-01-01T00:00:00.000Z",
+				},
+			],
+			SESSION_ID,
+		)
+		const persistedContent = markHarnessSteer(
+			(await import("./state-markdown.js")).renderTodoStateMarkdown(SESSION_ID) ?? "",
+		)
+
+		const harness = createHarness([
+			{ role: "user", content: [{ type: "text", text: "hello" }] },
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: persistedContent, display: false },
+		] as MessageLike[])
+		await harness.fire("session_start", { reason: "resume" })
+
+		// The store write path replays the same content → dedupe against history.
+		applyWriteTodos({ todos: [{ id: 1, content: "resumed task", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(0)
+	})
+
+	it("persists when the resumed store differs from the newest history block", async () => {
+		const harness = createHarness([
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: markHarnessSteer("stale block") },
+		] as MessageLike[])
+		await harness.fire("session_start", { reason: "resume" })
+
+		applyWriteTodos({ todos: [{ content: "new task", status: "pending" }] }, SESSION_ID)
+		expect(harness.stateSyncCalls()).toHaveLength(1)
+	})
+
+	it("context handler never appends state blocks (no tail push)", async () => {
+		const harness = createHarness()
+		await harness.fire("session_start", { reason: "new" })
+
+		applyWriteTodos({ todos: [{ content: "present task", status: "pending" }] }, SESSION_ID)
+
+		const result = (await harness.fire("context", { messages: [] })) as { messages: MessageLike[] } | undefined
+		expect(result).toBeUndefined()
+	})
+
+	it("context handler keeps only the newest persisted block", async () => {
+		const newest = markHarnessSteer("## Current Todos\n\n**Global** (0/1 done · 1 active)\n- ○ newest")
+		const messages: MessageLike[] = [
+			{ role: "user", content: "u1" },
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: markHarnessSteer("older block") },
+			{ role: "assistant", content: "asst" },
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: markHarnessSteer("middle block") },
+			{ role: "user", content: "u2" },
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: newest },
+			{ role: "user", content: "u3" },
+		]
+
+		const harness = createHarness()
+		const result = (await harness.fire("context", { messages })) as { messages: MessageLike[] }
+
+		const retained = result.messages.filter((m) => m.customType === TODO_STATE_CUSTOM_TYPE)
+		expect(retained).toHaveLength(1)
+		expect(retained[0]?.content).toBe(newest)
+		// Positions of non-state messages are preserved exactly.
+		expect(result.messages.filter((m) => m.customType !== TODO_STATE_CUSTOM_TYPE)).toEqual([
+			messages[0],
+			messages[2],
+			messages[4],
+			messages[6],
+		])
+	})
+
+	it("context handler leaves a single state block untouched", async () => {
+		const messages: MessageLike[] = [
+			{ role: "user", content: "u1" },
+			{ role: "custom", customType: TODO_STATE_CUSTOM_TYPE, content: markHarnessSteer("only block") },
+			{ role: "user", content: "u2" },
+		]
+
+		const harness = createHarness()
+		const result = (await harness.fire("context", { messages })) as unknown
+		expect(result).toBeUndefined()
+	})
+})

--- a/src/extensions/todos/context-state.ts
+++ b/src/extensions/todos/context-state.ts
@@ -1,10 +1,8 @@
-import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { latestRunTailIsAborted } from "../aborted-run.js"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { registerStateBlockPersistence } from "../state-block-persistence.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { renderTodoStateMarkdown } from "./state-markdown.js"
 import { subscribeTodoStore } from "./store.js"
-
-type OrchestratorMessages = ContextEvent["messages"]
 
 export const TODO_STATE_CUSTOM_TYPE = "todo-state"
 
@@ -12,164 +10,36 @@ export const TODO_STATE_CUSTOM_TYPE = "todo-state"
  *  already persisted. Constant, so repeated clears dedupe. */
 const TODO_CLEARED_MARKDOWN = "## Current Todos\n\nThe todo list was cleared."
 
-function isTodoStateMessage(m: unknown): boolean {
-	return (
-		m !== null &&
-		typeof m === "object" &&
-		(m as { role?: string }).role === "custom" &&
-		(m as { customType?: string }).customType === TODO_STATE_CUSTOM_TYPE
-	)
-}
-
-function extractTextContent(content: unknown): string | undefined {
-	if (typeof content === "string") return content
-	if (Array.isArray(content)) {
-		for (const part of content) {
-			if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
-				const text = (part as { text?: unknown }).text
-				if (typeof text === "string") return text
-			}
-		}
-	}
-	return undefined
+function renderForPersist(sessionId: string): string | undefined {
+	const markdown = renderTodoStateMarkdown(sessionId)
+	return markdown === undefined ? undefined : markHarnessSteer(markdown)
 }
 
 /**
- * Replay dedupe: find the newest persisted todo-state block in session
- * history so a resumed session does not re-persist an identical block.
- */
-function newestTodoStateContentFromHistory(ctx: ExtensionContext): string | undefined {
-	const branch = ctx.sessionManager.getBranch()
-	for (let i = branch.length - 1; i >= 0; i--) {
-		const m = branch[i] as { role?: string; customType?: string; content?: unknown }
-		if (isTodoStateMessage(m)) {
-			return extractTextContent(m.content)
-		}
-	}
-	return undefined
-}
-
-/**
- * Persist-on-change delivery of the todo state block.
+ * Persist-on-change delivery of the todo state block. Machinery (dedupe,
+ * busy-run deferral, settle flush, history replay dedupe, strip-only
+ * context view) lives in the shared `state-block-persistence` registrar —
+ * see its module comment for the cache-breakpoint rationale.
  *
- * Replaces the previous transient tail-injection: that old design pushed a
- * fresh `todo-state` custom message at the end of the message array inside
- * the `context` handler on every LLM request. Because the request-level
- * cache breakpoint sits on the last block of the stored prefix, every
- * cached prefix ended at a moving message — the tail cache read was
- * permanently poisoned and each request re-wrote the entire prefix.
- *
- * This registrar instead writes the rendered block into session history
- * (as a hidden custom message, delivered as a steer so it lands at the tool
- * boundary) exactly once per actual store change. The persisted entry sits
- * at a fixed chronological position, subsequent requests extend the stream
- * behind it, and it becomes part of the growing stable prefix.
- *
- * History is append-only for extensions (there is no delete API), so
- * superseded copies remain in the branch. The `context` handler registered
- * here is therefore strip-only: it deterministically drops every `todo-state`
- * message except the newest one. The resulting request view is a pure
- * function of persisted history — identical every round until the next real
- * todo write, which is the only moment a bounded prefix invalidation occurs.
- *
- * Timing: upstream compaction (`findCutPoint`) treats every custom message
- * as a turn start, so a block persisted mid-turn (steered between a tool
- * result and the next assistant message) becomes a turn boundary. That
- * turns the compaction into a split-turn compaction with an extra
- * prefix-summarization request and breaks turn accounting. Writes are
- * therefore deferred while the agent is busy: changes coalesce into a
- * single block flushed at `agent_end`, when the plain append path places it
- * after all persisted turn entries.
+ * Todo-specific bits retained here: the render source (`renderTodoStateMarkdown`,
+ * a pure function of the store), the cleared-list retraction marker
+ * (history is append-only, so a cleared list must persist a fixed marker or
+ * the strip-only view keeps showing stale todos), and the store
+ * subscription as the change source.
  */
 export function registerTodoStatePersistence(pi: ExtensionAPI): void {
-	/** Per-session newest persisted block content; `undefined` = nothing persisted yet. */
-	const lastPersistedContent = new Map<string, string | undefined>()
-	/** Sessions whose rendered block changed while the agent was busy. */
-	const pendingFlush = new Set<string>()
-	let agentBusy = 0
-
-	function persistIfChanged(sessionId: string): void {
-		const markdown = renderTodoStateMarkdown(sessionId)
-		let content = markdown === undefined ? undefined : markHarnessSteer(markdown)
-		if (content === undefined) {
-			if (lastPersistedContent.get(sessionId) === undefined) {
-				// Nothing persisted yet and nothing to show — no-op.
-				return
-			}
-			// The list was cleared after a block was persisted: history is
-			// append-only, so the previous block would otherwise linger
-			// forever (the strip handler keeps the newest copy). Persist a
-			// fixed retraction marker so the newest copy states reality.
-			content = markHarnessSteer(TODO_CLEARED_MARKDOWN)
-		}
-		if (content === lastPersistedContent.get(sessionId)) return
-		lastPersistedContent.set(sessionId, content)
-		pi.sendMessage(
-			{
-				customType: TODO_STATE_CUSTOM_TYPE,
-				display: false,
-				content,
-				details: { reason: "state_sync" },
-			},
-			{ deliverAs: "steer" },
-		)
-	}
-
-	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
-		const sessionId = ctx.sessionManager.getSessionId()
-		lastPersistedContent.set(sessionId, newestTodoStateContentFromHistory(ctx))
-	}
-	pi.on("session_start", initFromHistory)
-	pi.on("session_tree", initFromHistory)
-
-	// While the agent is busy, coalesce all changes into one block flushed
-	// after the run — see the module comment for the compaction rationale.
-	pi.on("agent_start", () => {
-		agentBusy++
-	})
-	pi.on("agent_end", () => {
-		agentBusy = Math.max(0, agentBusy - 1)
-	})
-	// Flush on agent_settled, not agent_end: during agent_end the run is
-	// still streaming upstream, so a steered custom message would be queued
-	// as a pending agent steer — that both disturbs compaction of the just-
-	// finished run and makes other extensions (e.g. the Ferment V2 gate at
-	// agent_settled) see hasPendingMessages() === true and drop continuations.
-	// At agent_settled the run is fully inactive, so sendCustomMessage takes
-	// the plain append path (no steer, no pending messages, no new turn).
-	pi.on("agent_settled", (_event, ctx) => {
-		if (agentBusy > 0) return
-		// Skip aborted runs: the flushed block would become the newest turn
-		// start and steal the interrupted turn's slot in a compaction cut.
-		if (latestRunTailIsAborted(ctx)) return
-		for (const sessionId of pendingFlush) {
-			persistIfChanged(sessionId)
-		}
-		pendingFlush.clear()
-	})
-
-	subscribeTodoStore((_details, sessionId) => {
-		if (agentBusy > 0) {
-			pendingFlush.add(sessionId)
-			return
-		}
-		persistIfChanged(sessionId)
-	})
-
-	// Strip-only context pass: drop every todo-state message except the newest.
-	// Never appends — the write path (store subscription above) is the only
-	// place todo-state messages are created.
-	pi.on("context", async (event) => {
-		const messages = event.messages
-		let newestIndex = -1
-		for (let i = 0; i < messages.length; i++) {
-			if (isTodoStateMessage(messages[i])) newestIndex = i
-		}
-		if (newestIndex === -1) return undefined
-		const hasSuperseded = messages.some((m, i) => i !== newestIndex && isTodoStateMessage(m))
-		if (!hasSuperseded) return undefined
-
-		const stripped: OrchestratorMessages = messages.filter((m, i) => !isTodoStateMessage(m) || i === newestIndex)
-		return { messages: stripped }
+	registerStateBlockPersistence(pi, {
+		customType: TODO_STATE_CUSTOM_TYPE,
+		render: (sessionId, previous) => {
+			const content = renderForPersist(sessionId)
+			if (content !== undefined) return content
+			// The list was cleared after a block was persisted: retract it.
+			return previous === undefined ? undefined : markHarnessSteer(TODO_CLEARED_MARKDOWN)
+		},
+		subscribe: (notify) => {
+			subscribeTodoStore((_details, sessionId) => {
+				notify(sessionId)
+			})
+		},
 	})
 }

--- a/src/extensions/todos/context-state.ts
+++ b/src/extensions/todos/context-state.ts
@@ -1,4 +1,5 @@
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
+import { latestRunTailIsAborted } from "../aborted-run.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { renderTodoStateMarkdown } from "./state-markdown.js"
 import { subscribeTodoStore } from "./store.js"
@@ -70,10 +71,22 @@ function newestTodoStateContentFromHistory(ctx: ExtensionContext): string | unde
  * message except the newest one. The resulting request view is a pure
  * function of persisted history — identical every round until the next real
  * todo write, which is the only moment a bounded prefix invalidation occurs.
+ *
+ * Timing: upstream compaction (`findCutPoint`) treats every custom message
+ * as a turn start, so a block persisted mid-turn (steered between a tool
+ * result and the next assistant message) becomes a turn boundary. That
+ * turns the compaction into a split-turn compaction with an extra
+ * prefix-summarization request and breaks turn accounting. Writes are
+ * therefore deferred while the agent is busy: changes coalesce into a
+ * single block flushed at `agent_end`, when the plain append path places it
+ * after all persisted turn entries.
  */
 export function registerTodoStatePersistence(pi: ExtensionAPI): void {
 	/** Per-session newest persisted block content; `undefined` = nothing persisted yet. */
 	const lastPersistedContent = new Map<string, string | undefined>()
+	/** Sessions whose rendered block changed while the agent was busy. */
+	const pendingFlush = new Set<string>()
+	let agentBusy = 0
 
 	function persistIfChanged(sessionId: string): void {
 		const markdown = renderTodoStateMarkdown(sessionId)
@@ -109,7 +122,37 @@ export function registerTodoStatePersistence(pi: ExtensionAPI): void {
 	pi.on("session_start", initFromHistory)
 	pi.on("session_tree", initFromHistory)
 
+	// While the agent is busy, coalesce all changes into one block flushed
+	// after the run — see the module comment for the compaction rationale.
+	pi.on("agent_start", () => {
+		agentBusy++
+	})
+	pi.on("agent_end", () => {
+		agentBusy = Math.max(0, agentBusy - 1)
+	})
+	// Flush on agent_settled, not agent_end: during agent_end the run is
+	// still streaming upstream, so a steered custom message would be queued
+	// as a pending agent steer — that both disturbs compaction of the just-
+	// finished run and makes other extensions (e.g. the Ferment V2 gate at
+	// agent_settled) see hasPendingMessages() === true and drop continuations.
+	// At agent_settled the run is fully inactive, so sendCustomMessage takes
+	// the plain append path (no steer, no pending messages, no new turn).
+	pi.on("agent_settled", (_event, ctx) => {
+		if (agentBusy > 0) return
+		// Skip aborted runs: the flushed block would become the newest turn
+		// start and steal the interrupted turn's slot in a compaction cut.
+		if (latestRunTailIsAborted(ctx)) return
+		for (const sessionId of pendingFlush) {
+			persistIfChanged(sessionId)
+		}
+		pendingFlush.clear()
+	})
+
 	subscribeTodoStore((_details, sessionId) => {
+		if (agentBusy > 0) {
+			pendingFlush.add(sessionId)
+			return
+		}
 		persistIfChanged(sessionId)
 	})
 

--- a/src/extensions/todos/context-state.ts
+++ b/src/extensions/todos/context-state.ts
@@ -1,57 +1,132 @@
-import type { ContextEvent, ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent"
 import { markHarnessSteer } from "../steer-marker.js"
 import { renderTodoStateMarkdown } from "./state-markdown.js"
+import { subscribeTodoStore } from "./store.js"
 
 type OrchestratorMessages = ContextEvent["messages"]
 
-const TODO_STATE_CUSTOM_TYPE = "todo-state"
+export const TODO_STATE_CUSTOM_TYPE = "todo-state"
 
-/**
- * Messages helper that knows how to strip todo-state injections from a
- * transient message array. Follows the same pattern as `stripStaleNudges`
- * in continuation-nudge.ts but targets this extension's custom type.
- */
-function stripTodoStateMessages(messages: OrchestratorMessages): OrchestratorMessages {
-	return messages.filter(
-		(m) =>
-			!(
-				m.role === "custom" &&
-				"customType" in m &&
-				(m as { customType: string }).customType === TODO_STATE_CUSTOM_TYPE
-			),
+/** Block persisted when the todo list is cleared after a state block was
+ *  already persisted. Constant, so repeated clears dedupe. */
+const TODO_CLEARED_MARKDOWN = "## Current Todos\n\nThe todo list was cleared."
+
+function isTodoStateMessage(m: unknown): boolean {
+	return (
+		m !== null &&
+		typeof m === "object" &&
+		(m as { role?: string }).role === "custom" &&
+		(m as { customType?: string }).customType === TODO_STATE_CUSTOM_TYPE
 	)
 }
 
+function extractTextContent(content: unknown): string | undefined {
+	if (typeof content === "string") return content
+	if (Array.isArray(content)) {
+		for (const part of content) {
+			if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
+				const text = (part as { text?: unknown }).text
+				if (typeof text === "string") return text
+			}
+		}
+	}
+	return undefined
+}
+
 /**
- * Registers a `context` event handler that injects the current todo state
- * at the tail of the message array on every LLM call. This is transient —
- * the injected message lives only in the single LLM request, never in the
- * persistent session history, and never touches the system prompt.
- *
- * Replaces the previous `before_agent_start` system-prompt injection for
- * the state block. The `## Todos` guidance block stays in the system
- * prompt (static, cache-friendly); only the dynamic state moves here.
+ * Replay dedupe: find the newest persisted todo-state block in session
+ * history so a resumed session does not re-persist an identical block.
  */
-export function registerTodoContextState(pi: ExtensionAPI): void {
-	pi.on("context", async (event, ctx) => {
+function newestTodoStateContentFromHistory(ctx: ExtensionContext): string | undefined {
+	const branch = ctx.sessionManager.getBranch()
+	for (let i = branch.length - 1; i >= 0; i--) {
+		const m = branch[i] as { role?: string; customType?: string; content?: unknown }
+		if (isTodoStateMessage(m)) {
+			return extractTextContent(m.content)
+		}
+	}
+	return undefined
+}
+
+/**
+ * Persist-on-change delivery of the todo state block.
+ *
+ * Replaces the previous transient tail-injection: that old design pushed a
+ * fresh `todo-state` custom message at the end of the message array inside
+ * the `context` handler on every LLM request. Because the request-level
+ * cache breakpoint sits on the last block of the stored prefix, every
+ * cached prefix ended at a moving message — the tail cache read was
+ * permanently poisoned and each request re-wrote the entire prefix.
+ *
+ * This registrar instead writes the rendered block into session history
+ * (as a hidden custom message, delivered as a steer so it lands at the tool
+ * boundary) exactly once per actual store change. The persisted entry sits
+ * at a fixed chronological position, subsequent requests extend the stream
+ * behind it, and it becomes part of the growing stable prefix.
+ *
+ * History is append-only for extensions (there is no delete API), so
+ * superseded copies remain in the branch. The `context` handler registered
+ * here is therefore strip-only: it deterministically drops every `todo-state`
+ * message except the newest one. The resulting request view is a pure
+ * function of persisted history — identical every round until the next real
+ * todo write, which is the only moment a bounded prefix invalidation occurs.
+ */
+export function registerTodoStatePersistence(pi: ExtensionAPI): void {
+	/** Per-session newest persisted block content; `undefined` = nothing persisted yet. */
+	const lastPersistedContent = new Map<string, string | undefined>()
+
+	function persistIfChanged(sessionId: string): void {
+		const markdown = renderTodoStateMarkdown(sessionId)
+		let content = markdown === undefined ? undefined : markHarnessSteer(markdown)
+		if (content === undefined) {
+			if (lastPersistedContent.get(sessionId) === undefined) {
+				// Nothing persisted yet and nothing to show — no-op.
+				return
+			}
+			// The list was cleared after a block was persisted: history is
+			// append-only, so the previous block would otherwise linger
+			// forever (the strip handler keeps the newest copy). Persist a
+			// fixed retraction marker so the newest copy states reality.
+			content = markHarnessSteer(TODO_CLEARED_MARKDOWN)
+		}
+		if (content === lastPersistedContent.get(sessionId)) return
+		lastPersistedContent.set(sessionId, content)
+		pi.sendMessage(
+			{
+				customType: TODO_STATE_CUSTOM_TYPE,
+				display: false,
+				content,
+				details: { reason: "state_sync" },
+			},
+			{ deliverAs: "steer" },
+		)
+	}
+
+	const initFromHistory = (_event: unknown, ctx: ExtensionContext) => {
 		const sessionId = ctx.sessionManager.getSessionId()
-		const stateMarkdown = renderTodoStateMarkdown(sessionId)
-		if (!stateMarkdown) return undefined
+		lastPersistedContent.set(sessionId, newestTodoStateContentFromHistory(ctx))
+	}
+	pi.on("session_start", initFromHistory)
+	pi.on("session_tree", initFromHistory)
 
-		// Defensive strip: if another handler in the chain already injected
-		// an older copy of todo-state, drop it so we never double-stack.
-		const messages = stripTodoStateMessages(event.messages)
+	subscribeTodoStore((_details, sessionId) => {
+		persistIfChanged(sessionId)
+	})
 
-		messages.push({
-			role: "custom",
-			customType: TODO_STATE_CUSTOM_TYPE,
-			// Brand harness-injected state so the model can distinguish it from
-			// user-authored text (upstream flattens custom messages to user role).
-			content: markHarnessSteer(stateMarkdown),
-			display: false,
-			timestamp: Date.now(),
-		})
+	// Strip-only context pass: drop every todo-state message except the newest.
+	// Never appends — the write path (store subscription above) is the only
+	// place todo-state messages are created.
+	pi.on("context", async (event) => {
+		const messages = event.messages
+		let newestIndex = -1
+		for (let i = 0; i < messages.length; i++) {
+			if (isTodoStateMessage(messages[i])) newestIndex = i
+		}
+		if (newestIndex === -1) return undefined
+		const hasSuperseded = messages.some((m, i) => i !== newestIndex && isTodoStateMessage(m))
+		if (!hasSuperseded) return undefined
 
-		return { messages }
+		const stripped: OrchestratorMessages = messages.filter((m, i) => !isTodoStateMessage(m) || i === newestIndex)
+		return { messages: stripped }
 	})
 }

--- a/src/extensions/todos/index.test.ts
+++ b/src/extensions/todos/index.test.ts
@@ -45,6 +45,21 @@ function createTodosHarness(activeTools: string[] = [...TODO_TOOL_NAMES]) {
 	}
 }
 
+/** sendMessage calls that are NOT persisted todo-state blocks. Reconciliation
+ *  semantics under test: state_sync blocks persist on every store change, so
+ *  they must be filtered out before asserting "no follow-ups were sent". */
+function nonStateSyncCalls(sendMessage: unknown): unknown[][] {
+	return vi
+		.mocked(sendMessage as ExtensionAPI["sendMessage"])
+		.mock.calls.filter(([message]) => (message as { details?: { reason?: string } }).details?.reason !== "state_sync")
+}
+
+function steerCallsByReason(sendMessage: unknown, reason: string): unknown[][] {
+	return vi
+		.mocked(sendMessage as ExtensionAPI["sendMessage"])
+		.mock.calls.filter(([message]) => (message as { details?: { reason?: string } }).details?.reason === reason)
+}
+
 function createContext(
 	sessionId: string,
 	branch: SessionEntry[],
@@ -228,7 +243,34 @@ describe("passive staleness counter", () => {
 		__resetTodoStore()
 	})
 
-	it("injects todo state into the context on every LLM call", async () => {
+	it("persists the todo state block as a hidden steer on todo writes", async () => {
+		const harness = createTodosHarness()
+		const ctx = createContext("session", [])
+		await harness.fire("session_start", { reason: "new" }, ctx)
+
+		applyWriteTodos({ todos: [{ content: "check work", status: "in_progress" }] }, "session")
+
+		const stateSync = steerCallsByReason(harness.sendMessage, "state_sync")
+		expect(stateSync).toHaveLength(1)
+		const [message, options] = stateSync[0] as [
+			{ customType?: string; display?: boolean; content?: string },
+			{ deliverAs?: string },
+		]
+		expect(message.customType).toBe("todo-state")
+		expect(message.display).toBe(false)
+		expect(options.deliverAs).toBe("steer")
+		expect(message.content).toMatch(/^<system-reminder>\n/)
+		expect(message.content).toMatch(/\n<\/system-reminder>$/)
+		expect(message.content).toContain("## Current Todos")
+		expect(message.content).toContain("check work")
+
+		// Two no-op turns must not persist additional blocks.
+		await harness.fire("turn_end", terminalTurn(), ctx)
+		await harness.fire("turn_end", terminalTurnWithText(), ctx)
+		expect(steerCallsByReason(harness.sendMessage, "state_sync")).toHaveLength(1)
+	})
+
+	it("does not inject todo state inside the context event (no tail push)", async () => {
 		const harness = createTodosHarness()
 		const ctx = createContext("session", [])
 		await harness.fire("session_start", { reason: "new" }, ctx)
@@ -238,12 +280,7 @@ describe("passive staleness counter", () => {
 		const result = (await harness.fire("context", { messages: [] }, ctx)) as
 			| { messages: Array<{ role?: string; content?: string }> }
 			| undefined
-		expect(result).toBeDefined()
-		expect(result?.messages).toHaveLength(1)
-		expect(result?.messages[0]?.content).toMatch(/^<system-reminder>\n/)
-		expect(result?.messages[0]?.content).toMatch(/\n<\/system-reminder>$/)
-		expect(result?.messages[0]?.content).toContain("## Current Todos")
-		expect(result?.messages[0]?.content).toContain("check work")
+		expect(result).toBeUndefined()
 	})
 
 	it("does not send reconciliation follow-ups after terminal turns", async () => {
@@ -256,8 +293,8 @@ describe("passive staleness counter", () => {
 		await harness.fire("turn_end", terminalTurnWithText(), ctx)
 
 		// No reconciliation follow-up should be sent — the old forced-turn
-		// mechanism has been removed.
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		// mechanism has been removed. Only the persisted state block is sent.
+		expect(nonStateSyncCalls(harness.sendMessage)).toHaveLength(0)
 	})
 
 	it("does not send reconciliation follow-ups even after multiple terminal stops", async () => {
@@ -271,7 +308,7 @@ describe("passive staleness counter", () => {
 		await harness.fire("turn_end", terminalTurnWithText(), ctx)
 		await harness.fire("turn_end", terminalTurnWithText(), ctx)
 
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(nonStateSyncCalls(harness.sendMessage)).toHaveLength(0)
 	})
 
 	it("does not reconcile immediately after only writing todos", async () => {
@@ -282,7 +319,7 @@ describe("passive staleness counter", () => {
 		applyWriteTodos({ todos: [{ content: "new plan", status: "pending" }] }, "session")
 		await harness.fire("turn_end", terminalTurn(), ctx)
 
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(nonStateSyncCalls(harness.sendMessage)).toHaveLength(0)
 	})
 
 	it("resyncs the active todo widget on terminal turns after the TUI clears widgets", async () => {
@@ -302,7 +339,7 @@ describe("passive staleness counter", () => {
 		await harness.fire("turn_end", terminalTurn(), ctx)
 
 		expect(setWidget).toHaveBeenCalledTimes(2)
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(nonStateSyncCalls(harness.sendMessage)).toHaveLength(0)
 	})
 
 	it("does not reconcile on non-terminal turns", async () => {
@@ -316,7 +353,7 @@ describe("passive staleness counter", () => {
 		await harness.fire("turn_end", { message: { role: "assistant" }, toolResults: [{}] }, ctx)
 		await harness.fire("turn_end", terminalTurn(), createContext("session", [], { hasPendingMessages: true }))
 
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(nonStateSyncCalls(harness.sendMessage)).toHaveLength(0)
 	})
 
 	it("isolates todos between concurrent sessions", async () => {
@@ -370,7 +407,7 @@ describe("early todo nudge", () => {
 			await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 		}
 
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(steerCallsByReason(harness.sendMessage, "early_nudge")).toHaveLength(0)
 	})
 
 	it("fires only once even if the model continues without creating a list", async () => {
@@ -414,6 +451,68 @@ describe("early todo nudge", () => {
 			await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
 		}
 
-		expect(harness.sendMessage).not.toHaveBeenCalled()
+		expect(steerCallsByReason(harness.sendMessage, "early_nudge")).toHaveLength(0)
+	})
+
+	describe("staleness threshold steers", () => {
+		it("fires one-shot steers at 9/17/25 post-write tool calls and resets on todo write", async () => {
+			const harness = createTodosHarness()
+			const ctx = createContext("session", [])
+			await harness.fire("session_start", { reason: "new" }, ctx)
+			applyWriteTodos({ todos: [{ content: "long task", status: "in_progress" }] }, "session")
+
+			const stalenessCalls = () => steerCallsByReason(harness.sendMessage, "staleness")
+
+			// Below the first threshold: nothing.
+			for (let i = 0; i < 8; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(stalenessCalls()).toHaveLength(0)
+
+			// Ninth call crosses 9: exactly one steer, and no refire on later calls.
+			await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			expect(stalenessCalls()).toHaveLength(1)
+			expect((stalenessCalls()[0]?.[0] as { content: string }).content).toContain("9 changes since last update")
+			expect((stalenessCalls()[0]?.[0] as { content: string }).content).toMatch(/^<system-reminder>\n/)
+			expect(stalenessCalls()[0]?.[1]).toEqual({ deliverAs: "steer" })
+
+			for (let i = 0; i < 3; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(stalenessCalls()).toHaveLength(1)
+
+			// 17 and 25 crossings each fire once more.
+			for (let i = 0; i < 5; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(stalenessCalls()).toHaveLength(2)
+			expect((stalenessCalls()[1]?.[0] as { content: string }).content).toContain("17 changes since last update")
+
+			for (let i = 0; i < 8; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(stalenessCalls()).toHaveLength(3)
+			expect((stalenessCalls()[2]?.[0] as { content: string }).content).toContain("significantly stale")
+
+			// A todo write resets both the counter and the epoch: crossing 9
+			// again fires a fresh steer.
+			applyWriteTodos({ todos: [{ id: 1, content: "long task", status: "completed" }] }, "session")
+			for (let i = 0; i < 9; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(stalenessCalls()).toHaveLength(4)
+		})
+
+		it("does not fire when the current scope has no todos", async () => {
+			const harness = createTodosHarness()
+			const ctx = createContext("session", [])
+			await harness.fire("session_start", { reason: "new" }, ctx)
+
+			// No list ever created: work calls only trigger the early nudge.
+			for (let i = 0; i < 12; i++) {
+				await harness.fire("tool_execution_end", { toolName: "bash", isError: false }, ctx)
+			}
+			expect(steerCallsByReason(harness.sendMessage, "staleness")).toHaveLength(0)
+		})
 	})
 })

--- a/src/extensions/todos/index.ts
+++ b/src/extensions/todos/index.ts
@@ -3,14 +3,22 @@ import { isAgentWorker } from "../agent-worker-context.js"
 import { markHarnessSteer } from "../steer-marker.js"
 import { registerTodosCommand } from "./command.js"
 import { TODO_CUSTOM_ENTRY_TYPE } from "./constants.js"
-import { registerTodoContextState } from "./context-state.js"
+import { registerTodoStatePersistence } from "./context-state.js"
 import { registerFermentTodoPromptBlock } from "./ferment-prompt-block.js"
 import { registerTodoPromptBlock } from "./prompt-block.js"
 import { getWriteTodosDetails, isTodoWriteToolName } from "./session.js"
 import {
+	createThresholdSteerTracker,
+	sendHiddenSteer,
+	stalenessIndicator,
+	TODO_STALENESS_CUSTOM_TYPE,
+	TODO_STALENESS_THRESHOLDS,
+} from "./staleness-steers.js"
+import {
 	bumpToolCallsSinceTodoWrite,
 	bumpWorkToolCalls,
 	getTodosForScope,
+	getToolCallsSinceTodoWrite,
 	getWorkToolCalls,
 	hasEverHadTodos,
 	hasTodoNudgeFired,
@@ -34,6 +42,7 @@ export * from "./constants.js"
 export * from "./ferment-prompt-block.js"
 export * from "./prompt-block.js"
 export * from "./reducer.js"
+export * from "./staleness-steers.js"
 export * from "./state-markdown.js"
 export * from "./store.js"
 export * from "./tool.js"
@@ -75,7 +84,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 	registerTodoPromptBlock(pi)
 	registerFermentTodoPromptBlock(pi)
 
-	registerTodoContextState(pi)
+	registerTodoStatePersistence(pi)
 
 	// No `before_agent_start` fallback appending the guidance block is
 	// registered here, on purpose: prompt-enrichment (registered earlier in
@@ -91,6 +100,11 @@ export default function todosExtension(pi: ExtensionAPI): void {
 
 	const _activeSessionContexts = new Map<string, ExtensionContext>()
 	let unsubscribeTodoStore: (() => void) | undefined
+
+	// One-shot staleness steers: fires once per threshold per write-epoch,
+	// reset whenever the todo store is written (the subscribeTodoStore
+	// listener below resets both the counter and this tracker).
+	const stalenessTracker = createThresholdSteerTracker()
 
 	function setSessionContext(sessionId: string, ctx: ExtensionContext): void {
 		_activeSessionContexts.set(sessionId, ctx)
@@ -122,6 +136,7 @@ export default function todosExtension(pi: ExtensionAPI): void {
 		unsubscribeTodoStore?.()
 		unsubscribeTodoStore = subscribeTodoStore((_, emitterSessionId) => {
 			resetToolCallsSinceTodoWrite(emitterSessionId)
+			stalenessTracker.reset(emitterSessionId)
 			const sessionCtx = getSessionContext(emitterSessionId)
 			if (sessionCtx) syncTodoWidget(sessionCtx)
 		})
@@ -155,15 +170,29 @@ export default function todosExtension(pi: ExtensionAPI): void {
 
 		// Only track staleness when there are existing todos to keep in sync.
 		const scope = resolveTodoScope()
-		if (getTodosForScope(scope, sessionId).length > 0) {
-			bumpToolCallsSinceTodoWrite(sessionId)
-		}
+		if (getTodosForScope(scope, sessionId).length === 0) return
+
+		bumpToolCallsSinceTodoWrite(sessionId)
+
+		// Staleness pressure as bounded one-shot steers, not as volatile text
+		// inside the persisted state block (which must stay byte-identical
+		// between real writes for prefix-cache stability).
+		const changes = getToolCallsSinceTodoWrite(sessionId)
+		stalenessTracker.fireCrossed({
+			sessionId,
+			count: changes,
+			thresholds: TODO_STALENESS_THRESHOLDS,
+			send: (threshold) => {
+				const text = stalenessIndicator(changes)
+				if (text) sendHiddenSteer(pi, TODO_STALENESS_CUSTOM_TYPE, text, { reason: "staleness", threshold })
+			},
+		})
 	})
 
 	pi.on("turn_end", (event, ctx) => {
 		// Sync the widget on terminal turns but do NOT force reconciliation.
 		// The model updates todos on its own schedule guided by the system
-		// prompt and the passive staleness indicator in the state block.
+		// prompt and the one-shot staleness steers.
 		const message = event.message
 		if (!isRecord(message) || message.role !== "assistant") return
 		if ((event.toolResults as readonly unknown[]).length > 0 || ctx.hasPendingMessages?.()) return

--- a/src/extensions/todos/prompt-block.test.ts
+++ b/src/extensions/todos/prompt-block.test.ts
@@ -1,19 +1,19 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Ferment, Phase } from "../../ferment/types.js"
 import { createContext } from "../__mocks__/context.js"
 import { FERMENT_EVENTS } from "../ferment/domain-events.js"
 import { setActive } from "../ferment/state.js"
-import { bumpStallCounter, registerFermentTodoSync } from "../ferment/todo-sync.js"
+import {
+	bumpStallCounter,
+	FERMENT_STEP_STALL_CUSTOM_TYPE,
+	fireStepStallSteerIfStalled,
+	registerFermentTodoSync,
+} from "../ferment/todo-sync.js"
 import { FERMENT_TODO_GUIDANCE, renderFermentTodoPromptBlock } from "./ferment-prompt-block.js"
 import { __test_renderTodoPromptBlock } from "./prompt-block.js"
 import { __test_renderTodoStateMarkdown, renderTodoStateBlock } from "./state-markdown.js"
-import {
-	__resetTodoStore,
-	applyWriteTodos,
-	bumpToolCallsSinceTodoWrite,
-	resetToolCallsSinceTodoWrite,
-} from "./store.js"
+import { __resetTodoStore, applyWriteTodos, bumpToolCallsSinceTodoWrite } from "./store.js"
 import type { TodoStatus } from "./types.js"
 
 const TEST_SESSION_ID = "test-session"
@@ -47,6 +47,7 @@ function createAndUpdateTodo(content: string, status: TodoStatus, sessionId: str
 function createFakePI(): {
 	pi: ExtensionAPI
 	emit: (channel: string, payload: unknown) => void
+	sendMessage: ExtensionAPI["sendMessage"]
 } {
 	const listeners = new Map<string, Array<(payload: unknown) => void>>()
 
@@ -77,11 +78,13 @@ function createFakePI(): {
 		},
 	}
 
+	const sendMessage = vi.fn()
 	const pi = {
 		events,
+		sendMessage,
 	} as unknown as ExtensionAPI
 
-	return { pi, emit: events.emit }
+	return { pi, emit: events.emit, sendMessage: sendMessage as unknown as ExtensionAPI["sendMessage"] }
 }
 
 function createTestFerment(phaseId: string, stepCount: number): Ferment {
@@ -308,74 +311,35 @@ describe("todo state prompt block (headless)", () => {
 	})
 })
 
-describe("staleness indicator in state markdown", () => {
+describe("state markdown purity (cache-safety contract)", () => {
 	beforeEach(() => {
 		__resetTodoStore()
 	})
 
-	it("does not show a staleness warning when changes are minimal (0-8)", () => {
-		writeTodoAndBump("work", "in_progress", 8)
+	it("renders byte-identical output across staleness counter changes", () => {
+		writeTodo("work", "in_progress")
+		const baseline = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
 
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).not.toContain("changes since last update")
-	})
-
-	it("shows a neutral staleness indicator at 9-16 changes", () => {
-		createAndUpdateTodo("work", "in_progress")
-		for (let i = 0; i < 12; i++) bumpToolCallsSinceTodoWrite(TEST_SESSION_ID)
-
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).toContain("12 changes since last update")
-		expect(md).not.toContain("⚠")
-	})
-
-	it("shows an advisory staleness warning at 17-24 changes", () => {
-		createAndUpdateTodo("work", "in_progress")
-		for (let i = 0; i < 20; i++) bumpToolCallsSinceTodoWrite(TEST_SESSION_ID)
-
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).toContain("⚠ 20 changes since last update — update at the next natural breakpoint")
-	})
-
-	it("shows a strong staleness warning at 25+ changes", () => {
-		createAndUpdateTodo("work", "in_progress")
 		for (let i = 0; i < 30; i++) bumpToolCallsSinceTodoWrite(TEST_SESSION_ID)
 
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).toContain("⚠ 30 changes — list is significantly stale")
+		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toBe(baseline)
 	})
 
-	it("resets staleness counter after a todo write", () => {
-		writeTodoAndBump("work", "in_progress", 5)
-
-		// The first write creates the list; since it was never updated,
-		// the create-and-forget warning appears instead of the normal one.
-		expect(__test_renderTodoStateMarkdown(TEST_SESSION_ID)).toContain("never updated")
-
-		// Simulate an update by writing again — resets the counter via subscribeTodoStore.
-		resetToolCallsSinceTodoWrite(TEST_SESSION_ID)
-		writeTodo("work", "completed")
+	it("contains no staleness or create-and-forget warnings at any counter value", () => {
+		writeTodoAndBump("work", "in_progress", 30)
 
 		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
+		expect(md).toContain("work")
 		expect(md).not.toContain("changes since last update")
 		expect(md).not.toContain("never updated")
 	})
 
-	it("shows create-and-forget warning when list was never updated", () => {
-		writeTodoAndBump("work", "in_progress", 5)
-
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).toContain("never updated")
-		expect(md).toContain("mark items as you complete them")
-	})
-
-	it("does not show create-and-forget warning after list has been updated", () => {
+	it("two renders of the same store are byte-identical", () => {
 		createAndUpdateTodo("work", "completed")
-		for (let i = 0; i < 10; i++) bumpToolCallsSinceTodoWrite(TEST_SESSION_ID)
 
-		const md = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
-		expect(md).not.toContain("never updated")
-		expect(md).toContain("10 changes since last update")
+		const first = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
+		const second = __test_renderTodoStateMarkdown(TEST_SESSION_ID)
+		expect(second).toBe(first)
 	})
 })
 
@@ -519,13 +483,21 @@ describe("ferment-conditional todo guidance", () => {
 	})
 })
 
-describe("cross-session stall counter isolation", () => {
+describe("cross-session stall steer isolation", () => {
 	afterEach(() => {
 		setActive(undefined)
 	})
 
-	it("only warns about stalls for the session whose step is running", () => {
-		const { pi, emit } = createFakePI()
+	function stallSteers(sendMessage: ExtensionAPI["sendMessage"]): unknown[] {
+		return vi
+			.mocked(sendMessage)
+			.mock.calls.filter(
+				([message]) => (message as { customType?: string }).customType === FERMENT_STEP_STALL_CUSTOM_TYPE,
+			)
+	}
+
+	it("fires the stall steer only for the session whose step stalls", () => {
+		const { pi, emit, sendMessage } = createFakePI()
 		const ferment = createTestFerment("phase-1", 1)
 		setActive(ferment)
 
@@ -544,35 +516,92 @@ describe("cross-session stall counter isolation", () => {
 			stepIndex: 1,
 		})
 
-		// Bump session A's stall counter enough times to trigger the warning.
+		// Bump session A's stall counter across the 12-turn threshold.
 		for (let i = 0; i < 12; i++) {
 			bumpStallCounter("session-a")
 		}
 
-		// Session A should see the stall warning.
-		const mdA = __test_renderTodoStateMarkdown("session-a")
-		expect(mdA).toContain("Step todos have not been updated for 12 turns")
+		fireStepStallSteerIfStalled(pi, "session-a")
+		// Session B has no running step and no stall counter; no steer.
+		fireStepStallSteerIfStalled(pi, "session-b")
 
-		// Session B has no running step and no stall counter; no warning.
-		const mdB = __test_renderTodoStateMarkdown("session-b")
-		expect(mdB).toBeUndefined()
+		const steers = stallSteers(sendMessage)
+		expect(steers).toHaveLength(1)
+		expect((steers[0] as [{ content: string }])[0].content).toContain("Step todos have not been updated for 12 turns")
+
+		// And the stalling session's own state block stays free of stall text.
+		const mdA = __test_renderTodoStateMarkdown("session-a")
+		expect(mdA).not.toContain("have not been updated")
 
 		unsubA()
 	})
 
-	it("does not nag steps at under-threshold turn counts (measured run: 5-turn nag manufactured churn)", () => {
-		const { pi } = createFakePI()
+	it("is one-shot per stall epoch and resets on a step-scope todo write", () => {
+		const { pi, emit, sendMessage } = createFakePI()
+		const ferment = createTestFerment("phase-epoch", 1)
+		setActive(ferment)
+
+		const unsub = registerFermentTodoSync(pi, "session-epoch")
+
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-epoch",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		emit(FERMENT_EVENTS.STEP_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-epoch",
+			stepId: "step-1",
+			stepIndex: 1,
+		})
+
+		for (let i = 0; i < 12; i++) bumpStallCounter("session-epoch")
+		fireStepStallSteerIfStalled(pi, "session-epoch")
+		for (let i = 0; i < 5; i++) bumpStallCounter("session-epoch")
+		fireStepStallSteerIfStalled(pi, "session-epoch")
+		expect(stallSteers(sendMessage)).toHaveLength(1)
+
+		// A step-scope todo write resets the epoch; crossing the threshold
+		// again fires exactly one more steer.
+		applyWriteTodos(
+			{
+				scope: { kind: "ferment-step", phaseId: "phase-epoch", stepId: "step-1" },
+				todos: [{ content: "tried X", status: "in_progress" }],
+			},
+			"session-epoch",
+		)
+		for (let i = 0; i < 12; i++) bumpStallCounter("session-epoch")
+		fireStepStallSteerIfStalled(pi, "session-epoch")
+		expect(stallSteers(sendMessage)).toHaveLength(2)
+
+		unsub()
+	})
+
+	it("does not fire at under-threshold turn counts (measured run: 5-turn nag manufactured churn)", () => {
+		const { pi, emit, sendMessage } = createFakePI()
+		const ferment = createTestFerment("phase-quiet", 1)
+		setActive(ferment)
+
 		const unsub = registerFermentTodoSync(pi, "session-quiet")
-		// A global todo forces the state block to render.
-		writeTodo("work", "in_progress", "session-quiet")
 
-		for (let i = 0; i < 10; i++) {
-			bumpStallCounter("session-quiet")
-		}
+		emit(FERMENT_EVENTS.PHASE_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-quiet",
+			phaseIndex: 1,
+			phaseName: "Test Phase",
+		})
+		emit(FERMENT_EVENTS.STEP_STARTED, {
+			fermentId: ferment.id,
+			phaseId: "phase-quiet",
+			stepId: "step-1",
+			stepIndex: 1,
+		})
 
-		const md = __test_renderTodoStateMarkdown("session-quiet")
-		expect(md).toContain("work")
-		expect(md).not.toContain("have not been updated")
+		for (let i = 0; i < 10; i++) bumpStallCounter("session-quiet")
+		fireStepStallSteerIfStalled(pi, "session-quiet")
+
+		expect(stallSteers(sendMessage)).toHaveLength(0)
 
 		unsub()
 	})

--- a/src/extensions/todos/staleness-steers.ts
+++ b/src/extensions/todos/staleness-steers.ts
@@ -1,0 +1,90 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { markHarnessSteer } from "../steer-marker.js"
+
+/**
+ * One-shot staleness steering.
+ *
+ * Staleness pressure used to be rendered inside the todo state block on every
+ * request. That made the block content depend on volatile counters, which is
+ * fine for a transient injection but breaks the persist-on-change model: the
+ * persisted block must be a pure function of the todo store so it stays
+ * byte-identical between real writes and can sit in the stable cache prefix.
+ *
+ * This module delivers the same pressure as bounded, persistent one-shot
+ * steers: when a per-session counter crosses a threshold, a single hidden
+ * message is sent (persisting in history at that point), and no more steers
+ * fire until the epoch resets on the next relevant todo write.
+ */
+
+export const TODO_STALENESS_CUSTOM_TYPE = "todo-staleness"
+
+/** Thresholds (post-increment count of non-todo tool calls) at which a
+ *  staleness steer fires. Mirrors the old per-request indicator ranges. */
+export const TODO_STALENESS_THRESHOLDS = [9, 17, 25] as const
+
+/** Graduated staleness wording — the old `stalenessIndicator` text, moved out
+ *  of the rendered block. */
+export function stalenessIndicator(changes: number): string | undefined {
+	if (changes <= 8) return undefined
+	if (changes <= 16) return `${changes} changes since last update — refresh the list at the next natural breakpoint`
+	if (changes <= 24) return `⚠ ${changes} changes since last update — update at the next natural breakpoint`
+	return `⚠ ${changes} changes — list is significantly stale, update at the next natural breakpoint`
+}
+
+/** Send a hidden persistent steer message (lands in session history at the
+ *  current chronological position, so it joins the stable cache prefix). */
+export function sendHiddenSteer(
+	pi: ExtensionAPI,
+	customType: string,
+	text: string,
+	details: Record<string, unknown>,
+): void {
+	pi.sendMessage(
+		{
+			customType,
+			display: false,
+			content: markHarnessSteer(text),
+			details,
+		},
+		{ deliverAs: "steer" },
+	)
+}
+
+/**
+ * Tracks which thresholds have fired for each session within the current
+ * write-epoch. `reset` clears the fired set so the next epoch can fire again.
+ */
+export function createThresholdSteerTracker(): {
+	fireCrossed(args: {
+		sessionId: string
+		count: number
+		thresholds: readonly number[]
+		send: (threshold: number) => void
+	}): void
+	reset(sessionId: string): void
+	clear(): void
+} {
+	const firedBySession = new Map<string, Set<number>>()
+
+	return {
+		fireCrossed({ sessionId, count, thresholds, send }) {
+			let fired = firedBySession.get(sessionId)
+			if (!fired) {
+				fired = new Set()
+				firedBySession.set(sessionId, fired)
+			}
+			for (const threshold of thresholds) {
+				if (count < threshold) continue
+				if (fired.has(threshold)) continue
+				fired.add(threshold)
+				send(threshold)
+			}
+		},
+		reset(sessionId) {
+			firedBySession.delete(sessionId)
+		},
+		clear() {
+			firedBySession.clear()
+		},
+	}
+}

--- a/src/extensions/todos/state-markdown.ts
+++ b/src/extensions/todos/state-markdown.ts
@@ -1,7 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
-import { getTurnsSinceStepTodoWrite } from "../ferment/todo-sync.js"
 import { parseTodoScopeKey } from "./scope.js"
-import { getTodoState, getToolCallsSinceTodoWrite, hasTodoListBeenUpdated } from "./store.js"
+import { getTodoState } from "./store.js"
 import type { TodoItem, TodoScope, TodoStatus } from "./types.js"
 
 function statusGlyph(status: TodoStatus): string {
@@ -35,30 +34,18 @@ function formatProgressSummary(todos: TodoItem[]): string {
 	return parts.join(" · ")
 }
 
-/**
- * Returns a graduated staleness indicator string based on the number of
- * non-todo tool calls since the last todo write. Returns `undefined` when
- * staleness is low enough not to warrant a warning.
- *
- * This replaces the old active nudge messages with passive state
- * enrichment — the model sees the warning in the state block it already
- * reads, and can choose to act on it at the next natural break point.
- */
-function stalenessIndicator(changes: number): string | undefined {
-	if (changes <= 8) return undefined
-	if (changes <= 16) return `${changes} changes since last update — refresh the list at the next natural breakpoint`
-	if (changes <= 24) return `⚠ ${changes} changes since last update — update at the next natural breakpoint`
-	return `⚠ ${changes} changes — list is significantly stale, update at the next natural breakpoint`
-}
-
 /** Render the current todo store as a markdown section. Returns `undefined`
  *  when there is nothing to show (no scopes at all).
  *
- *  This is volatile per-session state: it is consumed ONLY by the transient
- *  `context`-event path (`context-state.ts`), never by a system-prompt block.
- *  Keeping it here (rather than in `prompt-block.ts`) lets the cache-stability
- *  contract test hold the static todos registrar to a zero-volatile-imports
- *  standard — see system-prompt-stability.contract.test.ts. */
+ *  This is a PURE function of the todo store: no counters, no time. Persisted
+ *  todo-state blocks are cached by prefix, so two renders of the same store
+ *  must be byte-identical. Staleness/stall pressure is delivered separately
+ *  as bounded one-shot steers — see staleness-steers.ts (todo writes) and
+ *  ferment/todo-sync.ts (step stall).
+ *
+ *  The renderer lives outside any registrar file so the static import guard
+ *  in the cache-stability contract test can be strict (zero allowlisted
+ *  exceptions) — see system-prompt-stability.contract.test.ts. */
 export function renderTodoStateMarkdown(sessionId: string): string | undefined {
 	const state = getTodoState(sessionId)
 	const scopeKeys = Object.keys(state.byScope)
@@ -104,26 +91,11 @@ export function renderTodoStateMarkdown(sessionId: string): string | undefined {
 	lines.push("## Current Todos")
 	lines.push("")
 
-	// Collect all staleness signals to show the strongest one at the end.
-	const stalenessWarnings: string[] = []
-
 	if (global.length > 0) {
 		const summary = formatProgressSummary(global)
 		lines.push(`**Global**${summary ? ` (${summary})` : ""}`)
 		for (const todo of global) lines.push(formatTodoLine(todo))
 		lines.push("")
-
-		// Global-scope staleness (from toolCallsSinceTodoWrite counter)
-		const changes = getToolCallsSinceTodoWrite(sessionId)
-		if (changes > 2 && !hasTodoListBeenUpdated(sessionId)) {
-			// List was created but never updated — more urgent than generic staleness.
-			stalenessWarnings.push(
-				`⚠ List created but never updated — mark items as you complete them alongside your next tool call`,
-			)
-		} else {
-			const globalStale = stalenessIndicator(changes)
-			if (globalStale) stalenessWarnings.push(globalStale)
-		}
 	}
 
 	for (const phase of fermentScopes) {
@@ -140,24 +112,6 @@ export function renderTodoStateMarkdown(sessionId: string): string | undefined {
 		lines.push(`**Step ${stepScope.phaseId}/${stepScope.stepId}**${summary ? ` (${summary})` : ""}`)
 		for (const todo of stepScope.todos) lines.push(formatTodoLine(todo))
 		lines.push("")
-	}
-
-	// Ferment stall detection: if a ferment step is running and the step-scope
-	// todos haven't been updated in many turns, add a staleness warning.
-	// Step-list staleness health check. Now that sub-task lists are optional,
-	// nagging at a few turns manufactures todo churn exactly where we told the
-	// model to skip lists — one threshold at roughly one long step means the
-	// warning fires only on genuine iteration thrash.
-	const staleTurns = getTurnsSinceStepTodoWrite(sessionId)
-	if (staleTurns >= 12) {
-		stalenessWarnings.push(
-			`⚠ Step todos have not been updated for ${staleTurns} turns. If you are iterating without progress, step back and reassess your approach. Update your todo plan with what you have tried and what to try next.`,
-		)
-	}
-
-	if (stalenessWarnings.length > 0) {
-		lines.push("")
-		for (const warning of stalenessWarnings) lines.push(warning)
 	}
 
 	// Trim trailing blank line for cleanliness.


### PR DESCRIPTION
## Problem

Anthropic prompt caching stores the request prefix up to each `cache_control` marker, and a later request can only *read* a stored prefix if it appears as an **exact prefix of the new request — from position 0 onward**. pi-ai places three markers on our behalf: system prompt, last tool, and **the last message in the conversation**.

The todo-state and ferment-lifecycle blocks were injected **transiently at the request tail** — re-appended *after* any newly appended history on every LLM call. The tail marker therefore always sat on a block whose *position* moved each round:

```
round N   [history…, toolResultₙ, "## Current Todos"] ← marker; stored
round N+1 [history…, toolResultₙ, growth…, "## Current Todos"] ← marker moved
```

The stored breakpoint can never match a later request. Reads collapsed to the stable system+tools marker (~16.8k tokens) and the *entire conversation* was re-written to cache every single round (~135k tokens/round, at the 1.25× write premium).

## How the regression landed

- **`7307a8b5` (#984, Aug 10)** — *feat(todos): per-turn transient state injection*. Introduced the moving-tail mechanism: the `## Current Todos` block was appended via the `context` event on every round, replacing the older system-prompt injection. This alone is sufficient to poison the tail breakpoint — the position of the block shifts as history grows, so even with unchanging content the stored prefix is unreachable.
- **`f92992a8` (#1021, Aug 13)** — *ferment lifecycle state → per-request context*. Compounded it: moved the volatile lifecycle block **out of the system prompt (good) but into the same tail slot**, adding a second block whose content *changes every transition* (`timestamp: Date.now()`, step counters, next-action hint). Now even rounds with todo state unchanged rewrote the full tail region.

## What changed

**Persist-on-change.** State blocks are now rendered only when they actually change and written into append-only session history as hidden custom messages — a fixed chronological position that joins the growing stable prefix. The `context` handler no longer injects; it only strips superseded copies (keep-newest, deterministic). Staleness/stall pressure moved off the block into bounded one-shot steers, so block bytes are pure functions of state.

Writes now happen at `agent_settled` (never mid-turn, never after aborts), flush machinery is shared between todos and ferment (`state-block-persistence.ts`), and resume replay-dedupe matches real journal entry shapes (split predicates for journal vs. conversation view).

## Validation

TB2.1 benchmark slice, 10 tasks per arm, vs master:

**Claude (Anthropic API cache)**

| Metric | master | this PR |
| --- | --- | --- |
| Cache hit | 70.3% | **96.3%** |
| Cache write | 3.18M (≈11.3k/round) | **403K (≈1.4k/round)** |
| Cache read | 7.51M | **10.63M** |
| Cost | $10.74 | **$4.37** (−59%) |
| Wall clock | 9.8 min | 9.9 min |
| Accuracy | 9/10 | 10/10 (n=10; not significant) |

Workloads match: 281 vs 282 LLM rounds, 129K vs 123K output, 562 vs 564 fresh input tokens. The cost delta is the eliminated cache-write premium; reads now traverse the conversation instead of freezing at system+tools.

**Kimi K3 (Moonshot implicit prefix cache — no explicit markers)**

| Metric | master | this PR |
| --- | --- | --- |
| Cache hit | 89.2% | **94.2%** |
| Fresh input | 487K (≈2.8k/round) | **172K (≈1.1k/round)** |
| Cost | $4.33 | **$2.38** (−45%) |
| Wall clock | 9.0 min | **5.8 min** (−36%) |
| Accuracy | 8/10 | 9/10 (single-trial delta) |

Master's Kimi baseline (89.2%) being far healthier than Anthropic (70.3%) is itself consistent with the theory: implicit prefix matching only loses what follows the first divergence (the volatile tail), while Anthropic's explicit tail marker poisons the breakpoint itself. The fix also transfers to self-hosted sglang (verified `castai-llms`: RadixCache + hierarchical 100 GB L2 write-through, `cache_aware` router, live `prefix_cache_hit` instrumentation) — same reuse discipline, payoff as TTFT/GPU instead of billing.

## Alternatives considered

**Revert to system-prompt injection (pre-#984).** Re-imports both problems #984 legitimately fixed: every todo *write* breaks breakpoint #1 (full-prefix invalidation, worse under todo churn), and `before_agent_start` fires only once per `prompt()` so long autonomous runs see stale state. Persist-on-change keeps #984's freshness win without its position cost.

**Pin the tail marker on the last stable message (tool result) instead of the injected block.** Anthropic's marker scheme could in principle stamp the last *tool-result* block and leave every transient injection in the post-marker band. Modeled cost: the volatile tail band (~1.7k tokens/round measured) is re-sent as fresh 1.0× input every round with no read benefit — a standing ~7–21% slice-cost tax vs writing the block once and reading it at 0.1× thereafter. More decisively: (a) marker placement is sealed inside pi-ai's `buildParams` — extensions cannot reach it, so this requires an upstream API for message-stability classification (cross-repo feature) or permanent `patches/` debt; (b) it does nothing for Moonshot or self-hosted sglang, which use implicit prefix matching with *no markers at all* — tail content churn (`#1021`'s per-transition timestamps/counters) still poisons their page caches on every round; (c) each future per-round injector needs its own pin policy per provider. Append-stable bytes make every caching scheme optimal by default, with zero upstream surface.

**Keep transient injection for stale/stateless reads only.** Still architectural churn per round for the model and for implicit caches; the strip/keep-newest handler anyway converges to persist-on-change when combined with mid-run freshness steers.

## Supporting evidence

- `anthropic-prefix-cache.test.ts` — reproduces the freeze with the real `convertToLlm` + pi-ai `anthropic-messages` pipeline: fails 3/3 on master, passes on this branch.
- `context-handlers-cache-audit.test.ts` — same replay technique over every other transient context handler (model-guard, prompt-enrichment strips, tool-rendering, hide-thinking): no remaining per-round poisoners; one bounded invalidation when a stale steer ages out; one P2 follow-up (hide-thinking ANSI escapes after resume; separate PR).

CI green (incl. TUI e2e). 30 regression tests fail against master's behavior pre-fix.

Co-Authored-By: Kimchi <noreply@kimchi.dev>
