### PR TITLE
LLM-3416: send X-Provider-Type ai-enabler on base kimchi-dev provider

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -199,7 +199,7 @@ describe("updateModelsConfig", () => {
 		expect(model).not.toHaveProperty("thinkingLevelMap")
 	})
 
-	it("sets X-Provider-Type header at the provider level for sub-providers only", async () => {
+	it("sets X-Provider-Type header at the provider level for all kimchi providers", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce({
 			ok: true,
 			json: async () => ({ models: [SONNET_46, KIMI] }),
@@ -208,8 +208,9 @@ describe("updateModelsConfig", () => {
 		await updateModelsConfig(modelsJsonPath, "test-key")
 
 		const config = JSON.parse(readFileSync(modelsJsonPath, "utf-8"))
-		// base kimchi-dev provider does NOT have the header
-		expect(config.providers["kimchi-dev"].headers["X-Provider-Type"]).toBeUndefined()
+		// base kimchi-dev provider routes ai-enabler models
+		expect(config.providers["kimchi-dev"].headers["X-Provider-Type"]).toBe("ai-enabler")
+		expect(config.providers["kimchi-dev"].headers["User-Agent"]).toMatch(/^kimchi\//)
 
 		// anthropic sub-provider has the header
 		expect(config.providers["kimchi-dev/anthropic"].headers["X-Provider-Type"]).toBe("anthropic")

--- a/src/models.ts
+++ b/src/models.ts
@@ -272,7 +272,7 @@ function buildModelsConfig(models: ModelMetadata[], endpoint?: string) {
 			apiKey: "$KIMCHI_API_KEY",
 			api: "openai-completions",
 			authHeader: true,
-			headers: { "User-Agent": `kimchi/${getVersion()}` },
+			headers: providerHeaders("ai-enabler"),
 			models: aiEnablerModels.map(metadataToModel),
 		},
 	}


### PR DESCRIPTION
## Summary

Follow-up to #868. The base `kimchi-dev` provider (which holds all `ai-enabler` models) sent only `User-Agent` — no `X-Provider-Type`. On the proxy side, `GetRegisteredProviders` then receives a nil type filter and returns **all** registered providers, so ai-enabler requests are routed by model-slug matching across the entire list. That is deterministic only while every slug is globally unique across providers; a slug collision between providers (or the router, if `X-Routing-Enabled` were ever set) would make routing ambiguous.

The harness is the source of truth for user intent: the metadata catalog tags every model with its upstream `provider`, and `buildModelsConfig` places each model in exactly one provider entry keyed by that type. This change forwards that mapping explicitly on every request by reusing the existing `providerHeaders()` helper for the base provider, so every kimchi provider entry pins its upstream type (`ai-enabler` is a registered provider type in the proxy: `services/proxy/pkg/castai/types.go` `AIEnablerProvider`).

## Changes

- `src/models.ts`: base `kimchi-dev` provider headers now use `providerHeaders("ai-enabler")` (adds `X-Provider-Type`, preserves `User-Agent`)
- `src/models.test.ts`: flipped the base-provider assertion from "header absent" to `"ai-enabler"`, renamed the test, added a `User-Agent` assertion

## Test results

- `pnpm run test src/models.test.ts -t "X-Provider-Type"` — PASS (fails before the fix, per TDD)
- `pnpm run typecheck` — no errors
- `pnpm run lint` — clean on changed files
- Full unit suite: the 4 failing files (`acp/server.test.ts`, `permissions/index.test.ts`, `telemetry/*`) were verified to fail identically on clean `master` in a fresh worktree — pre-existing, unrelated to this change

