### PR TITLE
chore: increase teleport timeout

### DIFF
--- a/src/extensions/agents/manager/remote-agent-runner.test.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.test.ts
@@ -253,7 +253,7 @@ describe("runRemoteAgent", () => {
 				agentMode: "ACP",
 				yolo: true,
 			}),
-			expect.objectContaining({ timeoutMs: 5 * 60_000 }),
+			expect.objectContaining({ timeoutMs: 10 * 60_000 }),
 		)
 
 		// 4. ACP client — cwd matches the unique session directory
@@ -973,6 +973,14 @@ describe("runRemoteAgent", () => {
 			await expect(runRemoteAgent(WORKSPACE_ID, PROMPT, makeRecoveryOptions())).rejects.toThrow(
 				"remote session no longer reachable",
 			)
+
+			// Revive readiness waits are capped per attempt (5min), unlike the initial
+			// uncapped wait (10-min default) before the first prompt.
+			const readyCalls = vi.mocked(waitForWorkspaceReady).mock.calls
+			expect(readyCalls[0][0]).not.toHaveProperty("timeoutMs")
+			for (const call of readyCalls.slice(1)) {
+				expect(call[0]).toMatchObject({ timeoutMs: 5 * 60_000 })
+			}
 
 			expect(deleteSession).not.toHaveBeenCalled()
 		})

--- a/src/extensions/agents/manager/remote-agent-runner.ts
+++ b/src/extensions/agents/manager/remote-agent-runner.ts
@@ -132,8 +132,9 @@ export interface RemoteRunResult {
 	recoveryNote?: string
 }
 
-/** Per-call timeout for createSession: 5min — large repos take a while to clone. */
-const SESSION_CREATE_TIMEOUT_MS = 5 * 60_000
+/** Per-call timeout for createSession: 10min — large repos take a while to clone
+ *  into a freshly-bound PVC. Matches DEFAULT_READY_TIMEOUT_MS in readiness.ts. */
+const SESSION_CREATE_TIMEOUT_MS = 10 * 60_000
 
 /** Reconnect backoff schedule (2s, 4s, 8s) — one delay per reattach attempt. */
 const DEFAULT_RECONNECT_BACKOFFS_MS = [2_000, 4_000, 8_000]
@@ -146,6 +147,12 @@ const POLL_INTERVAL_MS = 15_000
 const POLL_JITTER_MS = 5_000
 /** Cap on re-auth + readiness attempts when a session is reported `!alive`. */
 const REVIVE_MAX_ATTEMPTS = 3
+/** Per-attempt readiness timeout when reviving a workspace. Smaller than the
+ *  10-min first-create default (readiness.ts): server-side re-provisioning
+ *  persists across attempts (re-auth is an idempotent upsert), so 3 × 5min
+ *  keeps the pre-change ~15-min aggregate — bounding how long a genuinely dead
+ *  workspace can hang recovery before failing honestly with "result unknown". */
+const REVIVE_READY_TIMEOUT_MS = 5 * 60_000
 /** Consecutive failed status polls before the recovery loop refreshes
  *  credentials and rebuilds the HTTP client — covers expired connect tokens
  *  (spec Q6: re-auth on 401/403) and wedged transports. */
@@ -263,7 +270,12 @@ async function tryReviveWorkspace(st: RemoteRecoveryState, config: RecoveryConfi
 					endpoint: config.endpoint,
 				}),
 			)
-			await waitForWorkspaceReady({ wsUrl: st.creds.wsUrl, connectToken: st.creds.connectToken, signal: config.signal })
+			await waitForWorkspaceReady({
+				wsUrl: st.creds.wsUrl,
+				connectToken: st.creds.connectToken,
+				signal: config.signal,
+				timeoutMs: REVIVE_READY_TIMEOUT_MS,
+			})
 			await st.client.close().catch(() => {})
 			st.client = new WorkerClient(st.creds)
 			const s = await getSession(st.client, config.sessionName, config.signal)

--- a/src/extensions/teleport/commands/teleport.ts
+++ b/src/extensions/teleport/commands/teleport.ts
@@ -37,8 +37,8 @@ import { parseTeleportArgs } from "./args.js"
 import { authFailureMessage, refuse, warn } from "./errors.js"
 import { resolveWorkspaceRef } from "./workspace-ref.js"
 
-/** Per-call timeout for createSession: 5min — the 30s WorkerClient default aborts mid-flight on large repos. */
-export const SESSION_CREATE_TIMEOUT_MS = 5 * 60_000
+/** Per-call timeout for createSession: 10min — the 30s WorkerClient default aborts mid-flight on large repos. */
+export const SESSION_CREATE_TIMEOUT_MS = 10 * 60_000
 
 export async function runTeleport(rawArgs: string, ctx: TeleportContext): Promise<void> {
 	if (hasHelpFlag(rawArgs)) {

--- a/src/sandbox/cloud/readiness.test.ts
+++ b/src/sandbox/cloud/readiness.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { waitForWorkspaceReady } from "./readiness.js"
+import { DEFAULT_READY_TIMEOUT_MS, waitForWorkspaceReady } from "./readiness.js"
 
 describe("waitForWorkspaceReady", () => {
 	function mockFetch(responses: Array<{ ok: boolean; status: number } | Error>) {
@@ -99,7 +99,7 @@ describe("waitForWorkspaceReady", () => {
 		await expect(promise).rejects.toThrow(/HTTP 503/)
 	})
 
-	it("times out after 10 minutes by default", async () => {
+	it("times out after the default timeout when the workspace never becomes ready", async () => {
 		vi.useFakeTimers()
 		mockFetch([new Error("nope")])
 
@@ -107,9 +107,12 @@ describe("waitForWorkspaceReady", () => {
 			wsUrl: "wss://h.example.com/",
 			connectToken: "tok",
 		})
-		const assertion = expect(promise).rejects.toThrow(/did not become ready within 600s/)
+		const defaultTimeoutSeconds = Math.round(DEFAULT_READY_TIMEOUT_MS / 1000)
+		const assertion = expect(promise).rejects.toThrow(
+			new RegExp(`did not become ready within ${defaultTimeoutSeconds}s`),
+		)
 
-		await vi.advanceTimersByTimeAsync(10 * 60_000 + 5_000)
+		await vi.advanceTimersByTimeAsync(DEFAULT_READY_TIMEOUT_MS + 5_000)
 		await assertion
 	})
 

--- a/src/sandbox/cloud/readiness.test.ts
+++ b/src/sandbox/cloud/readiness.test.ts
@@ -21,6 +21,7 @@ describe("waitForWorkspaceReady", () => {
 	}
 
 	afterEach(() => {
+		vi.useRealTimers()
 		vi.unstubAllGlobals()
 	})
 
@@ -96,6 +97,20 @@ describe("waitForWorkspaceReady", () => {
 		})
 
 		await expect(promise).rejects.toThrow(/HTTP 503/)
+	})
+
+	it("times out after 10 minutes by default", async () => {
+		vi.useFakeTimers()
+		mockFetch([new Error("nope")])
+
+		const promise = waitForWorkspaceReady({
+			wsUrl: "wss://h.example.com/",
+			connectToken: "tok",
+		})
+		const assertion = expect(promise).rejects.toThrow(/did not become ready within 600s/)
+
+		await vi.advanceTimersByTimeAsync(10 * 60_000 + 5_000)
+		await assertion
 	})
 
 	it("rejects when the abort signal fires", async () => {

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -4,9 +4,9 @@ import { RemoteNetworkError } from "./types.js"
 
 // First-time workspace creation is a cold start: the control plane must provision
 // the sandbox and attach the agentgateway policy before traffic is routable.
-// That routinely takes minutes, so allow up to 5 min (matches the createSession
-// timeout in remote-agent-runner.ts). Warm workspaces resolve far faster than this.
-const DEFAULT_READY_TIMEOUT_MS = 5 * 60_000
+// That routinely takes minutes, so allow up to 10 min. Warm workspaces resolve far
+// faster than this.
+const DEFAULT_READY_TIMEOUT_MS = 10 * 60_000
 const DEFAULT_POLL_INTERVAL_MS = 1_500
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000
 

--- a/src/sandbox/cloud/readiness.ts
+++ b/src/sandbox/cloud/readiness.ts
@@ -4,9 +4,10 @@ import { RemoteNetworkError } from "./types.js"
 
 // First-time workspace creation is a cold start: the control plane must provision
 // the sandbox and attach the agentgateway policy before traffic is routable.
-// That routinely takes minutes, so allow up to 10 min. Warm workspaces resolve far
+// That routinely takes minutes, so allow up to 10 min (matching the createSession
+// timeout in remote-agent-runner.ts / teleport.ts). Warm workspaces resolve far
 // faster than this.
-const DEFAULT_READY_TIMEOUT_MS = 10 * 60_000
+export const DEFAULT_READY_TIMEOUT_MS = 10 * 60_000
 const DEFAULT_POLL_INTERVAL_MS = 1_500
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000
 


### PR DESCRIPTION
## Linked issue

Closes #1185

<!-- Every PR must link to an existing issue. PRs without a linked issue will not be reviewed.
     Use one of: Closes #N / Fixes #N / Resolves #N -->

## What does this PR do?

Raises the remote-workspace cold-start budgets so slow provisioning no longer fails a run that would have succeeded:

- `DEFAULT_READY_TIMEOUT_MS` (readiness wait): 5 min → 10 min
- `SESSION_CREATE_TIMEOUT_MS` (session create / server-side clone): 5 min → 10 min, in both `teleport.ts` and `remote-agent-runner.ts`
- Caps per-attempt revive readiness at 5 min (`REVIVE_READY_TIMEOUT_MS`) so a dead workspace still fails honestly in ~15 min instead of ~30 min
- Exports `DEFAULT_READY_TIMEOUT_MS` and derives the readiness test's expectations from it, so future value changes can't leave a stale test

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [ ] Documentation updated if behavior changed