### PR TITLE
KAP-194: show usage and quota for cloud resources

### DIFF
--- a/src/extensions/teleport/commands/remote-sessions.test.ts
+++ b/src/extensions/teleport/commands/remote-sessions.test.ts
@@ -411,7 +411,12 @@ describe("runRemoteSessions", () => {
 		pickRemoteSessionsMock.mockResolvedValue(undefined)
 		const { ctx } = makeCtx()
 		await runRemoteSessions("", ctx)
-		expect(pickRemoteSessionsMock).toHaveBeenCalledWith(ctx, expect.anything(), quota)
+		const quotaArg = pickRemoteSessionsMock.mock.calls[0][2]
+		await expect(quotaArg).resolves.toBe(quota)
+		expect(getQuotaUsageMock).toHaveBeenCalledWith(
+			ctx.apiKey,
+			expect.objectContaining({ endpoint: ctx.endpoint, orgId: "org-1" }),
+		)
 	})
 
 	it("still opens the picker when the quota fetch fails (summary omitted)", async () => {
@@ -420,6 +425,16 @@ describe("runRemoteSessions", () => {
 		pickRemoteSessionsMock.mockResolvedValue(undefined)
 		const { ctx } = makeCtx()
 		await expect(runRemoteSessions("", ctx)).resolves.toBeUndefined()
-		expect(pickRemoteSessionsMock).toHaveBeenCalledWith(ctx, expect.anything(), undefined)
+		const quotaArg = pickRemoteSessionsMock.mock.calls[0][2]
+		await expect(quotaArg).resolves.toBeUndefined()
+	})
+
+	it("opens the picker without waiting for a slow quota fetch", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		getQuotaUsageMock.mockReturnValue(new Promise(() => {})) // never settles
+		pickRemoteSessionsMock.mockResolvedValue(undefined)
+		const { ctx } = makeCtx()
+		await runRemoteSessions("", ctx)
+		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/extensions/teleport/commands/remote-sessions.test.ts
+++ b/src/extensions/teleport/commands/remote-sessions.test.ts
@@ -417,6 +417,9 @@ describe("runRemoteSessions", () => {
 			ctx.apiKey,
 			expect.objectContaining({ endpoint: ctx.endpoint, orgId: "org-1" }),
 		)
+		// The cached orgId is also shared with the refresh loop's list call so
+		// listWorkspaces skips its own duplicate verifyKey round-trip.
+		expect(listWorkspacesMock).toHaveBeenCalledWith(ctx.apiKey, expect.objectContaining({ orgId: "org-1" }))
 	})
 
 	it("still opens the picker when the quota fetch fails (summary omitted)", async () => {

--- a/src/extensions/teleport/commands/remote-sessions.test.ts
+++ b/src/extensions/teleport/commands/remote-sessions.test.ts
@@ -6,6 +6,7 @@ const {
 	verifyApiKeyMock,
 	listWorkspacesMock,
 	deleteWorkspaceMock,
+	getQuotaUsageMock,
 	createOrUpdateWorkspaceMock,
 	listSessionsMock,
 	deleteSessionMock,
@@ -19,6 +20,7 @@ const {
 	verifyApiKeyMock: vi.fn(),
 	listWorkspacesMock: vi.fn(),
 	deleteWorkspaceMock: vi.fn(),
+	getQuotaUsageMock: vi.fn(),
 	createOrUpdateWorkspaceMock: vi.fn(),
 	listSessionsMock: vi.fn(),
 	deleteSessionMock: vi.fn(),
@@ -34,6 +36,7 @@ vi.mock("../../../sandbox/cloud/auth.js", () => ({
 	createOrUpdateWorkspace: createOrUpdateWorkspaceMock,
 }))
 vi.mock("../../../sandbox/cloud/keys.js", () => ({ verifyApiKey: verifyApiKeyMock }))
+vi.mock("../../../sandbox/cloud/quota.js", () => ({ getQuotaUsage: getQuotaUsageMock }))
 vi.mock("../../../sandbox/cloud/workspaces.js", () => ({
 	listWorkspaces: listWorkspacesMock,
 	deleteWorkspace: deleteWorkspaceMock,
@@ -58,7 +61,7 @@ vi.mock("../ssh-config/sync.js", () => ({
 	syncSshConfig: syncSshConfigMock,
 }))
 
-import type { Workspace } from "../../../sandbox/cloud/types.js"
+import type { QuotaUsage, Workspace } from "../../../sandbox/cloud/types.js"
 import type { Session } from "../../../sandbox/worker/types.js"
 import type { TeleportContext } from "../types.js"
 import type { RemoteWorkspaceNode } from "../ui/remote-sessions-panel.js"
@@ -172,6 +175,7 @@ beforeEach(() => {
 	verifyApiKeyMock.mockReset().mockResolvedValue("org-1")
 	listWorkspacesMock.mockReset().mockResolvedValue([])
 	deleteWorkspaceMock.mockReset().mockResolvedValue(undefined)
+	getQuotaUsageMock.mockReset().mockResolvedValue(undefined)
 	createOrUpdateWorkspaceMock.mockReset().mockResolvedValue({ uri: "u", description: "d" })
 	listSessionsMock.mockReset().mockResolvedValue([])
 	deleteSessionMock.mockReset().mockResolvedValue(undefined)
@@ -256,6 +260,28 @@ describe("buildTree", () => {
 		const nodes = await buildTree([ws("w-1", "alpha"), ws("w-2", "beta")], ctx, "proj")
 		expect(nodes[0]?.row.displayName).toBe("alpha")
 		expect(nodes[1]?.row.displayName).toBe("beta")
+	})
+
+	it("attaches resource request fields to workspace rows", async () => {
+		const { ctx } = makeCtx()
+		const nodes = await buildTree(
+			[{ ...ws("w-1", "alpha"), cpuMillicores: 1500, ramBytes: 6442450944, pvcSizeBytes: 21474836480 }],
+			ctx,
+			"proj",
+		)
+		expect(nodes[0]?.row).toMatchObject({
+			cpuMillicores: 1500,
+			ramBytes: 6442450944,
+			pvcSizeBytes: 21474836480,
+		})
+	})
+
+	it("leaves resource fields undefined on workspace rows when the server omits them", async () => {
+		const { ctx } = makeCtx()
+		const nodes = await buildTree([ws("w-1", "alpha")], ctx, "proj")
+		expect(nodes[0]?.row.cpuMillicores).toBeUndefined()
+		expect(nodes[0]?.row.ramBytes).toBeUndefined()
+		expect(nodes[0]?.row.pvcSizeBytes).toBeUndefined()
 	})
 })
 
@@ -367,5 +393,33 @@ describe("runRemoteSessions", () => {
 		await runRemoteSessions("", ctx)
 		expect(deleteSessionMock).toHaveBeenCalledWith(expect.anything(), "s-1", undefined)
 		expect(pickRemoteSessionsMock).toHaveBeenCalledTimes(2)
+	})
+
+	it("passes quota usage into the picker alongside the workspace tree", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		const quota: QuotaUsage = {
+			userUsage: {
+				currentSandboxes: 1,
+				maxSandboxes: 5,
+				currentCpuMillicores: 1500,
+				maxCpuMillicores: 16000,
+				currentRamBytes: 6442450944,
+				maxRamBytes: 17179869184,
+			},
+		}
+		getQuotaUsageMock.mockResolvedValue(quota)
+		pickRemoteSessionsMock.mockResolvedValue(undefined)
+		const { ctx } = makeCtx()
+		await runRemoteSessions("", ctx)
+		expect(pickRemoteSessionsMock).toHaveBeenCalledWith(ctx, expect.anything(), quota)
+	})
+
+	it("still opens the picker when the quota fetch fails (summary omitted)", async () => {
+		listWorkspacesMock.mockResolvedValue([ws("w-1", "alpha")])
+		getQuotaUsageMock.mockRejectedValue(new Error("quota down"))
+		pickRemoteSessionsMock.mockResolvedValue(undefined)
+		const { ctx } = makeCtx()
+		await expect(runRemoteSessions("", ctx)).resolves.toBeUndefined()
+		expect(pickRemoteSessionsMock).toHaveBeenCalledWith(ctx, expect.anything(), undefined)
 	})
 })

--- a/src/extensions/teleport/commands/remote-sessions.ts
+++ b/src/extensions/teleport/commands/remote-sessions.ts
@@ -25,7 +25,9 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 
 	const fallbackName = basename(ctx.cwd) || "kimchi"
 
-	// Verify once for orgId; cache for the loop (needed for rename/delete workspace).
+	// Verify once for orgId; cache for the loop (needed for rename/delete
+	// workspace) — also shared with listWorkspaces/getQuotaUsage below so both
+	// skip their own duplicate verifyKey round-trip.
 	let orgId: string
 	try {
 		orgId = await verifyApiKey(ctx.apiKey, { endpoint: ctx.endpoint })
@@ -46,7 +48,7 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 		)
 		let workspaces: Workspace[]
 		try {
-			workspaces = await listWorkspaces(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal })
+			workspaces = await listWorkspaces(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal, orgId })
 		} catch (err) {
 			status(ctx, undefined)
 			refuse(ctx, `Could not list workspaces: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/extensions/teleport/commands/remote-sessions.ts
+++ b/src/extensions/teleport/commands/remote-sessions.ts
@@ -1,6 +1,7 @@
 import { basename } from "node:path"
 import { authenticateWorkspace, createOrUpdateWorkspace } from "../../../sandbox/cloud/auth.js"
 import { verifyApiKey } from "../../../sandbox/cloud/keys.js"
+import { getQuotaUsage } from "../../../sandbox/cloud/quota.js"
 import type { Workspace } from "../../../sandbox/cloud/types.js"
 import { deleteWorkspace, listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
 import { WorkerClient } from "../../../sandbox/worker/client.js"
@@ -34,6 +35,11 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 
 	while (true) {
 		status(ctx, "Loading…")
+		// Quota summary is best-effort: fire it alongside the workspace list
+		// and let a failed fetch degrade to "no summary" instead of blocking.
+		const quotaPromise = getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal }).catch(
+			() => undefined,
+		)
 		let workspaces: Workspace[]
 		try {
 			workspaces = await listWorkspaces(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal })
@@ -46,9 +52,10 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 		await syncSshConfig(workspaces, ctx)
 
 		const nodes = await buildTree(workspaces, ctx, fallbackName)
+		const quota = await quotaPromise
 		status(ctx, undefined)
 
-		const result = await pickRemoteSessions(ctx, nodes)
+		const result = await pickRemoteSessions(ctx, nodes, quota)
 		if (!result) return
 
 		if (result.action === "open-terminal") {
@@ -165,6 +172,9 @@ export async function buildTree(
 				lastActivityAt: ws.lastActivityAt,
 				host: ws.host,
 				sessionCount: reachable ? sessions.length : "?",
+				cpuMillicores: ws.cpuMillicores,
+				ramBytes: ws.ramBytes,
+				pvcSizeBytes: ws.pvcSizeBytes,
 			},
 			sessions,
 			unreachable: !reachable,

--- a/src/extensions/teleport/commands/remote-sessions.ts
+++ b/src/extensions/teleport/commands/remote-sessions.ts
@@ -35,9 +35,13 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 
 	while (true) {
 		status(ctx, "Loading…")
-		// Quota summary is best-effort: fire it alongside the workspace list
-		// and let a failed fetch degrade to "no summary" instead of blocking.
-		const quotaPromise = getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal }).catch(
+		// Quota footer fills in asynchronously: fire it alongside the workspace
+		// list and hand the promise to the picker — its footer rows are reserved
+		// either way and populate when the fetch settles. Failures degrade to
+		// "no summary" (pre-caught so the picker never sees a rejection), and a
+		// slow quota endpoint never delays the picker. Reuse the orgId verified
+		// above to skip a duplicate verifyKey round-trip.
+		const quotaPromise = getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal, orgId }).catch(
 			() => undefined,
 		)
 		let workspaces: Workspace[]
@@ -52,10 +56,9 @@ export async function runRemoteSessions(_args: string, ctx: TeleportContext): Pr
 		await syncSshConfig(workspaces, ctx)
 
 		const nodes = await buildTree(workspaces, ctx, fallbackName)
-		const quota = await quotaPromise
 		status(ctx, undefined)
 
-		const result = await pickRemoteSessions(ctx, nodes, quota)
+		const result = await pickRemoteSessions(ctx, nodes, quotaPromise)
 		if (!result) return
 
 		if (result.action === "open-terminal") {

--- a/src/extensions/teleport/commands/teleport.test.ts
+++ b/src/extensions/teleport/commands/teleport.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const {
 	authMock,
 	waitReadyMock,
+	verifyApiKeyMock,
 	listWorkspacesMock,
 	listSessionsMock,
 	createSessionMock,
@@ -36,6 +37,7 @@ const {
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	waitReadyMock: vi.fn(),
+	verifyApiKeyMock: vi.fn(),
 	listWorkspacesMock: vi.fn(),
 	listSessionsMock: vi.fn(),
 	createSessionMock: vi.fn(),
@@ -74,6 +76,7 @@ const {
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
 vi.mock("../../../sandbox/cloud/readiness.js", () => ({ waitForWorkspaceReady: waitReadyMock }))
+vi.mock("../../../sandbox/cloud/keys.js", () => ({ verifyApiKey: verifyApiKeyMock }))
 // resources.js stays real (pure validator); the loader is stubbed, but the
 // real WorkspaceFileError class stays (importOriginal) so instanceof checks
 // in production code behave as in reality.
@@ -233,6 +236,7 @@ beforeEach(() => {
 	tempDir = mkdtempSync(join(tmpdir(), "teleport-test-"))
 	authMock.mockReset().mockResolvedValue(CREDS)
 	waitReadyMock.mockReset().mockResolvedValue(undefined)
+	verifyApiKeyMock.mockReset().mockResolvedValue("org-1")
 	listWorkspacesMock.mockReset().mockResolvedValue([])
 	listSessionsMock.mockReset().mockResolvedValue([])
 	createSessionMock.mockReset().mockResolvedValue({ freshClone: true })

--- a/src/extensions/teleport/commands/terminal.test.ts
+++ b/src/extensions/teleport/commands/terminal.test.ts
@@ -8,6 +8,7 @@ const {
 	provisionGitCredentialMock,
 	buildProxyCommandMock,
 	listWorkspacesMock,
+	verifyApiKeyMock,
 } = vi.hoisted(() => ({
 	authMock: vi.fn(),
 	getGitRemoteHostMock: vi.fn(),
@@ -15,9 +16,11 @@ const {
 	provisionGitCredentialMock: vi.fn(),
 	buildProxyCommandMock: vi.fn(),
 	listWorkspacesMock: vi.fn(),
+	verifyApiKeyMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/auth.js", () => ({ authenticateWorkspace: authMock }))
+vi.mock("../../../sandbox/cloud/keys.js", () => ({ verifyApiKey: verifyApiKeyMock }))
 vi.mock("../../../sandbox/cloud/workspaces.js", () => ({ listWorkspaces: listWorkspacesMock }))
 vi.mock("../../../sandbox/git-credentials.js", () => ({ getGitRemoteHost: getGitRemoteHostMock }))
 vi.mock("../../../config.js", () => ({ readGitToken: readGitTokenMock }))
@@ -101,6 +104,7 @@ beforeEach(() => {
 	provisionGitCredentialMock.mockReset().mockResolvedValue(undefined)
 	buildProxyCommandMock.mockReset().mockReturnValue("kimchi --ssh-proxy %h")
 	listWorkspacesMock.mockReset().mockResolvedValue([])
+	verifyApiKeyMock.mockReset().mockResolvedValue("org-1")
 })
 
 describe("runTerminal", () => {

--- a/src/extensions/teleport/commands/workspace-ref.test.ts
+++ b/src/extensions/teleport/commands/workspace-ref.test.ts
@@ -306,7 +306,7 @@ describe("resolveWorkspaceRef", () => {
 		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
 		const { ctx } = makeCtx()
 		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
-		expect(pickWorkspaceMock.mock.calls[0][2]).toMatchObject({ quota })
+		await expect(pickWorkspaceMock.mock.calls[0][2].quota).resolves.toBe(quota)
 	})
 
 	it("opens the picker with quota undefined when the fetch fails (best-effort)", async () => {
@@ -316,7 +316,16 @@ describe("resolveWorkspaceRef", () => {
 		const { ctx } = makeCtx()
 		const resolved = await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
 		expect(resolved.id).toBe(UUID_A)
-		expect(pickWorkspaceMock.mock.calls[0][2]).toMatchObject({ quota: undefined })
+		await expect(pickWorkspaceMock.mock.calls[0][2].quota).resolves.toBeUndefined()
+	})
+
+	it("opens the picker without waiting for a slow quota fetch", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A })])
+		getQuotaUsageMock.mockReturnValueOnce(new Promise(() => {})) // never settles
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		expect(pickWorkspaceMock).toHaveBeenCalledOnce()
 	})
 
 	it("does not fetch quota when an explicit ref is given (picker cannot open)", async () => {

--- a/src/extensions/teleport/commands/workspace-ref.test.ts
+++ b/src/extensions/teleport/commands/workspace-ref.test.ts
@@ -1,15 +1,17 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { listWorkspacesMock, pickWorkspaceMock } = vi.hoisted(() => ({
+const { listWorkspacesMock, pickWorkspaceMock, getQuotaUsageMock } = vi.hoisted(() => ({
 	listWorkspacesMock: vi.fn(),
 	pickWorkspaceMock: vi.fn(),
+	getQuotaUsageMock: vi.fn(),
 }))
 
 vi.mock("../../../sandbox/cloud/workspaces.js", () => ({ listWorkspaces: listWorkspacesMock }))
+vi.mock("../../../sandbox/cloud/quota.js", () => ({ getQuotaUsage: getQuotaUsageMock }))
 vi.mock("../ui/workspaces-panel.js", () => ({ pickWorkspace: pickWorkspaceMock }))
 
-import type { Workspace } from "../../../sandbox/cloud/types.js"
+import type { QuotaUsage, Workspace } from "../../../sandbox/cloud/types.js"
 import type { TeleportContext } from "../types.js"
 import type { WorkspaceRow } from "../ui/workspaces-table.js"
 import { TeleportRefusal } from "./errors.js"
@@ -78,6 +80,7 @@ function ws(over: Partial<Workspace> = {}): Workspace {
 beforeEach(() => {
 	listWorkspacesMock.mockReset().mockResolvedValue([])
 	pickWorkspaceMock.mockReset()
+	getQuotaUsageMock.mockReset().mockResolvedValue(undefined)
 })
 
 describe("isUuid", () => {
@@ -294,5 +297,32 @@ describe("resolveWorkspaceRef", () => {
 		expect(row.cpuMillicores).toBeUndefined()
 		expect(row.ramBytes).toBeUndefined()
 		expect(row.pvcSizeBytes).toBeUndefined()
+	})
+
+	it("passes the fetched quota to the picker", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A })])
+		const quota: QuotaUsage = { userUsage: { currentSandboxes: 1, maxSandboxes: 5 } }
+		getQuotaUsageMock.mockResolvedValueOnce(quota)
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		expect(pickWorkspaceMock.mock.calls[0][2]).toMatchObject({ quota })
+	})
+
+	it("opens the picker with quota undefined when the fetch fails (best-effort)", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A })])
+		getQuotaUsageMock.mockRejectedValueOnce(new Error("boom"))
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		const resolved = await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		expect(resolved.id).toBe(UUID_A)
+		expect(pickWorkspaceMock.mock.calls[0][2]).toMatchObject({ quota: undefined })
+	})
+
+	it("does not fetch quota when an explicit ref is given (picker cannot open)", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A, name: "kimchi-dev" })])
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, UUID_A, { onEmpty: { kind: "mint" } })
+		expect(getQuotaUsageMock).not.toHaveBeenCalled()
 	})
 })

--- a/src/extensions/teleport/commands/workspace-ref.test.ts
+++ b/src/extensions/teleport/commands/workspace-ref.test.ts
@@ -11,6 +11,7 @@ vi.mock("../ui/workspaces-panel.js", () => ({ pickWorkspace: pickWorkspaceMock }
 
 import type { Workspace } from "../../../sandbox/cloud/types.js"
 import type { TeleportContext } from "../types.js"
+import type { WorkspaceRow } from "../ui/workspaces-table.js"
 import { TeleportRefusal } from "./errors.js"
 import { isUuid, leftmostLabel, matchesHostNickname, resolveWorkspaceRef } from "./workspace-ref.js"
 
@@ -269,5 +270,29 @@ describe("resolveWorkspaceRef", () => {
 		await expect(resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })).rejects.toBeInstanceOf(
 			TeleportRefusal,
 		)
+	})
+
+	it("passes workspace resource fields through to the picker rows", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ cpuMillicores: 1500, ramBytes: 6442450944, pvcSizeBytes: 21474836480 })])
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		expect(pickWorkspaceMock.mock.calls[0][1][0]).toMatchObject({
+			id: UUID_A,
+			cpuMillicores: 1500,
+			ramBytes: 6442450944,
+			pvcSizeBytes: 21474836480,
+		})
+	})
+
+	it("leaves picker row resource fields undefined when the server omits them", async () => {
+		listWorkspacesMock.mockResolvedValue([ws()])
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		const row = pickWorkspaceMock.mock.calls[0][1][0] as WorkspaceRow
+		expect(row.cpuMillicores).toBeUndefined()
+		expect(row.ramBytes).toBeUndefined()
+		expect(row.pvcSizeBytes).toBeUndefined()
 	})
 })

--- a/src/extensions/teleport/commands/workspace-ref.test.ts
+++ b/src/extensions/teleport/commands/workspace-ref.test.ts
@@ -1,12 +1,14 @@
 import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { listWorkspacesMock, pickWorkspaceMock, getQuotaUsageMock } = vi.hoisted(() => ({
+const { listWorkspacesMock, pickWorkspaceMock, getQuotaUsageMock, verifyApiKeyMock } = vi.hoisted(() => ({
 	listWorkspacesMock: vi.fn(),
 	pickWorkspaceMock: vi.fn(),
 	getQuotaUsageMock: vi.fn(),
+	verifyApiKeyMock: vi.fn(),
 }))
 
+vi.mock("../../../sandbox/cloud/keys.js", () => ({ verifyApiKey: verifyApiKeyMock }))
 vi.mock("../../../sandbox/cloud/workspaces.js", () => ({ listWorkspaces: listWorkspacesMock }))
 vi.mock("../../../sandbox/cloud/quota.js", () => ({ getQuotaUsage: getQuotaUsageMock }))
 vi.mock("../ui/workspaces-panel.js", () => ({ pickWorkspace: pickWorkspaceMock }))
@@ -81,6 +83,7 @@ beforeEach(() => {
 	listWorkspacesMock.mockReset().mockResolvedValue([])
 	pickWorkspaceMock.mockReset()
 	getQuotaUsageMock.mockReset().mockResolvedValue(undefined)
+	verifyApiKeyMock.mockReset().mockResolvedValue("org-1")
 })
 
 describe("isUuid", () => {
@@ -326,6 +329,26 @@ describe("resolveWorkspaceRef", () => {
 		const { ctx } = makeCtx()
 		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
 		expect(pickWorkspaceMock).toHaveBeenCalledOnce()
+	})
+
+	it("verifies the key once and shares the orgId with list and quota", async () => {
+		listWorkspacesMock.mockResolvedValue([ws({ id: UUID_A })])
+		pickWorkspaceMock.mockResolvedValue({ action: "select", row: { id: UUID_A } })
+		const { ctx } = makeCtx()
+		await resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })
+		expect(verifyApiKeyMock).toHaveBeenCalledOnce()
+		expect(listWorkspacesMock).toHaveBeenCalledWith(ctx.apiKey, expect.objectContaining({ orgId: "org-1" }))
+		expect(getQuotaUsageMock).toHaveBeenCalledWith(ctx.apiKey, expect.objectContaining({ orgId: "org-1" }))
+	})
+
+	it("refuses when API key verification fails", async () => {
+		verifyApiKeyMock.mockRejectedValue(new Error("bad key"))
+		const { ctx, ui } = makeCtx()
+		await expect(resolveWorkspaceRef(ctx, undefined, { onEmpty: { kind: "mint" } })).rejects.toBeInstanceOf(
+			TeleportRefusal,
+		)
+		expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Could not verify API key"), "error")
+		expect(listWorkspacesMock).not.toHaveBeenCalled()
 	})
 
 	it("does not fetch quota when an explicit ref is given (picker cannot open)", async () => {

--- a/src/extensions/teleport/commands/workspace-ref.ts
+++ b/src/extensions/teleport/commands/workspace-ref.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { getQuotaUsage } from "../../../sandbox/cloud/quota.js"
 import type { Workspace } from "../../../sandbox/cloud/types.js"
 import { listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
 import type { TeleportContext } from "../types.js"
@@ -56,6 +57,13 @@ export async function resolveWorkspaceRef(
 	ref: string | undefined,
 	opts: ResolveOpts,
 ): Promise<ResolvedWorkspace> {
+	// Quota summary for the picker footer — best-effort, fired alongside the
+	// workspace list so the picker doesn't wait for it; a failed fetch
+	// degrades to no summary. Only the no-ref path can open the picker, so
+	// the request is skipped entirely when an explicit ref is given.
+	const quotaPromise = ref
+		? undefined
+		: getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal }).catch(() => undefined)
 	// Always list so we can return the workspace's current name to the caller —
 	// the UUID shortcut is gone because callers now use `resolved.name` to
 	// avoid clobbering the server-stored description on the next PUT.
@@ -107,7 +115,7 @@ export async function resolveWorkspaceRef(
 		ramBytes: w.ramBytes,
 		pvcSizeBytes: w.pvcSizeBytes,
 	}))
-	const choice = await pickWorkspace(ctx, rows, { allowNew, hideSessions: true })
+	const choice = await pickWorkspace(ctx, rows, { allowNew, hideSessions: true, quota: await quotaPromise })
 	if (!choice) {
 		throw new TeleportRefusal(opts.cancelledMessage ?? "cancelled")
 	}

--- a/src/extensions/teleport/commands/workspace-ref.ts
+++ b/src/extensions/teleport/commands/workspace-ref.ts
@@ -103,6 +103,9 @@ export async function resolveWorkspaceRef(
 		lastActivityAt: w.lastActivityAt,
 		host: w.host,
 		sessionCount: "?",
+		cpuMillicores: w.cpuMillicores,
+		ramBytes: w.ramBytes,
+		pvcSizeBytes: w.pvcSizeBytes,
 	}))
 	const choice = await pickWorkspace(ctx, rows, { allowNew, hideSessions: true })
 	if (!choice) {

--- a/src/extensions/teleport/commands/workspace-ref.ts
+++ b/src/extensions/teleport/commands/workspace-ref.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { verifyApiKey } from "../../../sandbox/cloud/keys.js"
 import { getQuotaUsage } from "../../../sandbox/cloud/quota.js"
 import type { Workspace } from "../../../sandbox/cloud/types.js"
 import { listWorkspaces } from "../../../sandbox/cloud/workspaces.js"
@@ -57,20 +58,29 @@ export async function resolveWorkspaceRef(
 	ref: string | undefined,
 	opts: ResolveOpts,
 ): Promise<ResolvedWorkspace> {
+	// Verify once up front; the orgId is shared with the workspace list and the
+	// quota fetch below (both skip their own verifyKey round-trip when given it).
+	let orgId: string
+	try {
+		orgId = await verifyApiKey(ctx.apiKey, { endpoint: ctx.endpoint })
+	} catch (err) {
+		refuse(ctx, `Could not verify API key: ${err instanceof Error ? err.message : String(err)}`)
+	}
+
 	// Quota summary for the picker footer — fired alongside the workspace
-	// list; the picker fills its footer when the fetch settles instead of
-	// blocking on it, and a failed fetch degrades to no summary (pre-caught
-	// here). Only the no-ref path can open the picker, so the request is
-	// skipped entirely when an explicit ref is given.
+	// list with the shared verified orgId; the picker fills its footer when
+	// the fetch settles instead of blocking on it, and a failed fetch degrades
+	// to no summary (pre-caught here). Only the no-ref path can open the
+	// picker, so the request is skipped entirely when an explicit ref is given.
 	const quotaPromise = ref
 		? undefined
-		: getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal }).catch(() => undefined)
+		: getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal, orgId }).catch(() => undefined)
 	// Always list so we can return the workspace's current name to the caller —
 	// the UUID shortcut is gone because callers now use `resolved.name` to
 	// avoid clobbering the server-stored description on the next PUT.
 	let workspaces: Workspace[]
 	try {
-		workspaces = await listWorkspaces(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal })
+		workspaces = await listWorkspaces(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal, orgId })
 	} catch (err) {
 		refuse(ctx, `Could not list workspaces: ${err instanceof Error ? err.message : String(err)}`)
 	}

--- a/src/extensions/teleport/commands/workspace-ref.ts
+++ b/src/extensions/teleport/commands/workspace-ref.ts
@@ -57,10 +57,11 @@ export async function resolveWorkspaceRef(
 	ref: string | undefined,
 	opts: ResolveOpts,
 ): Promise<ResolvedWorkspace> {
-	// Quota summary for the picker footer — best-effort, fired alongside the
-	// workspace list so the picker doesn't wait for it; a failed fetch
-	// degrades to no summary. Only the no-ref path can open the picker, so
-	// the request is skipped entirely when an explicit ref is given.
+	// Quota summary for the picker footer — fired alongside the workspace
+	// list; the picker fills its footer when the fetch settles instead of
+	// blocking on it, and a failed fetch degrades to no summary (pre-caught
+	// here). Only the no-ref path can open the picker, so the request is
+	// skipped entirely when an explicit ref is given.
 	const quotaPromise = ref
 		? undefined
 		: getQuotaUsage(ctx.apiKey, { endpoint: ctx.endpoint, signal: ctx.signal }).catch(() => undefined)
@@ -115,7 +116,7 @@ export async function resolveWorkspaceRef(
 		ramBytes: w.ramBytes,
 		pvcSizeBytes: w.pvcSizeBytes,
 	}))
-	const choice = await pickWorkspace(ctx, rows, { allowNew, hideSessions: true, quota: await quotaPromise })
+	const choice = await pickWorkspace(ctx, rows, { allowNew, hideSessions: true, quota: quotaPromise })
 	if (!choice) {
 		throw new TeleportRefusal(opts.cancelledMessage ?? "cancelled")
 	}

--- a/src/extensions/teleport/ui/format-bytes.test.ts
+++ b/src/extensions/teleport/ui/format-bytes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { formatBytes, formatK8sBytes, formatK8sBytesPair, formatMillicores } from "./format-bytes.js"
+
+describe("formatMillicores", () => {
+	it.each<[number, string]>([
+		[0, "0m"],
+		[250, "250m"],
+		[999, "999m"],
+		[1000, "1000m"],
+		[1500, "1500m"],
+		[2000, "2000m"],
+		[1234, "1234m"],
+		[16000, "16000m"],
+	])("formats %d millicores as %s", (millicores, expected) => {
+		expect(formatMillicores(millicores)).toBe(expected)
+	})
+})
+
+describe("formatK8sBytes", () => {
+	it.each<[number, string]>([
+		[0, "0"],
+		[1000, "1000"],
+		[1024, "1Ki"],
+		[1048576, "1Mi"],
+		[536870912, "512Mi"],
+		[1073741824, "1Gi"],
+		[1610612736, "1536Mi"],
+		[10737418240, "10Gi"],
+		[17179869184, "16Gi"],
+	])("formats %d bytes as %s", (bytes, expected) => {
+		expect(formatK8sBytes(bytes)).toBe(expected)
+	})
+})
+
+describe("formatK8sBytesPair", () => {
+	it.each<[number, number, string]>([
+		// the unit comes from max; the current side may need decimals
+		[1610612736, 128849018880, "1.5Gi/120Gi"],
+		[536870912, 128849018880, "0.5Gi/120Gi"],
+		[536870912, 1073741824, "0.5Gi/1Gi"],
+		// max that is not a whole multiple of the larger unit keeps both sides smaller
+		[1610612736, 1610612736, "1536Mi/1536Mi"],
+		[10737418240, 21474836480, "10Gi/20Gi"],
+		// below 1Ki both sides are plain bytes; non-divisible max falls back to the largest fitting unit
+		[500, 1000, "500/1000"],
+		[1048576, 1500000, "1Mi/1.43Mi"],
+	])("formats %d/%d bytes as %s", (current, max, expected) => {
+		expect(formatK8sBytesPair(current, max)).toBe(expected)
+	})
+})
+
+describe("formatBytes", () => {
+	it.each<[number, string]>([
+		[0, "0 B"],
+		[999, "999 B"],
+		[1073741824, "1.07 GB"],
+		[21474836480, "21.47 GB"],
+	])("formats %d bytes as %s", (bytes, expected) => {
+		expect(formatBytes(bytes)).toBe(expected)
+	})
+})

--- a/src/extensions/teleport/ui/format-bytes.ts
+++ b/src/extensions/teleport/ui/format-bytes.ts
@@ -11,3 +11,73 @@ export function formatBytes(bytes: number): string {
 	if (bytes < 1_000_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`
 	return `${(bytes / 1_000_000_000).toFixed(2)} GB`
 }
+
+/** Binary-SI units, smallest to largest, as used by Kubernetes quantities. */
+const BINARY_UNITS: [suffix: string, bytes: number][] = [
+	["Ki", 1024],
+	["Mi", 1024 ** 2],
+	["Gi", 1024 ** 3],
+	["Ti", 1024 ** 4],
+	["Pi", 1024 ** 5],
+	["Ei", 1024 ** 6],
+]
+
+/**
+ * Format a byte count in Kubernetes convention: the largest binary unit
+ * (Ki…Ei) that divides the value exactly, integers only (1.5 Gi shows as
+ * "1536Mi", matching kubectl); a value that is not a whole multiple of Ki
+ * renders as plain bytes. Mirrors the quantity strings the control plane
+ * round-trips ("512Mi", "10Gi").
+ */
+export function formatK8sBytes(bytes: number): string {
+	for (let i = BINARY_UNITS.length - 1; i >= 0; i--) {
+		const [suffix, size] = BINARY_UNITS[i]
+		if (bytes >= size && bytes % size === 0) return `${bytes / size}${suffix}`
+	}
+	return `${bytes}`
+}
+
+/**
+ * Format a current/max byte pair in one shared unit so the two sides are
+ * directly comparable: the unit is the largest binary unit that divides max
+ * exactly (the largest that fits when max is not a whole multiple; plain
+ * bytes below 1Ki). The current side may render with up to two decimals
+ * ("1.5Gi/120Gi") — both sides stay valid Kubernetes quantities.
+ */
+export function formatK8sBytesPair(current: number, max: number): string {
+	let suffix = ""
+	let size = 1
+	for (let i = BINARY_UNITS.length - 1; i >= 0; i--) {
+		const [s, b] = BINARY_UNITS[i]
+		if (max >= b && max % b === 0) {
+			suffix = s
+			size = b
+			break
+		}
+	}
+	if (suffix === "") {
+		for (let i = BINARY_UNITS.length - 1; i >= 0; i--) {
+			if (max >= BINARY_UNITS[i][1]) {
+				suffix = BINARY_UNITS[i][0]
+				size = BINARY_UNITS[i][1]
+				break
+			}
+		}
+	}
+	return `${mantissa(current / size)}${suffix}/${mantissa(max / size)}${suffix}`
+}
+
+/** Integer mantissas print bare; others trim to at most two decimals. */
+function mantissa(scaled: number): string {
+	if (Number.isInteger(scaled)) return String(scaled)
+	return String(Number(scaled.toFixed(2)))
+}
+
+/**
+ * Format a millicore count in Kubernetes convention: kubectl (describe
+ * node/pod, top) keeps the millicore "m" suffix even above one core
+ * (1500 → "1500m", not "1.5").
+ */
+export function formatMillicores(millicores: number): string {
+	return `${millicores}m`
+}

--- a/src/extensions/teleport/ui/quota-footer.test.ts
+++ b/src/extensions/teleport/ui/quota-footer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
+import { quotaLines } from "./quota-footer.js"
+
+const full: QuotaUsage = {
+	userUsage: {
+		currentSandboxes: 3,
+		maxSandboxes: 10,
+		currentCpuMillicores: 4500,
+		maxCpuMillicores: 16000,
+		currentRamBytes: 6442450944,
+		maxRamBytes: 17179869184,
+		currentPvcSizeBytes: 21474836480,
+		maxPvcSizeBytes: 128849018880,
+	},
+	orgUsage: {
+		currentSandboxes: 7,
+		maxSandboxes: 10,
+		currentCpuMillicores: 9000,
+		maxCpuMillicores: 16000,
+		currentRamBytes: 6442450944,
+		maxRamBytes: 17179869184,
+		currentPvcSizeBytes: 32212254720,
+		maxPvcSizeBytes: 429496729600,
+	},
+}
+
+describe("quotaLines", () => {
+	it("formats each scope on its own line with all four dimensions", () => {
+		const [user, org] = quotaLines(full)
+		expect(user).toBe("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
+		expect(org).toBe("org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces")
+	})
+
+	it("drops segments whose fields are missing", () => {
+		const [user] = quotaLines({ userUsage: { currentSandboxes: 1, maxSandboxes: 5 } })
+		expect(user).toBe("You: 1/5 workspaces")
+	})
+
+	it("yields undefined for absent scopes", () => {
+		const [user, org] = quotaLines({
+			userUsage: { currentPvcSizeBytes: 5368709120, maxPvcSizeBytes: 107374182400 },
+		})
+		expect(user).toBe("You: 5Gi/100Gi PVC")
+		expect(org).toBeUndefined()
+	})
+
+	it("yields a scope undefined when it carries no usable fields", () => {
+		const [user, org] = quotaLines({ userUsage: full.userUsage, orgUsage: {} })
+		expect(user).toContain("CPU")
+		expect(org).toBeUndefined()
+	})
+
+	it("returns both lines undefined when quota is undefined", () => {
+		const [user, org] = quotaLines(undefined)
+		expect(user).toBeUndefined()
+		expect(org).toBeUndefined()
+	})
+})

--- a/src/extensions/teleport/ui/quota-footer.test.ts
+++ b/src/extensions/teleport/ui/quota-footer.test.ts
@@ -28,20 +28,20 @@ const full: QuotaUsage = {
 describe("quotaLines", () => {
 	it("formats each scope on its own line with all four dimensions", () => {
 		const [user, org] = quotaLines(full)
-		expect(user).toBe("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
+		expect(user).toBe("you: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
 		expect(org).toBe("org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces")
 	})
 
 	it("drops segments whose fields are missing", () => {
 		const [user] = quotaLines({ userUsage: { currentSandboxes: 1, maxSandboxes: 5 } })
-		expect(user).toBe("You: 1/5 workspaces")
+		expect(user).toBe("you: 1/5 workspaces")
 	})
 
 	it("yields undefined for absent scopes", () => {
 		const [user, org] = quotaLines({
 			userUsage: { currentPvcSizeBytes: 5368709120, maxPvcSizeBytes: 107374182400 },
 		})
-		expect(user).toBe("You: 5Gi/100Gi PVC")
+		expect(user).toBe("you: 5Gi/100Gi PVC")
 		expect(org).toBeUndefined()
 	})
 

--- a/src/extensions/teleport/ui/quota-footer.ts
+++ b/src/extensions/teleport/ui/quota-footer.ts
@@ -1,0 +1,35 @@
+import type { QuotaUsage, ResourceUsage } from "../../../sandbox/cloud/types.js"
+import { formatK8sBytesPair, formatMillicores } from "./format-bytes.js"
+
+/**
+ * Usage-vs-quota footer lines: the user scope on the first line, the org
+ * scope on its own line below it — one line per scope keeps both fully
+ * readable at common terminal widths instead of truncating the org tail.
+ * Segments with missing fields are dropped; a scope with nothing to show
+ * yields undefined, which callers replace with an empty row so the panel
+ * always emits the same line count.
+ *
+ * Shared by the workspace picker (WorkspacesPanel) and the remote-sessions
+ * panel so the two footers cannot drift apart.
+ */
+export function quotaLines(quota: QuotaUsage | undefined): [string | undefined, string | undefined] {
+	const scope = (u: ResourceUsage): string | undefined => {
+		const parts: string[] = []
+		if (u.currentCpuMillicores !== undefined && u.maxCpuMillicores !== undefined) {
+			parts.push(`${formatMillicores(u.currentCpuMillicores)}/${formatMillicores(u.maxCpuMillicores)} CPU`)
+		}
+		if (u.currentRamBytes !== undefined && u.maxRamBytes !== undefined) {
+			parts.push(`${formatK8sBytesPair(u.currentRamBytes, u.maxRamBytes)} RAM`)
+		}
+		if (u.currentPvcSizeBytes !== undefined && u.maxPvcSizeBytes !== undefined) {
+			parts.push(`${formatK8sBytesPair(u.currentPvcSizeBytes, u.maxPvcSizeBytes)} PVC`)
+		}
+		if (u.currentSandboxes !== undefined && u.maxSandboxes !== undefined) {
+			parts.push(`${u.currentSandboxes}/${u.maxSandboxes} workspaces`)
+		}
+		return parts.length > 0 ? parts.join(" · ") : undefined
+	}
+	const user = quota?.userUsage ? scope(quota.userUsage) : undefined
+	const org = quota?.orgUsage ? scope(quota.orgUsage) : undefined
+	return [user ? `You: ${user}` : undefined, org ? `org: ${org}` : undefined]
+}

--- a/src/extensions/teleport/ui/quota-footer.ts
+++ b/src/extensions/teleport/ui/quota-footer.ts
@@ -2,6 +2,50 @@ import type { QuotaUsage, ResourceUsage } from "../../../sandbox/cloud/types.js"
 import { formatK8sBytesPair, formatMillicores } from "./format-bytes.js"
 
 /**
+ * Quota footer input: a settled value, or an in-flight fetch. Panels accept
+ * either — the two footer rows are reserved regardless, so a promise simply
+ * fills them in (and requests a re-render) when it settles, never blocking
+ * the picker from opening. Callers should attach `.catch(() => undefined)`
+ * so failures degrade to "no summary"; panels also ignore rejections
+ * defensively.
+ */
+export type QuotaInput = QuotaUsage | Promise<QuotaUsage | undefined>
+
+/** Narrow a QuotaInput: true when the fetch is still in flight. */
+export function isQuotaPending(input: QuotaInput | undefined): input is Promise<QuotaUsage | undefined> {
+	return input !== undefined && typeof (input as Promise<QuotaUsage | undefined>).then === "function"
+}
+
+/**
+ * Apply a QuotaInput to a panel footer. A settled value is assigned
+ * immediately; an in-flight fetch assigns and re-renders when it settles —
+ * unless the panel was disposed in the meantime — and rejections are
+ * ignored (callers pre-catch; the footer simply stays empty). Shared by the
+ * two picker panels so their footer behavior cannot drift apart.
+ */
+export function settleQuota(
+	input: QuotaInput | undefined,
+	hooks: {
+		isDisposed: () => boolean
+		set: (q: QuotaUsage | undefined) => void
+		requestRender: () => void
+	},
+): void {
+	if (!isQuotaPending(input)) {
+		hooks.set(input)
+		return
+	}
+	void input.then(
+		(q) => {
+			if (hooks.isDisposed()) return
+			hooks.set(q)
+			hooks.requestRender()
+		},
+		() => undefined,
+	)
+}
+
+/**
  * Usage-vs-quota footer lines: the user scope on the first line, the org
  * scope on its own line below it — one line per scope keeps both fully
  * readable at common terminal widths instead of truncating the org tail.
@@ -31,5 +75,5 @@ export function quotaLines(quota: QuotaUsage | undefined): [string | undefined, 
 	}
 	const user = quota?.userUsage ? scope(quota.userUsage) : undefined
 	const org = quota?.orgUsage ? scope(quota.orgUsage) : undefined
-	return [user ? `You: ${user}` : undefined, org ? `org: ${org}` : undefined]
+	return [user ? `you: ${user}` : undefined, org ? `org: ${org}` : undefined]
 }

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -363,17 +363,22 @@ describe("RemoteSessionsPanel", () => {
 
 		const summaryLine = (panel: RemoteSessionsPanel): string | undefined =>
 			panel
-				// Wide enough for the full two-scope summary; truncation at narrower
-				// widths is covered by the narrow-terminal render tests.
-				.render(200)
+				.render(120)
 				.map(stripAnsi)
 				.find((l) => l.includes("You:"))
 
-		it("renders a one-line usage-vs-quota summary above the hint", () => {
+		const orgLine = (panel: RemoteSessionsPanel): string | undefined =>
+			panel
+				.render(120)
+				.map(stripAnsi)
+				.find((l) => l.includes("org:"))
+
+		it("renders the usage-vs-quota summary as two lines: user first, org below", () => {
 			const { panel } = makePanel(treeNodes, { quota })
 			const line = summaryLine(panel)
 			expect(line).toContain("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
-			expect(line).toContain("(org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces)")
+			expect(line).not.toContain("org:")
+			expect(orgLine(panel)).toContain("org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces")
 		})
 
 		it("renders current and max RAM in one shared unit, decimals on the current side when needed", () => {
@@ -398,6 +403,7 @@ describe("RemoteSessionsPanel", () => {
 			const line = summaryLine(panel)
 			expect(line).toContain("You: 4500m/16000m CPU")
 			expect(line).not.toContain("org:")
+			expect(orgLine(panel)).toBeUndefined()
 		})
 
 		it("drops segments whose fields are missing", () => {

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -1,5 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { describe, expect, it, vi } from "vitest"
+import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
 import type { RemoteSessionNode, RemoteWorkspaceNode } from "./remote-sessions-panel.js"
 import { createRemoteSessionsPanel, RemoteSessionsPanel } from "./remote-sessions-panel.js"
 
@@ -26,6 +27,9 @@ function node(over: Partial<RemoteWorkspaceNode> = {}): RemoteWorkspaceNode {
 		lastActivityAt: new Date(NOW.getTime() - 60_000),
 		host: "host.example",
 		sessionCount: 2,
+		cpuMillicores: 1500,
+		ramBytes: 6442450944,
+		pvcSizeBytes: 21474836480,
 		...over.row,
 	}
 	return {
@@ -49,13 +53,16 @@ const treeNodes: RemoteWorkspaceNode[] = [
 	}),
 ]
 
-function makePanel(nodes: RemoteWorkspaceNode[] = treeNodes, opts?: { termRows?: number; termCols?: number }) {
+function makePanel(
+	nodes: RemoteWorkspaceNode[] = treeNodes,
+	opts?: { termRows?: number; termCols?: number; quota?: QuotaUsage },
+) {
 	const tui = {
 		requestRender: vi.fn(),
 		terminal: { rows: opts?.termRows ?? 40, cols: opts?.termCols ?? 120 },
 	}
 	const done = vi.fn()
-	const panel = createRemoteSessionsPanel(nodes, tui, done)
+	const panel = createRemoteSessionsPanel(nodes, tui, done, opts?.quota)
 	return { panel, tui, done }
 }
 
@@ -105,6 +112,44 @@ describe("RemoteSessionsPanel", () => {
 			const { panel } = makePanel([])
 			const text = panel.render(120).map(stripAnsi).join("\n")
 			expect(text).toContain("(no workspaces)")
+		})
+	})
+
+	describe("resource columns", () => {
+		it("shows resource values on workspace rows only; session rows stay blank", () => {
+			const { panel } = makePanel()
+			const lines = panel.render(120).map(stripAnsi)
+			const wsLine = lines.find((l) => l.includes("alpha"))
+			const sessionLine = lines.find((l) => l.includes("pty-abc12"))
+			expect(wsLine).toContain("1500m")
+			expect(wsLine).toContain("6Gi")
+			expect(wsLine).toContain("20Gi")
+			expect(sessionLine).not.toContain("1500m")
+			expect(sessionLine).not.toContain("6Gi")
+			expect(sessionLine).not.toContain("20Gi")
+		})
+
+		it("renders '-' on workspace rows when the server omitted resource fields", () => {
+			const { panel } = makePanel([
+				node({
+					row: {
+						id: "ws-x",
+						name: "gamma",
+						status: "active",
+						sessionCount: 0,
+						cpuMillicores: undefined,
+						ramBytes: undefined,
+						pvcSizeBytes: undefined,
+					},
+				}),
+			])
+			const line = panel
+				.render(120)
+				.map(stripAnsi)
+				.find((l) => l.includes("gamma"))
+			// CPU, RAM and PVC cells are the only dash sources on this line
+			// (name/status/relative times never contain dashes).
+			expect((line?.match(/-/g) ?? []).length).toBe(3)
 		})
 	})
 
@@ -202,6 +247,39 @@ describe("RemoteSessionsPanel", () => {
 			expect(text).not.toContain("NAME / SESSION")
 		})
 
+		it("'i' shows the workspace's resource requests in details", () => {
+			const { panel } = makePanel()
+			panel.handleInput("i")
+			const text = panel.render(120).map(stripAnsi).join("\n")
+			expect(text).toContain("CPU")
+			expect(text).toContain("1500m")
+			expect(text).toContain("RAM")
+			expect(text).toContain("6Gi")
+			expect(text).toContain("PVC")
+			expect(text).toContain("20Gi")
+		})
+
+		it("'i' shows '-' for resource fields the server omitted", () => {
+			const { panel } = makePanel([
+				node({
+					row: {
+						id: "ws-x",
+						name: "gamma",
+						status: "active",
+						sessionCount: 0,
+						cpuMillicores: undefined,
+						ramBytes: undefined,
+						pvcSizeBytes: undefined,
+					},
+				}),
+			])
+			panel.handleInput("i")
+			const text = panel.render(120).map(stripAnsi).join("\n")
+			expect(text).toMatch(/CPU\s+-/)
+			expect(text).toMatch(/RAM\s+-/)
+			expect(text).toMatch(/PVC\s+-/)
+		})
+
 		it("'i' on a session shows session details including workspace host", () => {
 			const { panel } = makePanel()
 			panel.handleInput("j")
@@ -256,6 +334,86 @@ describe("RemoteSessionsPanel", () => {
 			const baseline = panel.render(120).length
 			panel.handleInput("i")
 			expect(panel.render(120).length).toBe(baseline)
+		})
+	})
+
+	describe("quota summary", () => {
+		const quota: QuotaUsage = {
+			userUsage: {
+				currentSandboxes: 3,
+				maxSandboxes: 10,
+				currentCpuMillicores: 4500,
+				maxCpuMillicores: 16000,
+				currentRamBytes: 6442450944,
+				maxRamBytes: 17179869184,
+			},
+			orgUsage: {
+				currentSandboxes: 7,
+				maxSandboxes: 10,
+				currentCpuMillicores: 9000,
+				maxCpuMillicores: 16000,
+				currentRamBytes: 6442450944,
+				maxRamBytes: 17179869184,
+			},
+		}
+
+		const summaryLine = (panel: RemoteSessionsPanel): string | undefined =>
+			panel
+				.render(120)
+				.map(stripAnsi)
+				.find((l) => l.includes("You:"))
+
+		it("renders a one-line usage-vs-quota summary above the hint", () => {
+			const { panel } = makePanel(treeNodes, { quota })
+			const line = summaryLine(panel)
+			expect(line).toContain("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 3/10 workspaces")
+			expect(line).toContain("(org: 9000m/16000m CPU · 6Gi/16Gi RAM · 7/10 workspaces)")
+		})
+
+		it("renders current and max RAM in one shared unit, decimals on the current side when needed", () => {
+			const { panel } = makePanel(treeNodes, {
+				quota: {
+					userUsage: {
+						currentSandboxes: 2,
+						maxSandboxes: 10,
+						currentCpuMillicores: 1700,
+						maxCpuMillicores: 3000,
+						currentRamBytes: 1610612736, // 1.5 Gi
+						maxRamBytes: 128849018880, // 120 Gi
+					},
+				},
+			})
+			const line = summaryLine(panel)
+			expect(line).toContain("You: 1700m/3000m CPU · 1.5Gi/120Gi RAM · 2/10 workspaces")
+		})
+
+		it("renders only the user scope when org usage is missing", () => {
+			const { panel } = makePanel(treeNodes, { quota: { userUsage: quota.userUsage } })
+			const line = summaryLine(panel)
+			expect(line).toContain("You: 4500m/16000m CPU")
+			expect(line).not.toContain("org:")
+		})
+
+		it("drops segments whose fields are missing", () => {
+			const { panel } = makePanel(treeNodes, {
+				quota: { userUsage: { currentSandboxes: 1, maxSandboxes: 5 } },
+			})
+			const line = summaryLine(panel)
+			expect(line).toContain("You: 1/5 workspaces")
+			expect(line).not.toContain("CPU")
+			expect(line).not.toContain("RAM")
+		})
+
+		it("omits the summary line entirely when no quota was fetched, keeping the line count constant", () => {
+			const withQuota = makePanel(treeNodes, { quota, termRows: 20 })
+			const without = makePanel(treeNodes, { termRows: 20 })
+			expect(without.panel.render(120).length).toBe(withQuota.panel.render(120).length)
+			expect(summaryLine(without.panel)).toBeUndefined()
+		})
+
+		it("omits the summary when the quota carries no usable fields", () => {
+			const { panel } = makePanel(treeNodes, { quota: {} })
+			expect(summaryLine(panel)).toBeUndefined()
 		})
 	})
 

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -500,6 +500,23 @@ describe("RemoteSessionsPanel", () => {
 	})
 
 	describe("narrow terminals", () => {
+		it("keeps the NAME flex column at MIN_COL_WIDTH when the fixed resource columns crowd the row", () => {
+			const { panel } = makePanel([
+				node({ row: { id: "ws-long-1", name: "abcdefghijklmnop", status: "active", sessionCount: 0 } }),
+			])
+			const lines = panel.render(60).map(stripAnsi)
+			const line = lines.find((l) => l.includes("> "))
+			// The name truncates but never below MIN_COL_WIDTH: a width-8 cell
+			// still shows 7 name characters plus the ellipsis.
+			expect(line).toContain("abcdefg")
+			// The fixed resource columns are never squeezed: their headers
+			// survive intact on the header row.
+			const header = lines.find((l) => l.includes("NAME / SESSION"))
+			expect(header).toContain("CPU")
+			expect(header).toContain("RAM")
+			expect(header).toContain("PVC")
+		})
+
 		// Regression: border title math produced a negative "─".repeat count
 		// below the title width, crashing with RangeError.
 		for (const width of [1, 2, 3, 4, 5, 8, 10, 16, 24]) {

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -346,6 +346,8 @@ describe("RemoteSessionsPanel", () => {
 				maxCpuMillicores: 16000,
 				currentRamBytes: 6442450944,
 				maxRamBytes: 17179869184,
+				currentPvcSizeBytes: 21474836480,
+				maxPvcSizeBytes: 128849018880,
 			},
 			orgUsage: {
 				currentSandboxes: 7,
@@ -354,20 +356,24 @@ describe("RemoteSessionsPanel", () => {
 				maxCpuMillicores: 16000,
 				currentRamBytes: 6442450944,
 				maxRamBytes: 17179869184,
+				currentPvcSizeBytes: 32212254720,
+				maxPvcSizeBytes: 429496729600,
 			},
 		}
 
 		const summaryLine = (panel: RemoteSessionsPanel): string | undefined =>
 			panel
-				.render(120)
+				// Wide enough for the full two-scope summary; truncation at narrower
+				// widths is covered by the narrow-terminal render tests.
+				.render(200)
 				.map(stripAnsi)
 				.find((l) => l.includes("You:"))
 
 		it("renders a one-line usage-vs-quota summary above the hint", () => {
 			const { panel } = makePanel(treeNodes, { quota })
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 3/10 workspaces")
-			expect(line).toContain("(org: 9000m/16000m CPU · 6Gi/16Gi RAM · 7/10 workspaces)")
+			expect(line).toContain("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
+			expect(line).toContain("(org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces)")
 		})
 
 		it("renders current and max RAM in one shared unit, decimals on the current side when needed", () => {
@@ -402,6 +408,18 @@ describe("RemoteSessionsPanel", () => {
 			expect(line).toContain("You: 1/5 workspaces")
 			expect(line).not.toContain("CPU")
 			expect(line).not.toContain("RAM")
+			expect(line).not.toContain("PVC")
+		})
+
+		it("renders a PVC segment when only PVC fields are present", () => {
+			const { panel } = makePanel(treeNodes, {
+				quota: { userUsage: { currentPvcSizeBytes: 5368709120, maxPvcSizeBytes: 107374182400 } },
+			})
+			const line = summaryLine(panel)
+			expect(line).toContain("You: 5Gi/100Gi PVC")
+			expect(line).not.toContain("CPU")
+			expect(line).not.toContain("RAM")
+			expect(line).not.toContain("workspaces")
 		})
 
 		it("omits the summary line entirely when no quota was fetched, keeping the line count constant", () => {

--- a/src/extensions/teleport/ui/remote-sessions-panel.test.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.test.ts
@@ -1,6 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { describe, expect, it, vi } from "vitest"
 import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
+import type { QuotaInput } from "./quota-footer.js"
 import type { RemoteSessionNode, RemoteWorkspaceNode } from "./remote-sessions-panel.js"
 import { createRemoteSessionsPanel, RemoteSessionsPanel } from "./remote-sessions-panel.js"
 
@@ -55,7 +56,7 @@ const treeNodes: RemoteWorkspaceNode[] = [
 
 function makePanel(
 	nodes: RemoteWorkspaceNode[] = treeNodes,
-	opts?: { termRows?: number; termCols?: number; quota?: QuotaUsage },
+	opts?: { termRows?: number; termCols?: number; quota?: QuotaInput },
 ) {
 	const tui = {
 		requestRender: vi.fn(),
@@ -365,7 +366,7 @@ describe("RemoteSessionsPanel", () => {
 			panel
 				.render(120)
 				.map(stripAnsi)
-				.find((l) => l.includes("You:"))
+				.find((l) => l.includes("you:"))
 
 		const orgLine = (panel: RemoteSessionsPanel): string | undefined =>
 			panel
@@ -376,7 +377,7 @@ describe("RemoteSessionsPanel", () => {
 		it("renders the usage-vs-quota summary as two lines: user first, org below", () => {
 			const { panel } = makePanel(treeNodes, { quota })
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
+			expect(line).toContain("you: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces")
 			expect(line).not.toContain("org:")
 			expect(orgLine(panel)).toContain("org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces")
 		})
@@ -395,13 +396,13 @@ describe("RemoteSessionsPanel", () => {
 				},
 			})
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 1700m/3000m CPU · 1.5Gi/120Gi RAM · 2/10 workspaces")
+			expect(line).toContain("you: 1700m/3000m CPU · 1.5Gi/120Gi RAM · 2/10 workspaces")
 		})
 
 		it("renders only the user scope when org usage is missing", () => {
 			const { panel } = makePanel(treeNodes, { quota: { userUsage: quota.userUsage } })
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 4500m/16000m CPU")
+			expect(line).toContain("you: 4500m/16000m CPU")
 			expect(line).not.toContain("org:")
 			expect(orgLine(panel)).toBeUndefined()
 		})
@@ -411,7 +412,7 @@ describe("RemoteSessionsPanel", () => {
 				quota: { userUsage: { currentSandboxes: 1, maxSandboxes: 5 } },
 			})
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 1/5 workspaces")
+			expect(line).toContain("you: 1/5 workspaces")
 			expect(line).not.toContain("CPU")
 			expect(line).not.toContain("RAM")
 			expect(line).not.toContain("PVC")
@@ -422,7 +423,7 @@ describe("RemoteSessionsPanel", () => {
 				quota: { userUsage: { currentPvcSizeBytes: 5368709120, maxPvcSizeBytes: 107374182400 } },
 			})
 			const line = summaryLine(panel)
-			expect(line).toContain("You: 5Gi/100Gi PVC")
+			expect(line).toContain("you: 5Gi/100Gi PVC")
 			expect(line).not.toContain("CPU")
 			expect(line).not.toContain("RAM")
 			expect(line).not.toContain("workspaces")
@@ -437,6 +438,31 @@ describe("RemoteSessionsPanel", () => {
 
 		it("omits the summary when the quota carries no usable fields", () => {
 			const { panel } = makePanel(treeNodes, { quota: {} })
+			expect(summaryLine(panel)).toBeUndefined()
+		})
+
+		it("fills the summary in when an in-flight quota fetch settles", async () => {
+			const quotaPromise = Promise.resolve(quota)
+			const { panel, tui } = makePanel(treeNodes, { quota: quotaPromise })
+			expect(summaryLine(panel)).toBeUndefined()
+			await quotaPromise
+			expect(tui.requestRender).toHaveBeenCalled()
+			expect(summaryLine(panel)).toContain("you: 4500m/16000m CPU")
+		})
+
+		it("keeps the summary empty when the quota promise rejects", async () => {
+			const failing = Promise.reject(new Error("boom"))
+			const { panel } = makePanel(treeNodes, { quota: failing })
+			await failing.catch(() => undefined)
+			expect(summaryLine(panel)).toBeUndefined()
+		})
+
+		it("ignores a quota fetch that settles after the panel was disposed", async () => {
+			const quotaPromise = Promise.resolve(quota)
+			const { panel, tui } = makePanel(treeNodes, { quota: quotaPromise })
+			panel.dispose()
+			await quotaPromise
+			expect(tui.requestRender).not.toHaveBeenCalled()
 			expect(summaryLine(panel)).toBeUndefined()
 		})
 	})

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -1,8 +1,10 @@
 import type { Component } from "@earendil-works/pi-tui"
 import { matchesKey } from "@earendil-works/pi-tui"
 import { fg } from "../../../ansi.js"
+import type { QuotaUsage, ResourceUsage } from "../../../sandbox/cloud/types.js"
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
+import { formatK8sBytes, formatK8sBytesPair, formatMillicores } from "./format-bytes.js"
 import type { CombinedStatus, SessionRow } from "./sessions-table.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
@@ -16,7 +18,7 @@ const MAX_HEIGHT_PCT = 0.8
 // Lines outside the scrollable body:
 //   top border (1) + header (1) + divider (1)
 //   + top scroll indicator (1) + bottom scroll indicator (1)
-//   + empty row (1) + hint (1) + bottom border (1)
+//   + quota summary or empty row (1) + hint (1) + bottom border (1)
 const CHROME_LINES = 8
 
 /** A session nested under a workspace. Structurally identical to SessionRow. */
@@ -101,6 +103,9 @@ const HEADERS = {
 	name: "NAME / SESSION",
 	status: "STATUS",
 	lastActivity: "LAST ACTIVITY",
+	cpu: "CPU",
+	ram: "RAM",
+	pvc: "PVC",
 }
 
 const MIN_COL_WIDTH = 8
@@ -136,6 +141,8 @@ export class RemoteSessionsPanel implements Component {
 		readonly nodes: RemoteWorkspaceNode[],
 		private readonly tui: PickerTui,
 		private readonly done: (result: RemoteSessionsResult | undefined) => void,
+		/** Org/user quota usage for the footer summary; undefined omits it. */
+		private readonly quota?: QuotaUsage,
 	) {
 		const entries: Entry[] = []
 		for (const node of nodes) {
@@ -215,6 +222,9 @@ export class RemoteSessionsPanel implements Component {
 				["Name", row.name || "-"],
 				["ID", row.id],
 				["Host", row.host || "-"],
+				["CPU", row.cpuMillicores !== undefined ? formatMillicores(row.cpuMillicores) : "-"],
+				["RAM", row.ramBytes !== undefined ? formatK8sBytes(row.ramBytes) : "-"],
+				["PVC", row.pvcSizeBytes !== undefined ? formatK8sBytes(row.pvcSizeBytes) : "-"],
 				["Status", entry.node.unreachable ? "unreachable" : row.status],
 				["Sessions", String(row.sessionCount)],
 				["Created", abs(row.createdAt)],
@@ -234,6 +244,33 @@ export class RemoteSessionsPanel implements Component {
 		]
 	}
 
+	/**
+	 * One-line usage-vs-quota summary for the reserved footer row: user scope
+	 * first, org in parentheses; segments with missing fields are dropped.
+	 * Undefined when there is nothing to show (no quota data at all).
+	 */
+	private quotaSummary(): string | undefined {
+		const scope = (u: ResourceUsage): string | undefined => {
+			const parts: string[] = []
+			if (u.currentCpuMillicores !== undefined && u.maxCpuMillicores !== undefined) {
+				parts.push(`${formatMillicores(u.currentCpuMillicores)}/${formatMillicores(u.maxCpuMillicores)} CPU`)
+			}
+			if (u.currentRamBytes !== undefined && u.maxRamBytes !== undefined) {
+				parts.push(`${formatK8sBytesPair(u.currentRamBytes, u.maxRamBytes)} RAM`)
+			}
+			if (u.currentSandboxes !== undefined && u.maxSandboxes !== undefined) {
+				parts.push(`${u.currentSandboxes}/${u.maxSandboxes} workspaces`)
+			}
+			return parts.length > 0 ? parts.join(" · ") : undefined
+		}
+		const user = this.quota?.userUsage ? scope(this.quota.userUsage) : undefined
+		const org = this.quota?.orgUsage ? scope(this.quota.orgUsage) : undefined
+		const parts: string[] = []
+		if (user) parts.push(`You: ${user}`)
+		if (org) parts.push(`(org: ${org})`)
+		return parts.length > 0 ? parts.join("  ") : undefined
+	}
+
 	render(width: number): string[] {
 		const { entries } = this
 		const b = (s: string) => fg("2", s)
@@ -244,15 +281,42 @@ export class RemoteSessionsPanel implements Component {
 			const d = entryLastActivity(entry)
 			return d ? formatRelativeTime(d, this.now) : "-"
 		}
+		// Resource columns: values on workspace rows, blanks on session rows,
+		// "-" on workspace rows whose server omitted the field.
+		const cpuLabel = (entry: Entry): string => {
+			if (entry.kind !== "workspace") return ""
+			const v = entry.node.row.cpuMillicores
+			return v !== undefined ? formatMillicores(v) : "-"
+		}
+		const ramLabel = (entry: Entry): string => {
+			if (entry.kind !== "workspace") return ""
+			const v = entry.node.row.ramBytes
+			return v !== undefined ? formatK8sBytes(v) : "-"
+		}
+		const pvcLabel = (entry: Entry): string => {
+			if (entry.kind !== "workspace") return ""
+			const v = entry.node.row.pvcSizeBytes
+			return v !== undefined ? formatK8sBytes(v) : "-"
+		}
 
 		const statusWidth = Math.max(HEADERS.status.length, ...entries.map((e) => STATUS_LABEL[entryStatus(e)].length))
 		const lastWidth = Math.max(HEADERS.lastActivity.length, ...entries.map((e) => lastLabel(e).length))
+		const cpuWidth = Math.max(HEADERS.cpu.length, ...entries.map((e) => cpuLabel(e).length))
+		const ramWidth = Math.max(HEADERS.ram.length, ...entries.map((e) => ramLabel(e).length))
+		const pvcWidth = Math.max(HEADERS.pvc.length, ...entries.map((e) => pvcLabel(e).length))
 
 		// Name is the only flex column; it absorbs the tree-connector indent.
-		const fixedNoFlex = 2 /* prefix */ + 1 + statusWidth + 1 + lastWidth
+		const fixedNoFlex = 2 /* prefix */ + 1 + statusWidth + 1 + lastWidth + 1 + cpuWidth + 1 + ramWidth + 1 + pvcWidth
 		const nameW = Math.max(MIN_COL_WIDTH, contentW - fixedNoFlex)
 
-		const headerCells = [pad(HEADERS.name, nameW), pad(HEADERS.status, statusWidth), HEADERS.lastActivity]
+		const headerCells = [
+			pad(HEADERS.name, nameW),
+			pad(HEADERS.status, statusWidth),
+			pad(HEADERS.lastActivity, lastWidth),
+			pad(HEADERS.cpu, cpuWidth),
+			pad(HEADERS.ram, ramWidth),
+			HEADERS.pvc,
+		]
 		const headerLine = headerCells.join(" ")
 
 		const ansiRow = (content: string, rawLen: number) =>
@@ -262,8 +326,10 @@ export class RemoteSessionsPanel implements Component {
 		const formatPlain = (entry: Entry): string => {
 			const name = pad(truncate(entryNameText(entry), nameW), nameW)
 			const status = pad(STATUS_LABEL[entryStatus(entry)], statusWidth)
-			const last = lastLabel(entry)
-			return [name, status, last].join(" ")
+			const last = pad(lastLabel(entry), lastWidth)
+			const cpu = pad(cpuLabel(entry), cpuWidth)
+			const ram = pad(ramLabel(entry), ramWidth)
+			return [name, status, last, cpu, ram, pvcLabel(entry)].join(" ")
 		}
 
 		const formatStyled = (entry: Entry): { styled: string; plainLen: number } => {
@@ -271,9 +337,12 @@ export class RemoteSessionsPanel implements Component {
 			const statusPlain = STATUS_LABEL[entryStatus(entry)]
 			const statusPadding = " ".repeat(Math.max(0, statusWidth - statusPlain.length))
 			const statusCell = `${statusLabel(entryStatus(entry))}${statusPadding}`
-			const last = lastLabel(entry)
-			const styled = [name, statusCell, last].join(" ")
-			const plainCombined = [name, pad(statusPlain, statusWidth), last].join(" ")
+			const last = pad(lastLabel(entry), lastWidth)
+			const cpu = pad(cpuLabel(entry), cpuWidth)
+			const ram = pad(ramLabel(entry), ramWidth)
+			const pvc = pvcLabel(entry)
+			const styled = [name, statusCell, last, cpu, ram, pvc].join(" ")
+			const plainCombined = [name, pad(statusPlain, statusWidth), last, cpu, ram, pvc].join(" ")
 			return { styled, plainLen: plainCombined.length }
 		}
 
@@ -354,7 +423,15 @@ export class RemoteSessionsPanel implements Component {
 			}
 		}
 
-		lines.push(emptyRow())
+		// Reserved footer line: the quota summary when available, otherwise an
+		// empty row — the panel always emits the same line count either way.
+		const summary = this.quotaSummary()
+		if (summary) {
+			const text = truncate(`  ${summary}`, contentW)
+			lines.push(ansiRow(dim(text), text.length))
+		} else {
+			lines.push(emptyRow())
+		}
 		const hint = this.showDetails
 			? "i: back  esc/q/x: close details"
 			: "↑/↓ j/k: navigate  enter: open  d: delete  r: rename  i: details  esc: close"
@@ -372,16 +449,18 @@ export function createRemoteSessionsPanel(
 	nodes: RemoteWorkspaceNode[],
 	tui: PickerTui,
 	done: (result: RemoteSessionsResult | undefined) => void,
+	quota?: QuotaUsage,
 ): RemoteSessionsPanel & { dispose(): void } {
-	return new RemoteSessionsPanel(nodes, tui, done)
+	return new RemoteSessionsPanel(nodes, tui, done, quota)
 }
 
 export function pickRemoteSessions(
 	ctx: TeleportContext,
 	nodes: RemoteWorkspaceNode[],
+	quota?: QuotaUsage,
 ): Promise<RemoteSessionsResult | undefined> {
 	return ctx.ui.custom<RemoteSessionsResult | undefined>(
-		(tui, _theme, _kb, done) => new RemoteSessionsPanel(nodes, tui, done),
+		(tui, _theme, _kb, done) => new RemoteSessionsPanel(nodes, tui, done, quota),
 		{ overlay: true, overlayOptions: { anchor: "center", width: "80%", maxHeight: "80%" } },
 	)
 }

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -5,7 +5,7 @@ import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
 import { formatK8sBytes, formatMillicores } from "./format-bytes.js"
-import { quotaLines } from "./quota-footer.js"
+import { type QuotaInput, quotaLines, settleQuota } from "./quota-footer.js"
 import type { CombinedStatus, SessionRow } from "./sessions-table.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
@@ -137,14 +137,25 @@ export class RemoteSessionsPanel implements Component {
 	private readonly entries: Entry[]
 	/** Details overlay for the selected entry, toggled with `i`. */
 	private showDetails = false
+	private quota: QuotaUsage | undefined
+	private disposed = false
 
 	constructor(
 		readonly nodes: RemoteWorkspaceNode[],
 		private readonly tui: PickerTui,
 		private readonly done: (result: RemoteSessionsResult | undefined) => void,
-		/** Org/user quota usage for the footer summary; undefined omits it. */
-		private readonly quota?: QuotaUsage,
+		/** Org/user quota for the footer summary — a settled value or an
+		 *  in-flight (pre-caught) fetch that fills the footer when it settles.
+		 *  Undefined omits it. */
+		quota?: QuotaInput,
 	) {
+		settleQuota(quota, {
+			isDisposed: () => this.disposed,
+			set: (q) => {
+				this.quota = q
+			},
+			requestRender: () => this.tui.requestRender(),
+		})
 		const entries: Entry[] = []
 		for (const node of nodes) {
 			entries.push({ kind: "workspace", node })
@@ -418,14 +429,16 @@ export class RemoteSessionsPanel implements Component {
 	}
 
 	invalidate(): void {}
-	dispose(): void {}
+	dispose(): void {
+		this.disposed = true
+	}
 }
 
 export function createRemoteSessionsPanel(
 	nodes: RemoteWorkspaceNode[],
 	tui: PickerTui,
 	done: (result: RemoteSessionsResult | undefined) => void,
-	quota?: QuotaUsage,
+	quota?: QuotaInput,
 ): RemoteSessionsPanel & { dispose(): void } {
 	return new RemoteSessionsPanel(nodes, tui, done, quota)
 }
@@ -433,7 +446,7 @@ export function createRemoteSessionsPanel(
 export function pickRemoteSessions(
 	ctx: TeleportContext,
 	nodes: RemoteWorkspaceNode[],
-	quota?: QuotaUsage,
+	quota?: QuotaInput,
 ): Promise<RemoteSessionsResult | undefined> {
 	return ctx.ui.custom<RemoteSessionsResult | undefined>(
 		(tui, _theme, _kb, done) => new RemoteSessionsPanel(nodes, tui, done, quota),

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -18,8 +18,8 @@ const MAX_HEIGHT_PCT = 0.8
 // Lines outside the scrollable body:
 //   top border (1) + header (1) + divider (1)
 //   + top scroll indicator (1) + bottom scroll indicator (1)
-//   + quota summary or empty row (1) + hint (1) + bottom border (1)
-const CHROME_LINES = 8
+//   + quota summary or empty rows (2) + hint (1) + bottom border (1)
+const CHROME_LINES = 9
 
 /** A session nested under a workspace. Structurally identical to SessionRow. */
 export type RemoteSessionNode = SessionRow
@@ -245,11 +245,14 @@ export class RemoteSessionsPanel implements Component {
 	}
 
 	/**
-	 * One-line usage-vs-quota summary for the reserved footer row: user scope
-	 * first, org in parentheses; segments with missing fields are dropped.
-	 * Undefined when there is nothing to show (no quota data at all).
+	 * Usage-vs-quota footer lines: the user scope on the first line, the org
+	 * scope on its own line below it — one line per scope keeps both fully
+	 * readable at common terminal widths instead of truncating the org tail.
+	 * Segments with missing fields are dropped; a scope with nothing to show
+	 * yields undefined, which the render loop replaces with an empty row so
+	 * the panel always emits the same line count.
 	 */
-	private quotaSummary(): string | undefined {
+	private quotaLines(): [string | undefined, string | undefined] {
 		const scope = (u: ResourceUsage): string | undefined => {
 			const parts: string[] = []
 			if (u.currentCpuMillicores !== undefined && u.maxCpuMillicores !== undefined) {
@@ -268,10 +271,7 @@ export class RemoteSessionsPanel implements Component {
 		}
 		const user = this.quota?.userUsage ? scope(this.quota.userUsage) : undefined
 		const org = this.quota?.orgUsage ? scope(this.quota.orgUsage) : undefined
-		const parts: string[] = []
-		if (user) parts.push(`You: ${user}`)
-		if (org) parts.push(`(org: ${org})`)
-		return parts.length > 0 ? parts.join("  ") : undefined
+		return [user ? `You: ${user}` : undefined, org ? `org: ${org}` : undefined]
 	}
 
 	render(width: number): string[] {
@@ -426,14 +426,16 @@ export class RemoteSessionsPanel implements Component {
 			}
 		}
 
-		// Reserved footer line: the quota summary when available, otherwise an
-		// empty row — the panel always emits the same line count either way.
-		const summary = this.quotaSummary()
-		if (summary) {
-			const text = truncate(`  ${summary}`, contentW)
-			lines.push(ansiRow(dim(text), text.length))
-		} else {
-			lines.push(emptyRow())
+		// Reserved footer lines: the quota summary (user line + org line) when
+		// available, otherwise empty rows — the panel always emits the same
+		// line count either way.
+		for (const line of this.quotaLines()) {
+			if (line) {
+				const text = truncate(`  ${line}`, contentW)
+				lines.push(ansiRow(dim(text), text.length))
+			} else {
+				lines.push(emptyRow())
+			}
 		}
 		const hint = this.showDetails
 			? "i: back  esc/q/x: close details"

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -258,6 +258,9 @@ export class RemoteSessionsPanel implements Component {
 			if (u.currentRamBytes !== undefined && u.maxRamBytes !== undefined) {
 				parts.push(`${formatK8sBytesPair(u.currentRamBytes, u.maxRamBytes)} RAM`)
 			}
+			if (u.currentPvcSizeBytes !== undefined && u.maxPvcSizeBytes !== undefined) {
+				parts.push(`${formatK8sBytesPair(u.currentPvcSizeBytes, u.maxPvcSizeBytes)} PVC`)
+			}
 			if (u.currentSandboxes !== undefined && u.maxSandboxes !== undefined) {
 				parts.push(`${u.currentSandboxes}/${u.maxSandboxes} workspaces`)
 			}

--- a/src/extensions/teleport/ui/remote-sessions-panel.ts
+++ b/src/extensions/teleport/ui/remote-sessions-panel.ts
@@ -1,10 +1,11 @@
 import type { Component } from "@earendil-works/pi-tui"
 import { matchesKey } from "@earendil-works/pi-tui"
 import { fg } from "../../../ansi.js"
-import type { QuotaUsage, ResourceUsage } from "../../../sandbox/cloud/types.js"
+import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
-import { formatK8sBytes, formatK8sBytesPair, formatMillicores } from "./format-bytes.js"
+import { formatK8sBytes, formatMillicores } from "./format-bytes.js"
+import { quotaLines } from "./quota-footer.js"
 import type { CombinedStatus, SessionRow } from "./sessions-table.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
@@ -244,36 +245,6 @@ export class RemoteSessionsPanel implements Component {
 		]
 	}
 
-	/**
-	 * Usage-vs-quota footer lines: the user scope on the first line, the org
-	 * scope on its own line below it — one line per scope keeps both fully
-	 * readable at common terminal widths instead of truncating the org tail.
-	 * Segments with missing fields are dropped; a scope with nothing to show
-	 * yields undefined, which the render loop replaces with an empty row so
-	 * the panel always emits the same line count.
-	 */
-	private quotaLines(): [string | undefined, string | undefined] {
-		const scope = (u: ResourceUsage): string | undefined => {
-			const parts: string[] = []
-			if (u.currentCpuMillicores !== undefined && u.maxCpuMillicores !== undefined) {
-				parts.push(`${formatMillicores(u.currentCpuMillicores)}/${formatMillicores(u.maxCpuMillicores)} CPU`)
-			}
-			if (u.currentRamBytes !== undefined && u.maxRamBytes !== undefined) {
-				parts.push(`${formatK8sBytesPair(u.currentRamBytes, u.maxRamBytes)} RAM`)
-			}
-			if (u.currentPvcSizeBytes !== undefined && u.maxPvcSizeBytes !== undefined) {
-				parts.push(`${formatK8sBytesPair(u.currentPvcSizeBytes, u.maxPvcSizeBytes)} PVC`)
-			}
-			if (u.currentSandboxes !== undefined && u.maxSandboxes !== undefined) {
-				parts.push(`${u.currentSandboxes}/${u.maxSandboxes} workspaces`)
-			}
-			return parts.length > 0 ? parts.join(" · ") : undefined
-		}
-		const user = this.quota?.userUsage ? scope(this.quota.userUsage) : undefined
-		const org = this.quota?.orgUsage ? scope(this.quota.orgUsage) : undefined
-		return [user ? `You: ${user}` : undefined, org ? `org: ${org}` : undefined]
-	}
-
 	render(width: number): string[] {
 		const { entries } = this
 		const b = (s: string) => fg("2", s)
@@ -429,7 +400,7 @@ export class RemoteSessionsPanel implements Component {
 		// Reserved footer lines: the quota summary (user line + org line) when
 		// available, otherwise empty rows — the panel always emits the same
 		// line count either way.
-		for (const line of this.quotaLines()) {
+		for (const line of quotaLines(this.quota)) {
 			if (line) {
 				const text = truncate(`  ${line}`, contentW)
 				lines.push(ansiRow(dim(text), text.length))

--- a/src/extensions/teleport/ui/workspaces-panel.test.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.test.ts
@@ -1,5 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { describe, expect, it, vi } from "vitest"
+import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
 import { createWorkspacesPanel, WorkspacesPanel } from "./workspaces-panel.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
 
@@ -33,6 +34,7 @@ function makePanel(
 		allowDelete?: boolean
 		allowRename?: boolean
 		hideSessions?: boolean
+		quota?: QuotaUsage
 	},
 ) {
 	const tui = {
@@ -45,6 +47,7 @@ function makePanel(
 		allowDelete: opts?.allowDelete ?? true,
 		allowRename: opts?.allowRename,
 		hideSessions: opts?.hideSessions,
+		quota: opts?.quota,
 	})
 	return { panel, tui, done }
 }
@@ -369,5 +372,54 @@ describe("WorkspacesPanel", () => {
 				}
 			})
 		}
+	})
+
+	describe("quota footer", () => {
+		const quota: QuotaUsage = {
+			userUsage: {
+				currentSandboxes: 3,
+				maxSandboxes: 10,
+				currentCpuMillicores: 4500,
+				maxCpuMillicores: 16000,
+				currentRamBytes: 6442450944,
+				maxRamBytes: 17179869184,
+				currentPvcSizeBytes: 21474836480,
+				maxPvcSizeBytes: 128849018880,
+			},
+			orgUsage: {
+				currentSandboxes: 7,
+				maxSandboxes: 10,
+				currentCpuMillicores: 9000,
+				maxCpuMillicores: 16000,
+				currentRamBytes: 6442450944,
+				maxRamBytes: 17179869184,
+				currentPvcSizeBytes: 32212254720,
+				maxPvcSizeBytes: 429496729600,
+			},
+		}
+
+		const footerLine = (panel: WorkspacesPanel, needle: string): string | undefined =>
+			panel
+				.render(120)
+				.map(stripAnsi)
+				.find((l) => l.includes(needle))
+
+		it("renders the user and org quota on two footer lines", () => {
+			const { panel } = makePanel(testRows, { quota })
+			expect(footerLine(panel, "You:")).toContain(
+				"You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces",
+			)
+			expect(footerLine(panel, "org:")).toContain(
+				"org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces",
+			)
+		})
+
+		it("omits quota lines (blank rows) when no quota was provided, keeping the line count constant", () => {
+			const withQuota = makePanel(testRows, { quota, termRows: 20 })
+			const without = makePanel(testRows, { termRows: 20 })
+			expect(without.panel.render(120).length).toBe(withQuota.panel.render(120).length)
+			expect(footerLine(without.panel, "You:")).toBeUndefined()
+			expect(footerLine(without.panel, "org:")).toBeUndefined()
+		})
 	})
 })

--- a/src/extensions/teleport/ui/workspaces-panel.test.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.test.ts
@@ -306,6 +306,54 @@ describe("WorkspacesPanel", () => {
 		})
 	})
 
+	describe("resource columns", () => {
+		it("renders CPU, RAM and PVC headers", () => {
+			const { panel } = makePanel()
+			const text = panel.render(120).map(stripAnsi).join("\n")
+			expect(text).toContain("CPU")
+			expect(text).toContain("RAM")
+			expect(text).toContain("PVC")
+		})
+
+		it("formats known resource requests in the columns", () => {
+			const { panel } = makePanel([
+				makeRow({ name: "alpha", cpuMillicores: 1500, ramBytes: 6442450944, pvcSizeBytes: 21474836480 }),
+			])
+			const text = panel.render(120).map(stripAnsi).join("\n")
+			expect(text).toContain("1500m")
+			expect(text).toContain("6Gi")
+			expect(text).toContain("20Gi")
+		})
+
+		it("renders sub-core CPU requests with the m suffix", () => {
+			const { panel } = makePanel([makeRow({ name: "alpha", cpuMillicores: 250 })])
+			const text = panel.render(120).map(stripAnsi).join("\n")
+			expect(text).toContain("250m")
+		})
+
+		it("renders '-' for absent resource fields", () => {
+			const dashCount = (s: string) => (s.match(/-/g) ?? []).length
+			const withRes = makePanel([makeRow({ cpuMillicores: 1000, ramBytes: 1073741824, pvcSizeBytes: 10737418240 })])
+			const withoutRes = makePanel([makeRow()])
+			const a = withRes.panel.render(120).map(stripAnsi).join("\n")
+			const b = withoutRes.panel.render(120).map(stripAnsi).join("\n")
+			// Exactly the three resource cells turn into dashes; every other
+			// dash source (shortened ids) is identical between the two renders.
+			expect(dashCount(b)).toBe(dashCount(a) + 3)
+		})
+
+		it("keeps the NAME flex column at MIN_COL_WIDTH when the new fixed columns crowd the row", () => {
+			const { panel } = makePanel([makeRow({ name: "abcdefghijklmnop" })])
+			const line = panel
+				.render(60)
+				.map(stripAnsi)
+				.find((l) => l.includes("> "))
+			// The name truncates but never below MIN_COL_WIDTH: a width-8 cell
+			// still shows 7 name characters plus the ellipsis.
+			expect(line).toContain("abcdefg")
+		})
+	})
+
 	describe("narrow terminals", () => {
 		// Regression: border title math produced a negative "─".repeat count
 		// below the title width, crashing with RangeError.

--- a/src/extensions/teleport/ui/workspaces-panel.test.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.test.ts
@@ -1,6 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui"
 import { describe, expect, it, vi } from "vitest"
 import type { QuotaUsage } from "../../../sandbox/cloud/types.js"
+import type { QuotaInput } from "./quota-footer.js"
 import { createWorkspacesPanel, WorkspacesPanel } from "./workspaces-panel.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
 
@@ -34,7 +35,7 @@ function makePanel(
 		allowDelete?: boolean
 		allowRename?: boolean
 		hideSessions?: boolean
-		quota?: QuotaUsage
+		quota?: QuotaInput
 	},
 ) {
 	const tui = {
@@ -406,8 +407,8 @@ describe("WorkspacesPanel", () => {
 
 		it("renders the user and org quota on two footer lines", () => {
 			const { panel } = makePanel(testRows, { quota })
-			expect(footerLine(panel, "You:")).toContain(
-				"You: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces",
+			expect(footerLine(panel, "you:")).toContain(
+				"you: 4500m/16000m CPU · 6Gi/16Gi RAM · 20Gi/120Gi PVC · 3/10 workspaces",
 			)
 			expect(footerLine(panel, "org:")).toContain(
 				"org: 9000m/16000m CPU · 6Gi/16Gi RAM · 30Gi/400Gi PVC · 7/10 workspaces",
@@ -418,8 +419,33 @@ describe("WorkspacesPanel", () => {
 			const withQuota = makePanel(testRows, { quota, termRows: 20 })
 			const without = makePanel(testRows, { termRows: 20 })
 			expect(without.panel.render(120).length).toBe(withQuota.panel.render(120).length)
-			expect(footerLine(without.panel, "You:")).toBeUndefined()
+			expect(footerLine(without.panel, "you:")).toBeUndefined()
 			expect(footerLine(without.panel, "org:")).toBeUndefined()
+		})
+
+		it("fills the footer in when an in-flight quota fetch settles", async () => {
+			const quotaPromise = Promise.resolve(quota)
+			const { panel, tui } = makePanel(testRows, { quota: quotaPromise })
+			expect(footerLine(panel, "you:")).toBeUndefined()
+			await quotaPromise
+			expect(tui.requestRender).toHaveBeenCalled()
+			expect(footerLine(panel, "you:")).toContain("you: 4500m/16000m CPU")
+		})
+
+		it("keeps the footer empty when the quota promise rejects", async () => {
+			const failing = Promise.reject(new Error("boom"))
+			const { panel } = makePanel(testRows, { quota: failing })
+			await failing.catch(() => undefined)
+			expect(footerLine(panel, "you:")).toBeUndefined()
+		})
+
+		it("ignores a quota fetch that settles after the panel was disposed", async () => {
+			const quotaPromise = Promise.resolve(quota)
+			const { panel, tui } = makePanel(testRows, { quota: quotaPromise })
+			panel.dispose()
+			await quotaPromise
+			expect(tui.requestRender).not.toHaveBeenCalled()
+			expect(footerLine(panel, "you:")).toBeUndefined()
 		})
 	})
 })

--- a/src/extensions/teleport/ui/workspaces-panel.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.ts
@@ -5,7 +5,7 @@ import type { QuotaUsage, WorkspaceStatus } from "../../../sandbox/cloud/types.j
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
 import { formatK8sBytes, formatMillicores } from "./format-bytes.js"
-import { quotaLines } from "./quota-footer.js"
+import { type QuotaInput, quotaLines, settleQuota } from "./quota-footer.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
 
@@ -36,8 +36,9 @@ export interface WorkspacesPanelOptions {
 	allowRename?: boolean
 	/** Drop the SESSIONS column entirely (used when session counts aren't fetched). */
 	hideSessions?: boolean
-	/** Org/user quota usage for the two-line footer; undefined omits it. */
-	quota?: QuotaUsage
+	/** Org/user quota for the two-line footer — a settled value or an in-flight
+	 *  (pre-caught) fetch that fills the footer when it settles; undefined omits it. */
+	quota?: QuotaInput
 }
 
 interface PickerTui {
@@ -116,7 +117,8 @@ export class WorkspacesPanel implements Component {
 	private readonly allowDelete: boolean
 	private readonly allowRename: boolean
 	private readonly hideSessions: boolean
-	private readonly quota: QuotaUsage | undefined
+	private quota: QuotaUsage | undefined
+	private disposed = false
 
 	constructor(
 		private readonly rows: WorkspaceRow[],
@@ -128,7 +130,13 @@ export class WorkspacesPanel implements Component {
 		this.allowDelete = opts.allowDelete ?? false
 		this.allowRename = opts.allowRename ?? false
 		this.hideSessions = opts.hideSessions ?? false
-		this.quota = opts.quota
+		settleQuota(opts.quota, {
+			isDisposed: () => this.disposed,
+			set: (q) => {
+				this.quota = q
+			},
+			requestRender: () => this.tui.requestRender(),
+		})
 		const rowEntries: Entry[] = rows.map((row) => ({ kind: "row", row }))
 		this.entries = this.allowNew ? [...rowEntries, { kind: "new" }] : rowEntries
 	}
@@ -381,7 +389,9 @@ export class WorkspacesPanel implements Component {
 	}
 
 	invalidate(): void {}
-	dispose(): void {}
+	dispose(): void {
+		this.disposed = true
+	}
 }
 
 export function createWorkspacesPanel(

--- a/src/extensions/teleport/ui/workspaces-panel.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.ts
@@ -1,10 +1,11 @@
 import type { Component } from "@earendil-works/pi-tui"
 import { matchesKey } from "@earendil-works/pi-tui"
 import { fg } from "../../../ansi.js"
-import type { WorkspaceStatus } from "../../../sandbox/cloud/types.js"
+import type { QuotaUsage, WorkspaceStatus } from "../../../sandbox/cloud/types.js"
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
 import { formatK8sBytes, formatMillicores } from "./format-bytes.js"
+import { quotaLines } from "./quota-footer.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
 
@@ -17,8 +18,8 @@ const MAX_HEIGHT_PCT = 0.8
 // Lines outside the scrollable body:
 //   top border (1) + header (1) + divider (1)
 //   + top scroll indicator (1) + bottom scroll indicator (1)
-//   + empty row (1) + hint (1) + bottom border (1)
-const CHROME_LINES = 8
+//   + quota summary or empty rows (2) + hint (1) + bottom border (1)
+const CHROME_LINES = 9
 
 export type WorkspacePickerResult =
 	| { action: "select"; row: WorkspaceRow }
@@ -35,6 +36,8 @@ export interface WorkspacesPanelOptions {
 	allowRename?: boolean
 	/** Drop the SESSIONS column entirely (used when session counts aren't fetched). */
 	hideSessions?: boolean
+	/** Org/user quota usage for the two-line footer; undefined omits it. */
+	quota?: QuotaUsage
 }
 
 interface PickerTui {
@@ -113,6 +116,7 @@ export class WorkspacesPanel implements Component {
 	private readonly allowDelete: boolean
 	private readonly allowRename: boolean
 	private readonly hideSessions: boolean
+	private readonly quota: QuotaUsage | undefined
 
 	constructor(
 		private readonly rows: WorkspaceRow[],
@@ -124,6 +128,7 @@ export class WorkspacesPanel implements Component {
 		this.allowDelete = opts.allowDelete ?? false
 		this.allowRename = opts.allowRename ?? false
 		this.hideSessions = opts.hideSessions ?? false
+		this.quota = opts.quota
 		const rowEntries: Entry[] = rows.map((row) => ({ kind: "row", row }))
 		this.entries = this.allowNew ? [...rowEntries, { kind: "new" }] : rowEntries
 	}
@@ -352,7 +357,17 @@ export class WorkspacesPanel implements Component {
 			}
 		}
 
-		lines.push(emptyRow())
+		// Reserved footer lines: the quota summary (user line + org line) when
+		// available, otherwise empty rows — the panel always emits the same
+		// line count either way.
+		for (const line of quotaLines(this.quota)) {
+			if (line) {
+				const text = truncate(`  ${line}`, contentW)
+				lines.push(ansiRow(dim(text), text.length))
+			} else {
+				lines.push(emptyRow())
+			}
+		}
 		const hintParts = ["↑/↓ j/k: navigate", "enter: select"]
 		if (this.allowNew) hintParts.push("n: new")
 		if (this.allowRename) hintParts.push("r: rename")

--- a/src/extensions/teleport/ui/workspaces-panel.ts
+++ b/src/extensions/teleport/ui/workspaces-panel.ts
@@ -4,6 +4,7 @@ import { fg } from "../../../ansi.js"
 import type { WorkspaceStatus } from "../../../sandbox/cloud/types.js"
 import { truncateLinesToWidth } from "../../../truncate-lines.js"
 import type { TeleportContext } from "../types.js"
+import { formatK8sBytes, formatMillicores } from "./format-bytes.js"
 import { formatRelativeTime } from "./sessions-table.js"
 import type { WorkspaceRow } from "./workspaces-table.js"
 
@@ -89,6 +90,9 @@ const HEADERS = {
 	created: "CREATED",
 	lastActivity: "LAST ACTIVITY",
 	sessions: "SESSIONS",
+	cpu: "CPU",
+	ram: "RAM",
+	pvc: "PVC",
 	host: "HOST",
 }
 
@@ -178,6 +182,9 @@ export class WorkspacesPanel implements Component {
 		const lastLabel = (r: WorkspaceRow) => (r.lastActivityAt ? formatRelativeTime(r.lastActivityAt, this.now) : "-")
 		const sessionsLabel = (r: WorkspaceRow) => (r.sessionCount === "?" ? "?" : String(r.sessionCount))
 		const hostLabel = (r: WorkspaceRow) => r.host || "-"
+		const cpuLabel = (r: WorkspaceRow) => (r.cpuMillicores !== undefined ? formatMillicores(r.cpuMillicores) : "-")
+		const ramLabel = (r: WorkspaceRow) => (r.ramBytes !== undefined ? formatK8sBytes(r.ramBytes) : "-")
+		const pvcLabel = (r: WorkspaceRow) => (r.pvcSizeBytes !== undefined ? formatK8sBytes(r.pvcSizeBytes) : "-")
 
 		const idWidth = Math.max(HEADERS.id.length, ID_SHORT_LEN)
 		const statusWidth = Math.max(HEADERS.status.length, ...rows.map((r) => STATUS_LABEL[r.status].length))
@@ -186,6 +193,9 @@ export class WorkspacesPanel implements Component {
 		const sessionsWidth = hideSessions
 			? 0
 			: Math.max(HEADERS.sessions.length, ...rows.map((r) => sessionsLabel(r).length))
+		const cpuWidth = Math.max(HEADERS.cpu.length, ...rows.map((r) => cpuLabel(r).length))
+		const ramWidth = Math.max(HEADERS.ram.length, ...rows.map((r) => ramLabel(r).length))
+		const pvcWidth = Math.max(HEADERS.pvc.length, ...rows.map((r) => pvcLabel(r).length))
 
 		const nameWidth = Math.max(HEADERS.name.length, ...rows.map((r) => nameLabel(r).length))
 		const hostWidth = Math.max(HEADERS.host.length, ...rows.map((r) => hostLabel(r).length))
@@ -200,7 +210,13 @@ export class WorkspacesPanel implements Component {
 			createdWidth +
 			1 +
 			lastWidth +
-			(hideSessions ? 0 : 1 + sessionsWidth)
+			(hideSessions ? 0 : 1 + sessionsWidth) +
+			1 +
+			cpuWidth +
+			1 +
+			ramWidth +
+			1 +
+			pvcWidth
 		const availableForFlex = Math.max(2 * MIN_COL_WIDTH + 1, contentW - fixedNoFlex)
 		const desiredFlex = nameWidth + 1 + hostWidth
 		let nameW = nameWidth
@@ -218,6 +234,9 @@ export class WorkspacesPanel implements Component {
 			pad(HEADERS.created, createdWidth),
 			pad(HEADERS.lastActivity, lastWidth),
 			...(hideSessions ? [] : [pad(HEADERS.sessions, sessionsWidth)]),
+			pad(HEADERS.cpu, cpuWidth),
+			pad(HEADERS.ram, ramWidth),
+			pad(HEADERS.pvc, pvcWidth),
 			HEADERS.host,
 		]
 		const headerLine = headerCells.join(" ")
@@ -235,6 +254,7 @@ export class WorkspacesPanel implements Component {
 			const host = truncate(hostLabel(r), hostW)
 			const cells = [name, id, status, created, last]
 			if (!hideSessions) cells.push(pad(sessionsLabel(r), sessionsWidth))
+			cells.push(pad(cpuLabel(r), cpuWidth), pad(ramLabel(r), ramWidth), pad(pvcLabel(r), pvcWidth))
 			cells.push(host)
 			return cells.join(" ")
 		}
@@ -255,6 +275,11 @@ export class WorkspacesPanel implements Component {
 				styledCells.push(sessionsPad)
 				plainCells.push(sessionsPad)
 			}
+			const cpu = pad(cpuLabel(r), cpuWidth)
+			const ram = pad(ramLabel(r), ramWidth)
+			const pvc = pad(pvcLabel(r), pvcWidth)
+			styledCells.push(cpu, ram, pvc)
+			plainCells.push(cpu, ram, pvc)
 			styledCells.push(host)
 			plainCells.push(host)
 			return { styled: styledCells.join(" "), plainLen: plainCells.join(" ").length }

--- a/src/extensions/teleport/ui/workspaces-table.ts
+++ b/src/extensions/teleport/ui/workspaces-table.ts
@@ -14,4 +14,10 @@ export interface WorkspaceRow {
 	 * adds an `-<id-prefix>` suffix on collisions, matching the SSH alias logic.
 	 */
 	displayName?: string
+	/** Pod CPU request in millicores (1500 = 1.5 vCPU), when known. */
+	cpuMillicores?: number
+	/** Pod memory request in bytes, when known. */
+	ramBytes?: number
+	/** Persistent-volume claim size in bytes, when known. */
+	pvcSizeBytes?: number
 }

--- a/src/sandbox/cloud/http.test.ts
+++ b/src/sandbox/cloud/http.test.ts
@@ -80,13 +80,12 @@ describe("checkResponse", () => {
 
 	it("maps the humanized aggregation message (usage/requested/limit values)", async () => {
 		const resp = new Response(
-			'{"message":"quota exceeded: user cpu limit exceeded (current usage 9.5 cores, requested 1 core, limit 10 cores)","fieldViolations":[]}',
+			'{"message":"quota exceeded: user cpu limit exceeded (current usage 9500m, requested 1, limit 10)","fieldViolations":[]}',
 			{ status: 429 },
 		)
 		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
 			name: "RemoteQuotaError",
-			message:
-				"Unable to provision workspace: user cpu limit exceeded (current usage 9.5 cores, requested 1 core, limit 10 cores)",
+			message: "Unable to provision workspace: user cpu limit exceeded (current usage 9500m, requested 1, limit 10)",
 			statusCode: 429,
 		})
 	})

--- a/src/sandbox/cloud/http.test.ts
+++ b/src/sandbox/cloud/http.test.ts
@@ -78,6 +78,31 @@ describe("checkResponse", () => {
 		})
 	})
 
+	it("maps the humanized aggregation message (usage/requested/limit values)", async () => {
+		const resp = new Response(
+			'{"message":"quota exceeded: user cpu limit exceeded (current usage 9.5 cores, requested 1 core, limit 10 cores)","fieldViolations":[]}',
+			{ status: 429 },
+		)
+		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
+			name: "RemoteQuotaError",
+			message:
+				"Unable to provision workspace: user cpu limit exceeded (current usage 9.5 cores, requested 1 core, limit 10 cores)",
+			statusCode: 429,
+		})
+	})
+
+	it("maps the humanized multi-dimension resolution message verbatim", async () => {
+		const resp = new Response(
+			'{"message":"failed to resolve workspace resources: workspace resource request exceeds the per-user quota limit: memory requested 150Gi exceeds the per-user limit 120Gi; pvcSize requested 500Gi exceeds the per-user limit 120Gi","fieldViolations":[]}',
+			{ status: 429 },
+		)
+		await expect(checkResponse(resp, "https://x")).rejects.toMatchObject({
+			name: "RemoteQuotaError",
+			message:
+				"Unable to provision workspace: failed to resolve workspace resources: workspace resource request exceeds the per-user quota limit: memory requested 150Gi exceeds the per-user limit 120Gi; pvcSize requested 500Gi exceeds the per-user limit 120Gi",
+		})
+	})
+
 	it("maps non-auth statuses without a body to RemoteNetworkError", async () => {
 		await expect(checkResponse(new Response(null, { status: 502 }), "https://x")).rejects.toBeInstanceOf(
 			RemoteNetworkError,

--- a/src/sandbox/cloud/parse.test.ts
+++ b/src/sandbox/cloud/parse.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { parseInt64 } from "./parse.js"
+
+describe("parseInt64", () => {
+	it.each([
+		["1500", 1500],
+		["0", 0],
+		["-3", -3],
+		["6442450944", 6442450944],
+	])("parses canonical decimal string %s to %d", (raw, expected) => {
+		expect(parseInt64(raw)).toBe(expected)
+	})
+
+	it("passes finite numbers through", () => {
+		expect(parseInt64(1500)).toBe(1500)
+	})
+
+	it.each([
+		["undefined", undefined],
+		["null", null],
+		["empty string", ""],
+		["whitespace-only", "   "],
+		["hex", "0x10"],
+		["exponent", "1e3"],
+		["fractional", "12.5"],
+		["garbage", "banana"],
+		["object", {}],
+		["array", []],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	])("returns undefined for %s", (_label, raw) => {
+		expect(parseInt64(raw)).toBeUndefined()
+	})
+})

--- a/src/sandbox/cloud/parse.ts
+++ b/src/sandbox/cloud/parse.ts
@@ -1,12 +1,15 @@
 /**
  * Parse a proto-JSON integer field. gRPC-gateway encodes int64 as a JSON
  * *string* ("1500") while int32 arrives as a number — accept both so callers
- * don't need to care about the wire width. Returns undefined when the field
- * is absent or not parseable as a finite number.
+ * don't need to care about the wire width. Only canonical decimal encodings
+ * are accepted: strings matching anything else JS would coerce (whitespace,
+ * hex "0x10", exponent "1e3", fractional "12.5") degrade to undefined
+ * instead of silently parsing. Returns undefined when the field is absent
+ * or not parseable as a finite integer.
  */
 export function parseInt64(raw: unknown): number | undefined {
 	if (typeof raw === "number") return Number.isFinite(raw) ? raw : undefined
-	if (typeof raw === "string" && raw.length > 0) {
+	if (typeof raw === "string" && /^-?[0-9]+$/.test(raw)) {
 		const n = Number(raw)
 		if (Number.isFinite(n)) return n
 	}

--- a/src/sandbox/cloud/parse.ts
+++ b/src/sandbox/cloud/parse.ts
@@ -1,0 +1,14 @@
+/**
+ * Parse a proto-JSON integer field. gRPC-gateway encodes int64 as a JSON
+ * *string* ("1500") while int32 arrives as a number — accept both so callers
+ * don't need to care about the wire width. Returns undefined when the field
+ * is absent or not parseable as a finite number.
+ */
+export function parseInt64(raw: unknown): number | undefined {
+	if (typeof raw === "number") return Number.isFinite(raw) ? raw : undefined
+	if (typeof raw === "string" && raw.length > 0) {
+		const n = Number(raw)
+		if (Number.isFinite(n)) return n
+	}
+	return undefined
+}

--- a/src/sandbox/cloud/quota.test.ts
+++ b/src/sandbox/cloud/quota.test.ts
@@ -27,6 +27,8 @@ function usageFixture(over: Partial<Record<string, unknown>> = {}) {
 		maxCpuMillicores: "16000",
 		currentRamBytes: "6442450944",
 		maxRamBytes: "17179869184",
+		currentPvcSizeBytes: "21474836480",
+		maxPvcSizeBytes: "128849018880",
 		...over,
 	}
 }
@@ -52,6 +54,8 @@ describe("getQuotaUsage", () => {
 			maxCpuMillicores: 16000,
 			currentRamBytes: 6442450944,
 			maxRamBytes: 17179869184,
+			currentPvcSizeBytes: 21474836480,
+			maxPvcSizeBytes: 128849018880,
 		})
 		expect(usage.orgUsage).toMatchObject({ currentSandboxes: 7, currentCpuMillicores: 9000 })
 	})

--- a/src/sandbox/cloud/quota.test.ts
+++ b/src/sandbox/cloud/quota.test.ts
@@ -135,6 +135,14 @@ describe("getQuotaUsage", () => {
 		expect(usage.userUsage?.currentRamBytes).toBeUndefined()
 	})
 
+	it("skips key verification when a pre-resolved orgId is provided", async () => {
+		const mockFetch = vi.fn().mockResolvedValueOnce(quotaResponse({ userUsage: usageFixture() }))
+		const usage = await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch, orgId: ORG_ID })
+		expect(mockFetch).toHaveBeenCalledTimes(1)
+		expect(mockFetch.mock.calls[0][0]).toBe(QUOTA_URL)
+		expect(usage.userUsage).toBeDefined()
+	})
+
 	it("throws RemoteAuthError on 401", async () => {
 		const mockFetch = vi
 			.fn()

--- a/src/sandbox/cloud/quota.test.ts
+++ b/src/sandbox/cloud/quota.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest"
+import { getQuotaUsage } from "./quota.js"
+import { RemoteAuthError, RemoteNetworkError } from "./types.js"
+
+const BASE = "https://api.example.com"
+const ORG_ID = "org-516442fe-054a-49e2-ac2d-9dc9b104c3d2"
+const QUOTA_URL = `${BASE}/ai-optimizer/v1beta/organizations/${ORG_ID}/quotas:usage`
+
+function verifyResponse() {
+	return new Response(JSON.stringify({ organizationId: ORG_ID }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	})
+}
+
+function quotaResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } })
+}
+
+function usageFixture(over: Partial<Record<string, unknown>> = {}) {
+	// currentSandboxes/maxSandboxes are int32 (arrive as numbers);
+	// cpu/ram fields are int64 (gRPC-gateway emits JSON strings).
+	return {
+		currentSandboxes: 3,
+		maxSandboxes: 10,
+		currentCpuMillicores: "4500",
+		maxCpuMillicores: "16000",
+		currentRamBytes: "6442450944",
+		maxRamBytes: "17179869184",
+		...over,
+	}
+}
+
+describe("getQuotaUsage", () => {
+	it("parses orgUsage and userUsage, normalizing string int64s to numbers", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				quotaResponse({
+					orgUsage: usageFixture({ currentSandboxes: 7, currentCpuMillicores: "9000" }),
+					userUsage: usageFixture(),
+				}),
+			)
+
+		const usage = await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(usage.userUsage).toEqual({
+			currentSandboxes: 3,
+			maxSandboxes: 10,
+			currentCpuMillicores: 4500,
+			maxCpuMillicores: 16000,
+			currentRamBytes: 6442450944,
+			maxRamBytes: 17179869184,
+		})
+		expect(usage.orgUsage).toMatchObject({ currentSandboxes: 7, currentCpuMillicores: 9000 })
+	})
+
+	it("accepts plain-number int64 fields", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				quotaResponse({
+					orgUsage: usageFixture({
+						currentCpuMillicores: 1000,
+						maxCpuMillicores: 4000,
+						currentRamBytes: 4294967296,
+						maxRamBytes: 8589934592,
+					}),
+					userUsage: usageFixture(),
+				}),
+			)
+
+		const usage = await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(usage.orgUsage).toMatchObject({
+			currentCpuMillicores: 1000,
+			maxCpuMillicores: 4000,
+			currentRamBytes: 4294967296,
+			maxRamBytes: 8589934592,
+		})
+	})
+
+	it("sends bearer auth to the quotas:usage route after key verification", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(quotaResponse({ orgUsage: usageFixture(), userUsage: usageFixture() }))
+
+		await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(mockFetch).toHaveBeenCalledTimes(2)
+		expect(mockFetch.mock.calls[1][0]).toBe(QUOTA_URL)
+		expect(mockFetch.mock.calls[1][1]).toMatchObject({
+			method: "GET",
+			headers: expect.objectContaining({
+				Authorization: "Bearer key1",
+				Accept: "application/json",
+			}),
+		})
+	})
+
+	it("returns undefined scopes when the response omits them", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(quotaResponse({ userUsage: usageFixture() }))
+
+		const usage = await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(usage.orgUsage).toBeUndefined()
+		expect(usage.userUsage).toBeDefined()
+	})
+
+	it("leaves individual fields undefined when the scope is partial (older control planes)", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				quotaResponse({
+					userUsage: { currentSandboxes: 1, maxSandboxes: 5, currentCpuMillicores: "garbage" },
+				}),
+			)
+
+		const usage = await getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(usage.userUsage).toMatchObject({ currentSandboxes: 1, maxSandboxes: 5 })
+		expect(usage.userUsage?.currentCpuMillicores).toBeUndefined()
+		expect(usage.userUsage?.maxCpuMillicores).toBeUndefined()
+		expect(usage.userUsage?.currentRamBytes).toBeUndefined()
+	})
+
+	it("throws RemoteAuthError on 401", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(new Response(null, { status: 401 }))
+		await expect(getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })).rejects.toBeInstanceOf(RemoteAuthError)
+	})
+
+	it("throws RemoteNetworkError on 500", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(new Response(null, { status: 500 }))
+		await expect(getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })).rejects.toBeInstanceOf(RemoteNetworkError)
+	})
+
+	it("wraps low-level fetch failures as RemoteNetworkError", async () => {
+		const mockFetch = vi.fn().mockImplementation((url: string) => {
+			if (typeof url === "string" && url.endsWith("/workspace-tokens:verifyKey")) {
+				return Promise.resolve(verifyResponse())
+			}
+			return Promise.reject(new TypeError("fetch failed"))
+		})
+		await expect(getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })).rejects.toBeInstanceOf(RemoteNetworkError)
+	})
+
+	it("throws RemoteNetworkError on non-JSON response", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(new Response("not json", { status: 200 }))
+		await expect(getQuotaUsage("key1", { endpoint: BASE, fetch: mockFetch })).rejects.toBeInstanceOf(RemoteNetworkError)
+	})
+})

--- a/src/sandbox/cloud/quota.ts
+++ b/src/sandbox/cloud/quota.ts
@@ -19,7 +19,10 @@ export async function getQuotaUsage(apiKey: string, options?: GetQuotaUsageOptio
 	const signal = options?.signal
 
 	try {
-		const orgId = await verifyApiKey(apiKey, { ...options, fetch: fetchImpl })
+		// Callers that already verified the key (e.g. /remote-sessions, which
+		// caches orgId for its refresh loop) pass it through to skip the
+		// duplicate verifyKey round-trip.
+		const orgId = options?.orgId ?? (await verifyApiKey(apiKey, { ...options, fetch: fetchImpl }))
 
 		const url = `${endpoint}/ai-optimizer/v1beta/organizations/${encodeURIComponent(orgId)}/quotas:usage`
 		const resp = await fetchWithTimeout(

--- a/src/sandbox/cloud/quota.ts
+++ b/src/sandbox/cloud/quota.ts
@@ -71,5 +71,7 @@ function parseResourceUsage(raw: unknown): ResourceUsage | undefined {
 		maxCpuMillicores: parseInt64(r.maxCpuMillicores),
 		currentRamBytes: parseInt64(r.currentRamBytes),
 		maxRamBytes: parseInt64(r.maxRamBytes),
+		currentPvcSizeBytes: parseInt64(r.currentPvcSizeBytes),
+		maxPvcSizeBytes: parseInt64(r.maxPvcSizeBytes),
 	}
 }

--- a/src/sandbox/cloud/quota.ts
+++ b/src/sandbox/cloud/quota.ts
@@ -1,0 +1,75 @@
+import { checkResponse, fetchWithTimeout, resolveEndpoint } from "./http.js"
+import { verifyApiKey } from "./keys.js"
+import { parseInt64 } from "./parse.js"
+import type { GetQuotaUsageOptions, QuotaUsage, ResourceUsage } from "./types.js"
+import { RemoteAuthError, RemoteNetworkError } from "./types.js"
+
+/**
+ * Fetch org/user quota usage from the control plane
+ * (`GET /ai-optimizer/v1beta/organizations/{org}/quotas:usage`).
+ *
+ * Follows the same auth/timeout/error pattern as `listWorkspaces`: resolves
+ * the org id from the API key, sends bearer auth, and throws
+ * RemoteAuthError/RemoteNetworkError on failure. Callers that can live
+ * without the data should catch and degrade.
+ */
+export async function getQuotaUsage(apiKey: string, options?: GetQuotaUsageOptions): Promise<QuotaUsage> {
+	const fetchImpl = options?.fetch ?? globalThis.fetch
+	const endpoint = resolveEndpoint(options)
+	const signal = options?.signal
+
+	try {
+		const orgId = await verifyApiKey(apiKey, { ...options, fetch: fetchImpl })
+
+		const url = `${endpoint}/ai-optimizer/v1beta/organizations/${encodeURIComponent(orgId)}/quotas:usage`
+		const resp = await fetchWithTimeout(
+			url,
+			{
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					Accept: "application/json",
+				},
+			},
+			fetchImpl,
+			30_000,
+			signal,
+		)
+
+		await checkResponse(resp, url)
+
+		let data: unknown
+		try {
+			data = JSON.parse(await resp.text())
+		} catch {
+			throw new RemoteNetworkError(`Unexpected non-JSON response from quota usage endpoint ${endpoint}`)
+		}
+		if (typeof data !== "object" || data === null) {
+			throw new RemoteNetworkError(`Unexpected response shape from quota usage endpoint ${endpoint}`)
+		}
+		const r = data as Record<string, unknown>
+		return {
+			orgUsage: parseResourceUsage(r.orgUsage),
+			userUsage: parseResourceUsage(r.userUsage),
+		}
+	} catch (err) {
+		if (err instanceof RemoteAuthError || err instanceof RemoteNetworkError) {
+			throw err
+		}
+		throw new RemoteNetworkError(err instanceof Error ? err.message : String(err))
+	}
+}
+
+/** Parse one usage scope; absent or non-object scopes stay undefined. */
+function parseResourceUsage(raw: unknown): ResourceUsage | undefined {
+	if (typeof raw !== "object" || raw === null) return undefined
+	const r = raw as Record<string, unknown>
+	return {
+		currentSandboxes: parseInt64(r.currentSandboxes),
+		maxSandboxes: parseInt64(r.maxSandboxes),
+		currentCpuMillicores: parseInt64(r.currentCpuMillicores),
+		maxCpuMillicores: parseInt64(r.maxCpuMillicores),
+		currentRamBytes: parseInt64(r.currentRamBytes),
+		maxRamBytes: parseInt64(r.maxRamBytes),
+	}
+}

--- a/src/sandbox/cloud/resources.test.ts
+++ b/src/sandbox/cloud/resources.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { resolveWorkspaceResources, WorkspaceResourcesError } from "./resources.js"
+import {
+	byteQuantityToBytes,
+	cpuQuantityToMillicores,
+	resolveWorkspaceResources,
+	WorkspaceResourcesError,
+} from "./resources.js"
 
 describe("resolveWorkspaceResources", () => {
 	it("returns undefined for undefined or empty config", () => {
@@ -79,5 +84,52 @@ describe("resolveWorkspaceResources", () => {
 
 	it("a bad value in one field does not hide a good value in another field's error", () => {
 		expect(() => resolveWorkspaceResources({ cpu: "250m", memory: "bogus" })).toThrowError(/memory/)
+	})
+})
+
+describe("cpuQuantityToMillicores", () => {
+	it.each<[string, number]>([
+		["200m", 200],
+		["250m", 250],
+		["1", 1000],
+		["1.5", 1500],
+		["0.25", 250],
+		[".5", 500],
+		["1e1", 10000],
+		["2k", 2_000_000],
+		["2500n", 0],
+	])("parses %j into %d millicores", (raw, expected) => {
+		expect(cpuQuantityToMillicores(raw)).toBe(expected)
+	})
+
+	it("returns undefined for absent, non-string, or invalid values", () => {
+		expect(cpuQuantityToMillicores(undefined)).toBeUndefined()
+		expect(cpuQuantityToMillicores(200)).toBeUndefined()
+		expect(cpuQuantityToMillicores("banana")).toBeUndefined()
+		expect(cpuQuantityToMillicores("")).toBeUndefined()
+	})
+
+	it("trims surrounding whitespace like the config path", () => {
+		expect(cpuQuantityToMillicores(" 200m ")).toBe(200)
+	})
+})
+
+describe("byteQuantityToBytes", () => {
+	it.each<[string, number]>([
+		["512Mi", 536870912],
+		["10Gi", 10737418240],
+		["1.5Gi", 1610612736],
+		["1G", 1_000_000_000],
+		["128Ki", 131072],
+		["1e3", 1000],
+		["2048", 2048],
+	])("parses %j into %d bytes", (raw, expected) => {
+		expect(byteQuantityToBytes(raw)).toBe(expected)
+	})
+
+	it("returns undefined for absent, non-string, or invalid values", () => {
+		expect(byteQuantityToBytes(undefined)).toBeUndefined()
+		expect(byteQuantityToBytes(1024)).toBeUndefined()
+		expect(byteQuantityToBytes("half a gb")).toBeUndefined()
 	})
 })

--- a/src/sandbox/cloud/resources.ts
+++ b/src/sandbox/cloud/resources.ts
@@ -17,9 +17,71 @@ export class WorkspaceResourcesError extends Error {
  * Kubernetes quantity: numeric part (optionally decimal), then EITHER an
  * exponent OR a decimal-SI (n,u,m,k,M,G,T,P,E) / binary-SI (Ki…Ei) suffix —
  * never both (`1e3m` passes client validation only to 400 server-side, so it
- * is rejected here). Group 1 captures the mantissa for the positivity check.
+ * is rejected here). Group 1 captures the mantissa (positivity check),
+ * group 2 the exponent/suffix (base-unit parsing).
  */
-const QUANTITY_RE = /^([0-9]+(?:\.[0-9]+)?|\.[0-9]+)(?:(?:[eE][+-]?[0-9]+)|(?:n|u|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei))?$/
+const QUANTITY_RE = /^([0-9]+(?:\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+|n|u|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$/
+
+/** Decimal-SI suffix → multiplier (exponent forms are handled separately). */
+const DECIMAL_SUFFIX: Record<string, number> = {
+	n: 1e-9,
+	u: 1e-6,
+	m: 1e-3,
+	k: 1e3,
+	M: 1e6,
+	G: 1e9,
+	T: 1e12,
+	P: 1e15,
+	E: 1e18,
+}
+
+/** Binary-SI suffix → multiplier. */
+const BINARY_SUFFIX: Record<string, number> = {
+	Ki: 1024,
+	Mi: 1024 ** 2,
+	Gi: 1024 ** 3,
+	Ti: 1024 ** 4,
+	Pi: 1024 ** 5,
+	Ei: 1024 ** 6,
+}
+
+/**
+ * Parse a Kubernetes quantity into its base-unit value (cores for CPU,
+ * bytes for storage). Returns undefined for absent, non-string, or invalid
+ * values — callers degrade (render "-") instead of failing the listing.
+ */
+function parseQuantity(raw: unknown): number | undefined {
+	if (typeof raw !== "string") return undefined
+	const match = QUANTITY_RE.exec(raw.trim())
+	if (!match) return undefined
+	const mantissa = Number.parseFloat(match[1])
+	if (!Number.isFinite(mantissa)) return undefined
+	const suffix = match[2]
+	if (suffix === undefined) return mantissa
+	if (/^[eE][+-]?[0-9]+$/.test(suffix)) {
+		return mantissa * 10 ** Number.parseInt(suffix.slice(1), 10)
+	}
+	return mantissa * (BINARY_SUFFIX[suffix] ?? DECIMAL_SUFFIX[suffix] ?? 1)
+}
+
+/**
+ * Parse a Kubernetes CPU quantity into millicores ("200m" → 200, "1.5" →
+ * 1500, "1e1" → 10000). Undefined for absent or invalid values.
+ */
+export function cpuQuantityToMillicores(raw: unknown): number | undefined {
+	const cores = parseQuantity(raw)
+	return cores === undefined ? undefined : Math.round(cores * 1000)
+}
+
+/**
+ * Parse a Kubernetes byte quantity into bytes ("512Mi" → 536870912,
+ * "1.5Gi" → 1610612736, "1G" → 1000000000). Undefined for absent or
+ * invalid values.
+ */
+export function byteQuantityToBytes(raw: unknown): number | undefined {
+	const bytes = parseQuantity(raw)
+	return bytes === undefined ? undefined : Math.round(bytes)
+}
 
 /**
  * Validate and normalize resource requests from `kimchi_workspace.yaml`.

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -7,6 +7,33 @@ export interface Workspace {
 	lastActivityAt: Date
 	status: WorkspaceStatus
 	host?: string
+	/** Pod CPU request in millicores (1500 = 1.5 vCPU). Provisioned size, not live utilization. */
+	cpuMillicores?: number
+	/** Pod memory request in bytes. Provisioned size, not live utilization. */
+	ramBytes?: number
+	/** Persistent-volume claim size in bytes. */
+	pvcSizeBytes?: number
+}
+
+/**
+ * Current consumption vs. limits for one quota scope (organization or user).
+ * Mirrors the server's `ResourceUsage` proto message. Fields are optional so
+ * partial responses from older control planes degrade gracefully.
+ */
+export interface ResourceUsage {
+	/** Sandboxes (workspaces) currently counted against the quota. */
+	currentSandboxes?: number
+	maxSandboxes?: number
+	currentCpuMillicores?: number
+	maxCpuMillicores?: number
+	currentRamBytes?: number
+	maxRamBytes?: number
+}
+
+/** Org/user quota usage returned by the control plane's `quotas:usage` endpoint. */
+export interface QuotaUsage {
+	orgUsage?: ResourceUsage
+	userUsage?: ResourceUsage
 }
 
 /**
@@ -57,6 +84,10 @@ export interface AuthenticateOptions {
 }
 
 export interface ListWorkspacesOptions extends AuthenticateOptions {
+	signal?: AbortSignal
+}
+
+export interface GetQuotaUsageOptions extends AuthenticateOptions {
 	signal?: AbortSignal
 }
 

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -93,6 +93,8 @@ export interface ListWorkspacesOptions extends AuthenticateOptions {
 
 export interface GetQuotaUsageOptions extends AuthenticateOptions {
 	signal?: AbortSignal
+	/** Pre-resolved organization id — skips the verifyKey round-trip. */
+	orgId?: string
 }
 
 export interface WaitForWorkspaceReadyOptions {

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -89,6 +89,8 @@ export interface AuthenticateOptions {
 
 export interface ListWorkspacesOptions extends AuthenticateOptions {
 	signal?: AbortSignal
+	/** Pre-resolved organization id — skips the verifyKey round-trip. */
+	orgId?: string
 }
 
 export interface GetQuotaUsageOptions extends AuthenticateOptions {

--- a/src/sandbox/cloud/types.ts
+++ b/src/sandbox/cloud/types.ts
@@ -28,6 +28,10 @@ export interface ResourceUsage {
 	maxCpuMillicores?: number
 	currentRamBytes?: number
 	maxRamBytes?: number
+	/** Persistent-volume storage currently counted against the quota, in bytes. */
+	currentPvcSizeBytes?: number
+	/** Maximum persistent-volume storage allowed by the quota, in bytes. */
+	maxPvcSizeBytes?: number
 }
 
 /** Org/user quota usage returned by the control plane's `quotas:usage` endpoint. */

--- a/src/sandbox/cloud/workspaces.test.ts
+++ b/src/sandbox/cloud/workspaces.test.ts
@@ -75,6 +75,23 @@ describe("listWorkspaces", () => {
 		})
 	})
 
+	it("skips key verification when a pre-resolved orgId is provided", async () => {
+		const mockFetch = vi.fn().mockResolvedValueOnce(
+			new Response(JSON.stringify({ items: [workspaceFixture({ id: "ws-1", description: "feature-x" })] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch, orgId: ORG_ID })
+
+		// A single fetch: the list URL — no verifyKey round-trip first.
+		expect(mockFetch).toHaveBeenCalledTimes(1)
+		expect(mockFetch.mock.calls[0][0]).toBe(listUrl())
+		expect(result).toHaveLength(1)
+		expect(result[0]).toMatchObject({ id: "ws-1", name: "feature-x" })
+	})
+
 	it("follows cursor across multiple pages", async () => {
 		const mockFetch = vi
 			.fn()

--- a/src/sandbox/cloud/workspaces.test.ts
+++ b/src/sandbox/cloud/workspaces.test.ts
@@ -159,6 +159,137 @@ describe("listWorkspaces", () => {
 		expect(mockFetch).toHaveBeenCalledTimes(11)
 	})
 
+	it("maps resource request fields from string-encoded int64 values (gRPC-gateway JSON)", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						items: [
+							workspaceFixture({
+								cpuMillicores: "1500",
+								ramBytes: "6442450944",
+								pvcSizeBytes: "21474836480",
+							}),
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0]).toMatchObject({
+			cpuMillicores: 1500,
+			ramBytes: 6442450944,
+			pvcSizeBytes: 21474836480,
+		})
+	})
+
+	it("maps resource request fields from plain numbers", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						items: [workspaceFixture({ cpuMillicores: 250, ramBytes: 1073741824, pvcSizeBytes: 10737418240 })],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0]).toMatchObject({ cpuMillicores: 250, ramBytes: 1073741824, pvcSizeBytes: 10737418240 })
+	})
+
+	it("leaves resource fields undefined when the server omits them (older control planes)", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ items: [workspaceFixture({ cpuMillicores: "not-a-number" })] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0].cpuMillicores).toBeUndefined()
+		expect(result[0].ramBytes).toBeUndefined()
+		expect(result[0].pvcSizeBytes).toBeUndefined()
+	})
+
+	it("maps resource fields from the nested quantity-string shape served by current servers", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						items: [workspaceFixture({ resources: { cpu: "200m", memory: "512Mi", pvcSize: "10Gi" } })],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0]).toMatchObject({
+			cpuMillicores: 200,
+			ramBytes: 536870912,
+			pvcSizeBytes: 10737418240,
+		})
+	})
+
+	it("prefers flat int64 fields over nested quantity strings when both shapes are present", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						items: [
+							workspaceFixture({
+								cpuMillicores: "1500",
+								resources: { cpu: "200m", memory: "512Mi", pvcSize: "10Gi" },
+							}),
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0].cpuMillicores).toBe(1500)
+		expect(result[0].ramBytes).toBe(536870912)
+		expect(result[0].pvcSizeBytes).toBe(10737418240)
+	})
+
+	it("leaves a resource field undefined when its nested quantity is invalid, without dropping the others", async () => {
+		const mockFetch = vi
+			.fn()
+			.mockResolvedValueOnce(verifyResponse())
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						items: [workspaceFixture({ resources: { cpu: "banana", memory: "512Mi" } })],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			)
+
+		const result = await listWorkspaces("key1", { endpoint: BASE, fetch: mockFetch })
+
+		expect(result[0].cpuMillicores).toBeUndefined()
+		expect(result[0].ramBytes).toBe(536870912)
+		expect(result[0].pvcSizeBytes).toBeUndefined()
+	})
+
 	it("propagates an external abort signal", async () => {
 		const ctrl = new AbortController()
 		const mockFetch = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {

--- a/src/sandbox/cloud/workspaces.ts
+++ b/src/sandbox/cloud/workspaces.ts
@@ -16,7 +16,10 @@ export async function listWorkspaces(apiKey: string, options?: ListWorkspacesOpt
 	const signal = options?.signal
 
 	try {
-		const orgId = await verifyApiKey(apiKey, { ...options, fetch: fetchImpl })
+		// Callers that already verified the key (e.g. /remote-sessions, which
+		// caches orgId for its refresh loop) pass it through to skip the
+		// duplicate verifyKey round-trip.
+		const orgId = options?.orgId ?? (await verifyApiKey(apiKey, { ...options, fetch: fetchImpl }))
 
 		const results: Workspace[] = []
 		let cursor = ""

--- a/src/sandbox/cloud/workspaces.ts
+++ b/src/sandbox/cloud/workspaces.ts
@@ -1,6 +1,8 @@
 import { HARNESS_CLIENT_TYPE } from "../constants.js"
 import { checkResponse, fetchWithTimeout, resolveEndpoint } from "./http.js"
 import { verifyApiKey } from "./keys.js"
+import { parseInt64 } from "./parse.js"
+import { byteQuantityToBytes, cpuQuantityToMillicores } from "./resources.js"
 import type { AuthenticateOptions, ListWorkspacesOptions, Workspace, WorkspaceStatus } from "./types.js"
 import { RemoteAuthError, RemoteNetworkError } from "./types.js"
 import { normalizeWsUri } from "./uri.js"
@@ -137,6 +139,18 @@ function mapWorkspace(raw: unknown, endpoint: string): Workspace {
 		}
 	}
 
+	// Resource requests (provisioned sizes), in both wire shapes the control
+	// plane has used: current servers nest them under `resources` as
+	// Kubernetes quantity strings ("200m", "512Mi", "10Gi") — the same shape
+	// the client sends on create; the KAP-191 server flattens them to int64
+	// fields (gRPC-gateway emits int64 as JSON strings). Explicit numbers win
+	// when both shapes are present.
+	const res = typeof r.resources === "object" && r.resources !== null ? r.resources : {}
+	const resFields = res as Record<string, unknown>
+	const cpuMillicores = parseInt64(r.cpuMillicores) ?? cpuQuantityToMillicores(resFields.cpu)
+	const ramBytes = parseInt64(r.ramBytes) ?? byteQuantityToBytes(resFields.memory)
+	const pvcSizeBytes = parseInt64(r.pvcSizeBytes) ?? byteQuantityToBytes(resFields.pvcSize)
+
 	// Server proto has no last_activity_time field yet — placeholder for v1.
 	return {
 		id,
@@ -145,6 +159,9 @@ function mapWorkspace(raw: unknown, endpoint: string): Workspace {
 		lastActivityAt: createdAt,
 		status,
 		host,
+		cpuMillicores,
+		ramBytes,
+		pvcSizeBytes,
 	}
 }
 


### PR DESCRIPTION
## Linked issue

Closes #1171

<img width="2308" height="1370" alt="image" src="https://github.com/user-attachments/assets/0ece4412-cce0-4b8a-bb6b-d36ddf76fb98" />
<img width="2311" height="1255" alt="image" src="https://github.com/user-attachments/assets/1b99c39a-b303-41f5-a6c3-cf84545b17b7" />

## What does this PR do?

Surfaces cloud resource usage and quota in the remote-workspace pickers:

- **Per-workspace provisioned size** (CPU millicores, RAM, PVC) as columns in `/remote-sessions` and its details view, and in the teleport workspace picker. Parsed from both wire shapes the control plane has used — flat gRPC-gateway int64 fields (arriving as JSON strings) and nested Kubernetes quantity strings (`200m`, `512Mi`, `10Gi`) — degrading to `-` when the server omits them.
- **User/org quota footer** (`you:`/`org:`, kubectl-style quantities) in `/remote-sessions` and the workspace picker, from `GET .../quotas:usage`. Fired alongside the workspace list and handed to the panel as a promise: the picker's reserved footer rows fill in when it settles, so a slow quota endpoint never blocks the picker; failures degrade to an empty footer; settles after panel dispose are ignored (`settleQuota`).
- `getQuotaUsage` accepts a pre-resolved orgId, so `/remote-sessions` reuses its cached key verification instead of a duplicate `verifyKey` round-trip per load and per refresh.
- Pins the humanized 429 quota-aggregation messages in `checkResponse` tests (k8s canonical quantity form, multi-dimension resolution errors).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (affected suites — teleport + sandbox/cloud — 152/152; full `pnpm run test` hits a pre-existing vitest pool IPC crash reproducible on master)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed — no user-facing docs cover these panels