### PR TITLE
feat(acp): add _kimchi.dev/set_onboarding_flag ext-method for onboarding completion

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -13,6 +13,7 @@ import {
 	readApiKeyFromConfigFile,
 	readGitToken,
 	readHideTips,
+	readStudioOnboardingSeenAt,
 	readTelemetryConfig,
 	readTeleportCompactHintEnabled,
 	upgradeLegacyRetrySettings,
@@ -21,6 +22,7 @@ import {
 	writeGitToken,
 	writeHideTips,
 	writeSessionModeWizardSeenAt,
+	writeStudioOnboardingSeenAt,
 	writeTeleportCompactHintEnabled,
 } from "./config.js"
 
@@ -542,6 +544,49 @@ describe("writeSessionModeWizardSeenAt", () => {
 			onboarding: {
 				otherWizardSeenAt: "2026-05-18T10:00:00.000Z",
 				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+			},
+		})
+	})
+})
+
+describe("readStudioOnboardingSeenAt / writeStudioOnboardingSeenAt", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("round-trips onboarding.studioOnboardingSeenAt", () => {
+		expect(readStudioOnboardingSeenAt(configPath)).toBeUndefined()
+
+		writeStudioOnboardingSeenAt("2026-09-11T10:00:00.000Z", configPath)
+		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T10:00:00.000Z")
+	})
+
+	it("preserves unrelated fields and existing onboarding fields", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				apiKey: "key",
+				onboarding: { sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z", otherMarker: true },
+			}),
+		)
+
+		writeStudioOnboardingSeenAt("2026-09-11T10:00:00.000Z", configPath)
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(raw).toEqual({
+			apiKey: "key",
+			onboarding: {
+				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+				otherMarker: true,
+				studioOnboardingSeenAt: "2026-09-11T10:00:00.000Z",
 			},
 		})
 	})

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,7 @@ export interface OnboardingConfig {
 	sessionModeWizardSeenAt?: string
 	hideSessionModeDialog?: boolean
 	teleportHelpSeenAt?: string
+	studioOnboardingSeenAt?: string
 }
 
 export interface SurveyConfig {
@@ -340,11 +341,16 @@ function parseOnboardingConfig(value: unknown): OnboardingConfig | undefined {
 	const hideSessionModeDialog = typeof raw.hideSessionModeDialog === "boolean" ? raw.hideSessionModeDialog : undefined
 	const teleportHelpSeenAt =
 		typeof raw.teleportHelpSeenAt === "string" && raw.teleportHelpSeenAt.length > 0 ? raw.teleportHelpSeenAt : undefined
+	const studioOnboardingSeenAt =
+		typeof raw.studioOnboardingSeenAt === "string" && raw.studioOnboardingSeenAt.length > 0
+			? raw.studioOnboardingSeenAt
+			: undefined
 
 	return {
 		...(sessionModeWizardSeenAt ? { sessionModeWizardSeenAt } : {}),
 		...(hideSessionModeDialog !== undefined ? { hideSessionModeDialog } : {}),
 		...(teleportHelpSeenAt ? { teleportHelpSeenAt } : {}),
+		...(studioOnboardingSeenAt ? { studioOnboardingSeenAt } : {}),
 	}
 }
 
@@ -570,6 +576,17 @@ export function writeSessionModeWizardSeenAt(seenAt: string, configPath?: string
 	const path = configPath ?? KIMCHI_CONFIG_PATH
 	updateOnboardingConfig(path, (onboarding) => {
 		onboarding.sessionModeWizardSeenAt = seenAt
+	})
+}
+
+export function readStudioOnboardingSeenAt(configPath?: string): string | undefined {
+	return readConfigExtras(configPath ?? KIMCHI_CONFIG_PATH).onboarding?.studioOnboardingSeenAt
+}
+
+export function writeStudioOnboardingSeenAt(seenAt: string, configPath?: string): void {
+	const path = configPath ?? KIMCHI_CONFIG_PATH
+	updateOnboardingConfig(path, (onboarding) => {
+		onboarding.studioOnboardingSeenAt = seenAt
 	})
 }
 

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -8,8 +8,9 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 //
 // Direction:
 // - pi_* methods are agent→client (the agent calls conn.extMethod on the client).
-// - probe_mcp_server, set_session_title, steering, and auth_status are
-//   client→agent inbound (the agent's extMethod() handler receives them).
+// - probe_mcp_server, set_session_title, steering, auth_status, and
+//   set_onboarding_flag are client→agent inbound (the agent's extMethod()
+//   handler receives them).
 //
 // Capability advertising: every entry here is exposed in
 // `_meta["kimchi.dev"][<key>] === true` so clients can discover the methods
@@ -20,6 +21,7 @@ export const AVAILABLE_EXT_METHODS = {
 	set_session_title: `_${CAPABILITIES_KEY}/set_session_title`,
 	steering: `_${CAPABILITIES_KEY}/steering`,
 	auth_status: `_${CAPABILITIES_KEY}/auth_status`,
+	set_onboarding_flag: `_${CAPABILITIES_KEY}/set_onboarding_flag`,
 } as const
 
 export const AVAILABLE_EXT_NOTIFICATIONS = {

--- a/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
@@ -5,9 +5,20 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { RequestError } from "@agentclientprotocol/sdk"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { readStudioOnboardingSeenAt } from "../../../config.js"
 import { handleSetOnboardingFlag } from "./set-onboarding-flag.js"
+
+/** Runs fn, returns the thrown RequestError, or fails the test if nothing threw. */
+function thrownRequestError(fn: () => void): RequestError {
+	try {
+		fn()
+	} catch (error) {
+		return error as RequestError
+	}
+	throw new Error("expected the call to throw a RequestError")
+}
 
 describe("handleSetOnboardingFlag", () => {
 	let tempDir: string
@@ -74,7 +85,10 @@ describe("handleSetOnboardingFlag", () => {
 	})
 
 	it.each([42, null, "", "not-a-date", "September 11, 2026"])("rejects invalid seenAt (%s)", (seenAt) => {
-		expect(() => handleSetOnboardingFlag({ configPath }, { seenAt })).toThrow(/seenAt must be an ISO-8601/)
+		// Assert the JSON-RPC error code (-32602) explicitly: resolveSeenAt sits
+		// outside the write try/catch precisely so invalid params are never
+		// re-wrapped as internalError (-32603).
+		expect(thrownRequestError(() => handleSetOnboardingFlag({ configPath }, { seenAt })).code).toBe(-32602)
 		// A rejected write must not leave a flag behind.
 		expect(readStudioOnboardingSeenAt(configPath)).toBeUndefined()
 	})
@@ -94,5 +108,12 @@ describe("handleSetOnboardingFlag", () => {
 		expect(() => handleSetOnboardingFlag({ configPath: blockedPath }, { seenAt: "2026-09-11T10:00:00.000Z" })).toThrow(
 			/Failed to persist onboarding flag/,
 		)
+		// Write failures are internal errors (-32603), distinct from the
+		// invalidParams (-32602) rejection for bad seenAt.
+		expect(
+			thrownRequestError(() =>
+				handleSetOnboardingFlag({ configPath: blockedPath }, { seenAt: "2026-09-11T10:00:00.000Z" }),
+			).code,
+		).toBe(-32603)
 	})
 })

--- a/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
@@ -1,0 +1,86 @@
+// Unit tests for the `_kimchi.dev/set_onboarding_flag` ACP extension method
+// handler (ADR-0043). All writes go through a temp config path so the real
+// shared config is never touched.
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { readStudioOnboardingSeenAt } from "../../../config.js"
+import { handleSetOnboardingFlag } from "./set-onboarding-flag.js"
+
+describe("handleSetOnboardingFlag", () => {
+	let tempDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-set-onboarding-flag-test-"))
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	it("writes onboarding.studioOnboardingSeenAt and returns an empty result", () => {
+		expect(handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T10:00:00.000Z" })).toEqual({})
+		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T10:00:00.000Z")
+	})
+
+	it("stamps the current time when seenAt is omitted", () => {
+		const before = Date.now() - 1000
+		handleSetOnboardingFlag({ configPath })
+		const after = Date.now() + 1000
+
+		const seenAt = readStudioOnboardingSeenAt(configPath)
+		expect(seenAt).toBeDefined()
+		const parsed = Date.parse(seenAt as string)
+		expect(parsed).toBeGreaterThanOrEqual(before)
+		expect(parsed).toBeLessThanOrEqual(after)
+	})
+
+	// The flag must survive a harness restart and be readable by any surface
+	// sharing the config — i.e. it is really on disk, not in memory.
+	it("persists the value to the config file for later readers", () => {
+		handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T10:00:00.000Z" })
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as { onboarding?: Record<string, unknown> }
+		expect(raw.onboarding?.studioOnboardingSeenAt).toBe("2026-09-11T10:00:00.000Z")
+	})
+
+	it("preserves sibling onboarding keys and other config fields", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				apiKey: "castai_v1_key",
+				onboarding: { sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z" },
+			}),
+		)
+
+		handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T10:00:00.000Z" })
+		const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+
+		expect(raw).toEqual({
+			apiKey: "castai_v1_key",
+			onboarding: {
+				sessionModeWizardSeenAt: "2026-05-19T09:30:00.000Z",
+				studioOnboardingSeenAt: "2026-09-11T10:00:00.000Z",
+			},
+		})
+	})
+
+	it("creates the config file when it does not exist", () => {
+		handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T10:00:00.000Z" })
+		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T10:00:00.000Z")
+	})
+
+	it.each([42, null, "", "not-a-date"])("rejects invalid seenAt (%s)", (seenAt) => {
+		expect(() => handleSetOnboardingFlag({ configPath }, { seenAt })).toThrow(/seenAt must be an ISO-8601/)
+		// A rejected write must not leave a flag behind.
+		expect(readStudioOnboardingSeenAt(configPath)).toBeUndefined()
+	})
+
+	it("accepts a non-ISO but parseable date string", () => {
+		handleSetOnboardingFlag({ configPath }, { seenAt: "September 11, 2026" })
+		expect(readStudioOnboardingSeenAt(configPath)).toBe("September 11, 2026")
+	})
+})

--- a/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
@@ -73,14 +73,14 @@ describe("handleSetOnboardingFlag", () => {
 		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T10:00:00.000Z")
 	})
 
-	it.each([42, null, "", "not-a-date"])("rejects invalid seenAt (%s)", (seenAt) => {
+	it.each([42, null, "", "not-a-date", "September 11, 2026"])("rejects invalid seenAt (%s)", (seenAt) => {
 		expect(() => handleSetOnboardingFlag({ configPath }, { seenAt })).toThrow(/seenAt must be an ISO-8601/)
 		// A rejected write must not leave a flag behind.
 		expect(readStudioOnboardingSeenAt(configPath)).toBeUndefined()
 	})
 
-	it("accepts a non-ISO but parseable date string", () => {
-		handleSetOnboardingFlag({ configPath }, { seenAt: "September 11, 2026" })
-		expect(readStudioOnboardingSeenAt(configPath)).toBe("September 11, 2026")
+	it("accepts an ISO-8601 timestamp with a numeric offset", () => {
+		handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T12:00:00+02:00" })
+		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T12:00:00+02:00")
 	})
 })

--- a/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
@@ -1,5 +1,5 @@
 // Unit tests for the `_kimchi.dev/set_onboarding_flag` ACP extension method
-// handler (ADR-0043). All writes go through a temp config path so the real
+// handler (kimchi-studio ADR-0043). All writes go through a temp config path so the real
 // shared config is never touched.
 
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"

--- a/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.test.ts
@@ -83,4 +83,16 @@ describe("handleSetOnboardingFlag", () => {
 		handleSetOnboardingFlag({ configPath }, { seenAt: "2026-09-11T12:00:00+02:00" })
 		expect(readStudioOnboardingSeenAt(configPath)).toBe("2026-09-11T12:00:00+02:00")
 	})
+
+	// Filesystem failures must reach Studio as an actionable internal error,
+	// not an opaque raw Error (review comment on PR #1182). Deterministic
+	// trigger: a file where the config directory should be, so mkdir fails.
+	it("wraps filesystem write failures in RequestError.internalError", () => {
+		const blockedPath = join(tempDir, "blocker", "config.json")
+		writeFileSync(join(tempDir, "blocker"), "not a directory")
+
+		expect(() => handleSetOnboardingFlag({ configPath: blockedPath }, { seenAt: "2026-09-11T10:00:00.000Z" })).toThrow(
+			/Failed to persist onboarding flag/,
+		)
+	})
 })

--- a/src/modes/acp/ext-methods/set-onboarding-flag.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.ts
@@ -51,8 +51,11 @@ export function handleSetOnboardingFlag(
 	paths: SetOnboardingFlagPaths,
 	params: Record<string, unknown> = {},
 ): Record<string, unknown> {
+	// Resolved outside the try/catch on purpose: invalidParams must surface as
+	// -32602, not be re-wrapped into the write-failure internalError below.
+	const seenAt = resolveSeenAt(params.seenAt)
 	try {
-		writeStudioOnboardingSeenAt(resolveSeenAt(params.seenAt), paths.configPath)
+		writeStudioOnboardingSeenAt(seenAt, paths.configPath)
 	} catch (error) {
 		const detail = error instanceof Error ? error.message : String(error)
 		throw RequestError.internalError(undefined, `Failed to persist onboarding flag: ${detail}`)

--- a/src/modes/acp/ext-methods/set-onboarding-flag.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.ts
@@ -9,8 +9,11 @@
 // `import_apply`): a user who declines the import never reaches it, but they
 // have still finished onboarding — so completion cannot be a side effect of
 // importing. The flag lands in the shared config's existing `onboarding`
-// namespace via the harness's read-modify-write helper, so a concurrent write
-// cannot clobber neighbouring "user has seen this" markers.
+// namespace via the harness's read-modify-write helper (temp file + atomic
+// rename). Read-modify-write narrows — but does not eliminate — the window in
+// which a concurrent write could clobber neighbouring "user has seen this"
+// markers: there is no lock, so two simultaneous read-modify-write cycles can
+// still lose one update.
 
 import { RequestError } from "@agentclientprotocol/sdk"
 import { writeStudioOnboardingSeenAt } from "../../../config.js"
@@ -37,12 +40,23 @@ export type SetOnboardingFlagPaths = {
  * Params: `{ seenAt?: string }` — optional ISO-8601 timestamp the client saw
  * the user finish onboarding. When omitted, the harness stamps the current
  * time.
+ *
+ * @throws RequestError.invalidParams when `seenAt` is not a valid ISO-8601
+ *   timestamp string.
+ * @throws RequestError.internalError when the config write fails (e.g.
+ *   EACCES, ENOSPC), so the client can tell a persistence failure apart from
+ *   a params rejection.
  */
 export function handleSetOnboardingFlag(
 	paths: SetOnboardingFlagPaths,
 	params: Record<string, unknown> = {},
 ): Record<string, unknown> {
-	writeStudioOnboardingSeenAt(resolveSeenAt(params.seenAt), paths.configPath)
+	try {
+		writeStudioOnboardingSeenAt(resolveSeenAt(params.seenAt), paths.configPath)
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error)
+		throw RequestError.internalError(undefined, `Failed to persist onboarding flag: ${detail}`)
+	}
 	return {}
 }
 

--- a/src/modes/acp/ext-methods/set-onboarding-flag.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.ts
@@ -1,7 +1,7 @@
 // ACP extension method handler for marking Studio onboarding complete.
 //
 // Wire name: `_kimchi.dev/set_onboarding_flag` — the vendor-namespaced method
-// for Studio's onboarding flow (ADR-0043), advertised via
+// for Studio's onboarding flow (kimchi-studio ADR-0043), advertised via
 // _meta["kimchi.dev"].set_onboarding_flag. Sessionless on purpose: onboarding
 // completion is global per-machine state, not session-scoped.
 //

--- a/src/modes/acp/ext-methods/set-onboarding-flag.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.ts
@@ -1,0 +1,55 @@
+// ACP extension method handler for marking Studio onboarding complete.
+//
+// Wire name: `_kimchi.dev/set_onboarding_flag` — the vendor-namespaced method
+// for Studio's onboarding flow (ADR-0043), advertised via
+// _meta["kimchi.dev"].set_onboarding_flag. Sessionless on purpose: onboarding
+// completion is global per-machine state, not session-scoped.
+//
+// Deliberately separate from the import methods (`import_discover` /
+// `import_apply`): a user who declines the import never reaches it, but they
+// have still finished onboarding — so completion cannot be a side effect of
+// importing. The flag lands in the shared config's existing `onboarding`
+// namespace via the harness's read-modify-write helper, so a concurrent write
+// cannot clobber neighbouring "user has seen this" markers.
+
+import { RequestError } from "@agentclientprotocol/sdk"
+import { writeStudioOnboardingSeenAt } from "../../../config.js"
+
+/**
+ * Config locations the flag write targets. Only the harness config override is
+ * needed for tests; production always writes the shared KIMCHI_CONFIG_PATH.
+ */
+export type SetOnboardingFlagPaths = {
+	/** Harness config path override; defaults to the shared KIMCHI_CONFIG_PATH. */
+	configPath?: string
+}
+
+/**
+ * Handler for the `_kimchi.dev/set_onboarding_flag` ACP extension method.
+ *
+ * Records that the user finished onboarding by writing
+ * `onboarding.studioOnboardingSeenAt` into the shared harness config
+ * (`~/.config/kimchi/config.json`). Sibling keys in the `onboarding` namespace
+ * and every other top-level config field (apiKey, skillPaths, …) are
+ * preserved, because the write goes through the same read-modify-write helper
+ * the terminal wizard's onboarding markers use.
+ *
+ * Params: `{ seenAt?: string }` — optional ISO-8601 timestamp the client saw
+ * the user finish onboarding. When omitted, the harness stamps the current
+ * time.
+ */
+export function handleSetOnboardingFlag(
+	paths: SetOnboardingFlagPaths,
+	params: Record<string, unknown> = {},
+): Record<string, unknown> {
+	writeStudioOnboardingSeenAt(resolveSeenAt(params.seenAt), paths.configPath)
+	return {}
+}
+
+function resolveSeenAt(seenAt: unknown): string {
+	if (seenAt === undefined) return new Date().toISOString()
+	if (typeof seenAt !== "string" || seenAt.length === 0 || Number.isNaN(Date.parse(seenAt))) {
+		throw RequestError.invalidParams(undefined, "seenAt must be an ISO-8601 timestamp string")
+	}
+	return seenAt
+}

--- a/src/modes/acp/ext-methods/set-onboarding-flag.ts
+++ b/src/modes/acp/ext-methods/set-onboarding-flag.ts
@@ -46,9 +46,21 @@ export function handleSetOnboardingFlag(
 	return {}
 }
 
+// ISO-8601 date-time with a UTC designator or numeric offset. Deliberately
+// strict: the value is a shared contract with Studio and any future reader of
+// the config, so arbitrary parseable strings (e.g. "September 11, 2026") are
+// rejected — Date.parse's handling of non-ISO input is engine-specific and
+// would persist non-machine-standard strings into the shared config.
+const ISO_8601_TIMESTAMP = /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:?\d{2})$/
+
 function resolveSeenAt(seenAt: unknown): string {
 	if (seenAt === undefined) return new Date().toISOString()
-	if (typeof seenAt !== "string" || seenAt.length === 0 || Number.isNaN(Date.parse(seenAt))) {
+	if (
+		typeof seenAt !== "string" ||
+		seenAt.length === 0 ||
+		!ISO_8601_TIMESTAMP.test(seenAt) ||
+		Number.isNaN(Date.parse(seenAt))
+	) {
 		throw RequestError.invalidParams(undefined, "seenAt must be an ISO-8601 timestamp string")
 	}
 	return seenAt

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -37,6 +37,11 @@ vi.mock("../../config.js", async (importOriginal) => {
 		...actual,
 		writeApiKey: vi.fn(),
 		clearApiKey: vi.fn(),
+		// The set_onboarding_flag ext-method writes the shared config's
+		// onboarding namespace; mock it so server-level tests don't touch the
+		// real config file. Write semantics are covered by the handler's own
+		// unit tests against a temp config path.
+		writeStudioOnboardingSeenAt: vi.fn(),
 		// Real implementation by default; individual tests use
 		// mockReturnValueOnce to simulate credential-store transitions
 		// (writeApiKey/clearApiKey are mocked, so they never touch disk).
@@ -63,7 +68,7 @@ const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
 
 import { populateCliArgs } from "../../cli-args.js"
 import { authenticateViaBrowser } from "../../cli-auth/index.js"
-import { clearApiKey, loadConfig, writeApiKey } from "../../config.js"
+import { clearApiKey, loadConfig, writeApiKey, writeStudioOnboardingSeenAt } from "../../config.js"
 import { isCredentialStale, markCredentialStale, resetCredentialStalenessForTests } from "../../credential-staleness.js"
 import { createMiniEventBus } from "../../extensions/__mocks__/mini-event-bus.js"
 import { PARENT_SESSION_ID_ENV_KEY } from "../../extensions/agents/manager/constants.js"
@@ -1015,6 +1020,49 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			await expect(testAgent.extMethod(AVAILABLE_EXT_METHODS.auth_status, {})).resolves.toEqual({
 				authenticated: true,
 			})
+		})
+	})
+
+	describe("extMethod set_onboarding_flag", () => {
+		// The shared-config write is mocked (see the config.js mock above) —
+		// handler write semantics (persistence, sibling-key preservation) are
+		// covered by ext-methods/set-onboarding-flag.test.ts against a temp path.
+
+		function makeTestAgent(): KimchiAcpAgent {
+			return new KimchiAcpAgent(makeConn(), {
+				extensionFactories: [],
+				agentDir: "/tmp/kimchi-acp-test-agent-dir-set-onboarding-flag",
+				sessionFactory: async () => asSession(fake),
+			})
+		}
+
+		it("advertises set_onboarding_flag in the initialize capabilities _meta", async () => {
+			const response = await makeTestAgent().initialize({ protocolVersion: 1 })
+			expect(response.agentCapabilities?._meta?.[CAPABILITIES_KEY]).toMatchObject({
+				set_onboarding_flag: true,
+			})
+		})
+
+		// Sessionless by design (ADR-0043): onboarding completion is global
+		// per-machine state, so the call carries no sessionId.
+		it("writes the onboarding flag without requiring a session", async () => {
+			vi.mocked(writeStudioOnboardingSeenAt).mockClear()
+
+			await expect(
+				makeTestAgent().extMethod(AVAILABLE_EXT_METHODS.set_onboarding_flag, {
+					seenAt: "2026-09-11T10:00:00.000Z",
+				}),
+			).resolves.toEqual({})
+
+			expect(writeStudioOnboardingSeenAt).toHaveBeenCalledWith("2026-09-11T10:00:00.000Z", undefined)
+		})
+
+		it("rejects an invalid seenAt as invalidParams", async () => {
+			vi.mocked(writeStudioOnboardingSeenAt).mockClear()
+			await expect(
+				makeTestAgent().extMethod(AVAILABLE_EXT_METHODS.set_onboarding_flag, { seenAt: "not-a-date" }),
+			).rejects.toThrow(/seenAt must be an ISO-8601/)
+			expect(writeStudioOnboardingSeenAt).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -1043,7 +1043,7 @@ describe("KimchiAcpAgent turn lifecycle", () => {
 			})
 		})
 
-		// Sessionless by design (ADR-0043): onboarding completion is global
+		// Sessionless by design (kimchi-studio ADR-0043): onboarding completion is global
 		// per-machine state, so the call carries no sessionId.
 		it("writes the onboarding flag without requiring a session", async () => {
 			vi.mocked(writeStudioOnboardingSeenAt).mockClear()

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -1055,7 +1055,7 @@ export class KimchiAcpAgent implements Agent {
 			case AVAILABLE_EXT_METHODS.set_onboarding_flag:
 				// Write the shared config per call through the harness's
 				// read-modify-write helper so sibling onboarding keys set by other
-				// Kimchi surfaces survive (ADR-0043).
+				// Kimchi surfaces survive.
 				return handleSetOnboardingFlag({}, params)
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -106,6 +106,7 @@ import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleAuthStatus } from "./ext-methods/auth-status.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
+import { handleSetOnboardingFlag } from "./ext-methods/set-onboarding-flag.js"
 import { handleSetSessionTitle } from "./ext-methods/set-session-title.js"
 import { handleSteering } from "./ext-methods/steering.js"
 import { registerAcpPrompter, unregisterAcpPrompter } from "./permission-prompter-registry.js"
@@ -1051,6 +1052,11 @@ export class KimchiAcpAgent implements Agent {
 					authPath: join(this.agentDir, "auth.json"),
 					modelsPath: join(this.agentDir, "models.json"),
 				})
+			case AVAILABLE_EXT_METHODS.set_onboarding_flag:
+				// Write the shared config per call through the harness's
+				// read-modify-write helper so sibling onboarding keys set by other
+				// Kimchi surfaces survive (ADR-0043).
+				return handleSetOnboardingFlag({}, params)
 			case AVAILABLE_EXT_METHODS.set_session_title:
 				return handleSetSessionTitle((sessionId) => this.sessions.get(sessionId)?.session, params)
 			case AVAILABLE_EXT_METHODS.steering:


### PR DESCRIPTION
## Summary

Adds a `_kimchi.dev/set_onboarding_flag` ACP extension method so a client (Studio) can record that the user finished onboarding. The value persists to the shared config's existing `onboarding` namespace as `onboarding.studioOnboardingSeenAt`, per ADR-0043.

Work item: kimchi-studio #371 (parent #368)

## How it works

- `handleSetOnboardingFlag` (new `src/modes/acp/ext-methods/set-onboarding-flag.ts`) writes through the harness's existing read-modify-write helper (`updateOnboardingConfig`), so a concurrent write cannot clobber neighbouring onboarding keys and every other top-level config field (`apiKey`, `skillPaths`, …) is preserved.
- Sessionless by design (ADR-0043): a user who declines the import never reaches `import_apply`, but has still completed onboarding — completion cannot be a side effect of importing.
- Optional `seenAt` param (ISO-8601, validated); defaults to the harness's current time. Invalid values reject as `invalidParams` without writing.
- Advertised via `_meta["kimchi.dev"].set_onboarding_flag: true` in `initialize()`, following the `_kimchi.dev/auth_status` precedent.
- Additive key: no existing terminal flow reads it, so the CLI stays green.

## Acceptance criteria (kimchi-studio #371)

- [x] A client can call the extension method to mark onboarding complete, and the value persists to the shared configuration's onboarding namespace
- [x] The write preserves any sibling keys already in that namespace
- [x] The method is advertised in the agent's capability block
- [x] The value survives a harness restart and is readable by any surface sharing the configuration (persisted to `~/.config/kimchi/config.json`, read back via `loadConfig().onboarding.studioOnboardingSeenAt`)
- [x] CLI stays green: the new key is additive; no existing terminal flow reads or is affected by it
- [x] Full harness test suite passes

## Tests run

- `src/modes/acp/ext-methods/set-onboarding-flag.test.ts` (new): persistence, sibling-key preservation, missing-file creation, default timestamp, param validation
- `src/config.test.ts`: read/write round trip for `studioOnboardingSeenAt`
- `src/modes/acp/server.test.ts`: capability advertising + sessionless dispatch round trip
- Full `pnpm run test`: 10382 passed; the only failures (4 in `src/extensions/pi-package-lookup/index.test.ts`) are pre-existing and reproduce on a clean upstream/master checkout. `tsc --noEmit` clean; biome clean on touched files.

## Risks / follow-ups

- Studio-side caller needs to invoke `_kimchi.dev/set_onboarding_flag` when the preferences screen completes (tracked in the parent epic #368).
- 4 pre-existing `pi-package-lookup` test failures on master are unrelated to this change (reproduced on a clean checkout).

Co-Authored-By: Kimchi <noreply@kimchi.dev>
