### PR TITLE
fix(remote-agent): remove 10-minute wall-clock timeout from ACP prompt()

### DIFF
--- a/src/sandbox/worker/acp-client.test.ts
+++ b/src/sandbox/worker/acp-client.test.ts
@@ -602,6 +602,36 @@ describe("AcpSessionClient", () => {
 			client.close()
 		})
 
+		it("does not time out a long-running prompt (no wall-clock cap)", async () => {
+			vi.useFakeTimers()
+			const { callbacks } = makeCallbacks()
+			const client = new AcpSessionClient({
+				sessionName: "sess-1",
+				credentials: makeCredentials(),
+				callbacks,
+				WebSocketImpl: MockWebSocket,
+			})
+			const { socket } = await initClient(client)
+
+			const promptPromise = client.prompt("long task")
+			await vi.waitFor(() => {
+				expect(getSentMessages(socket).some((m) => m.method === "session/prompt")).toBe(true)
+			})
+			const promptReq = findRequest(getSentMessages(socket), "session/prompt")
+
+			// Regression: prompt() previously rejected with RemoteConnectionError
+			// after 10 minutes ("prompt timed out after 600000ms"), killing healthy
+			// long-running remote turns. There is now no wall-clock cap — dead
+			// connections are detected by the ping keepalive instead.
+			vi.advanceTimersByTime(30 * 60_000)
+
+			serverSendMessage(socket, rpcResponse(promptReq.id, { stopReason: "end_turn" }))
+			const result = await promptPromise
+			expect(result.stopReason).toBe("end_turn")
+
+			client.close()
+		})
+
 		it("calls onTurnEnd with incremented turn count when prompt resolves", async () => {
 			const { callbacks } = makeCallbacks()
 			const client = new AcpSessionClient({

--- a/src/sandbox/worker/acp-client.test.ts
+++ b/src/sandbox/worker/acp-client.test.ts
@@ -43,6 +43,9 @@ function openSocket(socket: MockSocket): void {
 const CONNECTING = 0
 const OPEN = 1
 
+/** Whether MockWebSocket.ping() auto-responds with pong. Set false to simulate a dead transport. */
+let respondToPing = true
+
 class MockWebSocket {
 	static CONNECTING = CONNECTING
 	static OPEN = OPEN
@@ -100,6 +103,7 @@ class MockWebSocket {
 	ping(): void {
 		// Simulate a real WS: auto-respond with pong so the keepalive
 		// doesn't falsely detect a broken connection in tests.
+		if (!respondToPing) return
 		fireHandlers(this.socket, "pong")
 	}
 
@@ -276,11 +280,13 @@ async function initClientWithLoad(client: AcpSessionClient): Promise<{ socket: M
 
 beforeEach(() => {
 	mockSockets = []
+	respondToPing = true
 })
 
 afterEach(() => {
 	vi.useRealTimers()
 	mockSockets = []
+	respondToPing = true
 })
 
 describe("AcpSessionClient", () => {
@@ -712,6 +718,32 @@ describe("AcpSessionClient", () => {
 				cacheRead: 50,
 				cacheWrite: 10,
 			})
+
+			client.close()
+		})
+
+		it("rejects a pending prompt when the transport stops answering pings", async () => {
+			vi.useFakeTimers()
+			const client = new AcpSessionClient({
+				sessionName: "sess-1",
+				credentials: makeCredentials(),
+				WebSocketImpl: MockWebSocket,
+			})
+			const { socket } = await initClient(client)
+
+			const promptPromise = client.prompt("hello")
+			await vi.waitFor(() => {
+				expect(getSentMessages(socket).some((m) => m.method === "session/prompt")).toBe(true)
+			})
+
+			// Half-open connection: WS stays open, messages stop flowing, pings go
+			// unanswered. The keepalive (15s interval, 30s tolerance) must reject
+			// the pending prompt instead of hanging forever.
+			respondToPing = false
+			vi.advanceTimersByTime(31_000)
+
+			await expect(promptPromise).rejects.toThrow(RemoteConnectionError)
+			await expect(promptPromise).rejects.toThrow("ping timeout")
 
 			client.close()
 		})

--- a/src/sandbox/worker/acp-client.ts
+++ b/src/sandbox/worker/acp-client.ts
@@ -304,17 +304,15 @@ export class AcpSessionClient {
 
 		this._accumulatedText = ""
 
+		// No upper bound on prompt duration — remote agents can run for tens of
+		// minutes on large repos. A wall-clock timeout cannot distinguish a slow
+		// turn from a dead connection (and wrongly closes a healthy WS), so
+		// transport failure detection is left to the ping keepalive instead.
 		const response: PromptResponse = await this._withAbortRejection(
-			this._withTimeout(
-				this._connection.prompt({
-					sessionId: this._sessionId,
-					prompt: [{ type: "text", text }],
-				}),
-				// No upper bound on prompt duration — remote agents can run for
-				// minutes on large repos. Use a generous default of 10 minutes.
-				10 * 60_000,
-				"prompt",
-			),
+			this._connection.prompt({
+				sessionId: this._sessionId,
+				prompt: [{ type: "text", text }],
+			}),
 		)
 
 		this._turnCount++


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Description

Users of remote plan execution (cloud agent) reported `error: prompt timed out after 600000ms` on long-running tasks.

**Root cause:** `AcpSessionClient.prompt()` wrapped the ACP `session/prompt` RPC in a 10-minute `_withTimeout`, which on expiry rejected with `RemoteConnectionError("prompt timed out after 600000ms")` **and closed the WebSocket** — killing turns that were still running healthy server-side. A duration cap cannot distinguish a slow-but-healthy turn from a dead connection.

**Fix:** `prompt()` no longer has a wall-clock limit. Transport-failure detection is already covered by the WS ping keepalive (rejects within ~30s of a genuinely broken connection), and user abort still interrupts immediately via `_withAbortRejection`. All remaining timeouts on the remote path were audited (30s handshake ops, 5min session-create, status poller, Go bridge grace periods) — none limit turn duration.

**Side benefit:** the `remote-agent-runner` disconnect recovery no longer fires spuriously on slow turns; it now only triggers on genuine connection failures.

## Testing

- Regression test: a prompt left unanswered for 30 minutes (fake timers) resolves with `end_turn` instead of timing out
- All 51 `acp-client` tests pass; all 64 `remote-agent-runner` tests pass