### PR TITLE
Remove "LSP/DAP unavailable" startup warnings

### DIFF
--- a/src/extensions/dap.ts
+++ b/src/extensions/dap.ts
@@ -280,7 +280,6 @@ export default function (pi: ExtensionAPI) {
 	let cwd = ""
 	let activeAdapters = detectAdapters("")
 	let missingAdapters = detectMissingAdapters("")
-	let warned = false
 	let ui: ExtensionUIContext | undefined
 
 	// Per-extension-instance registries. Held in closure scope (not module-level)
@@ -356,7 +355,6 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		cwd = ctx.cwd
 		ui = ctx.ui
-		warned = false
 		goSkillActive = false
 		pythonSkillActive = false
 		tsSkillActive = false
@@ -416,18 +414,6 @@ export default function (pi: ExtensionAPI) {
 			ui.setStatus("dap", undefined)
 			ui = undefined
 		}
-		warned = false
-	})
-
-	// ── Degraded-state warning: notify once on the first agent turn ─────────────
-
-	pi.on("before_agent_start", async () => {
-		updateStatusFooter()
-
-		if (warned || missingAdapters.length === 0 || !ui?.notify) return
-		const lines = missingAdapters.map((a) => `${a.name} — install with: ${a.installHint ?? a.command}`)
-		ui.notify(`DAP unavailable: debug adapter(s) not installed for this project.\n${lines.join("\n")}`, "warning")
-		warned = true
 	})
 
 	// ── On-demand skill injection: activate language skills on first debug tool call ─

--- a/src/extensions/dap/dap-entry.test.ts
+++ b/src/extensions/dap/dap-entry.test.ts
@@ -4,7 +4,7 @@
 //   - session_start detects adapters and sets the status footer
 //     (`DAP: <names>` / `DAP: <names> not installed` / partial)
 //   - session_shutdown calls clearAllSessions + shutdownAll and clears footer
-//   - before_agent_start fires a one-time degraded warning when adapters missing
+//   - no before_agent_start handler: degraded state lives in the footer only
 //   - system prompt block renders `## Debugger (DAP)` only when adapters active
 //   - Layer 1 tools are registered on session_start
 //
@@ -291,31 +291,6 @@ describe("DAP extension entry point", () => {
 			expect(clientState.clearAllCalled).toBe(true)
 			expect(clientState.shutdownAllCalled).toBe(true)
 			expect(startCtx.ui?.setStatus).toHaveBeenCalledWith("dap", undefined)
-		})
-	})
-
-	describe("before_agent_start — degraded warning", () => {
-		it("fires a warning once when adapters are missing", async () => {
-			adapterState.missing = [DEBUGPY]
-			const ctx = createCtx()
-			await mock.handlers.session_start?.({ type: "session_start" }, ctx)
-			await mock.handlers.before_agent_start?.()
-			await mock.handlers.before_agent_start?.()
-
-			expect(ctx.ui?.notify).toHaveBeenCalledTimes(1)
-			const call = (ctx.ui?.notify as ReturnType<typeof vi.fn>).mock.calls[0]
-			expect(call[0]).toContain("DAP unavailable")
-			expect(call[0]).toContain("debugpy")
-			expect(call[1]).toBe("warning")
-		})
-
-		it("does not fire a warning when no adapters are missing", async () => {
-			adapterState.active = [JS_DEBUG]
-			const ctx = createCtx()
-			await mock.handlers.session_start?.({ type: "session_start" }, ctx)
-			await mock.handlers.before_agent_start?.()
-
-			expect(ctx.ui?.notify).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/extensions/lsp.test.ts
+++ b/src/extensions/lsp.test.ts
@@ -469,8 +469,8 @@ describe("degraded status (marker present, binary missing)", () => {
 	})
 })
 
-describe("one-time warning on before_agent_start", () => {
-	it("notifies once on the first before_agent_start in a degraded project", async () => {
+describe("no degraded warning notification", () => {
+	it("never notifies on before_agent_start, even when servers are missing", async () => {
 		vi.mocked(serversMod.detectServers).mockReturnValue([])
 		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
 		const notify = vi.fn()
@@ -478,30 +478,6 @@ describe("one-time warning on before_agent_start", () => {
 		lspExtension(pi)
 		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
 		await pi.fireBeforeAgentStart()
-		expect(notify).toHaveBeenCalledTimes(1)
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining(FAKE_GO_SERVER.name), "warning")
-		expect(notify).toHaveBeenCalledWith(expect.stringContaining("go install"), "warning")
-	})
-
-	it("does NOT re-notify on a second before_agent_start", async () => {
-		vi.mocked(serversMod.detectServers).mockReturnValue([])
-		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
-		const notify = vi.fn()
-		const pi = makePi()
-		lspExtension(pi)
-		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
-		await pi.fireBeforeAgentStart()
-		await pi.fireBeforeAgentStart()
-		expect(notify).toHaveBeenCalledTimes(1)
-	})
-
-	it("does not notify when not degraded (server present)", async () => {
-		vi.mocked(serversMod.detectServers).mockReturnValue([FAKE_SERVER])
-		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([])
-		const notify = vi.fn()
-		const pi = makePi()
-		lspExtension(pi)
-		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
 		await pi.fireBeforeAgentStart()
 		expect(notify).not.toHaveBeenCalled()
 	})
@@ -550,27 +526,6 @@ describe("no regression when a server is present", () => {
 // =============================================================================
 // 4c. Edge cases from PR review
 // =============================================================================
-
-describe("warned flag reset on session_start", () => {
-	it("allows a one-time warning in a new session after session_shutdown", async () => {
-		vi.mocked(serversMod.detectServers).mockReturnValue([])
-		vi.mocked(serversMod.detectMissingCandidates).mockReturnValue([FAKE_GO_SERVER])
-		const notify = vi.fn()
-		const pi = makePi()
-		lspExtension(pi)
-		// First session: warning fires
-		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify } })
-		await pi.fireBeforeAgentStart()
-		expect(notify).toHaveBeenCalledTimes(1)
-		// Shutdown resets warned
-		await pi.fireShutdown()
-		// Second session: warning should fire again
-		const notify2 = vi.fn()
-		await pi.fireSessionStart({ hasUI: true, ui: { setStatus: vi.fn(), notify: notify2 } })
-		await pi.fireBeforeAgentStart()
-		expect(notify2).toHaveBeenCalledTimes(1)
-	})
-})
 
 describe("ui.notify absent", () => {
 	it("does not throw when ui lacks notify method", async () => {

--- a/src/extensions/lsp.ts
+++ b/src/extensions/lsp.ts
@@ -77,7 +77,6 @@ export default function (pi: ExtensionAPI) {
 	let cwd = ""
 	let activeServers: ReturnType<typeof detectServers> = []
 	let degradedServers: ReturnType<typeof detectMissingCandidates> = []
-	let warned = false
 	let ui: ExtensionUIContext | undefined
 	// The five lsp_* tools (~670 est of
 	// description+schema) are dead weight when no language server exists for the
@@ -215,7 +214,6 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		cwd = ctx.cwd
 		ui = ctx.hasUI ? ctx.ui : undefined
-		warned = false
 		degradedServers = []
 		failedClients = new Map()
 		reportedFailures = new Set()
@@ -264,22 +262,10 @@ export default function (pi: ExtensionAPI) {
 			ui.setStatus("lsp", undefined)
 			ui = undefined
 		}
-		warned = false
 		degradedServers = []
 		failedClients = new Map()
 		reportedFailures = new Set()
 		shutdownAll()
-	})
-
-	// ── Degraded-state warning: notify once on the first agent turn ─────────────
-
-	pi.on("before_agent_start", async () => {
-		// One-time warning when in a project that would use LSP but has no
-		// server binary on PATH. No-op on subsequent turns and when not degraded.
-		if (warned || degradedServers.length === 0 || !ui?.notify) return
-		const lines = degradedServers.map((s) => `${s.name} — install with: ${s.installHint ?? s.command}`)
-		ui.notify(`LSP unavailable: language server(s) not installed for this project.\n${lines.join("\n")}`, "warning")
-		warned = true
 	})
 
 	// ── File sync: refresh LSP after agent edits files ───────────────────────────

--- a/tests/e2e/tui/dap-debug-workflow.test.ts
+++ b/tests/e2e/tui/dap-debug-workflow.test.ts
@@ -83,9 +83,9 @@ test("DAP degraded state: debug_launch surfaces the missing-adapter error and st
 			const view = viewText(terminal)
 			// The DAP tool rendered with its user-visible (name-derived) header.
 			expect(view).toContain("Debug Launch")
-			// The one-time degraded warning notification names the missing adapter
-			// and its install path.
-			expect(view).toContain("DAP unavailable: debug adapter(s) not installed")
+			// The degraded "DAP unavailable" notification was removed — the status
+			// footer still surfaces the missing adapter, no popup notification.
+			expect(view).not.toContain("DAP unavailable")
 			// The availability pre-check error made it back to the model as the
 			// tool result — without this, launch would have tried to spawn a
 			// missing binary (Chunk 3 regression).


### PR DESCRIPTION
Removes the one-time `LSP unavailable: language server(s) not installed` and `DAP unavailable: debug adapter(s) not installed` popup notifications fired on the first agent turn in projects whose language server / debug adapter binaries aren't on PATH.

The information is still surfaced non-intrusively via the status footer (`LSP: <name> not installed` / `DAP: <name> not installed`), and DAP tool calls already return an actionable "not installed or not on PATH" error to the model.