### PR TITLE
feat(remote-run): live token usage for cloud agents in the agent widget

### DIFF
--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -505,6 +505,7 @@ export class AgentManager {
 					addUsage(record.lifetimeUsage, usage)
 					options.onAssistantUsage?.(usage)
 				},
+				onContextUsage: (used, size) => remoteSession.setContextUsage(used, size),
 				onRawNotification: (params) => {
 					options.onRawNotification?.(params)
 				},
@@ -1051,6 +1052,7 @@ export class AgentManager {
 					addUsage(record.lifetimeUsage, usage)
 					options?.callbacks?.onAssistantUsage?.(usage)
 				},
+				onContextUsage: (used, size) => adapter.setContextUsage(used, size),
 			},
 		}).then((result) => {
 			record.recoveryNote = result.recoveryNote

--- a/src/extensions/agents/manager/remote-agent-runner.test.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.test.ts
@@ -426,12 +426,13 @@ describe("runRemoteAgent", () => {
 		expect(capturedOptions?.signal).toBe(controller.signal)
 	})
 
-	it("forwards onToolActivity, onTurnEnd, onAssistantUsage, onRawNotification callbacks", async () => {
+	it("forwards onToolActivity, onTurnEnd, onAssistantUsage, onRawNotification, onContextUsage callbacks", async () => {
 		const callbacks = {
 			onToolActivity: vi.fn(),
 			onTurnEnd: vi.fn(),
 			onAssistantUsage: vi.fn(),
 			onRawNotification: vi.fn(),
+			onContextUsage: vi.fn(),
 		}
 		await runRemoteAgent(WORKSPACE_ID, PROMPT, makeOptions({ callbacks }))
 
@@ -442,6 +443,7 @@ describe("runRemoteAgent", () => {
 		expect(typeof captured.onTurnEnd).toBe("function")
 		expect(typeof captured.onAssistantUsage).toBe("function")
 		expect(typeof captured.onRawNotification).toBe("function")
+		expect(typeof captured.onContextUsage).toBe("function")
 
 		// Verify forwarding
 		captured.onToolActivity({ status: "completed", toolName: "Read" })
@@ -457,6 +459,9 @@ describe("runRemoteAgent", () => {
 		const rawNotif = { update: { sessionUpdate: "tool_call" } }
 		captured.onRawNotification(rawNotif)
 		expect(callbacks.onRawNotification).toHaveBeenCalledWith(rawNotif)
+
+		captured.onContextUsage(5000, 128000)
+		expect(callbacks.onContextUsage).toHaveBeenCalledWith(5000, 128000)
 	})
 
 	it("forwards gitDetails to createSession with targetDirectory cleared so clone goes into session cwd", async () => {

--- a/src/extensions/agents/manager/remote-agent-session.test.ts
+++ b/src/extensions/agents/manager/remote-agent-session.test.ts
@@ -97,6 +97,19 @@ describe("RemoteAgentSession", () => {
 		})
 	})
 
+	describe("setContextUsage", () => {
+		it("getSessionStats reports a null percent before any usage_update", () => {
+			const session = new RemoteAgentSession()
+			expect(session.getSessionStats().contextUsage?.percent).toBeNull()
+		})
+
+		it("getSessionStats computes the percent from the last usage_update", () => {
+			const session = new RemoteAgentSession()
+			session.setContextUsage(50_000, 200_000)
+			expect(session.getSessionStats().contextUsage?.percent).toBe(25)
+		})
+	})
+
 	describe("subscribe / emit", () => {
 		it("delivers emitted events to subscribers", () => {
 			const session = new RemoteAgentSession()

--- a/src/extensions/agents/manager/remote-agent-session.ts
+++ b/src/extensions/agents/manager/remote-agent-session.ts
@@ -65,6 +65,11 @@ export class RemoteAgentSession {
 	private _textOffset = 0
 	/** Set to true when the runner enters the reconnecting state. */
 	private _reconnecting = false
+	/** Last context-window usage reported by the remote agent (usage_update).
+	 *  Null until the first notification arrives — getSessionStats reports a
+	 *  null percent so the widget omits the annotation instead of guessing. */
+	private _contextUsed: number | null = null
+	private _contextSize: number | null = null
 
 	/** Called by _runRemote() via runRemoteAgent's onReady callback. */
 	bindClient(acpClient: AcpSessionClient, meta: RemoteSessionMeta): void {
@@ -126,7 +131,12 @@ export class RemoteAgentSession {
 	getSessionStats(): SessionStatsLike {
 		return {
 			tokens: { ...this._usage },
-			contextUsage: { percent: null },
+			contextUsage: {
+				percent:
+					this._contextUsed != null && this._contextSize != null && this._contextSize > 0
+						? (this._contextUsed / this._contextSize) * 100
+						: null,
+			},
 		}
 	}
 
@@ -155,6 +165,14 @@ export class RemoteAgentSession {
 		this._usage.output += delta.output
 		this._usage.cacheRead += delta.cacheRead
 		this._usage.cacheWrite += delta.cacheWrite
+	}
+
+	/** Track the remote context-window usage (ACP usage_update used/size).
+	 *  Surfaced via getSessionStats() so the agent widget can show a live
+	 *  context percent for cloud agents, matching local agents. */
+	setContextUsage(used: number, size: number): void {
+		this._contextUsed = used
+		this._contextSize = size
 	}
 
 	/** Track streaming state. */

--- a/src/extensions/agents/ui/agent-widget.test.ts
+++ b/src/extensions/agents/ui/agent-widget.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest"
+import type { AgentManager } from "../manager/agent-manager.js"
+import type { LifetimeUsage } from "../manager/usage.js"
+import { type AgentActivity, AgentWidget, type Theme, type UICtx } from "./agent-widget.js"
+
+// The widget remounts the tips widget when it registers — the tips module
+// pulls in config/billing/ferment chains a unit test doesn't need.
+vi.mock("../../tips/index.js", () => ({ remountTipWidget: vi.fn() }))
+
+const theme: Theme = { fg: (_color, text) => text, bold: (text) => text }
+
+const ZERO_USAGE: LifetimeUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+
+function makeActivity(lifetimeUsage: LifetimeUsage): AgentActivity {
+	return {
+		activeTools: new Map(),
+		toolUses: 0,
+		responseText: "",
+		turnCount: 2,
+		lifetimeUsage,
+	}
+}
+
+function renderOnce(manager: AgentManager, activity: Map<string, AgentActivity>, markFinishedId?: string): string {
+	const widget = new AgentWidget(manager, activity)
+	let lines: string[] = []
+	const uiCtx: UICtx = {
+		setStatus: () => {},
+		setWidget: (_key, content) => {
+			if (content) lines = content(undefined, theme).render(120)
+		},
+	}
+	widget.setUICtx(uiCtx)
+	if (markFinishedId) widget.markFinished(markFinishedId)
+	widget.update()
+	return lines.join("\n")
+}
+
+describe("AgentWidget token display", () => {
+	it("finished agent lines show the record's lifetime tokens", () => {
+		const record = {
+			id: "fin-1",
+			type: "general-purpose",
+			description: "did things",
+			status: "completed",
+			visibility: "user",
+			toolUses: 3,
+			startedAt: 1_000,
+			completedAt: 2_000,
+			lifetimeUsage: { input: 1500, output: 500, cacheRead: 0, cacheWrite: 0 },
+		}
+		const manager = { listAgents: () => [record] } as unknown as AgentManager
+
+		const rendered = renderOnce(manager, new Map(), "fin-1")
+
+		expect(rendered).toContain("3 tool uses")
+		// 1500 input + 500 output = 2000 → "2.0k token", same order as the
+		// running line (turns · tool uses · tokens · duration).
+		expect(rendered).toContain("2.0k token")
+		expect(rendered).toContain("1.0s")
+	})
+
+	it("finished agent lines omit token text when nothing was consumed", () => {
+		const record = {
+			id: "fin-2",
+			type: "general-purpose",
+			description: "did nothing",
+			status: "completed",
+			visibility: "user",
+			toolUses: 0,
+			startedAt: 1_000,
+			completedAt: 2_000,
+			lifetimeUsage: ZERO_USAGE,
+		}
+		const manager = { listAgents: () => [record] } as unknown as AgentManager
+
+		const rendered = renderOnce(manager, new Map(), "fin-2")
+
+		expect(rendered).not.toContain("token")
+	})
+
+	it("running agent lines show live activity tokens", () => {
+		const record = {
+			id: "run-1",
+			type: "general-purpose",
+			description: "working",
+			status: "running",
+			visibility: "user",
+			toolUses: 0,
+			startedAt: Date.now() - 5_000,
+			lifetimeUsage: ZERO_USAGE,
+		}
+		const manager = { listAgents: () => [record] } as unknown as AgentManager
+		const activity = new Map<string, AgentActivity>([
+			["run-1", makeActivity({ input: 2500, output: 500, cacheRead: 0, cacheWrite: 0 })],
+		])
+
+		const rendered = renderOnce(manager, activity)
+
+		expect(rendered).toContain("3.0k token")
+		expect(rendered).toContain("⟳2")
+	})
+})

--- a/src/extensions/agents/ui/agent-widget.test.ts
+++ b/src/extensions/agents/ui/agent-widget.test.ts
@@ -100,4 +100,33 @@ describe("AgentWidget token display", () => {
 		expect(rendered).toContain("3.0k token")
 		expect(rendered).toContain("⟳2")
 	})
+
+	it("running agent lines show the context percent alone when usage totals are absent (old server)", () => {
+		const record = {
+			id: "run-2",
+			type: "general-purpose",
+			description: "working on old server",
+			status: "running",
+			visibility: "user",
+			toolUses: 0,
+			startedAt: Date.now() - 5_000,
+			lifetimeUsage: ZERO_USAGE,
+		}
+		const manager = { listAgents: () => [record] } as unknown as AgentManager
+		const session = {
+			getSessionStats: () => ({
+				tokens: ZERO_USAGE,
+				contextUsage: { percent: 42 },
+			}),
+		}
+		const activity = new Map<string, AgentActivity>([
+			["run-2", { ...makeActivity(ZERO_USAGE), session }],
+		])
+
+		const rendered = renderOnce(manager, activity)
+
+		// Percent renders standalone — no "0 token" placeholder.
+		expect(rendered).toContain("42%")
+		expect(rendered).not.toContain("token")
+	})
 })

--- a/src/extensions/agents/ui/agent-widget.test.ts
+++ b/src/extensions/agents/ui/agent-widget.test.ts
@@ -119,9 +119,7 @@ describe("AgentWidget token display", () => {
 				contextUsage: { percent: 42 },
 			}),
 		}
-		const activity = new Map<string, AgentActivity>([
-			["run-2", { ...makeActivity(ZERO_USAGE), session }],
-		])
+		const activity = new Map<string, AgentActivity>([["run-2", { ...makeActivity(ZERO_USAGE), session }]])
 
 		const rendered = renderOnce(manager, activity)
 

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -216,6 +216,7 @@ export class AgentWidget {
 			error?: string
 			abortReason?: AgentAbortReason
 			modelId?: string
+			lifetimeUsage?: LifetimeUsage
 		},
 		theme: Theme,
 	): string {
@@ -248,6 +249,10 @@ export class AgentWidget {
 		const activity = this.agentActivity.get(a.id)
 		if (activity) parts.push(formatTurns(activity.turnCount, activity.maxTurns))
 		if (a.toolUses > 0) parts.push(`${a.toolUses} tool use${a.toolUses === 1 ? "" : "s"}`)
+		// Same order as the running line: turns · tool uses · tokens · duration.
+		// Reads the manager record (activity entries are dropped on completion).
+		const tokens = getLifetimeTotal(a.lifetimeUsage)
+		if (tokens > 0) parts.push(formatTokens(tokens))
 		parts.push(duration)
 
 		const modelTag = a.modelId ? ` ${theme.fg("dim", `[${a.modelId}]`)}` : ""

--- a/src/extensions/agents/ui/agent-widget.ts
+++ b/src/extensions/agents/ui/agent-widget.ts
@@ -87,12 +87,16 @@ export function formatTokens(count: number): string {
 	return `${count} token`
 }
 
+export function formatContextPercent(percent: number, theme: Theme): string {
+	const color = percent >= 85 ? "error" : percent >= 70 ? "warning" : "dim"
+	return theme.fg(color, `${Math.round(percent)}%`)
+}
+
 export function formatSessionTokens(tokens: number, percent: number | null, theme: Theme, compactions = 0): string {
 	const tokenStr = formatTokens(tokens)
 	const annot: string[] = []
 	if (percent !== null) {
-		const color = percent >= 85 ? "error" : percent >= 70 ? "warning" : "dim"
-		annot.push(theme.fg(color, `${Math.round(percent)}%`))
+		annot.push(formatContextPercent(percent, theme))
 	}
 	if (compactions > 0) {
 		annot.push(theme.fg("dim", `↻${compactions}`))
@@ -295,7 +299,15 @@ export class AgentWidget {
 			const toolUses = bg?.toolUses ?? a.toolUses
 			const tokens = getLifetimeTotal(bg?.lifetimeUsage)
 			const contextPercent = getSessionContextPercent(bg?.session)
-			const tokenText = tokens > 0 ? formatSessionTokens(tokens, contextPercent, theme, a.compactionCount) : ""
+			// Combined "45.2k token (23%)" once usage flows; standalone "23%" when
+			// totals are absent (e.g. an older sandbox server that doesn't attach
+			// _meta lifetime totals but still streams usage_update used/size).
+			const tokenText =
+				tokens > 0
+					? formatSessionTokens(tokens, contextPercent, theme, a.compactionCount)
+					: contextPercent !== null
+						? formatContextPercent(contextPercent, theme)
+						: ""
 
 			const parts: string[] = []
 			if (bg) parts.push(formatTurns(bg.turnCount, bg.maxTurns))

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -78,7 +78,7 @@ import {
 	unregisterSessionPermissionFlagController,
 } from "../../extensions/permissions/mode-controller-registry.js"
 import { updateModelsConfig } from "../../models.js"
-import { ACP_REATTACH_MID_TURN_META_KEY } from "../../sandbox/worker/acp-protocol.js"
+import { ACP_LIFETIME_USAGE_META_KEY, ACP_REATTACH_MID_TURN_META_KEY } from "../../sandbox/worker/acp-protocol.js"
 import { AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { getAcpPrompter } from "./permission-prompter-registry.js"
 import {
@@ -2204,6 +2204,68 @@ describe("KimchiAcpAgent usage reporting", () => {
 		// turn-end emission — the indicator follows the turn live instead of
 		// updating only once at the end.
 		expect(usageUpdates()).toHaveLength(3)
+	})
+
+	it("attaches cumulative lifetime usage totals to usage_update _meta", async () => {
+		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(assistantUsageEvent({ input: 100, output: 20, cacheRead: 5, cacheWrite: 3 }))
+			fake.emit(assistantUsageEvent({ input: 50, output: 10, cacheRead: 2, cacheWrite: 1 }))
+			fake.emit(agentEnd())
+		}
+
+		const result = await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		const usage = usageUpdates()
+		// One per assistant message_end (2), plus the final turn-end emission.
+		expect(usage).toHaveLength(3)
+		// Each snapshot carries the cumulative lifetime totals so far — clients
+		// derive per-notification deltas from consecutive snapshots.
+		expect(usage[0]._meta?.[ACP_LIFETIME_USAGE_META_KEY]).toEqual({
+			input: 100,
+			output: 20,
+			cacheRead: 5,
+			cacheWrite: 3,
+		})
+		expect(usage[1]._meta?.[ACP_LIFETIME_USAGE_META_KEY]).toEqual({
+			input: 150,
+			output: 30,
+			cacheRead: 7,
+			cacheWrite: 4,
+		})
+		// The turn-end emission carries the same final totals.
+		expect(usage[2]._meta?.[ACP_LIFETIME_USAGE_META_KEY]).toEqual({
+			input: 150,
+			output: 30,
+			cacheRead: 7,
+			cacheWrite: 4,
+		})
+		// PromptResponse.usage equals the last cumulative snapshot — a client
+		// tracking _meta deltas owes nothing extra when the prompt resolves.
+		expect(result.usage).toEqual({
+			inputTokens: 150,
+			outputTokens: 30,
+			cachedReadTokens: 7,
+			cachedWriteTokens: 4,
+			totalTokens: 191,
+		})
+	})
+
+	it("omits the _meta usage totals when no usage was collected", async () => {
+		fake.contextUsage = { tokens: 1234, contextWindow: 200000, percent: 0.617 }
+		fake.promptImpl = async () => {
+			fake.emit({ type: "agent_start" })
+			fake.emit(agentEnd())
+		}
+
+		await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+
+		const usage = usageUpdates()
+		// Only the turn-end emission fires (contextUsage is set) — without any
+		// usage-bearing message it must not advertise a _meta totals object.
+		expect(usage).toHaveLength(1)
+		expect(usage[0]._meta?.[ACP_LIFETIME_USAGE_META_KEY]).toBeUndefined()
 	})
 
 	it("skips usage_update when getContextUsage returns undefined", async () => {

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -94,7 +94,11 @@ import { KIMCHI_PROVIDER_ID } from "../../kimchi-provider.js"
 import { updateModelsConfig } from "../../models.js"
 import { clearPiAuth, syncPiAuth } from "../../pi-auth.js"
 import { resolveHeadlessProjectTrust } from "../../project-trust.js"
-import { ACP_REATTACH_MID_TURN_META_KEY, buildToolCallId } from "../../sandbox/worker/acp-protocol.js"
+import {
+	ACP_LIFETIME_USAGE_META_KEY,
+	ACP_REATTACH_MID_TURN_META_KEY,
+	buildToolCallId,
+} from "../../sandbox/worker/acp-protocol.js"
 import { getVersion } from "../../utils.js"
 import { createAcpPermissionPrompter } from "./acp-prompter.js"
 import { createAcpUIContext } from "./acp-ui-context.js"
@@ -1294,7 +1298,7 @@ export class KimchiAcpAgent implements Agent {
 					// the session's estimate just moved. Emit here (subject to
 					// emitUsageUpdate's undefined/null skip) so clients track the
 					// context window across chained steps, not just at turn end.
-					this.emitUsageUpdate(entry)
+					this.emitUsageUpdate(entry, turn.usage)
 				}
 				return
 			}
@@ -1693,15 +1697,31 @@ export class KimchiAcpAgent implements Agent {
 		})
 	}
 
-	private emitUsageUpdate(entry: SessionRecord): void {
+	private emitUsageUpdate(entry: SessionRecord, lifetime: TurnUsage): void {
 		const session = entry.session
 		const ctx = session.getContextUsage()
 		// Per the issue doc: skip when getContextUsage() returns undefined or
 		// tokens is null (e.g. right after compaction). ACP requires both `used`
 		// and `size`, so there is no null-safe emission.
 		if (!ctx || ctx.tokens === null) return
+		// Piggyback the turn's cumulative lifetime token totals on the
+		// notification via _meta — usage_update's used/size only describe the
+		// context window, so long-running remote clients would otherwise see no
+		// token consumption until the PromptResponse resolves. Cumulative (not
+		// per-update) totals keep client-side delta computation idempotent across
+		// session/load replays.
+		const usageMeta =
+			lifetime.messages > 0
+				? {
+						input: lifetime.input,
+						output: lifetime.output,
+						cacheRead: lifetime.cacheRead,
+						cacheWrite: lifetime.cacheWrite,
+					}
+				: undefined
 		this.send({
 			sessionId: session.sessionId,
+			...(usageMeta ? { _meta: { [ACP_LIFETIME_USAGE_META_KEY]: usageMeta } } : {}),
 			update: {
 				sessionUpdate: "usage_update",
 				used: ctx.tokens,
@@ -1715,7 +1735,7 @@ export class KimchiAcpAgent implements Agent {
 		if (!turn) return
 		entry.turn = undefined
 		try {
-			this.emitUsageUpdate(entry)
+			this.emitUsageUpdate(entry, turn.usage)
 		} finally {
 			const response: PromptResponse = { stopReason }
 			// usage is v1/experimental-only on PromptResponse (v2 drops it in favor

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1298,7 +1298,7 @@ export class KimchiAcpAgent implements Agent {
 					// the session's estimate just moved. Emit here (subject to
 					// emitUsageUpdate's undefined/null skip) so clients track the
 					// context window across chained steps, not just at turn end.
-					this.emitUsageUpdate(entry, turn.usage)
+					this.emitUsageUpdate(entry.session, turn.usage)
 				}
 				return
 			}
@@ -1697,8 +1697,7 @@ export class KimchiAcpAgent implements Agent {
 		})
 	}
 
-	private emitUsageUpdate(entry: SessionRecord, lifetime: TurnUsage): void {
-		const session = entry.session
+	private emitUsageUpdate(session: AgentSession, lifetime: TurnUsage): void {
 		const ctx = session.getContextUsage()
 		// Per the issue doc: skip when getContextUsage() returns undefined or
 		// tokens is null (e.g. right after compaction). ACP requires both `used`
@@ -1735,7 +1734,7 @@ export class KimchiAcpAgent implements Agent {
 		if (!turn) return
 		entry.turn = undefined
 		try {
-			this.emitUsageUpdate(entry, turn.usage)
+			this.emitUsageUpdate(entry.session, turn.usage)
 		} finally {
 			const response: PromptResponse = { stopReason }
 			// usage is v1/experimental-only on PromptResponse (v2 drops it in favor

--- a/src/sandbox/worker/acp-client.test.ts
+++ b/src/sandbox/worker/acp-client.test.ts
@@ -194,6 +194,7 @@ function makeCallbacks(): { callbacks: AcpSessionCallbacks; calls: ReturnType<ty
 		onTextDelta: vi.fn(),
 		onToolActivity: vi.fn(),
 		onTurnEnd: vi.fn(),
+		onContextUsage: vi.fn(),
 		onAssistantUsage: vi.fn(),
 	}
 	return { callbacks, calls }
@@ -681,6 +682,90 @@ describe("AcpSessionClient", () => {
 				output: 200,
 				cacheRead: 50,
 				cacheWrite: 10,
+			})
+
+			client.close()
+		})
+
+		it("reports lifetime usage deltas from usage_update _meta and only the remainder from PromptResponse", async () => {
+			const { callbacks } = makeCallbacks()
+			const client = new AcpSessionClient({
+				sessionName: "sess-1",
+				credentials: makeCredentials(),
+				callbacks,
+				WebSocketImpl: MockWebSocket,
+			})
+			const { socket } = await initClient(client)
+
+			const p = client.prompt("hello")
+			await vi.waitFor(() => {
+				expect(getSentMessages(socket).some((m) => m.method === "session/prompt")).toBe(true)
+			})
+			const promptReq = findRequest(getSentMessages(socket), "session/prompt")
+
+			// Mid-run usage_update with cumulative lifetime totals — first
+			// snapshot reports everything seen so far as one delta.
+			serverSendMessage(
+				socket,
+				rpcNotification("session/update", {
+					sessionId: "session-abc",
+					_meta: { "kimchi/lifetimeUsage": { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 } },
+					update: { sessionUpdate: "usage_update", used: 5000, size: 128000 },
+				}),
+			)
+			// Second snapshot — only the growth since the last one is reported.
+			serverSendMessage(
+				socket,
+				rpcNotification("session/update", {
+					sessionId: "session-abc",
+					_meta: { "kimchi/lifetimeUsage": { input: 150, output: 80, cacheRead: 10, cacheWrite: 5 } },
+					update: { sessionUpdate: "usage_update", used: 6000, size: 128000 },
+				}),
+			)
+			await new Promise((resolve) => setImmediate(resolve))
+
+			expect(callbacks.onContextUsage).toHaveBeenCalledTimes(2)
+			expect(callbacks.onContextUsage).toHaveBeenNthCalledWith(1, 5000, 128000)
+			expect(callbacks.onContextUsage).toHaveBeenNthCalledWith(2, 6000, 128000)
+			expect(callbacks.onAssistantUsage).toHaveBeenCalledTimes(2)
+			expect(callbacks.onAssistantUsage).toHaveBeenNthCalledWith(1, {
+				input: 100,
+				output: 50,
+				cacheRead: 10,
+				cacheWrite: 5,
+			})
+			expect(callbacks.onAssistantUsage).toHaveBeenNthCalledWith(2, {
+				input: 50,
+				output: 30,
+				cacheRead: 0,
+				cacheWrite: 0,
+			})
+
+			// Prompt resolves with the final totals — only the remainder (output
+			// grew 80 → 90) is emitted, so consumers never double-count the turn.
+			serverSendMessage(
+				socket,
+				rpcResponse(promptReq.id, {
+					stopReason: "end_turn",
+					usage: {
+						inputTokens: 150,
+						outputTokens: 90,
+						cachedReadTokens: 10,
+						cachedWriteTokens: 5,
+						totalTokens: 335,
+					},
+				}),
+			)
+			const result = await p
+
+			// The returned usage is still the full turn's totals.
+			expect(result.usage).toEqual({ input: 150, output: 90, cacheRead: 10, cacheWrite: 5 })
+			expect(callbacks.onAssistantUsage).toHaveBeenCalledTimes(3)
+			expect(callbacks.onAssistantUsage).toHaveBeenNthCalledWith(3, {
+				input: 0,
+				output: 10,
+				cacheRead: 0,
+				cacheWrite: 0,
 			})
 
 			client.close()
@@ -1343,7 +1428,7 @@ describe("AcpSessionClient", () => {
 			client.close()
 		})
 
-		it("ignores agent_thought_chunk, usage_update, plan, and other updates", async () => {
+		it("ignores agent_thought_chunk and plan updates; usage_update only reports context usage", async () => {
 			const { callbacks } = makeCallbacks()
 			const client = new AcpSessionClient({
 				sessionName: "sess-1",
@@ -1395,9 +1480,14 @@ describe("AcpSessionClient", () => {
 			// Yield so the async stream pipeline can process the notifications
 			await new Promise((resolve) => setImmediate(resolve))
 
-			// None of these should trigger any callback
+			// Thought/plan chunks trigger no callback at all.
 			expect(callbacks.onTextDelta).not.toHaveBeenCalled()
 			expect(callbacks.onToolActivity).not.toHaveBeenCalled()
+			// usage_update without _meta lifetime totals (old server) surfaces
+			// only the context-window state — no usage deltas.
+			expect(callbacks.onContextUsage).toHaveBeenCalledTimes(1)
+			expect(callbacks.onContextUsage).toHaveBeenCalledWith(5000, 128000)
+			expect(callbacks.onAssistantUsage).not.toHaveBeenCalled()
 
 			serverSendMessage(socket, rpcResponse(promptReq.id, { stopReason: "end_turn" }))
 			await p

--- a/src/sandbox/worker/acp-client.ts
+++ b/src/sandbox/worker/acp-client.ts
@@ -16,7 +16,9 @@
  * | `tool_call` (completed/failed)  | `onToolActivity({ status: "completed"/"failed" })` |
  * | `tool_call_update` (→completed) | `onToolActivity({ status: "completed"/"failed" })` |
  * | `prompt()` resolves             | `onTurnEnd(++turnCount)`          |
- * | `PromptResponse.usage`          | `onAssistantUsage({...})`         |
+ * | `usage_update`                  | `onContextUsage(used, size)`      |
+ * | `usage_update` (+ `_meta` totals)| `onAssistantUsage(delta)`         |
+ * | `PromptResponse.usage`          | `onAssistantUsage({remainder})`   |
  *
  * Designed to be plugged into a `runRemoteAgent()` function that mirrors `runAgent()`'s
  * callback contract but sources events from this client instead of a local `AgentSession`.
@@ -37,7 +39,7 @@ import {
 import WebSocket from "ws"
 import type { LifetimeUsage } from "../../extensions/agents/manager/usage.js"
 import type { WorkspaceCredentials } from "../cloud/types.js"
-import { ACP_REATTACH_MID_TURN_META_KEY, parseToolCallId } from "./acp-protocol.js"
+import { ACP_REATTACH_MID_TURN_META_KEY, parseToolCallId, readLifetimeUsageMeta } from "./acp-protocol.js"
 
 // Hoisted once — reused across WebSocket frames instead of allocating per message.
 const textEncoder = new TextEncoder()
@@ -77,7 +79,11 @@ export interface AcpSessionCallbacks {
 	}) => void
 	/** Called at the end of each ACP turn with the cumulative turn count. */
 	onTurnEnd?: (turnCount: number) => void
-	/** Called with per-turn token usage when a `prompt()` resolves. */
+	/** Called on each usage_update with the context-window state (used/size). */
+	onContextUsage?: (used: number, size: number) => void
+	/** Called with per-turn token usage when a `prompt()` resolves, and — when
+	 *  the server attaches cumulative lifetime totals to usage_update `_meta` —
+	 *  incrementally during the turn as deltas. */
 	onAssistantUsage?: (usage: LifetimeUsage) => void
 	/** Receives every raw SessionNotification before dispatch to typed callbacks. */
 	onRawNotification?: (params: SessionNotification) => void
@@ -162,6 +168,10 @@ export class AcpSessionClient {
 	 *  load was in flight. Exposed via `loadReplay` for protocol-level result
 	 *  recovery when the transcript file cannot be fetched. */
 	private _loadReplay: SessionNotification[] = []
+	/** Last cumulative lifetime usage totals seen via usage_update `_meta` —
+	 *  the baseline for delta computation. Reset per prompt() so consecutive
+	 *  prompts on one session don't suppress each other's usage. */
+	private _lastLifetimeUsage: LifetimeUsage | undefined
 	/** WS ping interval — detects broken connections within ~30s instead of minutes. */
 	private _pingTimer: ReturnType<typeof setInterval> | undefined
 	/** Tracks whether we've received any data since the last ping. The WS 'pong'
@@ -303,6 +313,7 @@ export class AcpSessionClient {
 		}
 
 		this._accumulatedText = ""
+		this._lastLifetimeUsage = undefined
 
 		const response: PromptResponse = await this._withAbortRejection(
 			this._withTimeout(
@@ -328,7 +339,14 @@ export class AcpSessionClient {
 				cacheRead: response.usage.cachedReadTokens ?? 0,
 				cacheWrite: response.usage.cachedWriteTokens ?? 0,
 			}
-			this._options.callbacks?.onAssistantUsage?.(usage)
+			if (this._lastLifetimeUsage) {
+				// Mid-run usage_update notifications already reported the turn's
+				// consumption via _meta deltas — emit only the remainder so the
+				// turn's totals aren't double-counted.
+				this._emitLifetimeDelta(usage)
+			} else {
+				this._options.callbacks?.onAssistantUsage?.(usage)
+			}
 		}
 
 		return {
@@ -648,6 +666,15 @@ export class AcpSessionClient {
 				this._dispatchToolActivity(cb, update.status, update.toolCallId, title, update.rawInput)
 				break
 			}
+			case "usage_update": {
+				cb.onContextUsage?.(update.used, update.size)
+				// Servers that fold lifetime totals into _meta let clients show
+				// live token counts during long remote runs. Cumulative totals
+				// make the delta idempotent across session/load replays.
+				const totals = readLifetimeUsageMeta(params._meta)
+				if (totals) this._emitLifetimeDelta(totals)
+				break
+			}
 			default:
 				break
 		}
@@ -679,6 +706,24 @@ export class AcpSessionClient {
 		})
 		// completed/failed clears the title cache entry.
 		if (status !== "in_progress") this._toolCallTitles.delete(toolCallId)
+	}
+
+	/** Reports the increase of cumulative lifetime usage totals over the last
+	 *  seen snapshot as an onAssistantUsage delta. All-zero deltas are swallowed
+	 *  (idempotent replays); the snapshot is recorded even when swallowed so a
+	 *  later decrease (fresh turn) can't fabricate negative counts. */
+	private _emitLifetimeDelta(totals: LifetimeUsage): void {
+		const last = this._lastLifetimeUsage
+		const delta: LifetimeUsage = {
+			input: Math.max(0, totals.input - (last?.input ?? 0)),
+			output: Math.max(0, totals.output - (last?.output ?? 0)),
+			cacheRead: Math.max(0, totals.cacheRead - (last?.cacheRead ?? 0)),
+			cacheWrite: Math.max(0, totals.cacheWrite - (last?.cacheWrite ?? 0)),
+		}
+		this._lastLifetimeUsage = totals
+		if (delta.input > 0 || delta.output > 0 || delta.cacheRead > 0 || delta.cacheWrite > 0) {
+			this._options.callbacks?.onAssistantUsage?.(delta)
+		}
 	}
 
 	/**

--- a/src/sandbox/worker/acp-protocol.ts
+++ b/src/sandbox/worker/acp-protocol.ts
@@ -1,6 +1,7 @@
 /**
  * Shared ACP wire-format constants for the toolCallId format and the
- * reattach `_meta` key. Used by both the ACP mode server
+ * `_meta` extension keys (mid-turn reattach opt-in, lifetime usage totals).
+ * Used by both the ACP mode server
  * (`src/modes/acp/server.ts`, which generates ids) and the sandbox worker
  * client (`src/sandbox/worker/acp-client.ts`, which parses them back).
  *
@@ -9,8 +10,39 @@
  * path, so they must stay byte-identical across releases.
  */
 
+import type { LifetimeUsage } from "../../extensions/agents/manager/usage.js"
+
 /** `_meta` key opting `session/load` into mid-turn attach; strict guard stays default. */
 export const ACP_REATTACH_MID_TURN_META_KEY = "kimchi/reattachMidTurn"
+
+/**
+ * `_meta` key carrying cumulative lifetime token usage on `usage_update`
+ * session notifications. ACP's `usage_update` only reports context-window
+ * state (used/size), which cannot express consumed-token totals — the server
+ * folds its turn usage accumulator into this key so clients can show live
+ * token counts for long-running remote agents.
+ */
+export const ACP_LIFETIME_USAGE_META_KEY = "kimchi/lifetimeUsage"
+
+/**
+ * Reads the cumulative lifetime usage totals from a notification's `_meta`.
+ * Tolerant by design: absent/shape-mismatched values yield undefined (or 0
+ * per field), so a server version without the key degrades gracefully to
+ * end-of-prompt usage reporting.
+ */
+export function readLifetimeUsageMeta(meta: unknown): LifetimeUsage | undefined {
+	if (!meta || typeof meta !== "object") return undefined
+	const raw = (meta as Record<string, unknown>)[ACP_LIFETIME_USAGE_META_KEY]
+	if (!raw || typeof raw !== "object") return undefined
+	const u = raw as Record<string, unknown>
+	const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : 0)
+	return {
+		input: num(u.input),
+		output: num(u.output),
+		cacheRead: num(u.cacheRead),
+		cacheWrite: num(u.cacheWrite),
+	}
+}
 
 /** Builds the ACP toolCallId for a tool call: `kt.<toolName>.<seq>`. */
 export function buildToolCallId(toolName: string, seq: number): string {

--- a/tests/e2e/acp/plan-updates.test.ts
+++ b/tests/e2e/acp/plan-updates.test.ts
@@ -302,33 +302,35 @@ describe("ACP integration — plan updates from todo writes", () => {
 				stepIsPending,
 				"Ferment phase Todo snapshot did not arrive",
 				8_000,
-			).catch(async () => {
-				if (kickIsStreaming()) {
-					// Kick is running, just slow — wait for the condition, no deadline.
+			)
+				.catch(async () => {
+					if (kickIsStreaming()) {
+						// Kick is running, just slow — wait for the condition, no deadline.
+						return waitForPlanSnapshot(
+							fixture,
+							sessionId,
+							stepIsPending,
+							"Ferment phase Todo snapshot did not arrive from the in-flight resume kick",
+						)
+					}
+					// The kick never ran — drive the phase manually.
+					await prompt(fixture, sessionId, "Continue the Ferment")
 					return waitForPlanSnapshot(
 						fixture,
 						sessionId,
 						stepIsPending,
-						"Ferment phase Todo snapshot did not arrive from the in-flight resume kick",
+						"Prompt-driven Ferment phase Todo snapshot did not arrive",
 					)
-				}
-				// The kick never ran — drive the phase manually.
-				await prompt(fixture, sessionId, "Continue the Ferment")
-				return waitForPlanSnapshot(
-					fixture,
-					sessionId,
-					stepIsPending,
-					"Prompt-driven Ferment phase Todo snapshot did not arrive",
-				)
-			}).catch(async () => {
-				await prompt(fixture, sessionId, "Continue the Ferment")
-				return waitForPlanSnapshot(
-					fixture,
-					sessionId,
-					(entries) => entries.some((entry) => entry.content.includes(STEP_DESCRIPTION)),
-					"Prompt-driven Ferment phase Todo snapshot did not arrive",
-				)
-			})
+				})
+				.catch(async () => {
+					await prompt(fixture, sessionId, "Continue the Ferment")
+					return waitForPlanSnapshot(
+						fixture,
+						sessionId,
+						(entries) => entries.some((entry) => entry.content.includes(STEP_DESCRIPTION)),
+						"Prompt-driven Ferment phase Todo snapshot did not arrive",
+					)
+				})
 			expect(initial.some((entry) => entry.status === "pending" && entry.content.includes(STEP_DESCRIPTION))).toBe(true)
 
 			await prompt(fixture, sessionId, "Start the step")


### PR DESCRIPTION
Cloud agents previously showed no token consumption in the agent widget: usage only arrived when the whole ACP prompt resolved (i.e. at the very end of the run), and finished lines never rendered tokens at all.

- ACP server folds cumulative lifetime usage totals onto usage_update notifications via the `kimchi/lifetimeUsage` _meta key after every assistant message (cumulative snapshots keep client deltas idempotent across session/load replays)
- ACP client converts _meta snapshots into onAssistantUsage deltas; PromptResponse.usage now emits only the remainder at prompt end so turn totals are never double-counted
- RemoteAgentSession exposes a real contextUsage.percent from the usage_update used/size values; wired through _runRemote and resumeRemoteRecord so resumed cloud agents report live too
- Widget shows tokens on finished agent lines, same order as running lines (turns · tool uses · tokens · duration)

Servers without the _meta key degrade gracefully to end-of-prompt usage reporting.

## Linked issue

Closes #

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

<!-- Brief description of the change and why it's needed. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [ ] This PR links to an open issue above
- [ ] Tests pass locally (`pnpm run test`)
- [ ] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed
