### PR TITLE
fix(agents): deduplicate in_progress repeats in cloud transcript output

### DIFF
--- a/src/extensions/agents/manager/remote-output-file.test.ts
+++ b/src/extensions/agents/manager/remote-output-file.test.ts
@@ -459,6 +459,70 @@ describe("streamRemoteToOutputFile", () => {
 		})
 	})
 
+	describe("distinct pending tool calls", () => {
+		it("finalizes a pending call with a degraded result when a different call starts before it completes", () => {
+			// ACP turns can run parallel tool calls (or a call may be abandoned):
+			// in_progress B arrives while A is still pending. A must keep its own
+			// entry — its id must not end up paired with B's title, and B's entry
+			// must be written separately.
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			callbacks.onRawNotification?.(toolCallNotification("call-a", "Tool A", "in_progress", { rawInput: { a: 1 } }))
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Tool A", toolCallId: "call-a" })
+			callbacks.onRawNotification?.(toolCallNotification("call-b", "Tool B", "in_progress"))
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Tool B", toolCallId: "call-b" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-b", { status: "in_progress", rawInput: { b: 2 } }))
+			// A completes after it was already finalized — an orphan completion
+			// for the now-pending B's slot; its rawOutput must not attach to B
+			// and no third entry may be written.
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-a", { status: "completed", rawOutput: "a out" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Tool A", toolCallId: "call-a" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-b", { status: "completed", rawOutput: "b out" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Tool B", toolCallId: "call-b" })
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUses = findToolUseEntries(entries).map((e) => getToolUseContent(e))
+			expect(toolUses.map((t) => t.id)).toEqual(["call-a", "call-b"])
+			expect(toolUses[0].name).toBe("Tool A")
+			expect(toolUses[0].input).toEqual({ a: 1 })
+			expect(toolUses[1].name).toBe("Tool B")
+			expect(toolUses[1].input).toEqual({ b: 2 })
+
+			const results = entries.filter((e) => e.type === "toolResult").map((e) => getTextContent(e).text)
+			expect(results).toHaveLength(2)
+			expect(results[0]).toBe("Tool A") // degraded placeholder for the finalized call
+			expect(results[1]).toBe('"b out"') // B's own real output, not A's late one
+		})
+
+		it("does not leak the previous call's rawInput into a call that streamed no args", () => {
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			callbacks.onRawNotification?.(
+				toolCallNotification("call-1", "Shell command", "in_progress", { rawInput: { command: "ls" } }),
+			)
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command", toolCallId: "call-1" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-1", { status: "completed", rawOutput: "ok" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command", toolCallId: "call-1" })
+
+			callbacks.onRawNotification?.(toolCallNotification("call-2", "Shell command", "in_progress"))
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command", toolCallId: "call-2" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-2", { status: "completed", rawOutput: "ok" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command", toolCallId: "call-2" })
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUses = findToolUseEntries(entries).map((e) => getToolUseContent(e))
+			expect(toolUses).toHaveLength(2)
+			expect(toolUses[0].input).toEqual({ command: "ls" })
+			expect(toolUses[1].input).toEqual({})
+		})
+	})
+
 	describe("in_progress forwarding dedup", () => {
 		it("forwards repeated in_progress notifications for the same toolCallId only once to the tracker", () => {
 			const { callbacks: inner, activities } = makeInnerCallbacks()

--- a/src/extensions/agents/manager/remote-output-file.test.ts
+++ b/src/extensions/agents/manager/remote-output-file.test.ts
@@ -43,6 +43,10 @@ function findToolUseEntry(entries: ParsedEntry[]): ParsedEntry | undefined {
 	return entries.find((e) => e.type === "assistant" && e.message.content?.some((c) => c.type === "tool_use"))
 }
 
+function findToolUseEntries(entries: ParsedEntry[]): ParsedEntry[] {
+	return entries.filter((e) => e.type === "assistant" && e.message.content?.some((c) => c.type === "tool_use"))
+}
+
 function findTextEntry(entries: ParsedEntry[]): ParsedEntry | undefined {
 	return entries.find((e) => e.type === "assistant" && e.message.content?.some((c) => c.type === "text"))
 }
@@ -160,13 +164,15 @@ describe("streamRemoteToOutputFile", () => {
 			expect(activities).toContain("completed:Reading file.ts")
 		})
 
-		it("falls back to toolName for id when no toolCallId arrived before start", () => {
+		it("uses the toolCallId that arrives in a later update, before completion", () => {
 			const { callbacks: inner } = makeInnerCallbacks()
 			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
 			setOutputPath(outputPath, "agent-1")
 
 			// onToolActivity fires before any raw notification with toolCallId
 			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command" })
+			// The toolCallId arrives in the completion update — because the
+			// tool_use entry is written at completion, it picks up this id.
 			callbacks.onRawNotification?.(toolCallUpdateNotification("call-456", { status: "completed", rawOutput: "done" }))
 			callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command" })
 			callbacks.onTurnEnd?.(1)
@@ -175,7 +181,23 @@ describe("streamRemoteToOutputFile", () => {
 			const toolUseEntry = findToolUseEntry(entries)
 			expect(toolUseEntry).toBeDefined()
 			const toolUse = getToolUseContent(toolUseEntry as ParsedEntry)
-			// No toolCallId was seen before start, so falls back to toolName
+			expect(toolUse.id).toBe("call-456")
+		})
+
+		it("falls back to toolName for id when no toolCallId ever arrives", () => {
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			// Activity-only flow — no raw notifications carry a toolCallId.
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command" })
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command" })
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUseEntry = findToolUseEntry(entries)
+			expect(toolUseEntry).toBeDefined()
+			const toolUse = getToolUseContent(toolUseEntry as ParsedEntry)
 			expect(toolUse.id).toBe("Shell command")
 		})
 
@@ -294,7 +316,7 @@ describe("streamRemoteToOutputFile", () => {
 	})
 
 	describe("rawInput handling", () => {
-		it("stores rawInput from tool_call_update if it arrives after start", () => {
+		it("captures rawInput from tool_call_update that arrives after start", () => {
 			const { callbacks: inner } = makeInnerCallbacks()
 			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
 			setOutputPath(outputPath, "agent-1")
@@ -318,10 +340,9 @@ describe("streamRemoteToOutputFile", () => {
 			const toolUseEntry = findToolUseEntry(entries)
 			expect(toolUseEntry).toBeDefined()
 			const toolUse = getToolUseContent(toolUseEntry as ParsedEntry)
-			// rawInput arrived after start, so it wasn't captured in the tool_use entry
-			// (the entry was already written at "start" time). This is expected behavior —
-			// the input is written at start time using whatever was available.
-			expect(toolUse.input).toEqual({})
+			// The tool_use entry is written once, at completion — so args that
+			// streamed in after start are included.
+			expect(toolUse.input).toEqual({ command: "ls -la" })
 		})
 
 		it("captures rawInput from tool_call notification when it arrives before start", () => {
@@ -346,6 +367,95 @@ describe("streamRemoteToOutputFile", () => {
 			expect(toolUseEntry).toBeDefined()
 			const toolUse = getToolUseContent(toolUseEntry as ParsedEntry)
 			expect(toolUse.input).toEqual({ path: "/app/file.ts" })
+		})
+	})
+
+	describe("repeated in_progress dedup", () => {
+		it("writes a single tool_use entry despite repeated in_progress heartbeats", () => {
+			// Regression: cloud agents broadcast identical in_progress
+			// notifications for the same toolCallId periodically (~80ms) while a
+			// long-running tool executes. Each repeat used to append another
+			// assistant tool_use entry — a 30-minute nested Agent call produced
+			// ~5,800 identical lines and a 29MB .output file.
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			const args = { description: "Build Chunk 3 quiz polish", prompt: "You are building Chunk 3…" }
+			callbacks.onRawNotification?.(toolCallNotification("kt.Agent.8", "Agent", "in_progress", { rawInput: args }))
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Agent", toolCallId: "kt.Agent.8" })
+
+			// Heartbeat: the server re-broadcasts the same in_progress activity
+			// (with identical args) many times while the tool runs.
+			for (let i = 0; i < 50; i++) {
+				callbacks.onRawNotification?.(
+					toolCallUpdateNotification("kt.Agent.8", { status: "in_progress", rawInput: args }),
+				)
+				callbacks.onToolActivity?.({ status: "in_progress", toolName: "Agent", toolCallId: "kt.Agent.8" })
+			}
+
+			callbacks.onRawNotification?.(
+				toolCallUpdateNotification("kt.Agent.8", { status: "completed", rawOutput: "done" }),
+			)
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Agent", toolCallId: "kt.Agent.8" })
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUseEntries = findToolUseEntries(entries)
+			expect(toolUseEntries).toHaveLength(1)
+			const toolUse = getToolUseContent(toolUseEntries[0])
+			expect(toolUse.id).toBe("kt.Agent.8")
+			expect(toolUse.name).toBe("Agent")
+			expect(toolUse.input).toEqual(args)
+			expect(entries.filter((e) => e.type === "toolResult")).toHaveLength(1)
+		})
+
+		it("keeps the latest streamed rawInput in the single tool_use entry", () => {
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			// Args stream in across repeated in_progress notifications: partial
+			// first, complete later.
+			callbacks.onRawNotification?.(toolCallNotification("call-stream", "Shell command", "in_progress"))
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command" })
+			callbacks.onRawNotification?.(
+				toolCallUpdateNotification("call-stream", { status: "in_progress", rawInput: { command: "ls" } }),
+			)
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command" })
+			callbacks.onRawNotification?.(
+				toolCallUpdateNotification("call-stream", { status: "in_progress", rawInput: { command: "ls -la" } }),
+			)
+			callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-stream", { status: "completed", rawOutput: "ok" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command" })
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUseEntries = findToolUseEntries(entries)
+			expect(toolUseEntries).toHaveLength(1)
+			const toolUse = getToolUseContent(toolUseEntries[0])
+			expect(toolUse.input).toEqual({ command: "ls -la" })
+		})
+
+		it("writes one tool_use entry per completed tool call across sequential calls with the same name", () => {
+			const { callbacks: inner } = makeInnerCallbacks()
+			const { callbacks, setOutputPath } = streamRemoteToOutputFile(inner, "/cwd")
+			setOutputPath(outputPath, "agent-1")
+
+			for (const id of ["call-1", "call-2", "call-3"]) {
+				callbacks.onRawNotification?.(toolCallNotification(id, "Shell command", "in_progress"))
+				callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command", toolCallId: id })
+				callbacks.onToolActivity?.({ status: "in_progress", toolName: "Shell command", toolCallId: id })
+				callbacks.onRawNotification?.(toolCallUpdateNotification(id, { status: "completed", rawOutput: "ok" }))
+				callbacks.onToolActivity?.({ status: "completed", toolName: "Shell command", toolCallId: id })
+			}
+			callbacks.onTurnEnd?.(1)
+
+			const entries = parseEntries(readJsonl(outputPath))
+			const toolUseIds = findToolUseEntries(entries).map((e) => getToolUseContent(e).id)
+			expect(toolUseIds).toEqual(["call-1", "call-2", "call-3"])
+			expect(entries.filter((e) => e.type === "toolResult")).toHaveLength(3)
 		})
 	})
 
@@ -482,16 +592,19 @@ describe("streamRemoteToOutputFile", () => {
 			// Tool tracking is cleared — the next tool call starts clean
 			callbacks.onRawNotification?.(toolCallNotification("call-y", "New tool", "in_progress"))
 			callbacks.onToolActivity?.({ status: "in_progress", toolName: "New tool" })
+			callbacks.onRawNotification?.(toolCallUpdateNotification("call-y", { status: "completed", rawOutput: "ok" }))
+			callbacks.onToolActivity?.({ status: "completed", toolName: "New tool" })
 			callbacks.onTurnEnd?.(2)
 
 			const after = parseEntries(readJsonl(outputPath))
 			// No degraded title-only toolResult was written for the discarded
 			// pre-disconnect tool call — the recovery backfill supplies the tool's
 			// real output from session.jsonl.
-			expect(findToolResultEntry(after)).toBeUndefined()
+			expect(findToolResultEntry(after)).toBeDefined()
 			// Only the post-reattach tool call is present locally
-			const toolUses = after.filter((e) => e.type === "assistant").flatMap((e) => e.message.content)
-			expect(toolUses.filter((c) => c.type === "tool_use")).toHaveLength(1)
+			const toolUseEntries = findToolUseEntries(after)
+			expect(toolUseEntries).toHaveLength(1)
+			expect(getToolUseContent(toolUseEntries[0]).id).toBe("call-y")
 		})
 
 		it("keeps outputPath and agentId (subsequent flushes still write)", () => {

--- a/src/extensions/agents/manager/remote-output-file.ts
+++ b/src/extensions/agents/manager/remote-output-file.ts
@@ -74,6 +74,26 @@ export function streamRemoteToOutputFile(
 		pendingEntries = []
 	}
 
+	/** Writes the single tool_use transcript entry for a tool call. Deferred to
+	 *  completion/abort so repeated in_progress notifications don't duplicate it
+	 *  and its input carries the fully streamed args. The entry's id prefers the
+	 *  ACP toolCallId (so consumers can correlate tool_use and tool_result),
+	 *  falling back to the display title only if no id arrived (should not
+	 *  happen in practice — toolCallId is present from the first notification). */
+	const writeToolUseEntry = (toolCall: { title: string; toolCallId?: string }) => {
+		writeEntry("assistant", {
+			role: "assistant",
+			content: [
+				{
+					type: "tool_use",
+					name: toolCall.title,
+					id: toolCall.toolCallId ?? toolCall.title,
+					input: pendingRawInput ?? {},
+				},
+			],
+		})
+	}
+
 	const callbacks: AcpSessionCallbacks = {
 		onToolActivity: (activity) => {
 			if (activity.status === "in_progress") {
@@ -81,25 +101,20 @@ export function streamRemoteToOutputFile(
 					writeEntry("assistant", { role: "assistant", content: [{ type: "text", text: pendingAssistantText }] })
 					pendingAssistantText = ""
 				}
-				pendingToolCall = { title: activity.toolName, toolCallId: pendingRawInputId }
-				// Use the actual tool-call ID (from the ACP toolCallId) for the
-				// tool_use entry's id field so consumers can correlate tool_use and
-				// tool_result. Fall back to the display title only if no id arrived
-				// (should not happen in practice — toolCallId is present from the
-				// first tool_call notification).
-				writeEntry("assistant", {
-					role: "assistant",
-					content: [
-						{
-							type: "tool_use",
-							name: activity.toolName,
-							id: pendingRawInputId ?? activity.toolName,
-							input: pendingRawInput ?? {},
-						},
-					],
-				})
+				if (pendingToolCall === undefined) {
+					pendingToolCall = { title: activity.toolName, toolCallId: pendingRawInputId }
+				} else {
+					// Repeated in_progress for the same call — the ACP server re-sends
+					// these as args/title stream in, and cloud agents broadcast them
+					// periodically (~80ms) while a long-running tool executes. Only
+					// refresh the display title; a transcript entry per repeat would
+					// append thousands of identical tool_use lines to the .output
+					// file (observed: 29MB files, ~99% duplicate lines).
+					pendingToolCall.title = activity.toolName
+				}
 			}
 			if (activity.status !== "in_progress" && pendingToolCall) {
+				writeToolUseEntry(pendingToolCall)
 				const outputText =
 					pendingToolCall.rawOutput != null ? JSON.stringify(pendingToolCall.rawOutput) : activity.toolName
 				writeEntry("toolResult", { role: "tool", content: [{ type: "text", text: outputText }] })
@@ -114,8 +129,8 @@ export function streamRemoteToOutputFile(
 			}
 			// Forward to the activity tracker at most once per tool call: the ACP
 			// server re-sends in_progress notifications for the same toolCallId as
-			// args/title stream in. The transcript logic above must see every
-			// repeat (it refreshes the pending tool's title/args), but downstream
+			// args/title stream in. The transcript logic above tolerates every
+			// repeat (it refreshes the pending tool's title), but downstream
 			// consumers would stack a duplicate progress-line entry per repeat
 			// ("run_command, run_command, …").
 			if (activity.toolCallId) {
@@ -182,6 +197,9 @@ export function streamRemoteToOutputFile(
 			pendingAssistantText = ""
 		}
 		if (pendingToolCall) {
+			// The tool_use entry is deferred to completion — on abort it has not
+			// been written yet, so write it here with whatever input streamed in.
+			writeToolUseEntry(pendingToolCall)
 			const outputText =
 				pendingToolCall.rawOutput != null ? JSON.stringify(pendingToolCall.rawOutput) : pendingToolCall.title
 			writeEntry("toolResult", { role: "tool", content: [{ type: "text", text: outputText }] })

--- a/src/extensions/agents/manager/remote-output-file.ts
+++ b/src/extensions/agents/manager/remote-output-file.ts
@@ -76,10 +76,12 @@ export function streamRemoteToOutputFile(
 
 	/** Writes the single tool_use transcript entry for a tool call. Deferred to
 	 *  completion/abort so repeated in_progress notifications don't duplicate it
-	 *  and its input carries the fully streamed args. The entry's id prefers the
-	 *  ACP toolCallId (so consumers can correlate tool_use and tool_result),
-	 *  falling back to the display title only if no id arrived (should not
-	 *  happen in practice — toolCallId is present from the first notification). */
+	 *  and its input carries the fully streamed args. This means no entry exists
+	 *  for a call while it runs — live progress is surfaced via the forwarded
+	 *  activity callbacks, not this file. The entry's id prefers the ACP
+	 *  toolCallId (so consumers can correlate tool_use and tool_result), falling
+	 *  back to the display title only if no id arrived (should not happen in
+	 *  practice — toolCallId is present from the first notification). */
 	const writeToolUseEntry = (toolCall: { title: string; toolCallId?: string }) => {
 		writeEntry("assistant", {
 			role: "assistant",
@@ -94,6 +96,25 @@ export function streamRemoteToOutputFile(
 		})
 	}
 
+	/** Two channel ids refer to the same call when either side is missing
+	 *  (can't disprove identity) or they match. */
+	const sameCall = (a: string | undefined, b: string | undefined) => a === undefined || b === undefined || a === b
+
+	/** Finalizes the pending tool call: writes its single tool_use entry plus a
+	 *  toolResult (the real rawOutput if it arrived, otherwise the title as a
+	 *  degraded placeholder), then clears the pending state. Does NOT flush —
+	 *  the caller decides when to write to disk. */
+	const finalizePendingToolCall = () => {
+		if (!pendingToolCall) return
+		writeToolUseEntry(pendingToolCall)
+		const outputText =
+			pendingToolCall.rawOutput != null ? JSON.stringify(pendingToolCall.rawOutput) : pendingToolCall.title
+		writeEntry("toolResult", { role: "tool", content: [{ type: "text", text: outputText }] })
+		pendingToolCall = undefined
+		pendingRawInput = undefined
+		pendingRawInputId = undefined
+	}
+
 	const callbacks: AcpSessionCallbacks = {
 		onToolActivity: (activity) => {
 			if (activity.status === "in_progress") {
@@ -102,25 +123,33 @@ export function streamRemoteToOutputFile(
 					pendingAssistantText = ""
 				}
 				if (pendingToolCall === undefined) {
-					pendingToolCall = { title: activity.toolName, toolCallId: pendingRawInputId }
-				} else {
+					pendingToolCall = { title: activity.toolName, toolCallId: pendingRawInputId ?? activity.toolCallId }
+				} else if (sameCall(activity.toolCallId, pendingToolCall.toolCallId)) {
 					// Repeated in_progress for the same call — the ACP server re-sends
 					// these as args/title stream in, and cloud agents broadcast them
 					// periodically (~80ms) while a long-running tool executes. Only
-					// refresh the display title; a transcript entry per repeat would
+					// refresh the display state; a transcript entry per repeat would
 					// append thousands of identical tool_use lines to the .output
 					// file (observed: 29MB files, ~99% duplicate lines).
 					pendingToolCall.title = activity.toolName
+					pendingToolCall.toolCallId ??= activity.toolCallId
+				} else {
+					// A different tool call started before this one completed
+					// (parallel tool use, or a call abandoned without a completion
+					// event) — finalize the pending call with a degraded result so
+					// its entry keeps its own id and title, then start fresh.
+					finalizePendingToolCall()
+					pendingToolCall = { title: activity.toolName, toolCallId: pendingRawInputId ?? activity.toolCallId }
 				}
 			}
-			if (activity.status !== "in_progress" && pendingToolCall) {
-				writeToolUseEntry(pendingToolCall)
-				const outputText =
-					pendingToolCall.rawOutput != null ? JSON.stringify(pendingToolCall.rawOutput) : activity.toolName
-				writeEntry("toolResult", { role: "tool", content: [{ type: "text", text: outputText }] })
-				pendingToolCall = undefined
-				pendingRawInput = undefined
-				pendingRawInputId = undefined
+			// Ignores completions for a call that was already finalized via the
+			// mismatch path above (late completion of a parallel/abandoned call).
+			if (
+				activity.status !== "in_progress" &&
+				pendingToolCall &&
+				sameCall(activity.toolCallId, pendingToolCall.toolCallId)
+			) {
+				finalizePendingToolCall()
 				// Set textOffset so the next onTextDelta only shows text after this tool call.
 				// Use lastFullTextLength (not pendingAssistantText.length) because
 				// pendingAssistantText is cleared when the tool started.
@@ -169,9 +198,14 @@ export function streamRemoteToOutputFile(
 				// tool_call_update, but toolCallId is present from the first notification.
 				if (u.toolCallId != null) {
 					pendingRawInputId = u.toolCallId
-					if (pendingToolCall) pendingToolCall.toolCallId = u.toolCallId
+					// Attach state to the pending call only when it plausibly belongs
+					// to it — under parallel tool use, updates for a different call
+					// must not overwrite the pending call's id or output.
+					if (pendingToolCall && sameCall(pendingToolCall.toolCallId, u.toolCallId)) {
+						pendingToolCall.toolCallId = u.toolCallId
+					}
 				}
-				if (u.rawOutput != null && pendingToolCall) {
+				if (u.rawOutput != null && pendingToolCall && sameCall(pendingToolCall.toolCallId, u.toolCallId)) {
 					pendingToolCall.rawOutput = u.rawOutput
 				}
 				if (u.rawInput != null) {
@@ -196,17 +230,10 @@ export function streamRemoteToOutputFile(
 			writeEntry("assistant", { role: "assistant", content: [{ type: "text", text: pendingAssistantText }] })
 			pendingAssistantText = ""
 		}
-		if (pendingToolCall) {
-			// The tool_use entry is deferred to completion — on abort it has not
-			// been written yet, so write it here with whatever input streamed in.
-			writeToolUseEntry(pendingToolCall)
-			const outputText =
-				pendingToolCall.rawOutput != null ? JSON.stringify(pendingToolCall.rawOutput) : pendingToolCall.title
-			writeEntry("toolResult", { role: "tool", content: [{ type: "text", text: outputText }] })
-			pendingToolCall = undefined
-			pendingRawInput = undefined
-			pendingRawInputId = undefined
-		}
+		// The tool_use entry is deferred to completion — on abort it has not
+		// been written yet, so finalize writes it with whatever input
+		// streamed in before the abort.
+		finalizePendingToolCall()
 		flush()
 	}
 


### PR DESCRIPTION
## Linked issue

Fixes #1187

## What does this PR do?

Fixes the duplication of assistant `tool_use` entries in cloud agent transcript `.output` files. Cloud ACP servers re-broadcast the same `in_progress` tool activity (~80ms cadence) while a long-running tool executes, and every repeat was appended as a new transcript line — a 30-minute nested `Agent` call produced ~5,800 identical lines (observed: 29.5MB file, 99% duplicates).

**Fix** (`remote-output-file.ts`): the `tool_use` entry is written **once**, at tool completion (or abort), instead of at every `in_progress` notification. Repeats now only refresh the pending tool's display title. The duplicated write block is shared via a `writeToolUseEntry()` closure.

Side improvements from the deferred write:
- Args that stream in *after* start are captured in the entry (previously frozen as `{}` at start time).
- A `toolCallId` arriving in any update before completion is used for the entry id (previously fell back to the display title).

Behavioral note: the `tool_use` entry timestamp now reflects completion time rather than start time, matching the local writer's (`streamToOutputFile`) turn_end-deferred semantics. Consumers (`export-subagents`, the agents widget) read transcripts post-completion and are unaffected — tool_use/toolResult adjacency and ordering are preserved.

## Tests

- New "repeated in_progress dedup" regression block: 50× identical heartbeat repeats → exactly one `tool_use` + one `toolResult`; args updated across repeats keep the latest value; sequential same-name calls still produce one entry each.
- Updated tests whose expectations improved with the deferral (rawInput-after-start, toolCallId-in-later-update) and one `resetForReattach` test for the new flush timing.
- 20/20 file tests, 442/442 `src/extensions/agents` suite, `pnpm run check` (biome + tsc) clean.

Pre-existing observation flagged for follow-up (not this PR): `resetForReattach` does not clear `forwardedToolCalls`, so a re-forwarded `in_progress` for the same toolCallId after a WS reattach is suppressed from the activity tracker.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the CLA
- [x] This PR links to an open issue above
- [x] Tests pass locally (`pnpm run test`)
- [x] Lint passes (`pnpm run check`)
- [x] Documentation updated if behavior changed
