### PR TITLE
fix(telemetry): scope traceparent per request instead of per session

### DIFF
--- a/src/extensions/telemetry/README.md
+++ b/src/extensions/telemetry/README.md
@@ -100,13 +100,13 @@ Fired from `session-context.ts` via `ctx.emit()`. Batched (max 20) and flushed e
 | `session.start` | Session begins | `model` |
 | `session.end` | Session ends | `model`, `duration_ms`, `ended_by`, `source`, `mode` |
 | `user_message` | User sends a message | `model`, `message_length` |
-| `api_request` | Assistant response completes | `model`, `provider`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd`, `duration_ms` |
+| `api_request` | Assistant response completes | `model`, `provider`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd`, `duration_ms`, `request.trace_id`, `request.span_id` *(trace of the request that produced it — present when a provider request has been issued)* |
 | `tool_result` | Any tool finishes | `tool_name`, `model`, `success`, `duration_ms` |
 | `file_read` | `read` tool succeeds | `model`, `language`, `file_hash`, `duration_ms` |
 | `file_written` | `write` tool succeeds | `model`, `language`, `file_hash`, `lines_added`, `duration_ms` |
 | `file_edited` | `edit` / `multiedit` / `patch` succeed | `model`, `language`, `file_hash`, `lines_added`, `lines_deleted`, `duration_ms` |
 | `command_executed` | `bash` tool runs | `model`, `command_type`, `exit_code`, `duration_ms` |
-| `error` | Agent, tool, or transport error | `model`, `error_type` (`agent_error` / `tool_failure` / `transport_error`), `error_message` *(truncated to 300 chars)* |
+| `error` | Agent, tool, or transport error | `model`, `error_type` (`agent_error` / `tool_failure` / `transport_error`), `error_message` *(truncated to 300 chars)*, `request.trace_id` / `request.span_id` *(when a provider request context exists)* |
 | `subagent.spawned` | Sub-agent created | `model`, `agent_type`, `reason` |
 | `remote_execution.started` | Remote cloud agent successfully spawned | `origin` |
 | `remote_execution.completed` | Remote cloud agent finished successfully | `origin`, `duration_ms`, `tool_calls`, `turns`, `input_tokens`, `output_tokens` |

--- a/src/extensions/telemetry/handlers/messages.test.ts
+++ b/src/extensions/telemetry/handlers/messages.test.ts
@@ -359,6 +359,35 @@ describe("handleMessageEnd", () => {
 			expect.anything(),
 		)
 	})
+
+	it("stamps the request trace context on transport_error events", async () => {
+		const { ctx, piCtx } = makeCtx()
+		ctx.lastTraceContext = { traceId: "aaaabbbbccccddddeeeeffff00001111", spanId: "1122334455667788" }
+		const emitSpy = vi.spyOn(ctx, "emit")
+
+		await handleMessageEnd(ctx, piCtx, {
+			message: {
+				role: "assistant",
+				model: "kimi-k2.6",
+				provider: "kimchi-dev",
+				stopReason: "error",
+				errorMessage: "The socket connection was closed unexpectedly",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+				timestamp: BASE_TS,
+				responseId: "chatcmpl-transport-trace",
+			} as Message,
+		})
+
+		expect(emitSpy).toHaveBeenCalledWith(
+			"error",
+			expect.objectContaining({
+				error_type: "transport_error",
+				"request.trace_id": "aaaabbbbccccddddeeeeffff00001111",
+				"request.span_id": "1122334455667788",
+			}),
+			expect.anything(),
+		)
+	})
 })
 
 describe("handleBeforeAgentStart", () => {

--- a/src/extensions/telemetry/handlers/messages.test.ts
+++ b/src/extensions/telemetry/handlers/messages.test.ts
@@ -106,6 +106,67 @@ describe("handleMessageEnd", () => {
 		expect(attrs.cost_usd).toBe(0.005)
 	})
 
+	it("stamps the request trace context on api_request when set", async () => {
+		const { ctx, piCtx } = makeCtx()
+		ctx.lastTraceContext = { traceId: "aaaabbbbccccddddeeeeffff00001111", spanId: "1122334455667788" }
+		const emitSpy = vi.spyOn(ctx, "emit")
+
+		await handleMessageEnd(ctx, piCtx, {
+			message: {
+				role: "assistant",
+				responseId: "resp-trace",
+				model: "claude-3-5-sonnet",
+				provider: "anthropic",
+				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+			} as Message,
+		})
+
+		expect(emitSpy).toHaveBeenCalledOnce()
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [eventName, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
+		expect(eventName).toBe("api_request")
+		expect(attrs["request.trace_id"]).toBe("aaaabbbbccccddddeeeeffff00001111")
+		expect(attrs["request.span_id"]).toBe("1122334455667788")
+	})
+
+	it("omits trace attributes from api_request when no provider request context exists", async () => {
+		const { ctx, piCtx } = makeCtx()
+		const emitSpy = vi.spyOn(ctx, "emit")
+
+		await handleMessageEnd(ctx, piCtx, {
+			message: {
+				role: "assistant",
+				responseId: "resp-no-trace",
+				model: "claude-3-5-sonnet",
+				provider: "anthropic",
+				usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } },
+			} as Message,
+		})
+
+		expect(emitSpy).toHaveBeenCalledOnce()
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
+		expect(attrs["request.trace_id"]).toBeUndefined()
+		expect(attrs["request.span_id"]).toBeUndefined()
+	})
+
+	it("stamps the request trace context on error events", async () => {
+		const { ctx, piCtx } = makeCtx()
+		ctx.lastTraceContext = { traceId: "aaaabbbbccccddddeeeeffff00001111", spanId: "1122334455667788" }
+		const emitSpy = vi.spyOn(ctx, "emit")
+
+		handleAgentEnd(ctx, piCtx, {
+			messages: [{ role: "toolResult", isError: true, content: [{ type: "text", text: "boom" }] }],
+		} as AgentEndEvent)
+
+		expect(emitSpy).toHaveBeenCalledOnce()
+		// biome-ignore lint/style/noNonNullAssertion: -
+		const [eventName, attrs] = emitSpy.mock.calls[0]! as [string, TelemetryAttributes]
+		expect(eventName).toBe("error")
+		expect(attrs.error_type).toBe("agent_error")
+		expect(attrs["request.trace_id"]).toBe("aaaabbbbccccddddeeeeffff00001111")
+	})
+
 	it("deduplicates messages by responseId", async () => {
 		const { ctx, piCtx } = makeCtx()
 		const emitSpy = vi.spyOn(ctx, "emit")

--- a/src/extensions/telemetry/handlers/messages.ts
+++ b/src/extensions/telemetry/handlers/messages.ts
@@ -65,6 +65,7 @@ export async function handleMessageEnd(
 				cache_creation_tokens: cacheWrite,
 				cost_usd: costTotal,
 				duration_ms: durationMs,
+				...tm.getTraceAttributes(),
 			},
 			ctx,
 		)
@@ -117,6 +118,7 @@ export function handleAgentEnd(tm: TelemetryContext, ctx: ExtensionContext, even
 			error_type: "agent_error",
 			error_message: text.slice(0, 300),
 			turn_index: tm.turnIndex,
+			...tm.getTraceAttributes(),
 		},
 		ctx,
 	)

--- a/src/extensions/telemetry/handlers/tools.test.ts
+++ b/src/extensions/telemetry/handlers/tools.test.ts
@@ -230,6 +230,30 @@ describe("handlers/tools", () => {
 			expect(error?.attrs.error_message).toBe("command failed with exit code 1")
 			expect(error?.attrs.model).toBe("claude-3-5-sonnet")
 		})
+
+		it("stamps the request trace context on tool_failure error events", async () => {
+			const piCtx = createContext({ model: { id: "claude-3-5-sonnet" } })
+			const ctx = new TelemetryContext(makeConfig())
+			ctx.lastTraceContext = { traceId: "aaaabbbbccccddddeeeeffff00001111", spanId: "1122334455667788" }
+			const toolCallId = "tc-bash-err-trace"
+
+			handleToolExecutionStart(ctx, { toolCallId, toolName: "bash", args: { command: "false" } })
+			handleToolExecutionEnd(ctx, piCtx, {
+				toolCallId,
+				isError: true,
+				result: { content: [{ type: "text", text: "command failed with exit code 1" }] },
+			})
+
+			ctx.flushLogBuffer()
+			await Promise.allSettled([...ctx.inFlight])
+			const events = parseLogEvents(fetchMock)
+
+			const error = events.find((e) => e.eventName === "error")
+			expect(error).toBeDefined()
+			expect(error?.attrs.error_type).toBe("tool_failure")
+			expect(error?.attrs["request.trace_id"]).toBe("aaaabbbbccccddddeeeeffff00001111")
+			expect(error?.attrs["request.span_id"]).toBe("1122334455667788")
+		})
 	})
 
 	// -----------------------------------------------------------------------

--- a/src/extensions/telemetry/handlers/tools.ts
+++ b/src/extensions/telemetry/handlers/tools.ts
@@ -192,6 +192,7 @@ export function handleToolExecutionEnd(
 				tool_name: toolName,
 				error_message: errorMsg,
 				turn_index: tm.turnIndex,
+				...tm.getTraceAttributes(),
 			},
 			ctx,
 		)

--- a/src/extensions/telemetry/handlers/transport-errors.test.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.test.ts
@@ -5,9 +5,10 @@ import { createContext } from "../../__mocks__/context.js"
 import type { TelemetryContext } from "../session-context.js"
 import { handleTransportError } from "./transport-errors.js"
 
-function mockSessionCtx(): Pick<TelemetryContext, "emit"> {
+function mockSessionCtx(): Pick<TelemetryContext, "emit" | "getTraceAttributes"> {
 	return {
 		emit: vi.fn(),
+		getTraceAttributes: () => ({}),
 	}
 }
 

--- a/src/extensions/telemetry/handlers/transport-errors.ts
+++ b/src/extensions/telemetry/handlers/transport-errors.ts
@@ -32,6 +32,7 @@ export function handleTransportError(
 		{
 			error_type: "transport_error",
 			error_message: (msg.errorMessage ?? "").slice(0, 300),
+			...tm.getTraceAttributes(),
 		},
 		ctx,
 	)

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -525,6 +525,41 @@ describe("telemetryExtension integration", () => {
 		})
 	})
 
+	it("before_provider_headers clears the trace context on a malformed upstream traceparent", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		// Seed a valid context first — a malformed header must not leave it stale.
+		const seeded = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(seeded)
+		expect(_getTelemetryCtx()?.lastTraceContext).toBeDefined()
+
+		const event = { headers: { traceparent: "garbage" } as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(event.headers.traceparent).toBe("garbage") // header itself is preserved untouched
+		expect(_getTelemetryCtx()?.lastTraceContext).toBeUndefined()
+	})
+
+	it("before_provider_headers normalizes uppercase hex in a preserved upstream traceparent", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const event = {
+			headers: {
+				traceparent: "00-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-BBBBBBBBBBBBBBBB-01",
+			} as Record<string, string>,
+		}
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(_getTelemetryCtx()?.lastTraceContext).toEqual({
+			traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			spanId: "bbbbbbbbbbbbbbbb",
+		})
+	})
+
 	it("before_provider_headers injects X-Conversation-Id as a UUID", async () => {
 		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)

--- a/src/extensions/telemetry/index.test.ts
+++ b/src/extensions/telemetry/index.test.ts
@@ -4,6 +4,7 @@ import type { TelemetryConfig } from "../../config.js"
 import { resetAcpClientInfo, setAcpClientInfo } from "../../modes/acp/state.js"
 import { createContext } from "../__mocks__/context.js"
 import telemetryExtension, {
+	_getTelemetryCtx,
 	trackRemoteExecution,
 	trackSubagentSpawned,
 	trackSurveyAnswered,
@@ -437,7 +438,7 @@ describe("telemetryExtension integration", () => {
 		expect(event.headers["X-Parent-Session-Id"]).toBeUndefined()
 	})
 
-	it("before_provider_headers injects W3C traceparent derived from session id", async () => {
+	it("before_provider_headers injects a fresh per-request W3C traceparent", async () => {
 		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
 		await getHandler(handlers, "session_start")({}, ctx)
@@ -445,18 +446,19 @@ describe("telemetryExtension integration", () => {
 		const event = { headers: {} as Record<string, string> }
 		getHandler(handlers, "before_provider_headers")(event)
 
-		const sessionId = event.headers["X-Session-Id"]
 		const traceparent = event.headers.traceparent
 		expect(traceparent).toBeDefined()
 		const [version, traceId, spanId, flags] = traceparent.split("-")
 		expect(version).toBe("00")
-		expect(traceId).toBe(sessionId.replace(/-/g, "").toLowerCase())
 		expect(traceId).toMatch(/^[0-9a-f]{32}$/)
 		expect(spanId).toMatch(/^[0-9a-f]{16}$/)
 		expect(flags).toBe("01")
+		// Deliberately NOT derived from the session id — a per-request trace
+		// must not join session-scoped identity.
+		expect(traceId).not.toBe(event.headers["X-Session-Id"].replace(/-/g, "").toLowerCase())
 	})
 
-	it("before_provider_headers generates a fresh span id on each request", async () => {
+	it("before_provider_headers generates a fresh trace and span id on each request", async () => {
 		const { handlers, api, ctx } = createMockApi()
 		telemetryExtension(makeConfig())(api)
 		await getHandler(handlers, "session_start")({}, ctx)
@@ -466,9 +468,8 @@ describe("telemetryExtension integration", () => {
 		getHandler(handlers, "before_provider_headers")(event1)
 		getHandler(handlers, "before_provider_headers")(event2)
 
-		const spanId1 = event1.headers.traceparent.split("-")[2]
-		const spanId2 = event2.headers.traceparent.split("-")[2]
-		expect(spanId1).not.toBe(spanId2)
+		expect(event2.headers.traceparent.split("-")[1]).not.toBe(event1.headers.traceparent.split("-")[1])
+		expect(event2.headers.traceparent.split("-")[2]).not.toBe(event1.headers.traceparent.split("-")[2])
 	})
 
 	it("before_provider_headers preserves an existing traceparent header", async () => {
@@ -494,6 +495,34 @@ describe("telemetryExtension integration", () => {
 
 		expect(event.headers.Traceparent).toBe(existingTraceparent)
 		expect(event.headers.traceparent).toBeUndefined()
+	})
+
+	it("before_provider_headers stamps the trace context on the telemetry context", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const event = { headers: {} as Record<string, string> }
+		getHandler(handlers, "before_provider_headers")(event)
+
+		const [, traceId, spanId] = event.headers.traceparent.split("-")
+		expect(_getTelemetryCtx()?.lastTraceContext).toEqual({ traceId, spanId })
+	})
+
+	it("before_provider_headers stamps a preserved upstream traceparent", async () => {
+		const { handlers, api, ctx } = createMockApi()
+		telemetryExtension(makeConfig())(api)
+		await getHandler(handlers, "session_start")({}, ctx)
+
+		const event = {
+			headers: { Traceparent: "00-11111111111111111111111111111111-2222222222222222-01" } as Record<string, string>,
+		}
+		getHandler(handlers, "before_provider_headers")(event)
+
+		expect(_getTelemetryCtx()?.lastTraceContext).toEqual({
+			traceId: "11111111111111111111111111111111",
+			spanId: "2222222222222222",
+		})
 	})
 
 	it("before_provider_headers injects X-Conversation-Id as a UUID", async () => {

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -954,14 +954,18 @@ export default function telemetryExtension(config: TelemetryConfig) {
 			} else {
 				// An upstream component supplied the context — record it so
 				// telemetry events still join to whichever trace the request
-				// actually went out under.
+				// actually went out under. Malformed ids leave the context
+				// undefined rather than stamping a stale request's trace.
 				const existing = Object.entries(event.headers).find(
 					([name]) => name.toLowerCase() === TELEMETRY_PROVIDER_HEADER_NAMES.traceparent,
 				)?.[1]
 				const parts = existing?.split("-")
-				if (parts && parts.length === 4) {
-					telemetryCtx.lastTraceContext = { traceId: parts[1], spanId: parts[2] }
-				}
+				const traceId = parts?.length === 4 ? parts[1].toLowerCase() : undefined
+				const spanId = parts?.length === 4 ? parts[2].toLowerCase() : undefined
+				telemetryCtx.lastTraceContext =
+					traceId && /^[0-9a-f]{32}$/.test(traceId) && spanId && /^[0-9a-f]{16}$/.test(spanId)
+						? { traceId, spanId }
+						: undefined
 			}
 		})
 	}

--- a/src/extensions/telemetry/index.ts
+++ b/src/extensions/telemetry/index.ts
@@ -150,6 +150,11 @@ let _telemetryCtx: TelemetryContext | undefined
 let _telemetryConfig: TelemetryConfig = { enabled: false, endpoint: "", metricsEndpoint: "", headers: {}, apiKey: "" }
 let sessionStartEmitted = false
 
+/** @internal — exposed for testing only */
+export function _getTelemetryCtx(): TelemetryContext | undefined {
+	return _telemetryCtx
+}
+
 function isEnabled(): boolean {
 	return !!(_telemetryCtx && _telemetryConfig.enabled && _telemetryConfig.endpoint)
 }
@@ -932,22 +937,30 @@ export default function telemetryExtension(config: TelemetryConfig) {
 				event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.parentSessionId] = parentSessionId
 			}
 
-			// Inject W3C Trace Context (if not already present) derived from
-			// the session id so that downstream distributed tracing spans
-			// join the same trace. Header names are case-insensitive, so
-			// check all keys rather than a single property name.
-			// Example:
-			//   session id: 85a2d4f5-9f9f-49fb-890e-522a10e4a1e8
-			//   trace id:   85a2d4f59f9f49fb890e522a10e4a1e8
-			//   span id:    <new random 16-hex value per request>
+			// Inject W3C Trace Context (if not already present) with a fresh
+			// per-request trace id so each LLM request forms its own small,
+			// bounded downstream trace instead of every request of a multi-hour
+			// session piling into one giant trace.
+			// Session grouping stays in the X-Session-Id header above. Header names are case-insensitive, so check all
+			// keys rather than a single property name.
 			const hasTraceparent = Object.keys(event.headers).some(
 				(name) => name.toLowerCase() === TELEMETRY_PROVIDER_HEADER_NAMES.traceparent,
 			)
 			if (!hasTraceparent) {
-				const traceId = telemetryCtx.telemetryId.replace(/-/g, "").toLowerCase()
-				if (traceId.length === 32) {
-					const spanId = randomBytes(8).toString("hex")
-					event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.traceparent] = `00-${traceId}-${spanId}-01`
+				const traceId = randomBytes(16).toString("hex")
+				const spanId = randomBytes(8).toString("hex")
+				event.headers[TELEMETRY_PROVIDER_HEADER_NAMES.traceparent] = `00-${traceId}-${spanId}-01`
+				telemetryCtx.lastTraceContext = { traceId, spanId }
+			} else {
+				// An upstream component supplied the context — record it so
+				// telemetry events still join to whichever trace the request
+				// actually went out under.
+				const existing = Object.entries(event.headers).find(
+					([name]) => name.toLowerCase() === TELEMETRY_PROVIDER_HEADER_NAMES.traceparent,
+				)?.[1]
+				const parts = existing?.split("-")
+				if (parts && parts.length === 4) {
+					telemetryCtx.lastTraceContext = { traceId: parts[1], spanId: parts[2] }
 				}
 			}
 		})

--- a/src/extensions/telemetry/session-context.ts
+++ b/src/extensions/telemetry/session-context.ts
@@ -77,6 +77,15 @@ export class TelemetryContext {
 	 * `0` as "unknown / pre-turn" rather than a valid 1-based turn number.
 	 */
 	turnIndex = 0
+	/**
+	 * W3C trace context of the most recent provider request, stored by the
+	 * before_provider_headers handler (generated per request, or parsed from an
+	 * externally supplied traceparent). Requested events (api_request, error)
+	 * stamp this so they join to the exact request trace. Provider requests
+	 * within one TelemetryContext are sequential (agent loop; in-process
+	 * subagents have their own context), so a single slot is sufficient.
+	 */
+	lastTraceContext: { traceId: string; spanId: string } | undefined
 	sentMessages = new Set<string>()
 	pendingArgs = new Map<string, { toolName: string; args: unknown }>()
 	messageStartTimes = new Map<string, number>()
@@ -124,6 +133,7 @@ export class TelemetryContext {
 		this.telemetryStartMs = Date.now()
 		this.currentModel = "unknown"
 		this.turnIndex = 0
+		this.lastTraceContext = undefined
 		this.sentMessages.clear()
 		this.pendingArgs.clear()
 		this.messageStartTimes.clear()
@@ -141,6 +151,16 @@ export class TelemetryContext {
 		if (this.shuttingDown) return
 		this.inFlight.add(p)
 		p.finally(() => this.inFlight.delete(p))
+	}
+
+	/**
+	 * Trace-context attributes stamped on request-scoped events (api_request,
+	 * error) so they join to the exact provider request's trace. Empty when no
+	 * provider request has happened yet (or the traceparent was malformed).
+	 */
+	getTraceAttributes(): TelemetryAttributes {
+		if (!this.lastTraceContext) return {}
+		return { "request.trace_id": this.lastTraceContext.traceId, "request.span_id": this.lastTraceContext.spanId }
 	}
 
 	/**

--- a/tests/e2e/tui/auto-model.test.ts
+++ b/tests/e2e/tui/auto-model.test.ts
@@ -189,7 +189,16 @@ test("Auto routes once and keeps the selected concrete model for the session", a
 			expect(routerRequests[0]?.headers["x-session-id"]).toBe(chatRequests[0]?.headers["x-session-id"])
 			expect(routerRequests[0]?.headers["x-conversation-id"]).toBe(chatRequests[0]?.headers["x-conversation-id"])
 			expect(routerRequests[0]?.headers["x-turn-index"]).toBe(chatRequests[0]?.headers["x-turn-index"])
+			// traceparent is per provider-request header assembly: the router
+			// call inherits the correlation headers of the chat request it
+			// routes (same trace), while the second chat request is a separate
+			// assembly and therefore a fresh trace.
+			const traceparentShape = /^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/
+			expect(routerRequests[0]?.headers.traceparent).toMatch(traceparentShape)
+			expect(chatRequests[0]?.headers.traceparent).toMatch(traceparentShape)
+			expect(chatRequests[1]?.headers.traceparent).toMatch(traceparentShape)
 			expect(routerRequests[0]?.headers.traceparent).toBe(chatRequests[0]?.headers.traceparent)
+			expect(chatRequests[1]?.headers.traceparent).not.toBe(chatRequests[0]?.headers.traceparent)
 			expect(routerRequests[0]?.headers["x-parent-session-id"]).toBeUndefined()
 
 			const settings = JSON.parse(readFileSync(join(fixture.agentDir, "settings.json"), "utf-8"))


### PR DESCRIPTION
## Summary

The `before_provider_headers` hook seeded every provider request with a trace id derived from the process-level session id, joining **all** requests of a session (hours to days, potentially thousands of requests) into one never-closing trace. Downstream these giant traces became unusable for debugging, exceeded per-trace size limits at the tracing backend (silently dropping spans), and made per-trace sampling decisions all-or-nothing at session granularity.

**Change:** generate a fresh random trace id per provider request.

- Same trace shape standard OTel middleware on the inference gateway already produces for header-less callers — the downstream chain is unaffected, and each request becomes a small, bounded trace
- Session grouping is unchanged: `X-Session-Id` / `X-Conversation-Id` / `X-Parent-Session-Id` headers untouched
- New explicit join to replace the accidental `trace_id == session_id` identity: the generated (or preserved upstream) trace context is stamped as `request.trace_id` / `request.span_id` attributes on `api_request` and `error` telemetry events — works even for requests that die before a response

## Test plan

- [x] `pnpm vitest run src/extensions/telemetry/{index,handlers/messages,session-context}.test.ts src/extensions/router/router-client.test.ts` — 125 passed (incl. new distinctness + stamping tests)
- [x] `pnpm run typecheck` / `pnpm run lint` — clean
- [x] `pnpm run test:e2e:tui -- auto-model` — 13 passed (router call inherits the routed chat request's trace; the next chat request carries a fresh trace)

## Follow-ups (not in this PR)

- Record the incoming trace id on per-request accounting rows at the gateway → one-query row → trace joins
- Any dashboard assuming "one trace = one session" needs the new query pattern (session header → trace ids)

🤖 Generated with [Kimchi](https://kimchi.dev)
