### PR TITLE
Surface full tool calls in cloud agent conversation view

### DIFF
--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -41,7 +41,7 @@ import {
 	type RemoteSessionMeta,
 	runRemoteAgent,
 } from "./remote-agent-runner.js"
-import { extractToolOutputText, RemoteAgentSession } from "./remote-agent-session.js"
+import { RemoteAgentSession } from "./remote-agent-session.js"
 import { addUsage, type LifetimeUsage } from "./usage.js"
 
 export type OnAgentComplete = (record: AgentRecord) => void
@@ -489,13 +489,7 @@ export class AgentManager {
 					if (activity.status === "in_progress") {
 						remoteSession.recordToolCallStart(activity.toolName, activity.toolCallId, activity.rawInput)
 					} else {
-						const isError = activity.status === "failed"
-						remoteSession.recordToolCallEnd(
-							activity.toolName,
-							activity.toolCallId,
-							isError,
-							extractToolOutputText(activity.rawOutput),
-						)
+						remoteSession.recordToolCallEndFromActivity(activity)
 						record.toolUses++
 					}
 					options.onToolActivity?.(activity)
@@ -1041,12 +1035,7 @@ export class AgentManager {
 					if (activity.status === "in_progress") {
 						adapter.recordToolCallStart(activity.toolName, activity.toolCallId, activity.rawInput)
 					} else {
-						adapter.recordToolCallEnd(
-							activity.toolName,
-							activity.toolCallId,
-							activity.status === "failed",
-							extractToolOutputText(activity.rawOutput),
-						)
+						adapter.recordToolCallEndFromActivity(activity)
 						record.toolUses++
 					}
 					options?.callbacks?.onToolActivity?.(activity)

--- a/src/extensions/agents/manager/agent-manager.ts
+++ b/src/extensions/agents/manager/agent-manager.ts
@@ -41,7 +41,7 @@ import {
 	type RemoteSessionMeta,
 	runRemoteAgent,
 } from "./remote-agent-runner.js"
-import { RemoteAgentSession } from "./remote-agent-session.js"
+import { extractToolOutputText, RemoteAgentSession } from "./remote-agent-session.js"
 import { addUsage, type LifetimeUsage } from "./usage.js"
 
 export type OnAgentComplete = (record: AgentRecord) => void
@@ -490,7 +490,12 @@ export class AgentManager {
 						remoteSession.recordToolCallStart(activity.toolName, activity.toolCallId, activity.rawInput)
 					} else {
 						const isError = activity.status === "failed"
-						remoteSession.recordToolCallEnd(activity.toolName, activity.toolCallId, isError)
+						remoteSession.recordToolCallEnd(
+							activity.toolName,
+							activity.toolCallId,
+							isError,
+							extractToolOutputText(activity.rawOutput),
+						)
 						record.toolUses++
 					}
 					options.onToolActivity?.(activity)
@@ -1036,7 +1041,12 @@ export class AgentManager {
 					if (activity.status === "in_progress") {
 						adapter.recordToolCallStart(activity.toolName, activity.toolCallId, activity.rawInput)
 					} else {
-						adapter.recordToolCallEnd(activity.toolName, activity.toolCallId, activity.status === "failed")
+						adapter.recordToolCallEnd(
+							activity.toolName,
+							activity.toolCallId,
+							activity.status === "failed",
+							extractToolOutputText(activity.rawOutput),
+						)
 						record.toolUses++
 					}
 					options?.callbacks?.onToolActivity?.(activity)

--- a/src/extensions/agents/manager/agent-runner.ts
+++ b/src/extensions/agents/manager/agent-runner.ts
@@ -201,6 +201,8 @@ export interface ToolActivity {
 	title?: string
 	/** Tool arguments (ACP rawInput) — present on in_progress notifications. */
 	rawInput?: unknown
+	/** Structured tool result (ACP rawOutput — the pi AgentToolResult). */
+	rawOutput?: unknown
 }
 
 export interface RunOptions {

--- a/src/extensions/agents/manager/remote-agent-session.test.ts
+++ b/src/extensions/agents/manager/remote-agent-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { extractToolOutputText, RemoteAgentSession } from "./remote-agent-session.js"
+import { extractToolOutputText, RemoteAgentSession, summarizeToolArgs } from "./remote-agent-session.js"
 
 function makeMockAcpClient() {
 	return {
@@ -260,7 +260,7 @@ describe("RemoteAgentSession", () => {
 			const content = session.messages[0].content as Array<{ type: string; arguments?: unknown }>
 			expect(content[0]).toMatchObject({
 				type: "toolCall",
-				name: "bash",
+				name: "bash command=cd some dir && cat file.txt",
 				arguments: { command: "cd some dir && cat file.txt" },
 			})
 			expect(listener.mock.calls[0][0]).toMatchObject({
@@ -377,12 +377,60 @@ describe("RemoteAgentSession", () => {
 			expect((msg.content as Array<{ type: string; text: string }>)[0].text).toBe("(completed)")
 		})
 
+		it("stores the real error text (not the placeholder) when a tool fails with output", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallStart("bash", "kt.bash.1")
+			session.recordToolCallEnd("bash", "kt.bash.1", true, "ls: /missing: No such file or directory")
+
+			const msg = session.messages[1]
+			expect(msg.isError).toBe(true)
+			expect((msg.content as Array<{ type: string; text: string }>)[0].text).toBe(
+				"ls: /missing: No such file or directory",
+			)
+		})
+
+		it("caps stored output at 2000 chars", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallStart("bash")
+			session.recordToolCallEnd("bash", undefined, false, "x".repeat(5000))
+			expect((session.messages[1].content as Array<{ type: string; text: string }>)[0].text).toHaveLength(2000)
+		})
+
 		it("includes the real output in tool_execution_end events", () => {
 			const session = new RemoteAgentSession()
 			const listener = vi.fn()
 			session.subscribe(listener)
 			session.recordToolCallEnd("bash", undefined, false, "hello world")
 			expect(listener.mock.calls[0][0]).toMatchObject({ result: "hello world" })
+		})
+	})
+
+	describe("summarizeToolArgs", () => {
+		it("renders object args as compact key=value pairs", () => {
+			expect(summarizeToolArgs({ command: "ls -la", timeout: 60 })).toBe("command=ls -la timeout=60")
+		})
+
+		it("collapses whitespace in values", () => {
+			expect(summarizeToolArgs({ command: "cd app &&\npnpm run tests" })).toBe("command=cd app && pnpm run tests")
+		})
+
+		it("ellipsizes long values", () => {
+			expect(summarizeToolArgs({ content: "x".repeat(100) })).toBe(`content=${"x".repeat(40)}…`)
+		})
+
+		it("returns empty string for null/undefined/empty args", () => {
+			expect(summarizeToolArgs(undefined)).toBe("")
+			expect(summarizeToolArgs(null)).toBe("")
+			expect(summarizeToolArgs({})).toBe("")
+		})
+
+		it("caps the total summary length", () => {
+			const summary = summarizeToolArgs({ a: "1".repeat(40), b: "2".repeat(40), c: "3".repeat(40), d: "4".repeat(40) })
+			expect(summary.length).toBeLessThanOrEqual(100)
+		})
+
+		it("passes through string args directly", () => {
+			expect(summarizeToolArgs("plain string args")).toBe("plain string args")
 		})
 	})
 

--- a/src/extensions/agents/manager/remote-agent-session.test.ts
+++ b/src/extensions/agents/manager/remote-agent-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { RemoteAgentSession } from "./remote-agent-session.js"
+import { extractToolOutputText, RemoteAgentSession } from "./remote-agent-session.js"
 
 function makeMockAcpClient() {
 	return {
@@ -357,6 +357,44 @@ describe("RemoteAgentSession", () => {
 			session.recordToolCallEnd("bash")
 			expect(listener).toHaveBeenCalledTimes(1)
 			expect(listener.mock.calls[0][0]).toMatchObject({ type: "tool_execution_end", toolName: "bash" })
+		})
+
+		it("stores the real tool output text when provided", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallStart("bash", "kt.bash.1")
+			session.recordToolCallEnd("bash", "kt.bash.1", false, "total 42\n-rw-r--r-- file.ts")
+
+			const msg = session.messages[1]
+			expect(msg).toMatchObject({ role: "toolResult", isError: false })
+			expect((msg.content as Array<{ type: string; text: string }>)[0].text).toBe("total 42\n-rw-r--r-- file.ts")
+		})
+
+		it("falls back to the placeholder when output is blank or whitespace", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallStart("bash")
+			session.recordToolCallEnd("bash", undefined, false, "   ")
+			const msg = session.messages[1]
+			expect((msg.content as Array<{ type: string; text: string }>)[0].text).toBe("(completed)")
+		})
+
+		it("includes the real output in tool_execution_end events", () => {
+			const session = new RemoteAgentSession()
+			const listener = vi.fn()
+			session.subscribe(listener)
+			session.recordToolCallEnd("bash", undefined, false, "hello world")
+			expect(listener.mock.calls[0][0]).toMatchObject({ result: "hello world" })
+		})
+	})
+
+	describe("extractToolOutputText", () => {
+		it("returns text joined from rawOutput content parts", () => {
+			expect(extractToolOutputText({ content: [{ text: "line 1" }, { text: "line 2" }] })).toBe("line 1line 2")
+		})
+
+		it("returns empty string when rawOutput is absent or blank", () => {
+			expect(extractToolOutputText(undefined)).toBe("")
+			expect(extractToolOutputText({ content: [{ text: "  " }] })).toBe("")
+			expect(extractToolOutputText({ content: [] })).toBe("")
 		})
 	})
 

--- a/src/extensions/agents/manager/remote-agent-session.test.ts
+++ b/src/extensions/agents/manager/remote-agent-session.test.ts
@@ -261,6 +261,7 @@ describe("RemoteAgentSession", () => {
 			expect(content[0]).toMatchObject({
 				type: "toolCall",
 				name: "bash command=cd some dir && cat file.txt",
+				toolName: "bash",
 				arguments: { command: "cd some dir && cat file.txt" },
 			})
 			expect(listener.mock.calls[0][0]).toMatchObject({
@@ -389,11 +390,12 @@ describe("RemoteAgentSession", () => {
 			)
 		})
 
-		it("caps stored output at 2000 chars", () => {
+		it("caps stored output at 2000 chars with a truncation marker", () => {
 			const session = new RemoteAgentSession()
 			session.recordToolCallStart("bash")
 			session.recordToolCallEnd("bash", undefined, false, "x".repeat(5000))
-			expect((session.messages[1].content as Array<{ type: string; text: string }>)[0].text).toHaveLength(2000)
+			const text = (session.messages[1].content as Array<{ type: string; text: string }>)[0].text
+			expect(text).toBe(`${"x".repeat(2000)}… (truncated)`)
 		})
 
 		it("includes the real output in tool_execution_end events", () => {
@@ -431,6 +433,31 @@ describe("RemoteAgentSession", () => {
 
 		it("passes through string args directly", () => {
 			expect(summarizeToolArgs("plain string args")).toBe("plain string args")
+		})
+	})
+
+	describe("recordToolCallEndFromActivity", () => {
+		it("maps a failed activity with output to a real-error toolResult", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallStart("bash", "kt.bash.1")
+			session.recordToolCallEndFromActivity({
+				toolName: "bash",
+				toolCallId: "kt.bash.1",
+				status: "failed",
+				rawOutput: { content: [{ text: "ls: /missing: No such file or directory" }] },
+			})
+
+			const msg = session.messages[1]
+			expect(msg.isError).toBe(true)
+			expect((msg.content as Array<{ type: string; text: string }>)[0].text).toBe(
+				"ls: /missing: No such file or directory",
+			)
+		})
+
+		it("maps a completed activity without output to the placeholder", () => {
+			const session = new RemoteAgentSession()
+			session.recordToolCallEndFromActivity({ toolName: "read", status: "completed" })
+			expect((session.messages[0].content as Array<{ type: string; text: string }>)[0].text).toBe("(completed)")
 		})
 	})
 

--- a/src/extensions/agents/manager/remote-agent-session.ts
+++ b/src/extensions/agents/manager/remote-agent-session.ts
@@ -39,6 +39,29 @@ import type { LifetimeUsage, SessionStatsLike } from "./usage.js"
  */
 type RemoteSessionEvent = { type: string; [k: string]: unknown }
 
+/** Cap on stored tool result text — raw bash output can be tens of KB. */
+const MAX_RESULT_TEXT_CHARS = 2000
+
+/**
+ * Renders tool call arguments as a compact single-line summary for display —
+ * e.g. `command=ls -la timeout=60`. Object values become key=value pairs
+ * (long values ellipsized); anything else is stringified.
+ */
+export function summarizeToolArgs(args: unknown, max = 100): string {
+	if (args == null) return ""
+	if (typeof args !== "object") {
+		const s = typeof args === "string" ? args : JSON.stringify(args)
+		return (s ?? "").replace(/\s+/g, " ").trim().slice(0, max)
+	}
+	const parts: string[] = []
+	for (const [k, v] of Object.entries(args)) {
+		const val = (typeof v === "string" ? v : (JSON.stringify(v) ?? "")).replace(/\s+/g, " ").trim()
+		if (!val || val === "{}") continue
+		parts.push(`${k}=${val.length > 40 ? `${val.slice(0, 40)}…` : val}`)
+	}
+	return parts.join(" ").slice(0, max)
+}
+
 /**
  * Extracts plain-text tool output from an ACP tool_call_update's rawOutput
  * (pi AgentToolResult — `{ content: ContentBlock[] }`). Returns "" when
@@ -246,14 +269,19 @@ export class RemoteAgentSession {
 		if (toolCallId) this._acpToLocalId.set(toolCallId, localId)
 
 		const argsObj = args ?? {}
+		// Bake the args summary into the display name so subscribers (the
+		// conversation viewer) show how the tool was invoked without needing
+		// any renderer-side changes. Structured arguments are still kept.
+		const argsSummary = summarizeToolArgs(argsObj)
+		const displayName = argsSummary ? `${toolName} ${argsSummary}` : toolName
 		const last = this._messages[this._messages.length - 1]
 		if (last?.role === "assistant") {
 			const parts = last.content as Array<{ type: string; [k: string]: unknown }>
-			parts.push({ type: "toolCall", id: localId, name: toolName, arguments: argsObj })
+			parts.push({ type: "toolCall", id: localId, name: displayName, arguments: argsObj })
 		} else {
 			this._messages.push({
 				role: "assistant",
-				content: [{ type: "toolCall", id: localId, name: toolName, arguments: argsObj }],
+				content: [{ type: "toolCall", id: localId, name: displayName, arguments: argsObj }],
 			})
 		}
 		this.emit({
@@ -271,7 +299,9 @@ export class RemoteAgentSession {
 	 *  Saves the current accumulated text length so the next assistant message
 	 *  only includes text that came after this tool call.
 	 *  `output` is the tool's actual output text extracted from the ACP
-	 *  notification content/rawOutput (empty when unavailable). */
+	 *  notification content/rawOutput (empty when unavailable). Capped at
+	 *  MAX_RESULT_TEXT_CHARS — bash output can be tens of KB, and messages
+	 *  live in memory for the whole run (viewers truncate display anyway). */
 	recordToolCallEnd(toolName: string, toolCallId?: string, isError = false, output = ""): void {
 		this._textOffset = this._lastFullTextLength
 		let localId: string | undefined
@@ -289,7 +319,12 @@ export class RemoteAgentSession {
 			}
 		}
 		if (localId) this._pendingToolCalls.delete(localId)
-		const resultText = output.trim() || (isError ? "(tool failed)" : "(completed)")
+		const trimmedOutput = output.trim()
+		const resultText = trimmedOutput
+			? trimmedOutput.slice(0, MAX_RESULT_TEXT_CHARS)
+			: isError
+				? "(tool failed)"
+				: "(completed)"
 		this._messages.push({
 			role: "toolResult",
 			toolCallId: localId ?? toolName,

--- a/src/extensions/agents/manager/remote-agent-session.ts
+++ b/src/extensions/agents/manager/remote-agent-session.ts
@@ -39,6 +39,18 @@ import type { LifetimeUsage, SessionStatsLike } from "./usage.js"
  */
 type RemoteSessionEvent = { type: string; [k: string]: unknown }
 
+/**
+ * Extracts plain-text tool output from an ACP tool_call_update's rawOutput
+ * (pi AgentToolResult — `{ content: ContentBlock[] }`). Returns "" when
+ * it carries no text (e.g. pure diff tools), letting the caller keep its
+ * placeholder status text.
+ */
+export function extractToolOutputText(rawOutput?: unknown): string {
+	const content = (rawOutput as { content?: { text?: string }[] } | undefined)?.content
+	const text = Array.isArray(content) ? content.map((p) => p.text ?? "").join("") : ""
+	return text.trim() ? text : ""
+}
+
 export class RemoteAgentSession {
 	private acpClient: AcpSessionClient | undefined
 	private meta: RemoteSessionMeta | undefined
@@ -257,8 +269,10 @@ export class RemoteAgentSession {
 	 *  `{ role: "toolResult", toolCallId, toolName, content, isError, timestamp }`.
 	 *  Clears the pending-tool dedup so the same tool name can start again.
 	 *  Saves the current accumulated text length so the next assistant message
-	 *  only includes text that came after this tool call. */
-	recordToolCallEnd(toolName: string, toolCallId?: string, isError = false): void {
+	 *  only includes text that came after this tool call.
+	 *  `output` is the tool's actual output text extracted from the ACP
+	 *  notification content/rawOutput (empty when unavailable). */
+	recordToolCallEnd(toolName: string, toolCallId?: string, isError = false, output = ""): void {
 		this._textOffset = this._lastFullTextLength
 		let localId: string | undefined
 		if (toolCallId) {
@@ -275,11 +289,12 @@ export class RemoteAgentSession {
 			}
 		}
 		if (localId) this._pendingToolCalls.delete(localId)
+		const resultText = output.trim() || (isError ? "(tool failed)" : "(completed)")
 		this._messages.push({
 			role: "toolResult",
 			toolCallId: localId ?? toolName,
 			toolName,
-			content: [{ type: "text", text: isError ? "(tool failed)" : "(completed)" }],
+			content: [{ type: "text", text: resultText }],
 			isError,
 			timestamp: Date.now(),
 		})
@@ -287,7 +302,7 @@ export class RemoteAgentSession {
 			type: "tool_execution_end",
 			toolCallId: localId ?? toolName,
 			toolName,
-			result: isError ? "(tool failed)" : "(completed)",
+			result: resultText,
 			isError,
 		})
 	}

--- a/src/extensions/agents/manager/remote-agent-session.ts
+++ b/src/extensions/agents/manager/remote-agent-session.ts
@@ -39,8 +39,14 @@ import type { LifetimeUsage, SessionStatsLike } from "./usage.js"
  */
 type RemoteSessionEvent = { type: string; [k: string]: unknown }
 
-/** Cap on stored tool result text — raw bash output can be tens of KB. */
-const MAX_RESULT_TEXT_CHARS = 2000
+/** JSON.stringify that never throws on circular structures or bigint values. */
+function safeStringify(v: unknown): string {
+	try {
+		return JSON.stringify(v) ?? ""
+	} catch {
+		return String(v)
+	}
+}
 
 /**
  * Renders tool call arguments as a compact single-line summary for display —
@@ -50,23 +56,27 @@ const MAX_RESULT_TEXT_CHARS = 2000
 export function summarizeToolArgs(args: unknown, max = 100): string {
 	if (args == null) return ""
 	if (typeof args !== "object") {
-		const s = typeof args === "string" ? args : JSON.stringify(args)
-		return (s ?? "").replace(/\s+/g, " ").trim().slice(0, max)
+		const s = typeof args === "string" ? args : safeStringify(args)
+		return s.replace(/\s+/g, " ").trim().slice(0, max)
 	}
 	const parts: string[] = []
 	for (const [k, v] of Object.entries(args)) {
-		const val = (typeof v === "string" ? v : (JSON.stringify(v) ?? "")).replace(/\s+/g, " ").trim()
+		const val = (typeof v === "string" ? v : safeStringify(v)).replace(/\s+/g, " ").trim()
 		if (!val || val === "{}") continue
 		parts.push(`${k}=${val.length > 40 ? `${val.slice(0, 40)}…` : val}`)
 	}
 	return parts.join(" ").slice(0, max)
 }
 
+/** Cap on stored tool result text — raw bash output can be tens of KB. */
+const MAX_RESULT_TEXT_CHARS = 2000
+
 /**
  * Extracts plain-text tool output from an ACP tool_call_update's rawOutput
  * (pi AgentToolResult — `{ content: ContentBlock[] }`). Returns "" when
  * it carries no text (e.g. pure diff tools), letting the caller keep its
- * placeholder status text.
+ * placeholder status text. Parts are joined with no separator to mirror
+ * pi's transcript rendering (blocks carry their own trailing newlines).
  */
 export function extractToolOutputText(rawOutput?: unknown): string {
 	const content = (rawOutput as { content?: { text?: string }[] } | undefined)?.content
@@ -271,17 +281,19 @@ export class RemoteAgentSession {
 		const argsObj = args ?? {}
 		// Bake the args summary into the display name so subscribers (the
 		// conversation viewer) show how the tool was invoked without needing
-		// any renderer-side changes. Structured arguments are still kept.
+		// any renderer-side changes. `name` is therefore a DISPLAY string, not
+		// a stable tool identifier — consumers matching by tool must use the
+		// raw `toolName` field stored alongside.
 		const argsSummary = summarizeToolArgs(argsObj)
 		const displayName = argsSummary ? `${toolName} ${argsSummary}` : toolName
 		const last = this._messages[this._messages.length - 1]
 		if (last?.role === "assistant") {
 			const parts = last.content as Array<{ type: string; [k: string]: unknown }>
-			parts.push({ type: "toolCall", id: localId, name: displayName, arguments: argsObj })
+			parts.push({ type: "toolCall", id: localId, name: displayName, toolName, arguments: argsObj })
 		} else {
 			this._messages.push({
 				role: "assistant",
-				content: [{ type: "toolCall", id: localId, name: displayName, arguments: argsObj }],
+				content: [{ type: "toolCall", id: localId, name: displayName, toolName, arguments: argsObj }],
 			})
 		}
 		this.emit({
@@ -290,6 +302,22 @@ export class RemoteAgentSession {
 			toolName,
 			args: argsObj,
 		})
+	}
+
+	/** Record a tool call completion from a ToolActivity — keeps the
+	 *  isError/rawOutput mapping in one place for both agent-manager call sites. */
+	recordToolCallEndFromActivity(activity: {
+		toolName: string
+		toolCallId?: string
+		status: string
+		rawOutput?: unknown
+	}): void {
+		this.recordToolCallEnd(
+			activity.toolName,
+			activity.toolCallId,
+			activity.status === "failed",
+			extractToolOutputText(activity.rawOutput),
+		)
 	}
 
 	/** Record a tool call completion in the transcript.
@@ -320,11 +348,13 @@ export class RemoteAgentSession {
 		}
 		if (localId) this._pendingToolCalls.delete(localId)
 		const trimmedOutput = output.trim()
-		const resultText = trimmedOutput
-			? trimmedOutput.slice(0, MAX_RESULT_TEXT_CHARS)
-			: isError
+		const resultText = !trimmedOutput
+			? isError
 				? "(tool failed)"
 				: "(completed)"
+			: trimmedOutput.length > MAX_RESULT_TEXT_CHARS
+				? `${trimmedOutput.slice(0, MAX_RESULT_TEXT_CHARS)}… (truncated)`
+				: trimmedOutput
 		this._messages.push({
 			role: "toolResult",
 			toolCallId: localId ?? toolName,

--- a/src/extensions/remote-run/runner.test.ts
+++ b/src/extensions/remote-run/runner.test.ts
@@ -161,7 +161,7 @@ describe("runCloudAgent", () => {
 
 		expect(res.backgrounded).toBe(true)
 		expect(res.id).toBe("agent-bg")
-		// Should show a 'started in background' notification
+		// Should show a 'started in background' notification (no manager → no transcript path)
 		expect(ctx.ui.notify).toHaveBeenCalledWith(
 			"Cloud agent started in background. You'll be notified when it completes.",
 			"info",
@@ -170,5 +170,26 @@ describe("runCloudAgent", () => {
 		expect(pi.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ customType: "cloud_agent_started" }), {
 			triggerTurn: true,
 		})
+	})
+
+	it("includes the transcript file path in the start notification when the record has an outputFile", async () => {
+		const pi = makePi()
+		const ctx = makeCtx()
+		vi.mocked(spawnRemoteAgent).mockResolvedValue({
+			id: "agent-bg",
+			result: "backgrounded",
+			backgrounded: true,
+		})
+		const { getActiveManager } = await import("../agents/index.js")
+		vi.mocked(getActiveManager).mockReturnValue({
+			getRecord: vi.fn(() => ({ outputFile: "/tmp/transcripts/agent-bg.jsonl" })),
+		} as unknown as ReturnType<typeof getActiveManager>)
+
+		await runCloudAgent(pi, ctx, "hello", "desc")
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Cloud agent started in background. You'll be notified when it completes.\nFull transcript: /tmp/transcripts/agent-bg.jsonl",
+			"info",
+		)
 	})
 })

--- a/src/extensions/remote-run/runner.ts
+++ b/src/extensions/remote-run/runner.ts
@@ -45,7 +45,9 @@ export async function runCloudAgent(
 	trackRemoteExecution("started", opts?.origin ?? "plan")
 
 	if (backgrounded) {
-		ctx.ui.notify("Cloud agent started in background. You'll be notified when it completes.", "info")
+		const transcriptPath = getActiveManager()?.getRecord(id)?.outputFile
+		const transcriptNote = transcriptPath ? `\nFull transcript: ${transcriptPath}` : ""
+		ctx.ui.notify(`Cloud agent started in background. You'll be notified when it completes.${transcriptNote}`, "info")
 		if (opts?.fermentId) {
 			ctx.ui.notify(
 				"Ferment paused while the cloud agent executes the plan. It will resume or complete when the cloud agent finishes.",

--- a/src/sandbox/worker/acp-client.test.ts
+++ b/src/sandbox/worker/acp-client.test.ts
@@ -1365,6 +1365,62 @@ describe("AcpSessionClient", () => {
 			client.close()
 		})
 
+		it("passes rawOutput through onToolActivity on completion", async () => {
+			const { callbacks } = makeCallbacks()
+			const client = new AcpSessionClient({
+				sessionName: "sess-1",
+				credentials: makeCredentials(),
+				callbacks,
+				WebSocketImpl: MockWebSocket,
+			})
+			const { socket } = await initClient(client)
+
+			const p = client.prompt("hello")
+			await vi.waitFor(() => {
+				expect(getSentMessages(socket).some((m) => m.method === "session/prompt")).toBe(true)
+			})
+			const promptReq = findRequest(getSentMessages(socket), "session/prompt")
+
+			serverSendMessage(
+				socket,
+				rpcNotification("session/update", {
+					sessionId: "session-abc",
+					update: {
+						sessionUpdate: "tool_call",
+						toolCallId: "tc-1",
+						title: "Run bash",
+						status: "in_progress",
+					},
+				}),
+			)
+			serverSendMessage(
+				socket,
+				rpcNotification("session/update", {
+					sessionId: "session-abc",
+					update: {
+						sessionUpdate: "tool_call_update",
+						toolCallId: "tc-1",
+						status: "completed",
+						rawOutput: { content: [{ type: "text", text: "total 42" }] },
+					},
+				}),
+			)
+
+			await vi.waitFor(() => {
+				expect(callbacks.onToolActivity).toHaveBeenCalledWith({
+					toolName: "Run bash",
+					title: "Run bash",
+					toolCallId: "tc-1",
+					status: "completed",
+					rawOutput: { content: [{ type: "text", text: "total 42" }] },
+				})
+			})
+
+			serverSendMessage(socket, rpcResponse(promptReq.id, { stopReason: "end_turn" }))
+			await p
+			client.close()
+		})
+
 		it("omits rawInput from the activity payload when the notification has none", async () => {
 			const { callbacks } = makeCallbacks()
 			const client = new AcpSessionClient({

--- a/src/sandbox/worker/acp-client.ts
+++ b/src/sandbox/worker/acp-client.ts
@@ -74,6 +74,8 @@ export interface AcpSessionCallbacks {
 		title?: string
 		/** Tool arguments (ACP rawInput) — present on in_progress notifications. */
 		rawInput?: unknown
+		/** Structured tool result (ACP rawOutput — the pi AgentToolResult). */
+		rawOutput?: unknown
 	}) => void
 	/** Called at the end of each ACP turn with the cumulative turn count. */
 	onTurnEnd?: (turnCount: number) => void
@@ -643,7 +645,7 @@ export class AcpSessionClient {
 					this._toolCallTitles.set(update.toolCallId, update.title)
 				}
 				const title = update.title ?? this._toolCallTitles.get(update.toolCallId)
-				this._dispatchToolActivity(cb, update.status, update.toolCallId, title, update.rawInput)
+				this._dispatchToolActivity(cb, update.status, update.toolCallId, title, update.rawInput, update.rawOutput)
 				break
 			}
 			default:
@@ -659,6 +661,7 @@ export class AcpSessionClient {
 		toolCallId: string,
 		title: string | undefined,
 		rawInput?: unknown,
+		rawOutput?: unknown,
 	): void {
 		// pending = model is still streaming the args — nothing is executing yet.
 		if (!status || status === "pending") return
@@ -674,6 +677,7 @@ export class AcpSessionClient {
 			status,
 			title,
 			...(rawInput != null ? { rawInput } : {}),
+			...(rawOutput != null ? { rawOutput } : {}),
 		})
 		// completed/failed clears the title cache entry.
 		if (status !== "in_progress") this._toolCallTitles.delete(toolCallId)


### PR DESCRIPTION
## Summary

Cloud (remote ACP) agent conversations were nearly empty in the live conversation view: tool results showed a hardcoded `(completed)` placeholder and tool lines showed only the tool name. This branch surfaces the full conversation data without touching `ConversationViewer` or any general-agent rendering.

**Data pipeline (cloud-only):**
- `acp-client.ts` now passes ACP `rawOutput` (the pi `AgentToolResult`) through `onToolActivity` completion dispatches (previously dropped). The server already emitted it (live + replay) — no server change needed.
- `remote-agent-session.ts` stores the extracted output text in `toolResult` messages instead of the placeholder; capped at 2000 chars. Error calls keep their real error text.
- Tool invocation args are baked into the tool call's display name, so the viewer renders `[Tool: bash command=ls -la timeout=60]` with no renderer changes.

**Notification:** the "Cloud agent started in background" toast now includes the local transcript file path (the file exists from spawn time), so it can be inspected while the agent runs.

**Scope:** all behavior changes live in the remote-agent path (`acp-client`, `RemoteAgentSession`, `remote-run` wiring). Local/foreground agents are unaffected — the only shared-file change is an optional field on the `ToolActivity` type.

example:
<img width="2942" height="2096" alt="image" src="https://github.com/user-attachments/assets/aec70add-0e85-484f-bfbc-bad5d6658d13" />


## Test plan

- [x] `pnpm vitest run src/sandbox/worker/acp-client.test.ts src/extensions/agents/manager/remote-agent-session.test.ts src/extensions/remote-run/runner.test.ts` (client pass-through, output storage/cap, args summary, notification cases)
- [x] `pnpm vitest run src/extensions/agents/` (428 tests — no general-agent regressions)
- [x] `pnpm run typecheck`, `pnpm run lint`
