### PR TITLE
feat(acp): import_apply — perform a real import over ACP

### DIFF
--- a/src/agent-discovery/engine.test.ts
+++ b/src/agent-discovery/engine.test.ts
@@ -632,16 +632,41 @@ describe("discoverAgent engine", () => {
 				const skillsDir = join(tempDir, "locked")
 				mkdirSync(join(skillsDir, "alpha"), { recursive: true })
 				chmodSync(skillsDir, 0o000)
+				const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 				try {
 					const discovery = discoverAgent(makeDef({ skillsDirs: [skillsDir] }), { cwd: tempDir })
 					expect(discovery.skillsDir).toBe(skillsDir)
 					expect(discovery.skillCount).toBe(-1)
 					expect(discovery.skills).toEqual([])
+					// One root cause, one warning: enumeration is skipped when the
+					// listing already failed — loadSkillsFromDir would hit the same
+					// EACCES and emit a second, redundant diagnostic.
+					expect(warnSpy).toHaveBeenCalledTimes(1)
 				} finally {
+					warnSpy.mockRestore()
 					chmodSync(skillsDir, 0o700)
 				}
 			},
 		)
+
+		// S9b: count-only callers (telemetry snapshot, wizards) can skip the
+		// per-call frontmatter parsing — counts stay identical, enumeration is
+		// simply not performed.
+		it("S9b: enumerateSkills false skips frontmatter parsing — counts without enumerating", () => {
+			const skillsDir = join(tempDir, "skills")
+			writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship the service")
+			writeSkill(skillsDir, "review", "description: Review the diff")
+			const def = makeDef({ skillsDirs: [skillsDir] })
+
+			const enumerated = discoverAgent(def)
+			expect(enumerated.skillCount).toBe(2)
+			expect(enumerated.skills).toHaveLength(2)
+
+			const countOnly = discoverAgent(def, { enumerateSkills: false })
+			expect(countOnly.skillCount).toBe(2)
+			// Frontmatter is never parsed — no enumerated names, no path work.
+			expect(countOnly.skills).toEqual([])
+		})
 
 		// S10: process.cwd() throws ENOENT (uv_cwd) when the working directory
 		// has been deleted out from under a long-lived process. "home" scope

--- a/src/agent-discovery/engine.ts
+++ b/src/agent-discovery/engine.ts
@@ -67,6 +67,14 @@ export interface DiscoverAgentOptions {
 	 * long-lived process sees the caller's current directory.
 	 */
 	readonly cwd?: string
+	/**
+	 * Whether to fully enumerate skills (parse every SKILL.md frontmatter).
+	 * Defaults to `true`. Callers that only need `skillCount`/`skillsDir`
+	 * (telemetry snapshot, setup/skills wizards) can pass `false` to skip the
+	 * per-call frontmatter parsing cost that otherwise lands on every
+	 * discovery — bounded by skill count, but recurring for those callers.
+	 */
+	readonly enumerateSkills?: boolean
 }
 
 /**
@@ -187,6 +195,7 @@ export function discoverAgent(def: AgentDefinition, options?: DiscoverAgentOptio
 	for (const dir of skillsDirs) {
 		if (existsSync(dir)) {
 			skillsDir = dir
+			let readable = true
 			try {
 				skillCount = readdirSync(dir, { withFileTypes: true }).filter((e) => e.isDirectory()).length
 			} catch (err) {
@@ -196,8 +205,14 @@ export function discoverAgent(def: AgentDefinition, options?: DiscoverAgentOptio
 				// the client must be able to tell "nothing here" from "couldn't
 				// read what is here".
 				skillCount = -1
+				readable = false
 			}
-			skills = enumerateSkills(dir)
+			// Skip enumeration when the listing already failed — loadSkillsFromDir
+			// would hit the same EACCES and emit a second, redundant warning for
+			// one root cause. Also skipped when the caller only needs counts.
+			if (readable && (options?.enumerateSkills ?? true)) {
+				skills = enumerateSkills(dir)
+			}
 			break
 		}
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -510,9 +510,10 @@ export function writeJsonObjectFile(path: string, value: Record<string, unknown>
 	const tmp = `${path}.${process.pid}.tmp`
 	writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf-8")
 	renameSync(tmp, path)
-	// Restrict to owner-only (0600) — config.json holds the Cast AI API key and
-	// git tokens in plaintext. The atomic rename may inherit the tmp file's
-	// default umask perms, so chmod explicitly after the rename lands.
+	// Restrict to owner-only (0600) — every caller writes a file that holds
+	// plaintext credentials or user state, and the atomic rename may inherit
+	// the tmp file's default umask perms, so chmod explicitly after the rename
+	// lands.
 	chmodSync(path, 0o600)
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { dirname, join, relative, resolve } from "node:path"
 import type { RetrySettings } from "@earendil-works/pi-coding-agent"
 import { getVersion } from "./utils.js"
 
-const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
+export const KIMCHI_CONFIG_PATH = resolve(homedir(), ".config", "kimchi", "config.json")
 const AGENT_CONFIG_DIR = resolve(homedir(), ".config", "kimchi", "harness")
 const KIMCHI_LLM_ENDPOINT = "https://llm.kimchi.dev/openai/v1"
 const DEFAULT_TELEMETRY_LOGS_ENDPOINT = "https://api.cast.ai/ai-optimizer/v1beta/logs:ingest"

--- a/src/config.ts
+++ b/src/config.ts
@@ -494,15 +494,30 @@ export function getAgentConfigDir(): string {
 	return AGENT_CONFIG_DIR
 }
 
-function writeConfigObject(configPath: string, raw: Record<string, unknown>): void {
-	mkdirSync(dirname(configPath), { recursive: true })
-	const tmp = `${configPath}.${process.pid}.tmp`
-	writeFileSync(tmp, `${JSON.stringify(raw, null, 2)}\n`, "utf-8")
-	renameSync(tmp, configPath)
+/**
+ * Write a JSON object file atomically: mkdir the parent, write a same-dir tmp
+ * file, rename it into place, and restrict the result to owner-only (0600).
+ * The rename may inherit the tmp file's default umask perms, so chmod
+ * explicitly after the rename lands.
+ *
+ * Shared home of the repo's config-write idiom: every caller writes a file
+ * that holds plaintext credentials or user state (config.json carries the
+ * Cast AI API key and git tokens; the harness mcp.json carries imported
+ * server env/headers), so owner-only is the safe default for all of them.
+ */
+export function writeJsonObjectFile(path: string, value: Record<string, unknown>): void {
+	mkdirSync(dirname(path), { recursive: true })
+	const tmp = `${path}.${process.pid}.tmp`
+	writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf-8")
+	renameSync(tmp, path)
 	// Restrict to owner-only (0600) — config.json holds the Cast AI API key and
 	// git tokens in plaintext. The atomic rename may inherit the tmp file's
 	// default umask perms, so chmod explicitly after the rename lands.
-	chmodSync(configPath, 0o600)
+	chmodSync(path, 0o600)
+}
+
+function writeConfigObject(configPath: string, raw: Record<string, unknown>): void {
+	writeJsonObjectFile(configPath, raw)
 }
 
 function updateConfigFile(

--- a/src/extensions/mcp-adapter/index.test.ts
+++ b/src/extensions/mcp-adapter/index.test.ts
@@ -170,7 +170,7 @@ describe("mcp proxy registration gate", () => {
 				await pi.fireShutdown()
 			}
 		} finally {
-			delete mcpConfigState.config.settings
+			mcpConfigState.config.settings = undefined
 		}
 	})
 })

--- a/src/extensions/mcp-adapter/index.test.ts
+++ b/src/extensions/mcp-adapter/index.test.ts
@@ -170,7 +170,9 @@ describe("mcp proxy registration gate", () => {
 				await pi.fireShutdown()
 			}
 		} finally {
-			mcpConfigState.config.settings = undefined
+			// Preserve the original removal semantics (the key must be absent,
+			// not present-with-undefined) without tripping lint/performance/noDelete.
+			Reflect.deleteProperty(mcpConfigState.config, "settings")
 		}
 	})
 })

--- a/src/extensions/permissions/prompts.test.ts
+++ b/src/extensions/permissions/prompts.test.ts
@@ -108,6 +108,7 @@ describe("promptForCompoundApproval", () => {
 	const commands = [{ command: "git status" }, { command: "ls -la" }]
 
 	it("returns deny when ctx.hasUI is false", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
 		const ctx = { hasUI: false } as any
 		const result = await promptForCompoundApproval({ toolName: "bash", commands, ctx })
 		expect(result).toEqual({ kind: "deny" })

--- a/src/extensions/telemetry/config-snapshot.ts
+++ b/src/extensions/telemetry/config-snapshot.ts
@@ -99,7 +99,7 @@ function getDefaultPermissionMode(): string {
 function countMcpServers(): number {
 	let count = 0
 	for (const def of AGENT_DEFINITIONS) {
-		count += Object.keys(discoverAgent(def).mcpServers).length
+		count += Object.keys(discoverAgent(def, { enumerateSkills: false }).mcpServers).length
 	}
 	return count
 }

--- a/src/modes/acp/capabilities.ts
+++ b/src/modes/acp/capabilities.ts
@@ -9,8 +9,8 @@ export const CAPABILITIES_KEY = "kimchi.dev"
 // Direction:
 // - pi_* methods are agent→client (the agent calls conn.extMethod on the client).
 // - probe_mcp_server, set_session_title, steering, auth_status,
-//   import_discover, and set_onboarding_flag are client→agent inbound (the
-//   agent's extMethod() handler receives them).
+//   import_discover, import_apply, and set_onboarding_flag are client→agent
+//   inbound (the agent's extMethod() handler receives them).
 //
 // Capability advertising: every entry here is exposed in
 // `_meta["kimchi.dev"][<key>] === true` so clients can discover the methods
@@ -23,6 +23,7 @@ export const AVAILABLE_EXT_METHODS = {
 	auth_status: `_${CAPABILITIES_KEY}/auth_status`,
 	import_discover: `_${CAPABILITIES_KEY}/import_discover`,
 	set_onboarding_flag: `_${CAPABILITIES_KEY}/set_onboarding_flag`,
+	import_apply: `_${CAPABILITIES_KEY}/import_apply`,
 } as const
 
 export const AVAILABLE_EXT_NOTIFICATIONS = {

--- a/src/modes/acp/ext-methods/import-apply.test.ts
+++ b/src/modes/acp/ext-methods/import-apply.test.ts
@@ -11,6 +11,9 @@ import { handleImportApply } from "./import-apply.js"
 /** Path fragment that makes cpSync throw; set per-test, empty by default. */
 const failCopy = vi.hoisted(() => ({ pattern: "" }))
 
+/** When true, the completion writes (skillPaths + migration marker) throw. */
+const failConfigWrite = vi.hoisted(() => ({ fail: false }))
+
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>()
 	return {
@@ -18,6 +21,21 @@ vi.mock("node:fs", async (importOriginal) => {
 		cpSync: (src: string, dest: string, opts?: object) => {
 			if (failCopy.pattern && src.includes(failCopy.pattern)) throw new Error("simulated copy failure")
 			return actual.cpSync(src, dest, opts)
+		},
+	}
+})
+
+vi.mock("../../../config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../config.js")>()
+	return {
+		...actual,
+		writeSkillPaths: (paths: string[], configPath?: string) => {
+			if (failConfigWrite.fail) throw new Error("simulated config write failure")
+			return actual.writeSkillPaths(paths, configPath)
+		},
+		writeMigrationState: (state: Parameters<typeof actual.writeMigrationState>[0], configPath?: string) => {
+			if (failConfigWrite.fail) throw new Error("simulated config write failure")
+			return actual.writeMigrationState(state, configPath)
 		},
 	}
 })
@@ -197,7 +215,8 @@ describe("import_apply", () => {
 				kind: "skill",
 				sourceAppId: "claude-code",
 				path: gonePath,
-				name: "",
+				// Identified by source app + path; the client already knows the
+				// name from discover, so none is echoed.
 				outcome: "skipped",
 				reason: "not found at apply time",
 			},
@@ -316,6 +335,120 @@ describe("import_apply", () => {
 		expect(mcpConfig.mcpServers["studio-connector"]).toEqual(connectorEntry)
 		expect(mcpConfig.settings).toEqual({ toolPrefix: "server" })
 		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "fetchy" })
+	})
+
+	it("writes mcp.json owner-only (0600) — imported entries carry plaintext credentials", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(
+			config,
+			JSON.stringify({ mcpServers: { fetch: { command: "fetchy", env: { TOKEN: "t" } } } }),
+			"utf-8",
+		)
+
+		apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		const mcpJson = join(agentDir, "mcp.json")
+		expect(existsSync(mcpJson)).toBe(true)
+		// Same hardening config.ts applies to config.json (API key, git tokens):
+		// the rename may inherit umask perms, so the mode must be tightened
+		// explicitly.
+		expect(statSync(mcpJson).mode & 0o777).toBe(0o600)
+	})
+
+	it("cannot import an MCP server entry discover would never report (no command and no url)", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { broken: { args: ["--x"] } } }), "utf-8")
+
+		const result = apply({ mcpServers: [{ sourceAppId: "claude-code", name: "broken" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		// import_discover drops this entry, so apply must not accept it by name
+		// either — the two methods agree on what a selectable server is.
+		expect(result.results).toEqual([
+			{
+				kind: "mcpServer",
+				sourceAppId: "claude-code",
+				name: "broken",
+				outcome: "skipped",
+				reason: "not found at apply time",
+			},
+		])
+		expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
+	})
+
+	it("starts fresh when the existing mcp.json is corrupt, and still imports", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { fetch: { command: "fetchy" } } }), "utf-8")
+		const mcpJson = join(agentDir, "mcp.json")
+		mkdirSync(agentDir, { recursive: true })
+		writeFileSync(mcpJson, "{ not json", "utf-8")
+
+		const result = apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		expect(result.results).toEqual([
+			{ kind: "mcpServer", sourceAppId: "claude-code", name: "fetch", outcome: "imported" },
+		])
+		const mcpConfig = JSON.parse(readFileSync(mcpJson, "utf-8")) as { mcpServers: Record<string, ServerEntry> }
+		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "fetchy" })
+	})
+
+	it("reports persistence failures as warnings and still returns the per-item results", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship")
+
+		failConfigWrite.fail = true
+		try {
+			const result = apply({ skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }] }, [
+				makeDef({ id: "claude-code", skillsDirs: [skillsDir] }),
+			])
+
+			// Partial outcomes are reported, not hidden: the skill landed and the
+			// client hears about it, with a warning naming what could not persist.
+			expect(result.results).toEqual([
+				{
+					kind: "skill",
+					sourceAppId: "claude-code",
+					path: join(skillsDir, "deploy", "SKILL.md"),
+					name: "deploy",
+					outcome: "imported",
+				},
+			])
+			expect(result.warnings).toEqual([
+				"Failed to persist skill paths: simulated config write failure",
+				"Failed to persist the migration marker: simulated config write failure",
+			])
+		} finally {
+			failConfigWrite.fail = false
+		}
+	})
+
+	it("sets the migration marker even when the batch contained an error item", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "first", "name: first\ndescription: Lands fine")
+		writeSkill(skillsDir, "second", "name: second\ndescription: Copy explodes")
+
+		failCopy.pattern = "second"
+		try {
+			apply(
+				{
+					skills: [
+						{ sourceAppId: "claude-code", path: join(skillsDir, "first", "SKILL.md") },
+						{ sourceAppId: "claude-code", path: join(skillsDir, "second", "SKILL.md") },
+					],
+				},
+				[makeDef({ id: "claude-code", skillsDirs: [skillsDir] })],
+			)
+
+			const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { migrationState?: string }
+			expect(stored.migrationState).toBe("done")
+		} finally {
+			failCopy.pattern = ""
+		}
 	})
 
 	it("merges stored skill paths instead of replacing them — a hand-added custom path survives", () => {

--- a/src/modes/acp/ext-methods/import-apply.test.ts
+++ b/src/modes/acp/ext-methods/import-apply.test.ts
@@ -376,6 +376,29 @@ describe("import_apply", () => {
 				reason: "not found at apply time",
 			},
 		])
+	expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
+	})
+
+	it("cannot import an MCP server whose command/url are empty strings — the same falsy rule as discover", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { empty: { command: "" }, blank: { url: "" } } }), "utf-8")
+
+		const result = apply(
+			{
+				mcpServers: [
+					{ sourceAppId: "claude-code", name: "empty" },
+					{ sourceAppId: "claude-code", name: "blank" },
+				],
+			},
+			[makeDef({ id: "claude-code", configPaths: [config] })],
+		)
+
+		// import_discover treats an empty-string command/url as just as
+		// unactionable as an absent one (falsy check), so apply must too.
+		expect(result.results).toEqual([
+			{ kind: "mcpServer", sourceAppId: "claude-code", name: "empty", outcome: "skipped", reason: "not found at apply time" },
+			{ kind: "mcpServer", sourceAppId: "claude-code", name: "blank", outcome: "skipped", reason: "not found at apply time" },
+		])
 		expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
 	})
 

--- a/src/modes/acp/ext-methods/import-apply.test.ts
+++ b/src/modes/acp/ext-methods/import-apply.test.ts
@@ -376,7 +376,7 @@ describe("import_apply", () => {
 				reason: "not found at apply time",
 			},
 		])
-	expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
+		expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
 	})
 
 	it("cannot import an MCP server whose command/url are empty strings — the same falsy rule as discover", () => {
@@ -396,8 +396,20 @@ describe("import_apply", () => {
 		// import_discover treats an empty-string command/url as just as
 		// unactionable as an absent one (falsy check), so apply must too.
 		expect(result.results).toEqual([
-			{ kind: "mcpServer", sourceAppId: "claude-code", name: "empty", outcome: "skipped", reason: "not found at apply time" },
-			{ kind: "mcpServer", sourceAppId: "claude-code", name: "blank", outcome: "skipped", reason: "not found at apply time" },
+			{
+				kind: "mcpServer",
+				sourceAppId: "claude-code",
+				name: "empty",
+				outcome: "skipped",
+				reason: "not found at apply time",
+			},
+			{
+				kind: "mcpServer",
+				sourceAppId: "claude-code",
+				name: "blank",
+				outcome: "skipped",
+				reason: "not found at apply time",
+			},
 		])
 		expect(existsSync(join(agentDir, "mcp.json"))).toBe(false)
 	})

--- a/src/modes/acp/ext-methods/import-apply.test.ts
+++ b/src/modes/acp/ext-methods/import-apply.test.ts
@@ -14,6 +14,9 @@ const failCopy = vi.hoisted(() => ({ pattern: "" }))
 /** When true, the completion writes (skillPaths + migration marker) throw. */
 const failConfigWrite = vi.hoisted(() => ({ fail: false }))
 
+/** Path fragment that makes writeJsonObjectFile throw; set per-test, empty by default. */
+const failJsonWrite = vi.hoisted(() => ({ pattern: "" }))
+
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>()
 	return {
@@ -36,6 +39,11 @@ vi.mock("../../../config.js", async (importOriginal) => {
 		writeMigrationState: (state: Parameters<typeof actual.writeMigrationState>[0], configPath?: string) => {
 			if (failConfigWrite.fail) throw new Error("simulated config write failure")
 			return actual.writeMigrationState(state, configPath)
+		},
+		writeJsonObjectFile: (path: string, value: Record<string, unknown>) => {
+			if (failJsonWrite.pattern && path.includes(failJsonWrite.pattern))
+				throw new Error("simulated mcp config write failure")
+			return actual.writeJsonObjectFile(path, value)
 		},
 	}
 })
@@ -430,6 +438,74 @@ describe("import_apply", () => {
 		])
 		const mcpConfig = JSON.parse(readFileSync(mcpJson, "utf-8")) as { mcpServers: Record<string, ServerEntry> }
 		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "fetchy" })
+	})
+
+	it("starts fresh when mcpServers is a non-object (parses but corrupt), without persisting garbage", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { fetch: { command: "fetchy" } } }), "utf-8")
+		const mcpJson = join(agentDir, "mcp.json")
+		mkdirSync(agentDir, { recursive: true })
+		// Parses fine but mcpServers is a scalar: object-spreading it would
+		// write garbage numeric keys back into the user's mcp.json.
+		writeFileSync(mcpJson, JSON.stringify({ mcpServers: "oops", settings: { toolPrefix: "server" } }), "utf-8")
+
+		const result = apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		expect(result.results).toEqual([
+			{ kind: "mcpServer", sourceAppId: "claude-code", name: "fetch", outcome: "imported" },
+		])
+		const mcpConfig = JSON.parse(readFileSync(mcpJson, "utf-8")) as {
+			mcpServers: Record<string, ServerEntry>
+			settings?: unknown
+		}
+		expect(mcpConfig.mcpServers).toEqual({ fetch: { command: "fetchy" } })
+		// Sibling top-level keys survive the recovery.
+		expect(mcpConfig.settings).toEqual({ toolPrefix: "server" })
+	})
+
+	it("downgrades imported MCP servers to error with a warning when the mcp.json write fails", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { fetch: { command: "fetchy" } } }), "utf-8")
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship")
+
+		failJsonWrite.pattern = "mcp.json"
+		try {
+			const result = apply(
+				{
+					skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }],
+					mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }],
+				},
+				[makeDef({ id: "claude-code", configPaths: [config], skillsDirs: [skillsDir] })],
+			)
+
+			// The skill landed; the MCP server did not — reported honestly.
+			expect(result.results).toEqual([
+				{
+					kind: "skill",
+					sourceAppId: "claude-code",
+					path: join(skillsDir, "deploy", "SKILL.md"),
+					name: "deploy",
+					outcome: "imported",
+				},
+				{
+					kind: "mcpServer",
+					sourceAppId: "claude-code",
+					name: "fetch",
+					outcome: "error",
+					reason: "MCP config write failed: simulated mcp config write failure",
+				},
+			])
+			expect(result.warnings).toEqual(["Failed to persist the MCP config: simulated mcp config write failure"])
+			// The completion writes still ran — the marker is set, so the
+			// terminal wizard does not re-ask despite the partial import.
+			const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { migrationState?: string }
+			expect(stored.migrationState).toBe("done")
+		} finally {
+			failJsonWrite.pattern = ""
+		}
 	})
 
 	it("reports persistence failures as warnings and still returns the per-item results", () => {

--- a/src/modes/acp/ext-methods/import-apply.test.ts
+++ b/src/modes/acp/ext-methods/import-apply.test.ts
@@ -1,0 +1,379 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { loadSkillsFromDir } from "@earendil-works/pi-coding-agent"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { AgentDefinition, DirCandidate } from "../../../agent-discovery/index.js"
+import type { ServerEntry } from "../../../extensions/mcp-adapter/types.js"
+import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "../capabilities.js"
+import { handleImportApply } from "./import-apply.js"
+
+/** Path fragment that makes cpSync throw; set per-test, empty by default. */
+const failCopy = vi.hoisted(() => ({ pattern: "" }))
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>()
+	return {
+		...actual,
+		cpSync: (src: string, dest: string, opts?: object) => {
+			if (failCopy.pattern && src.includes(failCopy.pattern)) throw new Error("simulated copy failure")
+			return actual.cpSync(src, dest, opts)
+		},
+	}
+})
+
+/**
+ * A minimal source-app definition for driving handleImportApply against real
+ * temporary directory trees (same shape as the import_discover tests' makeDef).
+ */
+function makeDef(overrides?: {
+	id?: string
+	displayName?: string
+	configPaths?: string[]
+	skillsDirs?: DirCandidate[]
+}): AgentDefinition {
+	return {
+		id: overrides?.id ?? "test-agent",
+		displayName: overrides?.displayName ?? "Test Agent",
+		configPaths: overrides?.configPaths ?? [],
+		skillsDirs: overrides?.skillsDirs ?? [],
+		commandsDirs: [],
+		extractServerSources: (parsed: unknown) => {
+			if (!parsed || typeof parsed !== "object") return []
+			const root = parsed as Record<string, unknown>
+			if (root.mcpServers && typeof root.mcpServers === "object" && !Array.isArray(root.mcpServers)) {
+				return [root.mcpServers as Record<string, unknown>]
+			}
+			return []
+		},
+		transformServer: (raw: unknown) => {
+			if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined
+			return raw as ServerEntry
+		},
+	}
+}
+
+function writeSkill(
+	skillsDir: string,
+	name: string,
+	frontmatter: string,
+	extraFile?: { name: string; body: string },
+): void {
+	mkdirSync(join(skillsDir, name), { recursive: true })
+	writeFileSync(join(skillsDir, name, "SKILL.md"), `---\n${frontmatter}\n---\nBody.\n`, "utf-8")
+	if (extraFile) {
+		writeFileSync(join(skillsDir, name, extraFile.name), extraFile.body, "utf-8")
+	}
+}
+
+/** Recursive listing of every path in a tree, for byte-for-byte / unchanged assertions. */
+function snapshotTree(root: string): string[] {
+	const out: string[] = []
+	const walk = (dir: string, prefix: string): void => {
+		for (const entry of readdirSync(dir)) {
+			const rel = prefix ? `${prefix}/${entry}` : entry
+			out.push(rel)
+			if (statSync(join(dir, entry)).isDirectory()) walk(join(dir, entry), rel)
+		}
+	}
+	walk(root, "")
+	return out.sort()
+}
+
+describe("import_apply", () => {
+	let tempDir: string
+	let agentDir: string
+	let configPath: string
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "kimchi-import-apply-"))
+		agentDir = join(tempDir, "agent")
+		configPath = join(tempDir, "config.json")
+	})
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true })
+	})
+
+	function apply(
+		params: {
+			skills?: Array<{ sourceAppId: string; path: string }>
+			mcpServers?: Array<{ sourceAppId: string; name: string }>
+		},
+		defs: AgentDefinition[],
+	) {
+		return handleImportApply({ agentDir, configPath, definitions: defs }, params)
+	}
+
+	it("copies each selected skill into Kimchi's own skills directory with its tree intact, and it is then discoverable", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship the service", {
+			name: "helpers.txt",
+			body: "reference material",
+		})
+
+		const result = apply({ skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }] }, [
+			makeDef({ id: "claude-code", skillsDirs: [skillsDir] }),
+		])
+
+		expect(result.results).toEqual([
+			{
+				kind: "skill",
+				sourceAppId: "claude-code",
+				path: join(skillsDir, "deploy", "SKILL.md"),
+				name: "deploy",
+				outcome: "imported",
+			},
+		])
+
+		const copiedSkillMd = join(agentDir, "skills", "deploy", "SKILL.md")
+		expect(existsSync(copiedSkillMd)).toBe(true)
+		expect(readFileSync(copiedSkillMd, "utf-8")).toBe(readFileSync(join(skillsDir, "deploy", "SKILL.md"), "utf-8"))
+		expect(readFileSync(join(agentDir, "skills", "deploy", "helpers.txt"), "utf-8")).toBe("reference material")
+
+		// Discoverable by the harness: the copied skill loads under the same
+		// invocation name and description.
+		const { skills } = loadSkillsFromDir({ dir: join(agentDir, "skills"), source: join(agentDir, "skills") })
+		expect(skills.map((s) => ({ name: s.name, description: s.description }))).toEqual([
+			{ name: "deploy", description: "Ship the service" },
+		])
+	})
+
+	it("never adds a source app's directory to the stored skill paths", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship")
+
+		apply({ skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }] }, [
+			makeDef({ id: "claude-code", skillsDirs: [skillsDir] }),
+		])
+
+		const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { skillPaths?: string[] }
+		expect(stored.skillPaths).not.toContain(skillsDir)
+		// The skills phase of the terminal wizard must not re-arm either: the
+		// key is set even though the user never ran the wizard.
+		expect(Array.isArray(stored.skillPaths)).toBe(true)
+	})
+
+	it("skips a skill whose destination name already exists in Kimchi, leaving the existing one byte-for-byte unchanged", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Source version")
+		const destDir = join(agentDir, "skills", "deploy")
+		mkdirSync(destDir, { recursive: true })
+		writeFileSync(
+			join(destDir, "SKILL.md"),
+			"---\nname: deploy\ndescription: Existing Kimchi work\n---\nKeep me.\n",
+			"utf-8",
+		)
+		writeFileSync(join(destDir, "notes.txt"), "precious", "utf-8")
+
+		const before = snapshotTree(destDir)
+
+		const result = apply({ skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }] }, [
+			makeDef({ id: "claude-code", skillsDirs: [skillsDir] }),
+		])
+
+		expect(result.results).toEqual([
+			{
+				kind: "skill",
+				sourceAppId: "claude-code",
+				path: join(skillsDir, "deploy", "SKILL.md"),
+				name: "deploy",
+				outcome: "skipped",
+				reason: "already installed",
+			},
+		])
+		expect(snapshotTree(destDir)).toEqual(before)
+		expect(readFileSync(join(destDir, "SKILL.md"), "utf-8")).toContain("Existing Kimchi work")
+		expect(readFileSync(join(destDir, "notes.txt"), "utf-8")).toBe("precious")
+	})
+
+	it("skips a selected skill whose source has disappeared since discovery, and the call still succeeds", () => {
+		const gonePath = join(tempDir, "vanished-skills", "ghost", "SKILL.md")
+
+		const result = apply({ skills: [{ sourceAppId: "claude-code", path: gonePath }] }, [makeDef({ id: "claude-code" })])
+
+		expect(result.results).toEqual([
+			{
+				kind: "skill",
+				sourceAppId: "claude-code",
+				path: gonePath,
+				name: "",
+				outcome: "skipped",
+				reason: "not found at apply time",
+			},
+		])
+		expect(existsSync(agentDir)).toBe(false)
+	})
+
+	it("a failing item is reported as an error and does not prevent the remaining items from being written", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "first", "name: first\ndescription: Lands fine")
+		writeSkill(skillsDir, "second", "name: second\ndescription: Copy explodes")
+
+		// Make cpSync throw for the second skill's source only.
+		failCopy.pattern = "second"
+		try {
+			const result = apply(
+				{
+					skills: [
+						{ sourceAppId: "claude-code", path: join(skillsDir, "first", "SKILL.md") },
+						{ sourceAppId: "claude-code", path: join(skillsDir, "second", "SKILL.md") },
+					],
+				},
+				[makeDef({ id: "claude-code", skillsDirs: [skillsDir] })],
+			)
+
+			expect(result.results).toEqual([
+				{
+					kind: "skill",
+					sourceAppId: "claude-code",
+					path: join(skillsDir, "first", "SKILL.md"),
+					name: "first",
+					outcome: "imported",
+				},
+				{
+					kind: "skill",
+					sourceAppId: "claude-code",
+					path: join(skillsDir, "second", "SKILL.md"),
+					name: "second",
+					outcome: "error",
+					reason: "simulated copy failure",
+				},
+			])
+			expect(existsSync(join(agentDir, "skills", "first", "SKILL.md"))).toBe(true)
+			expect(existsSync(join(agentDir, "skills", "second"))).toBe(false)
+		} finally {
+			failCopy.pattern = ""
+		}
+	})
+
+	it("adds selected MCP servers to Kimchi's MCP config with their full entries", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(
+			config,
+			JSON.stringify({ mcpServers: { fetch: { command: "fetchy", args: ["--fast"], env: { TOKEN: "t" } } } }),
+			"utf-8",
+		)
+
+		const result = apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		expect(result.results).toEqual([
+			{ kind: "mcpServer", sourceAppId: "claude-code", name: "fetch", outcome: "imported" },
+		])
+		const mcpConfig = JSON.parse(readFileSync(join(agentDir, "mcp.json"), "utf-8")) as {
+			mcpServers: Record<string, ServerEntry>
+		}
+		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "fetchy", args: ["--fast"], env: { TOKEN: "t" } })
+	})
+
+	it("preserves an MCP server already present under the same name, and the imported one is not written", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { fetch: { command: "fetchy" } } }), "utf-8")
+		const mcpJson = join(agentDir, "mcp.json")
+		mkdirSync(agentDir, { recursive: true })
+		writeFileSync(mcpJson, JSON.stringify({ mcpServers: { fetch: { command: "mine" } } }), "utf-8")
+
+		const result = apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		expect(result.results).toEqual([
+			{
+				kind: "mcpServer",
+				sourceAppId: "claude-code",
+				name: "fetch",
+				outcome: "skipped",
+				reason: "already configured",
+			},
+		])
+		const mcpConfig = JSON.parse(readFileSync(mcpJson, "utf-8")) as { mcpServers: Record<string, ServerEntry> }
+		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "mine" })
+	})
+
+	it("leaves prefixed connector entries in the MCP config unchanged", () => {
+		const config = join(tempDir, "claude.json")
+		writeFileSync(config, JSON.stringify({ mcpServers: { fetch: { command: "fetchy" } } }), "utf-8")
+		const mcpJson = join(agentDir, "mcp.json")
+		mkdirSync(agentDir, { recursive: true })
+		const connectorEntry = { url: "https://studio.kimchi.dev/mcp", headers: { Authorization: "Bearer s" } }
+		writeFileSync(
+			mcpJson,
+			JSON.stringify({ mcpServers: { "studio-connector": connectorEntry }, settings: { toolPrefix: "server" } }),
+			"utf-8",
+		)
+
+		apply({ mcpServers: [{ sourceAppId: "claude-code", name: "fetch" }] }, [
+			makeDef({ id: "claude-code", configPaths: [config] }),
+		])
+
+		const mcpConfig = JSON.parse(readFileSync(mcpJson, "utf-8")) as {
+			mcpServers: Record<string, ServerEntry>
+			settings?: unknown
+		}
+		// The prefixed entry and sibling settings survive the import untouched.
+		expect(mcpConfig.mcpServers["studio-connector"]).toEqual(connectorEntry)
+		expect(mcpConfig.settings).toEqual({ toolPrefix: "server" })
+		expect(mcpConfig.mcpServers.fetch).toEqual({ command: "fetchy" })
+	})
+
+	it("merges stored skill paths instead of replacing them — a hand-added custom path survives", () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({ skillPaths: ["/my/custom/skills", ".config/kimchi/harness/skills"] }),
+			"utf-8",
+		)
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship")
+
+		apply({ skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }] }, [
+			makeDef({ id: "claude-code", skillsDirs: [skillsDir] }),
+		])
+
+		const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { skillPaths?: string[] }
+		expect(stored.skillPaths).toContain("/my/custom/skills")
+		expect(stored.skillPaths).toContain(".config/kimchi/harness/skills")
+	})
+
+	it("sets the migration marker on completion, including when the batch contained skipped items", () => {
+		const skillsDir = join(tempDir, "claude-skills")
+		writeSkill(skillsDir, "deploy", "name: deploy\ndescription: Ship")
+		const destDir = join(agentDir, "skills", "deploy")
+		writeSkill(destDir, "unused", "name: deploy\ndescription: Already here")
+
+		apply(
+			{
+				skills: [{ sourceAppId: "claude-code", path: join(skillsDir, "deploy", "SKILL.md") }],
+				mcpServers: [{ sourceAppId: "claude-code", name: "vanished" }],
+			},
+			[makeDef({ id: "claude-code", skillsDirs: [skillsDir] })],
+		)
+
+		const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { migrationState?: string }
+		expect(stored.migrationState).toBe("done")
+	})
+
+	it("completes with an empty selection, still satisfying the migration marker", () => {
+		const result = apply({}, [makeDef({ id: "claude-code" })])
+
+		expect(result.results).toEqual([])
+		const stored = JSON.parse(readFileSync(configPath, "utf-8")) as { migrationState?: string }
+		expect(stored.migrationState).toBe("done")
+	})
+
+	it("rejects malformed selections with invalid params", () => {
+		const badSkill = { sourceAppId: 42, path: "/x" } as unknown as { sourceAppId: string; path: string }
+		const emptyName = { sourceAppId: "a", name: "" } as unknown as { sourceAppId: string; name: string }
+		expect(() => apply({ skills: [badSkill] }, [])).toThrow(/sourceAppId/)
+		expect(() => apply({ mcpServers: [emptyName] }, [])).toThrow(/name/)
+		expect(() => apply({ skills: "nope" as unknown as Array<{ sourceAppId: string; path: string }> }, [])).toThrow(
+			/must be an array/,
+		)
+	})
+
+	it("registers and advertises the import_apply capability", () => {
+		expect(AVAILABLE_EXT_METHODS.import_apply).toBe(`_${CAPABILITIES_KEY}/import_apply`)
+		expect(ADVERTISED_CAPABILITIES.import_apply).toBe(true)
+	})
+})

--- a/src/modes/acp/ext-methods/import-apply.ts
+++ b/src/modes/acp/ext-methods/import-apply.ts
@@ -1,0 +1,326 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { basename, dirname, join, resolve } from "node:path"
+import { RequestError } from "@agentclientprotocol/sdk"
+import {
+	AGENT_DEFINITIONS,
+	type AgentDefinition,
+	type DiscoveredSkill,
+	discoverAgent,
+} from "../../../agent-discovery/index.js"
+import { ALWAYS_SHOWN_SKILL_PATHS, KIMCHI_CONFIG_PATH, writeMigrationState, writeSkillPaths } from "../../../config.js"
+import type { ServerEntry } from "../../../extensions/mcp-adapter/types.js"
+import { toSkillName } from "../../../setup-wizard.js"
+
+/**
+ * import_apply over ACP — the write half of the onboarding import
+ * (ADR-0043/ADR-0044). A client sends the user's selection as item
+ * identities — exactly what import_discover reported — and those items are
+ * actually imported: skills are *copied* into Kimchi's own skills directory
+ * with their tree intact, selected MCP servers are merged into Kimchi's MCP
+ * config, and the migration marker is set so the terminal wizard does not
+ * re-ask. Source apps are never registered as scan paths, and nothing the
+ * user already has is overwritten.
+ *
+ * The handler re-discovers home-scope instead of trusting client-supplied
+ * file contents: there is no trust boundary to defend (the client spawns the
+ * harness and already has unrestricted filesystem access), but binding the
+ * applied items back to what is on disk at apply time keeps the two calls
+ * consistent when the disk changed between the user seeing the screen and
+ * pressing the button.
+ *
+ * Source: castai/kimchi/kimchi-studio#372 (blocked-by sibling #370).
+ */
+
+/** One selected skill, addressed as import_discover reported it. */
+export interface ImportApplySkillSelection {
+	/** Stable id of the source app the skill was discovered under. */
+	sourceAppId: string
+	/** Absolute path to the skill's SKILL.md, as returned by discovery. */
+	path: string
+}
+
+/** One selected MCP server, addressed as import_discover reported it. */
+export interface ImportApplyMcpServerSelection {
+	/** Stable id of the source app the server was discovered under. */
+	sourceAppId: string
+	/** Server name in the source app's config. */
+	name: string
+}
+
+export interface ImportApplyParams {
+	skills?: ImportApplySkillSelection[]
+	mcpServers?: ImportApplyMcpServerSelection[]
+}
+
+export type ImportApplyOutcome = "imported" | "skipped" | "error"
+
+/** Per-item result so the client can report exactly what landed and what did not. */
+export interface ImportApplyItemResult {
+	kind: "skill" | "mcpServer"
+	sourceAppId: string
+	/** Skill invocation name, or MCP server name. */
+	name: string
+	/** Absolute SKILL.md path of the selected item (skills only). */
+	path?: string
+	outcome: ImportApplyOutcome
+	/** Why an item was skipped or failed. Absent for "imported". */
+	reason?: string
+}
+
+export interface ImportApplyResult {
+	results: ImportApplyItemResult[]
+}
+
+export interface ImportApplyDeps {
+	/**
+	 * Harness agent config dir (production: `~/.config/kimchi/harness`, set by
+	 * entry.ts). Skills are copied to `<agentDir>/skills` — pi loads that dir
+	 * natively — and MCP servers merge into `<agentDir>/mcp.json`.
+	 */
+	readonly agentDir: string
+	/**
+	 * Path to the global kimchi config.json, where skillPaths and the
+	 * migration marker live. Defaults to the real global path; tests inject a
+	 * temp file.
+	 */
+	readonly configPath?: string
+	/** Source-app definitions to re-discover. Defaults to AGENT_DEFINITIONS. */
+	readonly definitions?: readonly AgentDefinition[]
+}
+
+function invalidParams(detail: string): never {
+	throw RequestError.invalidParams(undefined, `import_apply: ${detail}`)
+}
+
+function asStringArray(value: unknown, what: string): string[] {
+	if (!Array.isArray(value)) invalidParams(`${what} must be an array of strings`)
+	return value.map((v) => {
+		if (typeof v !== "string") invalidParams(`${what} must contain only strings`)
+		return v
+	})
+}
+
+function parseParams(params: Record<string, unknown>): ImportApplyParams {
+	if (params === null || typeof params !== "object" || Array.isArray(params)) {
+		invalidParams("params must be an object")
+	}
+	const raw = params as Record<string, unknown>
+	const skills = raw.skills === undefined ? [] : parseSelection<ImportApplySkillSelection>(raw.skills, "skills", "path")
+	const mcpServers =
+		raw.mcpServers === undefined
+			? []
+			: parseSelection<ImportApplyMcpServerSelection>(raw.mcpServers, "mcpServers", "name")
+	return { skills, mcpServers }
+}
+
+function parseSelection<T extends { sourceAppId: string }>(
+	value: unknown,
+	field: string,
+	secondKey: keyof Omit<T, "sourceAppId"> & string,
+): T[] {
+	if (!Array.isArray(value)) invalidParams(`${field} must be an array`)
+	return value.map((entry) => {
+		if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+			invalidParams(`${field} entries must be objects`)
+		}
+		const obj = entry as Record<string, unknown>
+		if (typeof obj.sourceAppId !== "string" || obj.sourceAppId.length === 0) {
+			invalidParams(`${field} entries need a string sourceAppId`)
+		}
+		if (typeof obj[secondKey] !== "string" || (obj[secondKey] as string).length === 0) {
+			invalidParams(`${field} entries need a string ${secondKey}`)
+		}
+		return { sourceAppId: obj.sourceAppId, [secondKey]: obj[secondKey] } as T
+	})
+}
+
+/** Skill directory name for the destination: sanitized invocation name, with the source directory's own (already valid) name as a fallback. */
+function destinationDirName(skill: DiscoveredSkill): string {
+	const sanitized = toSkillName(skill.name)
+	if (sanitized.length > 0) return sanitized
+	return basename(dirname(skill.path))
+}
+
+function applySkills(
+	selected: ImportApplySkillSelection[],
+	discovered: readonly { id: string; skills: readonly DiscoveredSkill[] }[],
+	skillsRoot: string,
+): ImportApplyItemResult[] {
+	const byKey = new Map<string, DiscoveredSkill>()
+	for (const app of discovered) {
+		for (const skill of app.skills) {
+			byKey.set(`${app.id}\u0000${skill.path}`, skill)
+		}
+	}
+
+	const results: ImportApplyItemResult[] = []
+	for (const sel of selected) {
+		const skill = byKey.get(`${sel.sourceAppId}\u0000${sel.path}`)
+		if (!skill) {
+			results.push({
+				kind: "skill",
+				sourceAppId: sel.sourceAppId,
+				path: sel.path,
+				name: "",
+				outcome: "skipped",
+				reason: "not found at apply time",
+			})
+			continue
+		}
+		const name = destinationDirName(skill)
+		const srcDir = dirname(skill.path)
+		const destDir = join(skillsRoot, name)
+		// The copy guard: a skill name already present in Kimchi is skipped,
+		// never overwritten — an import must not eat work from an earlier one,
+		// and the existing skill stays byte-for-byte unchanged.
+		if (resolve(srcDir) === resolve(destDir) || existsSync(destDir)) {
+			results.push({
+				kind: "skill",
+				sourceAppId: sel.sourceAppId,
+				path: sel.path,
+				name: skill.name,
+				outcome: "skipped",
+				reason: "already installed",
+			})
+			continue
+		}
+		try {
+			mkdirSync(skillsRoot, { recursive: true })
+			cpSync(srcDir, destDir, { recursive: true })
+			results.push({
+				kind: "skill",
+				sourceAppId: sel.sourceAppId,
+				path: sel.path,
+				name: skill.name,
+				outcome: "imported",
+			})
+		} catch (err) {
+			// One failing item never aborts the rest of the batch.
+			results.push({
+				kind: "skill",
+				sourceAppId: sel.sourceAppId,
+				path: sel.path,
+				name: skill.name,
+				outcome: "error",
+				reason: err instanceof Error ? err.message : String(err),
+			})
+		}
+	}
+	return results
+}
+
+function applyMcpServers(
+	selected: ImportApplyMcpServerSelection[],
+	discovered: readonly { id: string; mcpServers: Record<string, ServerEntry> }[],
+	mcpPath: string,
+): ImportApplyItemResult[] {
+	const byKey = new Map<string, ServerEntry>()
+	for (const app of discovered) {
+		for (const [name, entry] of Object.entries(app.mcpServers)) {
+			byKey.set(`${app.id}\u0000${name}`, entry)
+		}
+	}
+
+	let existing: Record<string, unknown>
+	try {
+		existing = JSON.parse(readFileSync(mcpPath, "utf-8")) as Record<string, unknown>
+		if (existing === null || typeof existing !== "object" || Array.isArray(existing)) existing = {}
+	} catch {
+		// Missing or corrupt — start fresh (same policy as the terminal wizard).
+		existing = {}
+	}
+	const existingServers = (existing.mcpServers ?? {}) as Record<string, ServerEntry>
+
+	const results: ImportApplyItemResult[] = []
+	const toAdd: Record<string, ServerEntry> = {}
+	for (const sel of selected) {
+		const entry = byKey.get(`${sel.sourceAppId}\u0000${sel.name}`)
+		if (!entry) {
+			results.push({
+				kind: "mcpServer",
+				sourceAppId: sel.sourceAppId,
+				name: sel.name,
+				outcome: "skipped",
+				reason: "not found at apply time",
+			})
+			continue
+		}
+		// Existing wins by name: re-importing never clobbers a server the user
+		// (or Studio's prefixed connector entries) already has.
+		if (existingServers[sel.name] !== undefined || toAdd[sel.name] !== undefined) {
+			results.push({
+				kind: "mcpServer",
+				sourceAppId: sel.sourceAppId,
+				name: sel.name,
+				outcome: "skipped",
+				reason: "already configured",
+			})
+			continue
+		}
+		toAdd[sel.name] = entry
+		results.push({ kind: "mcpServer", sourceAppId: sel.sourceAppId, name: sel.name, outcome: "imported" })
+	}
+
+	if (Object.keys(toAdd).length > 0) {
+		mkdirSync(dirname(mcpPath), { recursive: true })
+		// Rewrite only the mcpServers map; every other top-level key in the
+		// file (settings, imports, …) is preserved untouched.
+		const merged = { ...toAdd, ...existingServers }
+		existing.mcpServers = merged
+		const tmp = `${mcpPath}.${process.pid}.tmp`
+		writeFileSync(tmp, `${JSON.stringify(existing, null, 2)}\n`, "utf-8")
+		renameSync(tmp, mcpPath)
+	}
+	return results
+}
+
+/**
+ * Stored skill paths are merged, never replaced: a hand-added custom path
+ * survives an import. Source apps are never added here — skills are copied,
+ * not linked, and registering a source directory would double-discover every
+ * skill in it.
+ */
+function mergeSkillPaths(configPath: string): string[] {
+	let stored: string[] = []
+	try {
+		const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>
+		if (Array.isArray(parsed.skillPaths)) stored = asStringArray(parsed.skillPaths, "skillPaths")
+	} catch {
+		// No config yet — first run; nothing to preserve.
+	}
+	const seen = new Set<string>()
+	const merged: string[] = []
+	for (const p of [...ALWAYS_SHOWN_SKILL_PATHS, ...stored]) {
+		if (seen.has(p)) continue
+		seen.add(p)
+		merged.push(p)
+	}
+	return merged
+}
+
+/**
+ * Perform the import for a client-supplied selection. Completing the call
+ * satisfies the migration marker — even when items were skipped or failed —
+ * so a user who imported in one surface is not re-interrogated in the other.
+ */
+export function handleImportApply(deps: ImportApplyDeps, params: Record<string, unknown>): ImportApplyResult {
+	const selection = parseParams(params)
+	const definitions = deps.definitions ?? AGENT_DEFINITIONS
+	// Home scope, same as import_discover: onboarding has no workspace, and
+	// project-relative roots are meaningless (and permission-prompting) here.
+	const discovered = definitions.map((def) => discoverAgent(def, { scope: "home" }))
+
+	const skillsRoot = join(deps.agentDir, "skills")
+	const mcpPath = join(deps.agentDir, "mcp.json")
+	const configPath = deps.configPath ?? KIMCHI_CONFIG_PATH
+
+	const results = [
+		...applySkills(selection.skills ?? [], discovered, skillsRoot),
+		...applyMcpServers(selection.mcpServers ?? [], discovered, mcpPath),
+	]
+
+	writeSkillPaths(mergeSkillPaths(configPath), configPath)
+	writeMigrationState("done", configPath)
+
+	return { results }
+}

--- a/src/modes/acp/ext-methods/import-apply.ts
+++ b/src/modes/acp/ext-methods/import-apply.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync } from "node:fs"
 import { basename, dirname, join, resolve } from "node:path"
 import { RequestError } from "@agentclientprotocol/sdk"
 import {
@@ -7,7 +7,13 @@ import {
 	type DiscoveredSkill,
 	discoverAgent,
 } from "../../../agent-discovery/index.js"
-import { ALWAYS_SHOWN_SKILL_PATHS, KIMCHI_CONFIG_PATH, writeMigrationState, writeSkillPaths } from "../../../config.js"
+import {
+	ALWAYS_SHOWN_SKILL_PATHS,
+	KIMCHI_CONFIG_PATH,
+	writeJsonObjectFile,
+	writeMigrationState,
+	writeSkillPaths,
+} from "../../../config.js"
 import type { ServerEntry } from "../../../extensions/mcp-adapter/types.js"
 import { toSkillName } from "../../../setup-wizard.js"
 
@@ -58,8 +64,8 @@ export type ImportApplyOutcome = "imported" | "skipped" | "error"
 export interface ImportApplyItemResult {
 	kind: "skill" | "mcpServer"
 	sourceAppId: string
-	/** Skill invocation name, or MCP server name. */
-	name: string
+	/** Skill invocation name, or MCP server name. Omitted when the item could not be resolved to a name at apply time. */
+	name?: string
 	/** Absolute SKILL.md path of the selected item (skills only). */
 	path?: string
 	outcome: ImportApplyOutcome
@@ -69,6 +75,8 @@ export interface ImportApplyItemResult {
 
 export interface ImportApplyResult {
 	results: ImportApplyItemResult[]
+	/** Non-fatal persistence problems (e.g. the config write failed after items landed). */
+	warnings?: string[]
 }
 
 export interface ImportApplyDeps {
@@ -92,15 +100,13 @@ function invalidParams(detail: string): never {
 	throw RequestError.invalidParams(undefined, `import_apply: ${detail}`)
 }
 
-function asStringArray(value: unknown, what: string): string[] {
-	if (!Array.isArray(value)) invalidParams(`${what} must be an array of strings`)
-	return value.map((v) => {
-		if (typeof v !== "string") invalidParams(`${what} must contain only strings`)
-		return v
-	})
+/** Validated selection; both arrays are always present (possibly empty). */
+interface ParsedSelections {
+	skills: ImportApplySkillSelection[]
+	mcpServers: ImportApplyMcpServerSelection[]
 }
 
-function parseParams(params: Record<string, unknown>): ImportApplyParams {
+function parseParams(params: Record<string, unknown>): ParsedSelections {
 	if (params === null || typeof params !== "object" || Array.isArray(params)) {
 		invalidParams("params must be an object")
 	}
@@ -157,11 +163,12 @@ function applySkills(
 	for (const sel of selected) {
 		const skill = byKey.get(`${sel.sourceAppId}\u0000${sel.path}`)
 		if (!skill) {
+			// Resolved only by identity (source app + SKILL.md path); the client
+			// already knows the name from discover, so none is echoed here.
 			results.push({
 				kind: "skill",
 				sourceAppId: sel.sourceAppId,
 				path: sel.path,
-				name: "",
 				outcome: "skipped",
 				reason: "not found at apply time",
 			})
@@ -217,6 +224,11 @@ function applyMcpServers(
 	const byKey = new Map<string, ServerEntry>()
 	for (const app of discovered) {
 		for (const [name, entry] of Object.entries(app.mcpServers)) {
+			// Same filter as import_discover's toImportDiscoverMcpServer: an
+			// entry with neither command nor url is never reported by discovery
+			// and must not be importable by identity either, so the two methods
+			// agree on what a selectable server is.
+			if (entry.command === undefined && entry.url === undefined) continue
 			byKey.set(`${app.id}\u0000${name}`, entry)
 		}
 	}
@@ -262,14 +274,11 @@ function applyMcpServers(
 	}
 
 	if (Object.keys(toAdd).length > 0) {
-		mkdirSync(dirname(mcpPath), { recursive: true })
 		// Rewrite only the mcpServers map; every other top-level key in the
 		// file (settings, imports, …) is preserved untouched.
 		const merged = { ...toAdd, ...existingServers }
 		existing.mcpServers = merged
-		const tmp = `${mcpPath}.${process.pid}.tmp`
-		writeFileSync(tmp, `${JSON.stringify(existing, null, 2)}\n`, "utf-8")
-		renameSync(tmp, mcpPath)
+		writeJsonObjectFile(mcpPath, existing)
 	}
 	return results
 }
@@ -284,7 +293,11 @@ function mergeSkillPaths(configPath: string): string[] {
 	let stored: string[] = []
 	try {
 		const parsed = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>
-		if (Array.isArray(parsed.skillPaths)) stored = asStringArray(parsed.skillPaths, "skillPaths")
+		// Server-side data, not client params: non-string entries are dropped
+		// rather than surfacing as an invalidParams error to the client.
+		if (Array.isArray(parsed.skillPaths)) {
+			stored = parsed.skillPaths.filter((p): p is string => typeof p === "string")
+		}
 	} catch {
 		// No config yet — first run; nothing to preserve.
 	}
@@ -302,6 +315,10 @@ function mergeSkillPaths(configPath: string): string[] {
  * Perform the import for a client-supplied selection. Completing the call
  * satisfies the migration marker — even when items were skipped or failed —
  * so a user who imported in one surface is not re-interrogated in the other.
+ *
+ * Partial outcomes are reported, not hidden: if the final config writes fail
+ * (EACCES, disk full) the per-item results still come back, with a top-level
+ * `warnings` entry naming what could not be persisted.
  */
 export function handleImportApply(deps: ImportApplyDeps, params: Record<string, unknown>): ImportApplyResult {
 	const selection = parseParams(params)
@@ -315,12 +332,31 @@ export function handleImportApply(deps: ImportApplyDeps, params: Record<string, 
 	const configPath = deps.configPath ?? KIMCHI_CONFIG_PATH
 
 	const results = [
-		...applySkills(selection.skills ?? [], discovered, skillsRoot),
-		...applyMcpServers(selection.mcpServers ?? [], discovered, mcpPath),
+		...applySkills(selection.skills, discovered, skillsRoot),
+		...applyMcpServers(selection.mcpServers, discovered, mcpPath),
 	]
 
-	writeSkillPaths(mergeSkillPaths(configPath), configPath)
-	writeMigrationState("done", configPath)
+	const warnings: string[] | undefined = recordFinalWrites(configPath)
+	return warnings === undefined ? { results } : { results, warnings }
+}
 
-	return { results }
+/**
+ * The two completion writes (skill paths + migration marker) run after the
+ * items may already be on disk, so a failure must not reject the call and
+ * bury the per-item results — it is reported as a warning instead.
+ */
+function recordFinalWrites(configPath: string): string[] | undefined {
+	const warnings: string[] = []
+	const steps: Array<{ label: string; run: () => void }> = [
+		{ label: "persist skill paths", run: () => writeSkillPaths(mergeSkillPaths(configPath), configPath) },
+		{ label: "persist the migration marker", run: () => writeMigrationState("done", configPath) },
+	]
+	for (const step of steps) {
+		try {
+			step.run()
+		} catch (err) {
+			warnings.push(`Failed to ${step.label}: ${err instanceof Error ? err.message : String(err)}`)
+		}
+	}
+	return warnings.length > 0 ? warnings : undefined
 }

--- a/src/modes/acp/ext-methods/import-apply.ts
+++ b/src/modes/acp/ext-methods/import-apply.ts
@@ -215,6 +215,7 @@ function applyMcpServers(
 	selected: ImportApplyMcpServerSelection[],
 	discovered: readonly { id: string; mcpServers: Record<string, ServerEntry> }[],
 	mcpPath: string,
+	warnings: string[],
 ): ImportApplyItemResult[] {
 	const byKey = new Map<string, ServerEntry>()
 	for (const app of discovered) {
@@ -237,7 +238,14 @@ function applyMcpServers(
 		// Missing or corrupt — start fresh (same policy as the terminal wizard).
 		existing = {}
 	}
-	const existingServers = (existing.mcpServers ?? {}) as Record<string, ServerEntry>
+	const rawServers = existing.mcpServers
+	// Same shape discipline as the root: a file that parses but carries a
+	// scalar/array mcpServers (hand-edit or partial-write corruption) must
+	// not be object-spread into garbage numeric keys and re-persisted.
+	const existingServers =
+		rawServers !== null && typeof rawServers === "object" && !Array.isArray(rawServers)
+			? (rawServers as Record<string, ServerEntry>)
+			: {}
 
 	const results: ImportApplyItemResult[] = []
 	const toAdd: Record<string, ServerEntry> = {}
@@ -274,7 +282,22 @@ function applyMcpServers(
 		// file (settings, imports, …) is preserved untouched.
 		const merged = { ...toAdd, ...existingServers }
 		existing.mcpServers = merged
-		writeJsonObjectFile(mcpPath, existing)
+		try {
+			writeJsonObjectFile(mcpPath, existing)
+		} catch (err) {
+			// Partial outcomes are reported, not hidden: skills may already be on
+			// disk, so a failed MCP-config write must not reject the call. The
+			// affected items are downgraded from "imported" to "error" (they did
+			// not land) and a top-level warning names the root cause.
+			const reason = `MCP config write failed: ${err instanceof Error ? err.message : String(err)}`
+			for (const r of results) {
+				if (r.kind === "mcpServer" && r.outcome === "imported") {
+					r.outcome = "error"
+					r.reason = reason
+				}
+			}
+			warnings.push(`Failed to persist the MCP config: ${err instanceof Error ? err.message : String(err)}`)
+		}
 	}
 	return results
 }
@@ -327,13 +350,15 @@ export function handleImportApply(deps: ImportApplyDeps, params: Record<string, 
 	const mcpPath = join(deps.agentDir, "mcp.json")
 	const configPath = deps.configPath ?? KIMCHI_CONFIG_PATH
 
+	const warnings: string[] = []
 	const results = [
 		...applySkills(selection.skills, discovered, skillsRoot),
-		...applyMcpServers(selection.mcpServers, discovered, mcpPath),
+		...applyMcpServers(selection.mcpServers, discovered, mcpPath, warnings),
 	]
 
-	const warnings: string[] | undefined = recordFinalWrites(configPath)
-	return warnings === undefined ? { results } : { results, warnings }
+	const persistenceWarnings = recordFinalWrites(configPath)
+	const allWarnings = [...warnings, ...(persistenceWarnings ?? [])]
+	return allWarnings.length > 0 ? { results, warnings: allWarnings } : { results }
 }
 
 /**

--- a/src/modes/acp/ext-methods/import-apply.ts
+++ b/src/modes/acp/ext-methods/import-apply.ts
@@ -53,11 +53,6 @@ export interface ImportApplyMcpServerSelection {
 	name: string
 }
 
-export interface ImportApplyParams {
-	skills?: ImportApplySkillSelection[]
-	mcpServers?: ImportApplyMcpServerSelection[]
-}
-
 export type ImportApplyOutcome = "imported" | "skipped" | "error"
 
 /** Per-item result so the client can report exactly what landed and what did not. */
@@ -224,11 +219,12 @@ function applyMcpServers(
 	const byKey = new Map<string, ServerEntry>()
 	for (const app of discovered) {
 		for (const [name, entry] of Object.entries(app.mcpServers)) {
-			// Same filter as import_discover's toImportDiscoverMcpServer: an
-			// entry with neither command nor url is never reported by discovery
-			// and must not be importable by identity either, so the two methods
-			// agree on what a selectable server is.
-			if (entry.command === undefined && entry.url === undefined) continue
+			// Same filter as import_discover's toImportDiscoverMcpServer — falsy,
+			// so an empty-string command/url is just as unactionable as an absent
+			// one: such entries are never reported by discovery and must not be
+			// importable by identity either, so the two methods agree on what a
+			// selectable server is.
+			if (!entry.command && !entry.url) continue
 			byKey.set(`${app.id}\u0000${name}`, entry)
 		}
 	}

--- a/src/modes/acp/ext-methods/set-session-title.test.ts
+++ b/src/modes/acp/ext-methods/set-session-title.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { asSession, BaseFakeAgentSession, makeAcpConn, makeAcpSessionFactory } from "../__mocks__/fake-agent-session.js"
+import { BaseFakeAgentSession, makeAcpConn, makeAcpSessionFactory } from "../__mocks__/fake-agent-session.js"
 import { AVAILABLE_EXT_METHODS } from "../capabilities.js"
 import { KimchiAcpAgent } from "../server.js"
 

--- a/src/modes/acp/server.test.ts
+++ b/src/modes/acp/server.test.ts
@@ -79,6 +79,13 @@ vi.mock("./ext-methods/import-discover.js", () => ({
 		],
 	})),
 }))
+// Hermetic stub for import_apply: the real handler would write skills, MCP
+// config and the migration marker into the developer's actual home directory.
+vi.mock("./ext-methods/import-apply.js", () => ({
+	handleImportApply: vi.fn(() => ({
+		results: [{ kind: "skill", sourceAppId: "stub-app", name: "stub-skill", path: "/tmp/s", outcome: "imported" }],
+	})),
+}))
 
 const THEME_KEY = Symbol.for("@earendil-works/pi-coding-agent:theme")
 const THEME_KEY_OLD = Symbol.for("@mariozechner/pi-coding-agent:theme")
@@ -8431,12 +8438,29 @@ describe("extMethod dispatch", () => {
 		])
 	})
 
+	it("dispatches the sessionless import_apply method and returns its per-item results", async () => {
+		const agent = new KimchiAcpAgent(makeConn(), {
+			extensionFactories: [],
+			agentDir: "/tmp/fake-agent-dir",
+		})
+
+		const result = (await agent.extMethod(AVAILABLE_EXT_METHODS.import_apply, {
+			skills: [{ sourceAppId: "stub-app", path: "/tmp/s" }],
+		})) as {
+			results: Array<{ kind: string; name: string; outcome: string }>
+		}
+
+		expect(result.results).toEqual([
+			{ kind: "skill", sourceAppId: "stub-app", name: "stub-skill", path: "/tmp/s", outcome: "imported" },
+		])
+	})
+
 	it("rejects unknown extension methods as method-not-found", async () => {
 		const agent = new KimchiAcpAgent(makeConn(), {
 			extensionFactories: [],
 			agentDir: "/tmp/fake-agent-dir",
 		})
 
-		await expect(agent.extMethod("_kimchi.dev/import_apply", {})).rejects.toThrow(/Method not found/)
+		await expect(agent.extMethod("_kimchi.dev/no_such_method", {})).rejects.toThrow(/Method not found/)
 	})
 })

--- a/src/modes/acp/server.ts
+++ b/src/modes/acp/server.ts
@@ -105,6 +105,7 @@ import { createAcpUIContext } from "./acp-ui-context.js"
 import { ADVERTISED_CAPABILITIES, AVAILABLE_EXT_METHODS, CAPABILITIES_KEY } from "./capabilities.js"
 import { AVAILABLE_COMMANDS } from "./commands.js"
 import { handleAuthStatus } from "./ext-methods/auth-status.js"
+import { handleImportApply } from "./ext-methods/import-apply.js"
 import { importDiscover } from "./ext-methods/import-discover.js"
 import { handleProbeMcpServer } from "./ext-methods/mcp.js"
 import { handleSetOnboardingFlag } from "./ext-methods/set-onboarding-flag.js"
@@ -1077,6 +1078,12 @@ export class KimchiAcpAgent implements Agent {
 				// assignable to the string-indexed record the extMethod contract
 				// wants — no cast, no spread.
 				return importDiscover()
+			case AVAILABLE_EXT_METHODS.import_apply:
+				// Sessionless write half of the import (ADR-0043/ADR-0044): copies
+				// selected skills into Kimchi's own skills dir, merges selected MCP
+				// servers conservatively, and satisfies the migration marker. No
+				// session is touched.
+				return { ...handleImportApply({ agentDir: this.agentDir }, params) }
 			default:
 				throw RequestError.methodNotFound(method)
 		}

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -24,7 +24,7 @@ interface MergedDiscovery {
 }
 
 function mergeDiscoveries(): MergedDiscovery {
-	const agents = AGENT_DEFINITIONS.map((def) => discoverAgent(def))
+	const agents = AGENT_DEFINITIONS.map((def) => discoverAgent(def, { enumerateSkills: false }))
 	// Merge MCP servers in *reverse* registry order so earlier-registered
 	// agents win on name collisions. Today: CC is registered first → CC
 	// wins, matching previous behaviour.

--- a/src/skills-wizard.ts
+++ b/src/skills-wizard.ts
@@ -10,7 +10,7 @@ export async function runSkillsWizard(): Promise<string[]> {
 		"First-time setup",
 	)
 
-	const agents = AGENT_DEFINITIONS.map((def) => discoverAgent(def))
+	const agents = AGENT_DEFINITIONS.map((def) => discoverAgent(def, { enumerateSkills: false }))
 	const discoveredDirs = agents
 		.filter((a): a is typeof a & { skillsDir: string } => !!a.skillsDir && a.skillCount > 0)
 		.map((a) => a.skillsDir)


### PR DESCRIPTION
> **⚠️ Stacked draft — do not merge before #1184.** This PR targets `master` because GitHub cannot target `ao/kimchi-8/import-discover` while that branch lives only on the fork (it is PR #1184's head branch). The PR therefore *contains* #1184's commits (import_discover) plus this PR's delta. Once #1184 merges, this PR should be rebased/retargeted so the diff shows only the import_apply delta. Kept as a draft until then.

## Summary

Implements castai/kimchi/kimchi-studio#372 — `_kimchi.dev/import_apply`: the write half of the onboarding import. A client sends the user's selection as item identities exactly as `import_discover` (#1184) reported them, and those items are actually imported.

- **Skills are copied, not linked.** Each selected skill's directory is copied into Kimchi's own skills dir (`<agentDir>/skills` — pi loads it natively) with its tree intact. Source apps are never registered as scan paths, so a skill can't be double-discovered from two drifting files, and per-item selection stays honest.
- **Nothing already in Kimchi is destroyed.** A skill whose destination name exists is skipped and left byte-for-byte unchanged; an MCP server already present under the same name is preserved and the imported one is not written — which also leaves Studio's prefixed connector entries untouched.
- **MCP servers merge conservatively** into `<agentDir>/mcp.json` via the shared `writeJsonObjectFile` helper (atomic tmp+rename, owner-only 0600 — imported entries carry plaintext credentials), preserving every other top-level key (`settings`, `imports`, …).
- **Stored skill paths are merged, never replaced.** A hand-added custom path survives an import. `buildSkillPathOptions` (which never reads stored config and would silently drop user entries) is deliberately not used here.
- **The migration marker is set on completion**, including when the batch contained skipped or errored items — a user who imported in one surface is not re-interrogated by the terminal wizard, and its skills phase does not re-arm (the documented consequence in ADR-0043).
- **Partial outcomes are reported, not hidden.** The response carries a per-item result (`imported` / `skipped` / `error` + reason); one failing item never aborts the rest; an item whose source vanished since discovery is skipped and reported; a failed completion write surfaces as a top-level `warnings` entry instead of rejecting with no results.
- **Apply agrees with discover on item identity.** The apply-side server filter uses the same falsy rule as `import_discover` (`!command && !url`), so an entry discover never reports cannot be imported by name.

There is no trust boundary to defend: the handler re-discovers home-scope at apply time instead of trusting client-supplied file contents — binding applied items back to what is on disk is a consistency concern (the disk can change between the user seeing the screen and pressing the button), not a security one.

`KIMCHI_CONFIG_PATH` is exported from `config.ts` and the atomic JSON-write idiom is extracted as `writeJsonObjectFile` so tests can inject paths and the credential hardening is shared with `writeConfigObject`.

## Testing

- `import-apply.test.ts` (19 tests): skill copy with tree intact + **discoverable via `loadSkillsFromDir`**, no source dir in stored skill paths, existing-name skip with byte-for-byte unchanged destination, vanished-source skip with call success, per-item error isolation, full MCP entry import, `mcp.json` written 0600, existing-server preservation, prefixed connector entries + settings untouched, corrupt-`mcp.json` start-fresh, entries discover drops (absent/empty command+url) not importable, skillPaths merge with custom path surviving, marker set on skipped/error/empty batches, persistence-failure warnings, invalidParams on malformed selections, capability advertised.
- `server.test.ts`: extMethod dispatch for `import_apply`; `config.test.ts`, `set-session-title.test.ts`, `mcp-adapter/index.test.ts`, `permissions/prompts.test.ts` green (three pre-existing lint findings in the latter three fixed to keep the full `pnpm run check` green).
- `pnpm run lint`, `pnpm run typecheck` green; 478 tests green across the touched suites.

## Known risks / follow-ups

- Setting the migration marker suppresses the terminal wizard's commands-to-prompts migration — the accepted consequence documented in the ticket.
- `set_onboarding_flag` (already on master) is deliberately separate: completing onboarding cannot be a side effect of importing.
- A5 (dedupe stored skillPaths by resolved path) left as a follow-up: relative skill paths scan under both `~` and the project, so single-anchor resolution risks dropping hand-added project-only paths.

Ref: castai/kimchi/kimchi-studio#372 (parent #368; blocked-by #370 → #1184)

Co-Authored-By: Kimchi <noreply@kimchi.dev>
