### PR TITLE
fix(acp): show neutral OAuth success copy for ACP-initiated logins

### DIFF
--- a/src/cli-auth/callback-server.test.ts
+++ b/src/cli-auth/callback-server.test.ts
@@ -74,6 +74,24 @@ describe("startCallbackServer", () => {
 		}
 	})
 
+	it("serves caller-provided success copy instead of the default CLI message", async () => {
+		const state = generateState()
+		// ACP authenticate() passes copy that doesn't assume the terminal CLI;
+		// the terminal default must stay untouched.
+		const server = await startCallbackServer(state, {
+			successMessage: "You are now connected to Kimchi. You can close this window and start using it.",
+		})
+
+		const res = await request(server.port, `/callback?token=t&state=${state}`)
+		const body = await res.text()
+		expect(body).toContain("You are now connected to Kimchi")
+		// The terminal-initiated copy must not leak into the ACP-initiated page.
+		expect(body).not.toContain("Your CLI is now connected")
+
+		await server.result
+		server.close()
+	})
+
 	it("rejects an invalid state parameter", async () => {
 		const state = generateState()
 		const server = await startCallbackServer(state)

--- a/src/cli-auth/callback-server.ts
+++ b/src/cli-auth/callback-server.ts
@@ -4,7 +4,14 @@ import { oauthErrorHtml, oauthSuccessHtml } from "../utils/oauth-page.js"
 
 const CALLBACK_PATH = "/callback"
 const CALLBACK_TIMEOUT_MS = 300_000 // 5 minutes
+// Default success copy for terminal-initiated logins (`kimchi login`). Flows
+// launched by other clients override it via CallbackServerOptions.
 const SUCCESS_MESSAGE = "Your CLI is now connected. You can close this window and start using Kimchi."
+
+export interface CallbackServerOptions {
+	/** Copy shown on the success page. Defaults to the terminal CLI message. */
+	successMessage?: string
+}
 
 export interface CallbackResult {
 	token?: string
@@ -27,7 +34,10 @@ export interface CallbackServer {
  * - Returns a success or error HTML page to the browser
  * - Times out after 5 minutes if no callback arrives
  */
-export function startCallbackServer(expectedState: string): Promise<CallbackServer> {
+export function startCallbackServer(
+	expectedState: string,
+	options: CallbackServerOptions = {},
+): Promise<CallbackServer> {
 	return new Promise<CallbackServer>((resolveStart, rejectStart) => {
 		let server: Server | undefined
 		let resolved = false
@@ -109,7 +119,7 @@ export function startCallbackServer(expectedState: string): Promise<CallbackServ
 
 				// Success
 				res.writeHead(200, { "Content-Type": "text/html", Connection: "close" })
-				res.end(oauthSuccessHtml(SUCCESS_MESSAGE))
+				res.end(oauthSuccessHtml(options.successMessage ?? SUCCESS_MESSAGE))
 				finish({ token })
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err)

--- a/src/cli-auth/index.ts
+++ b/src/cli-auth/index.ts
@@ -22,6 +22,11 @@ export interface BrowserAuthOptions {
 	onMessage?: (message: string) => void
 	/** Optional callback invoked with the browser URL before the browser opens */
 	onBrowserUrl?: (url: string) => void
+	/** Copy shown on the callback success page. Terminal logins keep the default
+	 *  ("Your CLI is now connected…"); flows launched by other clients (ACP
+	 *  authenticate(), e.g. Studio's in-app login) pass copy that doesn't
+	 *  assume the terminal CLI. */
+	successMessage?: string
 	/** Abort the flow (e.g. user pressed Esc): tears down the callback server early. */
 	signal?: AbortSignal
 }
@@ -43,7 +48,7 @@ export async function authenticateViaBrowser(options: BrowserAuthOptions = {}): 
 	const state = generateState()
 	const log = options.onMessage ?? console.log
 
-	const callbackServer = await startCallbackServer(state)
+	const callbackServer = await startCallbackServer(state, { successMessage: options.successMessage })
 
 	// Let callers cancel the wait (e.g. the login dialog's Esc) instead of leaving
 	// the callback server running until its 5-minute timeout. close() resolves the

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -82,6 +82,7 @@ import { AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
 	ACP_REATTACH_MID_TURN_META_KEY,
+	ACP_SUCCESS_MESSAGE,
 	type AcpSessionFactory,
 	type AcpSessionLister,
 	type AcpSessionLoader,
@@ -666,6 +667,10 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 
 			expect(result).toEqual({})
 			expect(authenticateViaBrowser).toHaveBeenCalledOnce()
+			// The callback page copy is per-context: ACP-initiated logins (Studio's
+			// in-app flow) must not show the terminal `kimchi login` CLI wording.
+			expect(authenticateViaBrowser).toHaveBeenCalledWith({ successMessage: ACP_SUCCESS_MESSAGE })
+			expect(ACP_SUCCESS_MESSAGE).not.toContain("CLI")
 			expect(writeApiKey).toHaveBeenCalledWith("castai_v1_test-token")
 			expect(updateModelsConfig).toHaveBeenCalledWith(join(tempAgentDir, "models.json"), "castai_v1_test-token")
 		})

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -122,6 +122,11 @@ import { asString, extractImages, truncate } from "./utils.js"
  * initialize() declaration and authenticate() validation to avoid typo drift. */
 const KIMCHI_AGENT_AUTH_METHOD_ID = "kimchi-agent"
 
+/** Copy shown on the OAuth callback success page when the flow was launched by
+ * an ACP client (e.g. Studio's in-app login) rather than `kimchi login`. It
+ * must not assume the terminal CLI. */
+export const ACP_SUCCESS_MESSAGE = "You are now connected to Kimchi. You can close this window and start using it."
+
 /** `_meta` key opting `session/load` into mid-turn attach; strict guard stays default. */
 export const ACP_REATTACH_MID_TURN_META_KEY = "kimchi/reattachMidTurn"
 
@@ -497,9 +502,11 @@ export class KimchiAcpAgent implements Agent {
 
 		// Run the browser OAuth flow: starts a local callback server, opens the
 		// user's browser to the Kimchi web app, and awaits the resulting token.
+		// The success page copy names no client: this flow may be launched by any
+		// ACP client, so it stays neutral instead of the terminal CLI wording.
 		let token: string
 		try {
-			;({ token } = await authenticateViaBrowser())
+			;({ token } = await authenticateViaBrowser({ successMessage: ACP_SUCCESS_MESSAGE }))
 		} catch (error) {
 			const detail = error instanceof Error ? error.message : String(error)
 			throw RequestError.internalError(undefined, `Browser authentication failed: ${detail}`)


### PR DESCRIPTION
## Linked issue

None yet — this fix was tracked on an internal work item (not linkable publicly). Happy to open a public tracking issue if reviewers prefer.

## What does this PR do?

When the browser OAuth flow is launched via the ACP `authenticate()` method (e.g. Studio's in-app login) rather than terminal `kimchi login`, the success callback page still showed terminal-oriented copy: "Your CLI is now connected. You can close this window and start using Kimchi." — the wrong context for a non-CLI client.

This threads an optional `successMessage` from callers through `authenticateViaBrowser()` down to `startCallbackServer()`:

- **Terminal logins unchanged** — the default copy stays byte-for-byte the same.
- **ACP-initiated logins** get neutral copy that names no client, since any ACP client can launch the flow: "You are now connected to Kimchi. You can close this window and start using it." (Kept apostrophe-free: the OAuth page renderer HTML-escapes `'` to `&#39;`, which made exact-match assertions brittle.)

## Testing

- `cli-auth/callback-server.test.ts`: new test asserts caller-provided copy is served and the CLI copy does not leak; the unchanged default-copy and branded-template tests cover the terminal flow.
- `modes/acp/server.test.ts`: `authenticate()` is asserted to pass the neutral success message.
- Full unit suite: 520 files / 10,045 tests pass.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed (none needed — no docs reference the callback copy)
